### PR TITLE
vnc type_string: give max_interval a meaning

### DIFF
--- a/backend/VNC.pm
+++ b/backend/VNC.pm
@@ -675,9 +675,9 @@ sub send_pointer_event {
 
 # drain the VNC socket from all pending incoming messages.  return
 # true if there was a screen update.
-sub update_framebuffer() { # fka capture
+sub update_framebuffer() { # upstream VNC.pm:  "capture"
     my ($self) = @_;
-    $self->send_update_request();
+
     my $have_recieved_update = 0;
     while ( defined( my $message_type = $self->_receive_message() ) ) {
         $have_recieved_update = 1 if $message_type == 0;

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -325,6 +325,7 @@ sub type_string($$) {
 
     my $typedchars  = 0;
     for my $letter (split( "", $string )) {
+	# FIXME: is this is dead code?  there ain't no plain send_key, no?
         send_key $self->map_letter($letter), 1;
         if ( $typedchars++ >= $maxinterval ) {
             sleep 2;

--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -104,8 +104,7 @@ sub relogin_vnc() {
         die $@;
     }
 
-    #$self->{'select'}->add($self->{'vnc'}->socket);
-    $self->{'vnc'}->update_framebuffer;
+    $self->capture_screenshot();
 }
 
 sub do_start_vm() {

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -476,10 +476,9 @@ sub start_qemu() {
 
     $self->handle_qmp_command({"execute" => "cont"});
 
-    #$self->{'select'}->add($self->{'vnc'}->socket);
     $self->{'select'}->add($self->{'qemupipe'});
 
-    $self->{'vnc'}->update_framebuffer;
+    $self->capture_screenshot();
 }
 
 sub _read_hmp($) {

--- a/backend/s390x.pm
+++ b/backend/s390x.pm
@@ -73,8 +73,7 @@ sub connect_vnc() {
         die $@;
     }
 
-    #$self->{'select'}->add($self->{'vnc'}->socket);
-    $self->{'vnc'}->update_framebuffer;
+    $self->capture_screenshot();
 
 }
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -291,17 +291,19 @@ sub send_key($;$) {
 
 =head2 type_string
 
-type_string($string)
+type_string($string, [$max_interval])
 
 send a string of characters, mapping them to appropriate key names as necessary
 
+max_interval (1-250) determines the typing speed, the lower the
+max_interval the slower the typing.
 =cut
 
 sub type_string($;$) {
     my $string      = shift;
-    my $maxinterval = shift || 250;
-    bmwqemu::fctlog( 'type_string', ["string", "'$string'"] );
-    $bmwqemu::backend->type_string($string, $maxinterval);
+    my $max_interval = shift || 250;
+    bmwqemu::fctlog( 'type_string', ["string", "'$string'"], ["max_interval", "'$max_interval'"] );
+    $bmwqemu::backend->type_string($string, $max_interval);
 }
 
 sub type_password() {


### PR DESCRIPTION
- bootloader code needs _slow_ key presses when scrolling the text
  input field.  This is in theory accomplished with the max_interval
  parameter in the test cases.  this patch brings the paramter to life
  and thus allows for speedy keyboard input in normal cases and
  throttling in the bootloader special case.
- fix the logic for the very first screenshot after connecting,  this
  takes out superflouous and unwanted screen update requests.