### PR TITLE
fixing audio support in qemu backend

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -25,6 +25,10 @@ sub new {
     $self->{'pid'}         = undef;
     $self->{'pidfilename'} = 'qemu.pid';
 
+    # make sure to set environment variables in the main thread
+    # exec uses the %ENV of the main thread
+    $ENV{'QEMU_AUDIO_DRV'} = "none";
+
     return $self;
 }
 
@@ -212,7 +216,6 @@ sub start_qemu() {
         symlink( $i, "$basedir/l$i" ) or die "$!\n";
     }
 
-    $ENV{QEMU_AUDIO_DRV} = "none";
     pipe(my $reader, my $writer);
     $self->{'pid'} = fork();
     die "fork failed" if ( !defined( $self->{'pid'} ) );


### PR DESCRIPTION
from http://perldoc.perl.org/threads.html:

Currently, on all platforms except MSWin32, all system calls (e.g.,
using system() or back-ticks) made from threads use the environment
variable settings from the main thread. In other words, changes made to
%ENV in a thread will not be visible in system calls made by that
%thread.