### PR TITLE
Workaround absolute pointer issue for Power

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -383,7 +383,12 @@ sub start_qemu() {
             no warnings 'qw';
             push(@params, qw"-net nic,vlan=1,model=$vars->{NICMODEL},macaddr=52:54:00:12:34:57 -net none,vlan=1");
         }
-        push(@params, qw/-device usb-ehci -device usb-tablet/);
+        if ($vars->{OFW}) {
+            push(@params, qw/-device usb-ehci -device usb-tablet,bus=usb-bus.0/);
+        }
+        else {
+            push(@params, qw/-device usb-ehci -device usb-tablet/);
+        }
         if ($use_usb_kbd) {
             push(@params, qw/-device usb-kbd/);
         }


### PR DESCRIPTION
On PowerPC, -vga std spawns ohci usb interface, where usb-kbd and
usb-mouse are attached. But usb-tablet (absolute) is attached to ehci
device. For some reason qemu, picks usb-mouse as pointer and ingnores
usb-tablet.

So, plug usb-tablet into ohci interface.

Signed-off-by: Dinar Valeev <dvaleev@suse.com>