### PR TITLE
don't require tests to be nested at least two levels

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -18,7 +18,7 @@ sub loadtest($) {
         warn "loadtest needs a script below $casedir\n";
         $script = File::Spec->abs2rel( $script, $bmwqemu::vars{CASEDIR} );
     }
-    unless ( $script =~ m,.*/(\w+)/([^/]+)\.pm$, ) {
+    unless ( $script =~ m,(\w+)/([^/]+)\.pm$, ) {
         die "loadtest needs a script to match \\w+/[^/]+.pm\n";
     }
     my $category = $1;


### PR DESCRIPTION
All of openSUSE's tests are in tests/foo/bar/sometest.pm, but
Fedora's are not, they are in tests/bar/sometest.pm. This regex
requires the former layout, for no apparent reason because it
doesn't actually capture anything other than 'bar' and
'sometest'.

I tested this with 'foo/bar/test.pm', 'bar/test.pm', and
'foo/monkeys/bar/test.pm' it captures 'bar' and 'test' in all
cases, so I think it's OK.