### PR TITLE
finally found the VNC bug I was hunting so long

### DIFF
--- a/backend/VNC.pm
+++ b/backend/VNC.pm
@@ -471,7 +471,10 @@ sub receive_message {
 
     my $socket = $self->socket;
 
-    $socket->read( my $message_type, 1 ) || die 'unexpected end of data';
+    $socket->blocking(0);
+    my $ret = $socket->read( my $message_type, 1 );
+    $socket->blocking(1);
+    return undef unless $ret;
     $message_type = unpack( 'C', $message_type );
 
     #bmwqemu::diag("RM $message_type");


### PR DESCRIPTION
It happens (against the strict interpretation of the RFB protocol) that qemu
sends 2 frame buffer update messages as answer to an update request. The buffered
read of perl's IO::Socket will read in both fully, so the select() we return
into after parsing the first message is not returning vnc socket. So we miss the
2nd message forever

So set the socket to non blocking, read a byte and if a byte can be read,
read the rest. And do this independent of select
