### PR TITLE
Fix boot order for PowerPC

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -285,8 +285,11 @@ sub start_qemu() {
         if ( $vars->{PXEBOOT} ) {
             push( @params, "-boot", "n");
         }
-        else {
+        elsif ( !$vars->{OFW} ) {
             push( @params, "-boot", "once=d,menu=on,splash-time=5000" );
+        }
+        else {
+            push( @params, "-boot", "order=cd" );
         }
 
         if ( $vars->{QEMUCPU} ) {


### PR DESCRIPTION
On qemu-system-ppc64 spapr machine, once=d boot option doesn't work.
Use order=cd for now.

Signed-off-by: Dinar Valeev <dvaleev@suse.com>