### PR TITLE
Implement multipath scenario

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -743,7 +743,7 @@ sub assert_screen {
     my @save_tags = @tags;
 
     # add some known env variables
-    for my $key (qw(VIDEOMODE DESKTOP DISTRI INSTLANG LIVECD LIVETEST OFW UEFI NETBOOT PROMO FLAVOR)) {
+    for my $key (qw(VIDEOMODE DESKTOP DISTRI INSTLANG LIVECD LIVETEST OFW UEFI NETBOOT PROMO FLAVOR MULTIPATH)) {
         push( @save_tags, "ENV-$key-" . $vars{$key} ) if $vars{$key};
     }
 


### PR DESCRIPTION
This patch implements multipath scenario. Basically we export the same
divice twice.

The mandatory here is we have to use virtio-scsi which implements serial
attribute of a device.

Signed-off-by: Dinar Valeev <dvaleev@suse.com>