### PR TITLE
fix "do_run" loop for steady screenshot stream

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -143,7 +143,7 @@ sub init {
     cv::init();
     require tinycv;
 
-    die "DISTRI undefined\n" unless $vars{DISTRI};
+    die "DISTRI undefined\n".Dumper(\%vars)."\n" unless $vars{DISTRI};
 
     unless ( $vars{CASEDIR} ) {
         my @dirs = ("$scriptdir/distri/$vars{DISTRI}");


### PR DESCRIPTION
- refactored vnc update logic

- use just one screen capture loop, which both updates the framebuffer
  and produces screenshots at a steady pace.  use this loop also from
  key press events, to keep up with screen changes.

can't get it working with ipmi at this time, assume pebcac in setting up ipmi.