### PR TITLE
do not set hd boot if PXEBOOT flag is set

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -161,15 +161,17 @@ sub start_qemu($) {
                 push( @params, "-device", "usb-ehci,id=ehci" );
                 push( @params, "-device", "usb-storage,bus=ehci.0,drive=usbstick,id=devusb" );
             }
-            elsif ( $vars->{PXEBOOT} ) {
-                push( @params, "-boot", "n");
-            }
             else {
                 push( @params, "-cdrom", $iso );
             }
         }
 
-        push( @params, "-boot", "once=d,menu=on,splash-time=5000" );
+        if ( $vars->{PXEBOOT} ) {
+            push( @params, "-boot", "n");
+        }
+        else {
+            push( @params, "-boot", "once=d,menu=on,splash-time=5000" );
+        }
 
         if ( $vars->{QEMUCPU} ) {
             push( @params, "-cpu", $vars->{QEMUCPU} );


### PR DESCRIPTION
PXEBOOT code in if ($iso) was wrong by itself (even though usually working).
Now don't even add hd boot option if PXEBOOT is set. Otherwise it messes some upgrade scenarios when backing HDD image is used.
