### PR TITLE
small fixes:

### DIFF
--- a/backend/driver.pm
+++ b/backend/driver.pm
@@ -93,6 +93,8 @@ sub start_vm($) {
     mkdir $bmwqemu::screenshotpath;
 
     $self->_send_json({ 'cmd' => "start_vm"} ) || die "failed to start VM";
+    # the backend thread might have added some defaults for the backend
+    bmwqemu::load_vars();
 
     $self->post_start_hook();
     return 1;

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -356,7 +356,7 @@ sub start_qemu() {
     }
     close $writer;
     $self->{'qemupipe'} = $reader;
-    sleep 4;    # time to let qemu start
+    sleep 2;    # time to let qemu start
     die "failed to start VM" unless $self->raw_alive();
     open( my $pidf, ">", $self->{'pidfilename'} ) or die "can not write " . $self->{'pidfilename'};
     print $pidf $self->{'pid'}, "\n";

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -66,18 +66,18 @@ our $direct_output;
 our $timesidleneeded     = 1;
 our $standstillthreshold = 600;
 
+our %vars;
+
 sub load_vars() {
     my $fn = "vars.json";
-    my $ret;
+    my $ret = {};
     local $/;
     open(my $fh, '<', $fn) or return 0;
-    eval {$ret = decode_json(<$fh>);};
+    eval { $ret = decode_json(<$fh>); };
     warn "openQA didn't write proper vars.json" if $@;
     close($fh);
-    return $ret;
+    %vars = %{$ret};
 }
-
-our %vars;
 
 sub save_vars() {
     my $fn = "vars.json";
@@ -107,7 +107,7 @@ our $scriptdir;
 our $testedversion;
 
 sub init {
-    %vars = %{load_vars() || {}};
+    load_vars();
     $vars{NAME} ||= 'noname';
     $liveresultpath = "$testresults/$vars{NAME}";
     if ($direct_output) {

--- a/testapi.pm
+++ b/testapi.pm
@@ -11,7 +11,7 @@ our @EXPORT = qw($realname $username $password $serialdev %cmd %vars send_key ty
   script_sudo wait_serial save_screenshot wait_screen_change
   assert_and_click mouse_hide mouse_set mouse_click mouse_dclick
   type_password get_var check_var set_var become_root x11_start_program ensure_installed
-  autoinst_url script_output validate_script_output eject_cd);
+  autoinst_url script_output validate_script_output eject_cd power);
 
 our %cmd;
 


### PR DESCRIPTION
- export the power function
- don't wait too long for qemu to start - the usb boot menu disappears otherwise
- load the vars after the backend started - it might save defaults ('NUMDISKS')