### PR TITLE
assert_and_click: move the mouse back to where it was before

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -21,6 +21,7 @@ use backend::VNC;
 
 my $MAGIC_PIPE_CLOSE_STRING = 'xxxQUITxxx';
 my $iscrashedfile           = 'backend.crashed';
+my %last_mouse_coords = ( 'x' => 0, 'y' => 0 );
 
 sub write_crash_file {
     if (open(my $fh, ">", $iscrashedfile )) {
@@ -275,6 +276,12 @@ sub mouse_set($$) {
     my ( $x, $y ) = @_;
 
     $self->send({ 'VNC' => "mouse_set", 'arguments' => { 'x' => $x, 'y' => $y } } );
+    %last_mouse_coords = ( 'x' => $x, 'y' => $y );
+}
+
+sub get_last_mouse_set {
+    my $self = shift;
+    return ($last_mouse_coords{'x'}, $last_mouse_coords{'y'});
 }
 
 sub mouse_button($$$) {

--- a/testapi.pm
+++ b/testapi.pm
@@ -114,6 +114,7 @@ sub assert_and_click($;$$$$) {
         mustmatch => $_[0],
         timeout   => $_[2]
     );
+    my @old_mouse_coords = $bmwqemu::backend->get_last_mouse_set();
     bmwqemu::fctlog( 'assert_and_click', ["mustmatch", $_[0]], ["button", $_[1]], ["timeout", $_[2]] );
 
     my $dclick = $_[4] || 0;
@@ -132,6 +133,10 @@ sub assert_and_click($;$$$$) {
     else {
         mouse_click( $_[1], $_[3] );
     }
+    # We can't just move the mouse, or we end up in a click-and-drag situation
+    sleep 1;
+    # move mouse back to where it was before we clicked
+    mouse_set( $old_mouse_coords[0], $old_mouse_coords[1]);
 }
 
 sub assert_and_dclick($;$$$) {


### PR DESCRIPTION
I used this to test the 12.2 Update scenario, where the mouse was in the way to make proper needles;
On my local system, I now worked with a needle with the mouse out of the way and this passes nicely through to the installation...

(not sure yet if the install will finish, but that is a different topic)
