### PR TITLE
init needles after main.pm

### DIFF
--- a/needle.pm
+++ b/needle.pm
@@ -150,6 +150,7 @@ sub wanted_($) {
 
 sub init(;$) {
     $needledir = shift if @_;
+    $needledir ||= "$ENV{CASEDIR}/needles/";
     %needles   = ();
     %tags      = ();
     bmwqemu::diag("init needles from $needledir");

--- a/start.pl
+++ b/start.pl
@@ -28,8 +28,6 @@ bmwqemu::clean_control_files();
 
 bmwqemu::save_results();
 
-needle::init("$ENV{CASEDIR}/needles/");
-
 my $init = 1;
 alarm( 7200 + ( $ENV{UPGRADE} ? 3600 : 0 ) );    # worst case timeout
 
@@ -81,6 +79,9 @@ my $r = 0;
 eval {
     # Load the main.pm from the casedir checked by the sanity checks above
     require "$ENV{CASEDIR}/main.pm";
+
+    needle::init();
+
     autotest::runalltests();
 };
 if ($@) {


### PR DESCRIPTION
cleanup handler is installed by main.pm so needles must be initialized
afterwards.
