### PR TITLE
explicitly start the bridge interface

### DIFF
--- a/systemd/os-autoinst-openvswitch.service
+++ b/systemd/os-autoinst-openvswitch.service
@@ -10,7 +10,9 @@ Before=openqa-worker.target
 [Service]
 Type=dbus
 BusName=org.opensuse.os_autoinst.switch
+Environment=OS_AUTOINST_USE_BRIDGE=br0
 EnvironmentFile=-/etc/sysconfig/os-autoinst-openvswitch
+ExecStartPre=/usr/sbin/ifup ${OS_AUTOINST_USE_BRIDGE}
 ExecStart=/usr/lib/os-autoinst/os-autoinst-openvswitch
 
 [Install]


### PR DESCRIPTION
there is a race during startup:
1. wicked is started, creates TAP devices
2. openvswitch is started, connects the TAP devices to a bridge,
   creates bridge local interface br0
3. wicked assigns an IP to br0, os-autoinst-openvswitch service
   is starting at the same time

calling ifup ensures that os-autoinst-openvswitch is started
on already configured interface