### PR TITLE
Do not force "scsi" interface for cdrom, add "ide" support

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -345,7 +345,9 @@ sub start_qemu() {
         for my $i (1 .. 6) {    # check for up to 6 ADDON ISOs
             if ($vars->{"ISO_$i"} && $vars->{"ADDONS"}) {
                 my $addoniso = $vars->{"ISO_$i"};
-                push(@params, "-drive", "if=scsi,id=addon_$i,file=$addoniso,media=cdrom");
+		my $cdinterface ="if=scsi";
+		if ($vars->{CDMODEL} eq "ide-cd") { $cdinterface = "if=ide"; }
+		push(@params, "-drive", "$cdinterface,id=addon_$i,file=$addoniso,media=cdrom");
             }
         }
 

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -344,10 +344,10 @@ sub start_qemu() {
 
         for my $i (1 .. 6) {    # check for up to 6 ADDON ISOs
             if ($vars->{"ISO_$i"} && $vars->{"ADDONS"}) {
-                my $addoniso = $vars->{"ISO_$i"};
-		my $cdinterface ="if=scsi";
-		if ($vars->{CDMODEL} eq "ide-cd") { $cdinterface = "if=ide"; }
-		push(@params, "-drive", "$cdinterface,id=addon_$i,file=$addoniso,media=cdrom");
+                my $addoniso    = $vars->{"ISO_$i"};
+                my $cdinterface = "if=scsi";
+                if ($vars->{CDMODEL} eq "ide-cd") { $cdinterface = "if=ide"; }
+                push(@params, "-drive", "$cdinterface,id=addon_$i,file=$addoniso,media=cdrom");
             }
         }
 


### PR DESCRIPTION
Do not force "scsi" interface for cdrom, "ide" can be used if CDMODEL=ide-cd var is used. By default "scsi" will be used.