### PR TITLE
add possibility to specify boot devices

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -329,6 +329,9 @@ sub start_qemu() {
         if ( $vars->{PXEBOOT} ) {
             push( @params, "-boot", "n");
         }
+        elsif ( $vars->{BOOTFROM} ) {
+            push( @params, "-boot", "order=$vars->{BOOTFROM},menu=on,splash-time=5000" );
+        }
         else {
             push( @params, "-boot", "once=d,menu=on,splash-time=5000" );
         }


### PR DESCRIPTION
Due to upgrade tests, we want possibility to boot only from disks, hence this commit adds a way how to specify boot devices and their order to Qemu.