### PR TITLE
change serialdev to ttyS1 for ipmi

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -35,7 +35,7 @@ sub init() {
     if ( get_var('OFW') ) {
         $serialdev = "hvc0";
     }
-
+    $serialdev = 'ttyS1' if check_var('BACKEND', 'ipmi');
 }
 
 sub set_distribution($) {


### PR DESCRIPTION
ttyS0 is the hardware, but we want SOL - see https://progress.opensuse.org/issues/6824