### PR TITLE
change lock api to POST method

### DIFF
--- a/lockapi.pm
+++ b/lockapi.pm
@@ -27,17 +27,17 @@ use mmapi qw/api_call/;
 
 sub mutex_lock($) {
     my ($name) = @_;
-    return _mutex_call('get', "mutex/lock/$name");
+    return _mutex_call('post', "mutex/$name/lock");
 }
 
 sub mutex_unlock($) {
     my ($name) = @_;
-    return _mutex_call('get', "mutex/unlock/$name");
+    return _mutex_call('post', "mutex/$name/unlock");
 }
 
 sub mutex_create($) {
     my ($name) = @_;
-    return _mutex_call('post', "mutex/lock/$name");
+    return _mutex_call('post', "mutex/$name");
 }
 
 sub _mutex_call($$) {


### PR DESCRIPTION
- using GET for lock operations was a bad idea (due to possible GET caching by proxy), so get it fixed before wider usage (action#6478)
- has openQA part, so worker&scheduler needs to be redeployed at the same time