### PR TITLE
Fix closing calc without save

### DIFF
--- a/x11test.d/430_oocalc.pm
+++ b/x11test.d/430_oocalc.pm
@@ -18,7 +18,7 @@ sub run()
 	$self->take_screenshot;
 	sendkey "alt-f4"; sleep 2;
 	$self->take_screenshot;
-	sendkey "alt-d"; sleep 2; # Discard
+	sendkey "alt-d"; sleep 2; # Close _without saving
 }
 
 sub checklist()


### PR DESCRIPTION
oocalc in factory changed "_Discard" to "Close _without saving".
