### PR TITLE
Set default resolution for -vga std

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -77,7 +77,7 @@ sub start_qemu($) {
         $vars->{QEMUVGA} ||= "cirrus";
     }
     else {
-        $vars->{QEMUVGA} ||= "std";
+        $vars->{QEMUVGA} ||= "std -g 1024x768";
     }
     $vars->{QEMUCPUS}  ||= 1;
     if ( defined( $vars->{RAIDLEVEL} ) ) {


### PR DESCRIPTION
Override default screen resolution for distributons where bochs_drm
driver is not avaialble.

Signed-off-by: Dinar Valeev <dvaleev@suse.com>