### PR TITLE
add a parameter to type_string to suppress logging

### DIFF
--- a/backend/driver.pm
+++ b/backend/driver.pm
@@ -122,12 +122,6 @@ sub send_key($) {
     return $self->_send_json({ 'cmd' => "send_key", 'arguments' => { 'key' => $key } });
 }
 
-sub type_string($$) {
-    my ( $self, $text, $max_interval ) = @_;
-    return unless ($text);
-    return $self->_send_json({ 'cmd' => "type_string", 'arguments' => { 'text' => $text, 'max_interval' => $max_interval } });
-}
-
 sub mouse_button($$$) {
     my ( $self, $button, $bstate ) = @_;
     return $self->_send_json({ 'cmd' => "mouse_button", 'arguments' => { 'button' => $button, 'bstate' => $bstate } } );

--- a/t/03-testapi.pl
+++ b/t/03-testapi.pl
@@ -1,0 +1,38 @@
+#!/usr/bin/perl -w -I..
+
+use strict;
+use Test::More tests => 6;
+
+require bmwqemu;
+require t::test_driver;
+
+$bmwqemu::backend = t::test_driver->new;
+
+use testapi;
+
+type_string 'hallo';
+is_deeply($bmwqemu::backend->{cmds}, ['type_string', { max_interval => 250, text => 'hallo' } ]);
+$bmwqemu::backend->{cmds} = [];
+
+type_string 'hallo', 4;
+is_deeply($bmwqemu::backend->{cmds}, ['type_string', { max_interval => 4, text => 'hallo' } ]);
+$bmwqemu::backend->{cmds} = [];
+
+type_string 'hallo', secret => 1;
+is_deeply($bmwqemu::backend->{cmds}, ['type_string', { max_interval => 250, text => 'hallo' } ]);
+$bmwqemu::backend->{cmds} = [];
+
+type_string 'hallo', secret => 1, max_interval => 10;
+is_deeply($bmwqemu::backend->{cmds}, ['type_string', { max_interval => 10, text => 'hallo' } ]);
+$bmwqemu::backend->{cmds} = [];
+
+$testapi::password = 'stupid';
+type_password;
+is_deeply($bmwqemu::backend->{cmds}, ['type_string', { max_interval => 250, text => 'stupid' } ]);
+$bmwqemu::backend->{cmds} = [];
+
+type_password 'hallo';
+is_deeply($bmwqemu::backend->{cmds}, ['type_string', { max_interval => 250, text => 'hallo' } ]);
+$bmwqemu::backend->{cmds} = [];
+
+# vim: set sw=4 et:

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,3 +1,3 @@
-TESTS = 01-test_needle.pl 02-test_ocr.pl
+TESTS = 01-test_needle.pl 02-test_ocr.pl 03-testapi.pl
 
-EXTRA_DIST = $(TESTS)
+EXTRA_DIST = $(TESTS) t/test_driver.pm

--- a/t/test_driver.pm
+++ b/t/test_driver.pm
@@ -1,0 +1,20 @@
+# This provides a mean to test things without requiring a real backend
+package t::test_driver;
+
+use strict;
+use Carp;
+
+sub new {
+    my $class = shift;
+
+    my $hash;
+    $hash->{cmds} = [];
+    return bless $hash, $class;
+}
+
+sub type_string {
+    my ($self, $args) = @_;
+    push(@{ $self->{cmds} }, 'type_string', $args);
+}
+
+1;


### PR DESCRIPTION
Sometimes maybe we type stuff we don't want to log for the
world to see, so add a param which lets us not log the actual
string typed if we don't want to.

Superseding #215