### PR TITLE
Revert "avoid calling status in the backend if not needed"

### DIFF
--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -122,11 +122,11 @@ sub do_loadvm($) {
     die "if you need loadvm, you're screwed with IPMI";
 }
 
-sub do_upload_image($) {
+sub status($) {
     my ($self) = @_;
-    print "do_upload_image ignored\n";
+    print "status ignored\n";
+    return undef;
 }
-
 
 # serial grab
 

--- a/backend/kvm2usb.pm
+++ b/backend/kvm2usb.pm
@@ -292,8 +292,9 @@ sub do_loadvm($) {
     print STDOUT "do_loadvm=NOP\n";
 }
 
-sub do_upload_image($) {
+sub status($) {
     print STDOUT "do_upload_image=NOP\n";
+    return undef;
 }
 
 # baseclass virt method overwrite end

--- a/backend/s390x.pm
+++ b/backend/s390x.pm
@@ -435,9 +435,13 @@ sub do_loadvm() {
     notimplemented;
 }
 
-sub do_upload_image() {
-    notimplemented;
+sub status {
+    my ($self) = @_;
+    # FIXME: do something useful here.
+    carp "status not implemented";
+    return undef;
 }
+
 sub init_charmap($) {
     my ($self) = (@_);
 

--- a/backend/vbox.pm
+++ b/backend/vbox.pm
@@ -174,9 +174,10 @@ sub do_loadvm($) {
     $self->raw_vbox_snapshot("restore", $vmname);
 }
 
-sub do_upload_image($) {
+sub status($) {
     my ($self) = @_;
-    print "do_upload_image ignored\n";
+    print "status ignored\n";
+    return undef;
 }
 
 1;

--- a/isotovideo
+++ b/isotovideo
@@ -150,15 +150,11 @@ diag "FAIL" if $r;
 
 $SIG{ALRM} = 'IGNORE';    # ignore ALRM so the readthread doesn't kill us here
 
-# query the backend - it has to support status call (only few do)
-sub clean_shutdown() {
-  my $clean_shutdown;
-  eval {
+my $clean_shutdown;
+eval {
     my $status = $bmwqemu::backend->status();
     $clean_shutdown = 1 if $status||'' eq "shutdown";
-  };
-  return $clean_shutdown;
-}
+};
 
 bmwqemu::stop_vm();
 print "killing commands thread\n";
@@ -181,7 +177,7 @@ if (!$r && (my $nd = $bmwqemu::vars{NUMDISKS})) {
         next unless $name;
         push @toextract, { hdd_num => $i, name => $name, dir => $dir };
     }
-    if (@toextract && !clean_shutdown()) {
+    if (@toextract && !$clean_shutdown) {
         diag "ERROR: Machine not shut down when uploading disks!\n";
     }
     else {


### PR DESCRIPTION
To be able to upload images the status must be queried before the VM
is stopped.

This reverts commit 0907920c15c2b5ec6fd51c272003747db58b0ba9.