### PR TITLE
introduce cleanup handler

### DIFF
--- a/needle.pm
+++ b/needle.pm
@@ -11,6 +11,7 @@ use File::Basename;
 our %needles;
 our %tags;
 our $needledir;
+our $cleanuphandler;
 
 sub new($;$) {
     my $classname = shift;
@@ -161,6 +162,9 @@ sub init(;$) {
     #		print "  ", $p->{'name'}, "\n";
     #	}
     #}
+    if ($cleanuphandler) {
+        &$cleanuphandler();
+    }
 }
 
 sub tags($) {


### PR DESCRIPTION
when reading needles we need to throw some away that don't match the
tags. In interactive mode needes are re-read so there needs to be a
handler that is called on init. Therefore introduce a callback.
