### PR TITLE
imroot: check if we're really root

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -42,7 +42,7 @@ sub become_root() {
     my ($self) = @_;
 
     testapi::script_sudo( "bash", 0 );    # become root
-    testapi::script_run("echo 'imroot' > /dev/$testapi::serialdev");
+    testapi::script_run("test $(id -u) -eq 0 && echo 'imroot' > /dev/$testapi::serialdev");
     testapi::wait_serial( "imroot", 5 ) || die "Root prompt not there";
     testapi::script_run("cd /tmp");
 }


### PR DESCRIPTION
The current setup simply prints 'imroot' to the serial port - which also works as a regular user and thus the 'assert' if imroot is not found is most useless.

Let's first test if our id is actually 0 and only then print out that we're actually root.
