### PR TITLE
add %vars usage parsing script to test + initial doc

### DIFF
--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -1,0 +1,75 @@
+Supported variables per backend
+-------------------------------
+
+.IPMI backend
+[grid="rows",format="csv"]
+[options="header",cols="^m,^m,^m,v",separator=";"]
+|====================
+Variable;Values allowed;Default value;Explanation
+IPMI_HOSTNAME;;;
+IPMI_PASSWORD;;;
+IPMI_USER;;;
+|====================
+
+.KVM2USB backend
+[grid="rows",format="csv"]
+[options="header",cols="^m,^m,^m,v",separator=";"]
+|====================
+Variable;Values allowed;Default value;Explanation
+HWSLOT;;;
+ISO;;;
+|====================
+
+.QEMU backend
+[grid="rows",format="csv"]
+[options="header",cols="^m,^m,^m,v",separator=";"]
+|====================
+Variable;Values allowed;Default value;Explanation
+ADDONS;boolean;0;Enables use of ISO_$i variables
+ARCH;x86_64|i686|aarch64|...;depends on tested medium;Architecture of VM.
+AUTO_INST;;;
+BIOS;;;
+BOOTFROM;chars;undef;Influences order of boot devices. See qemu -boot option
+CDMODEL;see qemu -device ?;undef;Storage device for virtualized CD
+HDDMODEL;see qemu -device ?;virtio-blk;Storage device for virtualized HDD.
+HDDSIZEGB;integer;10;Creates HDD with specified size in GiB
+HDD_$i;filename;;Filename of HDD image to be used for VM. Up to 9
+ISO;filename;;Filename of ISO file to be attached to VM
+ISO_$i;filename;;Aditional ISO to be attached to VM. Up to 9
+KEEPHDDS;boolean;;Leave created HDD after test finishes. Useful for debugging tests
+LAPTOP;boolean or filename;0;If 1, loads Dell E6330 DMI. If filename, loads specified DMI
+MULTINET;boolean;0;VM will have two virtual NIC. Can't be used with NICTYPE tap
+MULTIPATH;boolean;0;Add HDD drives as multipath devices. Override HDDMODEL to virtio-scsi-pci
+NICMAC;any MAC address;52:54:00:12:34:56;MAC address to be assigned to virtual network card
+NICMODEL;see qemu -device ?;virtio-net;Network device virtual NIC.
+NICTYPE;user|tap;user;Instruct QEMU to either use user networking or to connect virtual NIC to existin system TAP device
+NUMDISKS;integer;1;Number of disks to be created and attached to VM
+OFW;;;
+PATHCNT;integer;2;Number of paths in MULTIPATH scenario
+PXEBOOT;boolean;0;Boot VM from network
+QEMU;QEMU binary filename;undef;Filename of QEMU binary to use
+QEMUCPU;see qemu -cpu ?;undef;CPU to emulate
+QEMUCPUS;integer;1;Number of CPUs to assign to VM
+QEMUMACHINE;see qemu -machine ?;undef;Machine and chipset to emulate
+QEMUPORT;integer;20002 + worker instance * 10;Port on which QEMU monitor should listen
+QEMURAM;integer;1024;Size of RAM of VM in MiB
+QEMUVGA;see qemu -device ?;cirrus;VGA device to use with VM
+QEMU_NO_KVM;boolean;0;Don't use KVM acceleration.
+RAIDLEVEL;;;
+SKIPTO;name of snapshot;;Restore VM from given snapshot. Needs HDD image with snapshots present. Used for test debugging
+TAPDEV;device name;undef;TAP device name to which virtual NIC should be connected. Usually undef so automatic matching is used
+UEFI;;;
+UEFI_BIOS;;;
+USBBOOT;boolean;0;Mount ISO as USB disk and boot VM from it
+VNC;integer;worker instance + 90;Display on which VNC server is running. Actual port is 5900 + VNC
+VNCKB;;;
+|====================
+
+.VBOX backend
+[grid="rows",format="csv"]
+[options="header",cols="^m,^m,^m,v",separator=";"]
+|====================
+Variable;Values allowed;Default value;Explanation
+ISO;;;
+|====================
+

--- a/t/04-check_vars_docu.pl
+++ b/t/04-check_vars_docu.pl
@@ -1,0 +1,135 @@
+#!/usr/bin/perl
+#
+# Copyright (c) 2015 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+
+use strict;
+use warnings;
+
+use FindBin;
+use File::Find;
+
+use constant {
+    BACKEND_DIR => "$FindBin::Bin/../backend",
+    DOC_DIR     => "$FindBin::Bin/../doc",
+};
+use constant VARS_DOC => DOC_DIR . '/backend_vars.asciidoc';
+
+my @backend_blacklist = qw/BASECLASS/;
+my %backend_renames   = ();
+my %documented_vars   = ();
+my %found_vars;
+my $error_found = 0;
+# ignore errors for now
+my $ignore_errors = 1;
+
+my $table_header = 'Variable;Values allowed;Default value;Explanation';
+
+sub say($) {
+    my ($text) = @_;
+    print STDERR "$text\n";
+}
+
+sub read_doc {
+    # read and parse old vars doc
+    my $docfh;
+    open($docfh, '<', VARS_DOC) or die 'Unable to open ' . VARS_DOC;
+    my $backend;
+    my $reading;
+    while (<$docfh>) {
+        if (!$backend && /^\.([^ ]+) backend$/) {
+            $backend = $1;
+        }
+        elsif ($backend) {
+            if (/^\|====/) {
+                $reading = $reading ? 0 : 1;
+                $backend = undef unless $reading;
+            }
+            elsif ($reading) {
+                next if (/$table_header/);
+                my ($var, $value, $default, $explanation) = $_ =~ /^([^;]+);\s*([^;]*);\s*([^;]*);\s*(.*)$/;
+                next unless ($var);
+                $default = '' unless (defined $default);
+                $value   = '' unless (defined $value);
+                unless ($explanation) {
+                    say "still missing explanation for backend $backend variable $var";
+                }
+                $documented_vars{$backend}{$var} = [$value, $default, $explanation];
+            }
+        }
+    }
+    close($docfh);
+}
+
+sub write_doc {
+    my $docfh;
+    open($docfh, '>', VARS_DOC) or die 'Unable to open ' . VARS_DOC;
+    print $docfh <<EO_HEADER;
+Supported variables per backend
+-------------------------------
+
+EO_HEADER
+    for my $backend (sort keys %found_vars) {
+        my $backend = uc $backend;
+        print $docfh <<EO_BACKEND_HEADER;
+.$backend backend
+[grid="rows",format="csv"]
+[options="header",cols="^m,^m,^m,v",separator=";"]
+|====================
+$table_header
+EO_BACKEND_HEADER
+        for my $var (sort keys %{$found_vars{$backend}}) {
+            unless ($documented_vars{$backend}{$var}) {
+                $error_found = 1;
+                $documented_vars{$backend}{$var} = ['', ''];
+                say "missing documentation for backend $backend variable $var, please update backend_vars";
+            }
+            my @var_docu = @{$documented_vars{$backend}{$var}};
+            printf $docfh "%s;%s;%s;%s\n", $var, @var_docu;
+        }
+        print $docfh <<EO_BACKEND_FOOTER;
+|====================
+
+EO_BACKEND_FOOTER
+    }
+}
+
+sub read_backend_pm {
+    my ($backend) = $_ =~ /^([^\.]+)\.pm/;
+    return unless $backend;
+    $backend = uc $backend;
+    return if (grep { /$backend/ } @backend_blacklist);
+    $backend = $backend_renames{$backend} if $backend_renames{$backend};
+    my $fh;
+    open($fh, '<', $File::Find::name) or say 'Unable to open ' . $File::Find::name && return;
+    while (<$fh>) {
+        my @vars = /(?:\$bmwqemu::|\$)vars(?:->)?{["']?([^}"']+)["']?}/g;
+        for my $var (@vars) {
+            # initially I used array and kept greping through to maintain uniqueness, but I had problem greping ISO_$i
+            # and HDD_$i variables. And hash is faster anyway, memory consumption is no issue here.
+            $found_vars{$backend}{$var} = 1;
+        }
+    }
+    close($fh);
+}
+
+read_doc;
+# for each backend file vars usage
+find(\&read_backend_pm, (BACKEND_DIR));
+# check if vars are properly documented and update data
+write_doc;
+$error_found = $ignore_errors ? 0 : $error_found;
+exit $error_found;

--- a/t/04-check_vars_docu.pl
+++ b/t/04-check_vars_docu.pl
@@ -28,9 +28,14 @@ use constant {
 };
 use constant VARS_DOC => DOC_DIR . '/backend_vars.asciidoc';
 
+# array of ignored "backends". Write in upper case for successful match
 my @backend_blacklist = qw/BASECLASS/;
-my %backend_renames   = ();
-my %documented_vars   = ();
+# blacklist of vars per backend. These vars will be ignored during vars exploration
+my %var_blacklist = (QEMU => ['WORKER_ID', 'WORKER_INSTANCE']);
+# in case we want to present backend under different name, place it here
+my %backend_renames = ();
+
+my %documented_vars = ();
 my %found_vars;
 my $error_found = 0;
 # ignore errors for now
@@ -92,9 +97,10 @@ EO_HEADER
 $table_header
 EO_BACKEND_HEADER
         for my $var (sort keys %{$found_vars{$backend}}) {
+            next if (grep { /$var/ } @{$var_blacklist{$backend}});
             unless ($documented_vars{$backend}{$var}) {
                 $error_found = 1;
-                $documented_vars{$backend}{$var} = ['', ''];
+                $documented_vars{$backend}{$var} = ['', '', ''];
                 say "missing documentation for backend $backend variable $var, please update backend_vars";
             }
             my @var_docu = @{$documented_vars{$backend}{$var}};

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,3 +1,3 @@
-TESTS = 00-compile-check-all.pl 01-test_needle.pl 02-test_ocr.pl 03-testapi.pl
+TESTS = 00-compile-check-all.pl 01-test_needle.pl 02-test_ocr.pl 03-testapi.pl 04-check_vars_docu.pl
 
 EXTRA_DIST = $(TESTS) t/test_driver.pm


### PR DESCRIPTION
- idea is this script is run by travis during make check
- script loads data from doc/backend_vars.asciidoc. Then parses all
(except blacklisted) files in backend directory and collects $vars{XXX}
usage. If finds some undocumented variable produces error
- script updates doc file so only explanation is needed to be filled after
script run
- currently it always succeed since not all vars are documented