### PR TITLE
add -no-shutdown to qemu params

### DIFF
--- a/inst/startqemu.pm
+++ b/inst/startqemu.pm
@@ -149,6 +149,7 @@ sub run($$) {
         push( @params, "-usb", "-usbdevice", "tablet" );
         push( @params, "-smp", $vars->{QEMUCPUS} );
         push( @params, "-enable-kvm" );
+        push( @params, "-no-shutdown" );
 
         if ( open( my $cmdfd, '>', 'runqemu' ) ) {
             print $cmdfd "#!/bin/bash\n";


### PR DESCRIPTION
don't quit qemu if the vm shuts down as that could kill os-autoinst
unexpectedly. Let os-autoinst quit qemu explicitly instead.
