### PR TITLE
S390 worker

### DIFF
--- a/backend/s390x.pm
+++ b/backend/s390x.pm
@@ -154,7 +154,7 @@ sub _new_console($$) {
         # On older Xvnc there is no '-listen tcp' option
         # because that's the default there; need to test Xvnc version
         # and act accordingly.
-        my $Xvnc_listen_option = grep { /-listen/ } qx"Xvnc -help 2>&1" ? "-listen tcp" : "";
+        my $Xvnc_listen_option = (scalar grep { /-listen/ } qx"Xvnc -help 2>&1") ? "-listen tcp" : "";
         $self->{local_X_handle} = IPC::Run::start("Xvnc $display $Xvnc_listen_option -SecurityTypes None -ac");
         # REFACTOR from connect_vnc to new_vnc, which just returns a
         # new vnc connection.  add a DESTROY to VNC which closes the
@@ -214,7 +214,7 @@ sub _select_console() {
     my ($self, $console_info) = @_;
     #local $Devel::Trace::TRACE;
     #$Devel::Trace::TRACE = 1;
-    #CORE::say __FILE__ .':'. __LINE__ .':'.(caller 0)[3];#.':'.bmwqemu::pp($args);
+    #CORE::say __FILE__ .':'. __LINE__ .':'.(caller 0)[3].':'.bmwqemu::pp($args);
 
     my $backend_console = $console_info->{args}->{backend_console};
 
@@ -342,8 +342,8 @@ sub inflate_vars_json {
     my ($self) = @_;
 
     # these need to become parameters in the future, too:
-    my $installation_console          = "ssh-X";    # "x11", "vnc", "ssh"
-    my $installation_network_protocol = "ftp";      # nothing else is implemented so far on openqa.suse.de
+    my $installation_console          = "vnc";    # "x11", "vnc", "ssh-X", "ssh"
+    my $installation_network_protocol = "ftp";    # nothing else is implemented so far on openqa.suse.de
 
     # use external script to inflate vars.json
     my $vars_json_cmd = $bmwqemu::scriptdir . "/backend/s390x/vars.json.py";

--- a/backend/s390x.pm
+++ b/backend/s390x.pm
@@ -150,10 +150,12 @@ sub _new_console($$) {
         my $display = ":" . $display_id;
         # FIXME: do the full monty xauth authentication, with a local
         # XAUTHORITY=./XAuthority file
-        # FIXME: on older Xvnc there is no '-listen tcp' option,
-        # that's the default there; need to test Xvnc version and act
-        # accordingly.
-        $self->{local_X_handle} = IPC::Run::start("Xvnc $display -listen tcp -SecurityTypes None -ac");
+
+        # On older Xvnc there is no '-listen tcp' option
+        # because that's the default there; need to test Xvnc version
+        # and act accordingly.
+        my $Xvnc_listen_option = grep { /-listen/ } qx"Xvnc -help 2>&1" ? "-listen tcp" : "";
+        $self->{local_X_handle} = IPC::Run::start("Xvnc $display $Xvnc_listen_option -SecurityTypes None -ac");
         # REFACTOR from connect_vnc to new_vnc, which just returns a
         # new vnc connection.  add a DESTROY to VNC which closes the
         # socket, if that's needed.  Until then we need to remove this

--- a/backend/s390x.pm
+++ b/backend/s390x.pm
@@ -29,16 +29,16 @@ sub new {
 sub new_3270_console() {
     my ($self, $s3270) = @_;
     confess "expecting hashref" unless ref $s3270 eq "HASH";
+    my $display = ":" . (get_var("VNC") // die "VNC unset in vars.json.");
     $s3270->{s3270} = [
         qw(x3270),
-        "-display", ":" . get_var("VNC"),
+        "-display", $display,
         qw(-script -charset us -xrm x3270.visualBell:true -xrm x3270.keypadOn:false
           -set screenTrace -xrm x3270.traceDir:.
           -trace -xrm x3270.traceMonitor:false),
-        # Dark arts: ancient terminals don't have an
-        # Alt key.  They usually send Esc + the key
-        # instead.  FIXME: x3270 for whichever reason
-        # can't send the Escape keysym, so we have to
+        # Dark arts: ancient terminals (ansi.64, vt100) don't have an
+        # Alt key.  They send Esc + the key instead.  x3270 for
+        # whichever reason can't send the Escape keysym, so we have to
         # hard code it here (0x1b).
         '-xrm', 'x3270.keymap.base.nvt:#replace\nAlt<Key>: Key(0x1b) Default()'
     ];
@@ -46,9 +46,12 @@ sub new_3270_console() {
     $s3270->start();
     my $status = $s3270->send_3270()->{terminal_status};
     $status = &backend::s390x::s3270::nice_3270_status($status);
+    die "no worker Xvnc??" . bmwqemu::pp($self) unless exists $self->{consoles}->{worker};
     my $console_info = {
         window_id => $status->{window_id},
-        console   => $s3270
+        console   => $s3270,
+        vnc       => $self->{consoles}->{worker}->{vnc},
+        DISPLAY   => $display,
     };
     return $console_info;
 }
@@ -57,79 +60,146 @@ sub new_3270_console() {
 # rewritten using objects.
 sub _new_console($$) {
     my ($self, $args) = @_;
-    #CORE::say __FILE__ .':'. __LINE__ .':'. bmwqemu::pp($args);
-    my ($backend_console, $console_args) = @$args{qw(backend_console backend_args)};
-    my $console_info = {};
+    #CORE::say __FILE__ . ':' . __LINE__ . ':' . (caller 0)[3];    #.':'.bmwqemu::pp($args);
+    my ($testapi_console, $backend_console, $console_args) = @$args{qw(testapi_console backend_console backend_args)};
+    my $console_info = {
+        # vnc => the vnc for this console
+        # window_id => the x11 window id, if applicable
+        # DISPLAY => the x11 DISPLAY, if applicable
+        # console => the console object (backend::s390x::s3270 or backend::VNC)
+    };
     if ($backend_console eq "s3270") {
+        die "s3270 must be named 'bootloader'" unless $testapi_console eq 'bootloader';
         # my () = @console_args;
         $console_info = $self->new_3270_console(
             {
-                zVM_host    => (get_var("ZVM_HOST")     // die "ZVMHOST unset in vars.json"),
+                zVM_host    => (get_var("ZVM_HOST")     // die "ZVM_HOST unset in vars.json"),
                 guest_user  => (get_var("ZVM_GUEST")    // die "ZVM_GUEST unset in vars.json"),
                 guest_login => (get_var("ZVM_PASSWORD") // die "ZVM_PASSWORD unset in vars.json"),
+                vnc_backend => $self,
             });
     }
     elsif ($backend_console =~ qr/ssh(-X)?/) {
         my $host        = get_var("PARMFILE")->{Hostname};
         my $sshpassword = get_var("PARMFILE")->{sshpassword};
         system("ssh-keygen -R $host -f ./known_hosts");
-        # create s3270 console
-        $console_info = $self->new_3270_console({});
+        $console_info = $self->new_3270_console(
+            {
+                vnc_backend => $self,
+            });
         # do ssh connect
         my $s3270      = $console_info->{console};
         my $sshcommand = "TERM=vt100 ssh";
         if ($backend_console eq "ssh-X") {
-            my $display = get_var("VNC") || die "VNC unset in vars.json.";
-            $sshcommand = "DISPLAY=:$display " . $sshcommand . " -X";
+            my $display = $console_info->{DISPLAY};
+            $sshcommand = "DISPLAY=$display " . $sshcommand . " -X";
         }
         $sshcommand .= " -o UserKnownHostsFile=./known_hosts -o StrictHostKeyChecking=no root\@$host";
         $s3270->send_3270("Connect(\"-e $sshcommand\")");
-        # wait for password prompt...
-        while (1) {
+        # wait for 10 seconds for password prompt
+        for my $i (-9 .. 0) {
             $s3270->send_3270("Snap");
             my $r  = $s3270->send_3270("Snap(Ascii)");
             my $co = $r->{command_output};
-            CORE::say bmwqemu::pp($r);
+            # CORE::say bmwqemu::pp($r);
             CORE::say bmwqemu::pp($co);
             last if grep { /[Pp]assword:/ } @$co;
+            die "ssh password prompt timout connecting to $host" unless $i;
             sleep 1;
         }
         $s3270->send_3270("String(\"$sshpassword\")");
         $s3270->send_3270("ENTER");
     }
     elsif ($backend_console eq "remote-vnc") {
-        my ($vncpasswd) = @$console_args;
+        my $hostname = get_var("PARMFILE")->{Hostname};
+        my $password = get_var("DISPLAY")->{PASSWORD};
+        $self->{vnc} = undef;    # REFACTOR see below
         $self->connect_vnc(
             {
-                hostname => get_var("PARMFILE")->{Hostname},
+                hostname => $hostname,
                 port     => 5901,
-                password => get_var("DISPLAY")->{PASSWORD},
+                password => $password,
                 ikvm     => 0,
             });
         $console_info->{console} = $self->{vnc};
+        $console_info->{vnc}     = $self->{vnc};
+        if (exists get_var("DEBUG")->{vncviewer}) {
+
+            # start vncviewer and remember it's pid so it can be killed at exit.
+            my $subshell_pid;
+            {
+                defined($subshell_pid = fork) or die $!;
+                $subshell_pid and last;
+                # FIXME if the password could come from anyhwere, this
+                # echo '$password' would be a bobby tables backdoor:
+                exec "echo '$password' | vncviewer -autopass $hostname:1 & echo \$! >vncviewer_pid" or die "exec failed?";
+            }
+            waitpid $subshell_pid, 0;
+            open my $fh, '<', 'vncviewer_pid' or die $!;
+            my $vncviewer_pid = do { local $/; <$fh> };
+            chomp($vncviewer_pid);
+            $console_info->{vncviewer_pid} = $vncviewer_pid;
+            #CORE::say __FILE__ .':'. __LINE__ .':'.(caller 0)[3].':'.bmwqemu::pp($console_info);
+        }
     }
     elsif ($backend_console eq "local-Xvnc") {
+        # REFACTOR to have a $self->{localXvnc}
+        die "local-Xvnc must be named 'worker'" unless $testapi_console eq 'worker';
         ## start Xvnc Server, the local console to do all the work from
-        my $display = get_var("VNC") || die "VNC unset in vars.json.";
-
-        $self->{local_X_handle} = IPC::Run::start("Xvnc :$display -SecurityTypes None -ac");
+        my $display_id = get_var("VNC") || die "VNC unset in vars.json.";
+        my $display = ":" . $display_id;
+        # FIXME: do the full monty xauth authentication, with a local
+        # XAUTHORITY=./XAuthority file
+        # FIXME: on older Xvnc there is no '-listen tcp' option,
+        # that's the default there; need to test Xvnc version and act
+        # accordingly.
+        $self->{local_X_handle} = IPC::Run::start("Xvnc $display -listen tcp -SecurityTypes None -ac");
+        # REFACTOR from connect_vnc to new_vnc, which just returns a
+        # new vnc connection.  add a DESTROY to VNC which closes the
+        # socket, if that's needed.  Until then we need to remove this
+        # pointer to the VNC, so it's socket won't be mollested. aka:
+        # shit happens when a function has side-effects, here
+        # vnc_baseclass::connect_vnc will close the socket of
+        # $self->{vnc}
+        $self->{vnc} = undef;
         $self->connect_vnc(
             {
                 hostname => "localhost",
-                port     => 5900 + $display,
+                port     => 5900 + $display_id,
                 ikvm     => 0
             });
         $console_info->{console} = $self->{vnc};
         $console_info->{DISPLAY} = $display;
+        $console_info->{vnc}     = $self->{vnc};
         sleep 1;
 
         # magic stanza from
         # https://github.com/yast/yast-x11/blob/master/src/tools/testX.c
-        system("ICEWM_PRIVCFG=/etc/icewm/yast2 DISPLAY=:$display icewm -c preferences.yast2 -t yast2 &") != -1 || warn "couldn't start icewm on :$display";
+        system("ICEWM_PRIVCFG=/etc/icewm/yast2 DISPLAY=$display icewm -c preferences.yast2 -t yast2 &") != -1
+          || die "couldn't start icewm on $display";
+        # FIXME robustly wait for the window manager
+
         # FIXME proper debugging viewer, also needs to be switched when
         # switching vnc console...
-        system("vncviewer :$display &") != -1 || warn "couldn't start vncviewer :$display (err: $! retval: $?)";
+        if (exists get_var("DEBUG")->{vncviewer}) {
+            system("vncviewer $display &") != -1 || warn "couldn't start vncviewer $display (err: $! retval: $?)";
+        }
 
+    }
+    elsif ($backend_console eq "remote-window") {
+        my ($window_name) = @$console_args;
+        # This will only work on a remote X display, i.e. when
+        # current_console->{DISPLAY} is set for the current console.
+        # There is only one DISPLAY which we can do tis with: the
+        # local-Xvnc aka worker one
+        my $display = $self->{consoles}->{worker}->{DISPLAY};
+        # FIXME: verify the first in the list of window ids with the same name is the mothership
+        my $window_id = qx"DISPLAY=$display xdotool search --sync --limit 1 $window_name";
+        die if $?;
+        $console_info->{window_id} = $window_id;
+        $console_info->{DISPLAY}   = $display;
+        $console_info->{vnc}       = $self->{consoles}->{worker}->{vnc};
+        $console_info->{console}   = $self->{consoles}->{worker}->{vnc};
     }
     else {
         confess "unknown backend console $backend_console";
@@ -140,7 +210,10 @@ sub _new_console($$) {
 
 sub _select_console() {
     my ($self, $console_info) = @_;
-    #CORE::say __FILE__.":".__LINE__.":".bmwqemu::pp($console_info);
+    #local $Devel::Trace::TRACE;
+    #$Devel::Trace::TRACE = 1;
+    #CORE::say __FILE__ .':'. __LINE__ .':'.(caller 0)[3];#.':'.bmwqemu::pp($args);
+
     my $backend_console = $console_info->{args}->{backend_console};
 
     # There can be two vnc backends (local Xvnc or remote vnc) and
@@ -148,74 +221,142 @@ sub _select_console() {
     #
     # switching means: turn to the right vnc and if it's the Xvnc,
     # iconify/deiconify the right x3270 terminal window.
-    if ($backend_console eq "s3270" || $backend_console =~ qr/ssh(-X)?/) {
+    #
+    # FIXME? for now, we just raise the terminal window to the front on
+    # the local-Xvnc DISPLAY.
+    #
+    # should we hide the other windows, somehow?
+    #if exists $self->{current_console} ...
+    # my $current_window_id = $self->{current_console}->{window_id};
+    # if (defined $current_window_id) {
+    #     system("DISPLAY=$display xdotool windowminimize --sync $current_window_id") != -1 || die;
+    # }
+
+    if ($backend_console eq "s3270" || $backend_console =~ qr/ssh(-X)?/ || $backend_console eq "remote-window") {
         #CORE::say __FILE__.":".__LINE__.":".bmwqemu::pp($self->{current_console});
-        my $current_window_id = $self->{current_console}->{window_id};
-        # FIXME: do the full monty xauth authentication, with a local
-        # XAUTHORITY=./XAuthority-for-testing
-        #
-        # There is only one DISPLAY with x3270 terminals on it: the
-        # local-Xvnc aka worker one
-        my $display = $self->{consoles}->{worker}->{DISPLAY};
-        # FIXME: think about proper window switching for these
-        # consoles...  sometimes it's itneresting to see what's going
-        # on in the background.  on the other hand, on other
-        # architectures, the console needs to be switched explicitely
-        # in that case.
-        # if (defined $current_window_id) {
-        #     system("DISPLAY=:$display xdotool windowminimize --sync $current_window_id") != -1 || die;
-        # }
-        # set vnc to the right one...
-        $self->select_console({testapi_console => "worker"});
+        my $display       = $console_info->{DISPLAY};
         my $new_window_id = $console_info->{window_id};
-        system("DISPLAY=:$display xdotool windowactivate --sync $new_window_id") != -1 || die;
+        #CORE::say bmwqemu::pp($console_info);
+        system("DISPLAY=$display xdotool windowactivate --sync $new_window_id") != -1 || die;
     }
     elsif ($backend_console eq "remote-vnc" || $backend_console eq "local-Xvnc") {
-        $self->{vnc} = $console_info->{console};
     }
     else {
         confess "don't know how to switch to backend console $backend_console";
     }
+    # always set vnc to the right one...
+    $self->{vnc} = $console_info->{vnc};
+    $self->capture_screenshot();
 }
 
 sub _delete_console($$) {
     my ($self, $console_info) = @_;
-    my $backend_console = $console_info->{args}->{backend_console};
-    #CORE::say __FILE__ .':'. __LINE__ .':'. bmwqemu::pp($console_info);
-    if ($backend_console eq "s3270") {
+    my $args = $console_info->{args};
+    my ($testapi_console, $backend_console) = @$args{qw(testapi_console backend_console)};
+    CORE::say __FILE__ . ':' . __LINE__ . ':' . (caller 0)[3] . ':' . bmwqemu::pp($args);
+    #CORE::say __FILE__ .':'. __LINE__ .':'.(caller 0)[3].':'.bmwqemu::pp($console_info);
+    if ($testapi_console eq "bootloader") {
         if (exists get_var("DEBUG")->{"keep zVM guest"}) {
             $console_info->{console}->cp_disconnect();
         }
         else {
-            $self->{consoles}->{bootloader}->{console}->cp_logoff_disconnect();
+            $console_info->{console}->cp_logoff_disconnect();
         }
+        # REFACTOR: DRY (same as in the next two...)
+        my $window_id = $console_info->{window_id};
+        my $display   = $self->{consoles}->{worker}->{DISPLAY};
+        system("DISPLAY=$display xdotool windowkill $window_id") != -1 || die;
         $console_info->{console} = undef;
     }
-    elsif ($backend_console eq "ssh") {
+    elsif ($backend_console =~ qr/ssh(-X)?/) {
+        my $window_id = $console_info->{window_id};
+        my $display   = $self->{consoles}->{worker}->{DISPLAY};
+        system("DISPLAY=$display xdotool windowkill $window_id") != -1 || die;
+        $console_info->{console} = undef;
+    }
+    elsif ($backend_console eq "remote-window") {
+        my $window_id = $console_info->{window_id};
+        my $display   = $self->{consoles}->{worker}->{DISPLAY};
+        system("DISPLAY=$display xdotool windowkill $window_id") != -1 || die;
         $console_info->{console} = undef;
     }
     elsif ($backend_console eq "local-Xvnc") {
         # FIXME shut down more gracefully, some processes may still be
         # open on Xvnc.
-        #IPC::Run::signal($self->{local_X_handle}, "TERM");
+        IPC::Run::signal($self->{local_X_handle}, "TERM");
         IPC::Run::signal($self->{local_X_handle}, "KILL");
         IPC::Run::finish($self->{local_X_handle});
     }
     elsif ($backend_console eq "remote-vnc") {
+        #CORE::say __FILE__ .':'. __LINE__ .':'.(caller 0)[3].':'.bmwqemu::pp($console_info);
+        if (exists $console_info->{vncviewer_pid}) {
+            kill 'KILL', $console_info->{vncviewer_pid};
+        }
+        # FIXME? close remote socket?
+        $console_info->{console} = undef;
+        # FIXME: only do when {vnc} currently is "remote-vnc" (not local-Xvnc)?
         $self->{vnc} = undef;
     }
     else {
         confess "unknown backend console $backend_console";
     }
 }
+
+# cature send_key events to switch consoles on ctr-alt-fX
+sub send_key {
+    my ($self, $args) = @_;
+    my $_map = {
+        "ctrl-alt-f1" => "installation",
+        "ctrl-alt-f2" => "ctrl-alt-f2",
+        "ctrl-alt-f3" => "ctrl-alt-f2",
+        "ctrl-alt-f4" => "ctrl-alt-f2",
+        "ctrl-alt-f7" => "installation",
+        "ctrl-alt-f9" => "ctrl-alt-f2",
+    };
+    if ($args->{key} =~ qr/^ctrl-alt-f(\d+)/i) {
+        die "unkown ctrl-alt-fX combination $args->{key}" unless exists $_map->{$args->{key}};
+        $self->select_console({testapi_console => $_map->{$args->{key}}});
+        return;
+    }
+    return $self->SUPER::send_key($args);
+}
 ###################################################################
 sub do_start_vm() {
     my ($self) = @_;
 
     $self->unlink_crash_file();
-
+    $self->inflate_vars_json();
     $self->activate_console({testapi_console => "worker", backend_console => "local-Xvnc"});
     return 1;
+}
+
+# input from the worker in vars.json:
+#     "S390_CONSOLE" : "vnc",
+#     "S390_HOST" : "153",
+#     "S390_NETWORK" : "hsi-l3",
+#     "REPO_0" : "SLES-11-SP4-DVD-s390x-Build1050-Media1",
+# output: a full-featured vars.json suitable for s390 testing
+sub inflate_vars_json {
+    my ($self) = @_;
+
+    # these need to become parameters in the future, too:
+    my $installation_console          = "ssh-X";    # "x11", "vnc", "ssh"
+    my $installation_network_protocol = "ftp";      # nothing else is implemented so far on openqa.suse.de
+
+    # use external script to inflate vars.json
+    my $vars_json_cmd = $bmwqemu::scriptdir . "/backend/s390x/vars.json.py";
+
+    # the arguments to the script, in order
+    my ($insthost, $host, $network, $instsrc, $console, $distro) =    #
+      ("openqa", get_var('S390_HOST'), get_var('S390_NETWORK'), $installation_network_protocol, $installation_console, get_var('REPO_0'));
+
+    my $vars = qx($vars_json_cmd $insthost $host $network $instsrc $console $distro > vars.json.$$);
+    die "vars_json transform failed $?" if $?;
+    system("mv vars.json.$$ vars.json") != -1 || die;
+
+    bmwqemu::load_vars();
+    bmwqemu::expand_DEBUG_vars();
+    bmwqemu::save_vars();
 }
 
 sub do_stop_vm() {
@@ -223,7 +364,8 @@ sub do_stop_vm() {
 
     # first kill all _remote_ consoles except for the remote zVM
     # console (which would stop the vm guest)
-    for my $console (keys %{$self->{consoles}}) {
+    my @consoles = keys %{$self->{consoles}};
+    for my $console (@consoles) {
         $self->deactivate_console({testapi_console => $console})
           unless $console =~ qr/bootloader|worker/;
     }
@@ -232,7 +374,6 @@ sub do_stop_vm() {
     # Xvnc
     $self->deactivate_console({testapi_console => "bootloader"});
     $self->deactivate_console({testapi_console => "worker"});
-
 }
 
 sub do_savevm() {
@@ -246,6 +387,21 @@ sub do_loadvm() {
 sub do_upload_image() {
     notimplemented;
 }
+sub init_charmap($) {
+    my ($self) = (@_);
 
+    ## charmap (like L => shift+l)
+    # see http://en.wikipedia.org/wiki/IBM_PC_keyboard
+    $self->{charmap} = {
+        # minus is special as it splits key combinations
+        "-" => "minus",
 
+        "\t" => "tab",
+        "\n" => "ret",
+        "\b" => "backspace",
+
+        "\e" => "esc"
+    };
+    ## charmap end
+}
 1;

--- a/backend/s390x/s3270.pm
+++ b/backend/s390x/s3270.pm
@@ -21,6 +21,7 @@ use IPC::Run::Debug;    # set IPCRUNDEBUG=data in shell environment for trace
 
 use Thread::Queue;
 
+use Time::HiRes qw(usleep);
 
 sub new() {
     my $self = Class::Accessor::new(@_);
@@ -202,14 +203,13 @@ sub expect_3270() {
 
             # if there is MORE..., go and grab it.
             if ($status_line =~ /$arg{buffer_full}/) {
-                # # FIXME: we could capture_screenshot here to ensure
+                # # FIXME: we capture_screenshot here to ensure
                 # # no screen content is lost in the video.  It is
                 # # a hacky work around until this loop is properly
                 # # integrated with the baseclass run_capture_loop
-                # # alas this won't work because $self has no
-                # # capture_screenshot --- as $self deosn't know the X
-                # # display / VNC to capture from (yet).
-                # $self->capture_screenshot();
+                $self->{vnc_backend}->request_screen_update();
+                usleep(5_000);
+                $self->{vnc_backend}->capture_screenshot();
                 $self->send_3270("Clear");
                 next;
             }
@@ -279,14 +279,13 @@ sub expect_3270() {
         # For now we have to live with having a clear screen.
 
         if ($we_had_new_output) {
-            # # FIXME: we could capture_screenshot here to ensure
+            # # FIXME: we capture_screenshot here to ensure
             # # no screen content is lost in the video.  It is
             # # a hacky work around until this loop is properly
             # # integrated with the baseclass run_capture_loop
-            # # alas this won't work because $self has no
-            # # capture_screenshot --- as $self deosn't know the X
-            # # display / VNC to capture from (yet).
-            # $self->capture_screenshot();
+            $self->{vnc_backend}->request_screen_update();
+            usleep(5_000);
+            $self->{vnc_backend}->capture_screenshot();
             $self->send_3270("Clear");
         }
 

--- a/backend/s390x/vars.json.py
+++ b/backend/s390x/vars.json.py
@@ -238,7 +238,7 @@ def instsrc_vars(instsource, distro, host):
             },
         },
         "tftp": None,
-    }[instsrc]
+    }[instsource]
 
     unify(_instsrc_vars, {
         "INSTSRC": {
@@ -298,7 +298,13 @@ console_vars = lambda Xvnc_DISPLAY: {
     },
 }
 
-def update_vars_json(vars_json, insthost, guest, network_device, instsource, console, distro):
+def update_vars_json(vars_json):
+    insthost       = vars_json["S390_INSTHOST"]
+    guest          = vars_json["S390_HOST"]
+    network_device = vars_json["S390_NETWORK"]
+    instsource     = vars_json["S390_INSTSRC"]
+    console        = vars_json["S390_CONSOLE"]
+    distro         = vars_json["REPO_0"]
 
     vars_json_basics = {
         "BACKEND"	: "s390x",
@@ -310,7 +316,7 @@ def update_vars_json(vars_json, insthost, guest, network_device, instsource, con
 
         "DEBUG"         : {
             #"wait after linuxrc": None,
-            #    pauses os-autoinst just before it connects to YaST, rigth after linuxrc.
+            #    pauses os-autoinst just before it connects to YaST, right after linuxrc.
             #    also see PARMFILE: startshell
             #"keep zVM guest": None,
             #    do #cp disconnect at the end instead of #cp logoff
@@ -335,10 +341,6 @@ def update_vars_json(vars_json, insthost, guest, network_device, instsource, con
             #"dud": "nfs://10.160.0.111:/real-home/snwint/Export/bnc_913888.dud",
             #"dud": "ftp://{host}/bnc_913888/bnc_913888.dud".format(host=my_ip),
             #"linuxrc.log":"/dev/console",
-            ##startshell=1 linuxrc.log=/dev/console
-            ##install=http://10.160.0.100/install/SLP/SLES-11-SP4-Alpha3/s390x/DVD1
-            ##InstNetDev=osa OSAInterface=qdio OSAMedium=eth
-
         }
     }
 
@@ -365,30 +367,14 @@ def update_vars_json(vars_json, insthost, guest, network_device, instsource, con
 
     return vars_json
 
-def _default_vars_json():
-    return {
-
-        "DISTRI"	: "sle",
-        "CASEDIR"	: "/space/SVN/os-autoinst-distri-opensuse/",
-
-        "BETA": "1",
-        # $vars{VNC} is the *local* Xvnc $DISPLAY and vnc display id.
-        # connect to it locally, where isotovideo runs, to watch
-        # isotovideo do it's work.
-        "VNC": Xvnc_DISPLAY,
-    }
-
 import json
 from pprint import pprint as pp
 import sys
 if __name__ == "__main__":
-    _script, insthost, host, network, instsrc, console, distro = sys.argv
+    #_script, insthost, host, network, instsrc, console, distro = sys.argv
 
     import os.path
-    if os.path.isfile("vars.json"):
-        with open("vars.json") as f:
-            vars_json = json.load(f, );
-    else:
-        vars_json = _default_vars_json();
+    with open("vars.json") as f:
+        vars_json = json.load(f);
 
-    print(json.dumps( update_vars_json( vars_json, insthost, host, network, instsrc, console, distro), indent=True ))
+    print(json.dumps( update_vars_json( vars_json ), indent=True ))

--- a/backend/s390x/vars.json.py
+++ b/backend/s390x/vars.json.py
@@ -309,15 +309,16 @@ def update_vars_json(vars_json, insthost, guest, network_device, instsource, con
         "NETWORK"       : network_device,
 
         "DEBUG"         : {
-            #"wait after linuxrc",
+            #"wait after linuxrc": None,
             #    pauses os-autoinst just before it connects to YaST, rigth after linuxrc.
             #    also see PARMFILE: startshell
-            #"keep zVM guest",
+            #"keep zVM guest": None,
             #    do #cp disconnect at the end instead of #cp logoff
-            # "try vncviewer",
+            # "try vncviewer": None,
             #    don't connect and initialize.  Just do the vnc connect and
             #    go from there.
-            "vncviewer" : None,
+            # "vncviewer" : None,
+            #    start local vncviewer
         },
 
         "PARMFILE" : {

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -71,9 +71,7 @@ sub load_vars() {
     my $ret = {};
     local $/;
     open(my $fh, '<', $fn) or return 0;
-    # FIXME: allow for comments in the initial input json, like
-    # JSON->new->relaxed->decode_json
-    eval { $ret = decode_json(<$fh>); };
+    eval { $ret = JSON->new->relaxed->decode(<$fh>); };
     warn "openQA didn't write proper vars.json" if $@;
     close($fh);
     %vars = %{$ret};

--- a/isotovideo
+++ b/isotovideo
@@ -7,9 +7,10 @@
 use strict;
 use threads;
 
-local $Devel::Trace::TRACE = 0;
+local $Devel::Trace::TRACE;
+$Devel::Trace::TRACE = 0;
 
-our $installprefix;
+my $installprefix; # $bmwqemu::scriptdir
 
 BEGIN {
     # the following line is modified during make install


### PR DESCRIPTION
enable switching between multiple vnc servers:  the local Xvnc 'worker' console, on which the remote access terminal emulators are started.  potentially the remote vnc server on the system under test, once that is up and running.

This also enables the locally running terminal emulators proper, types 'ssh' and 'ssh-X' which connect to the SUT once a linux is running there, and 's3270', which connects to zVM.

I've tried this with various flavours of remote graphics:
   ssh -X, true remote X, bot use the local worker Xvnc as $DISPLAY
   vnc will access the remote Xvnc server on the SUT once that is available

it continues to work with qemu, it should also just work with ipmi.