### PR TITLE
use -drive to avoid different drive order

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -428,16 +428,17 @@ sub start_qemu() {
                 push(@params, '-device', "$vars->{CDMODEL},drive=cd0");
             }
             else {
-                push(@params, "-cdrom", $iso);
+                $vars->{CDINTERFACE} ||= "scsi";
+                my $cdinterface = "if=scsi";
+                if ($vars->{CDINTERFACE} eq "ide-cd") { $cdinterface = "if=ide"; }
+                push(@params, "-drive", "$cdinterface,id=cd0,file=$iso,media=cdrom");
             }
         }
 
         for my $i (1 .. 6) {    # check for up to 6 ADDON ISOs
             if ($vars->{"ISO_$i"}) {
-                my $addoniso    = $vars->{"ISO_$i"};
-                my $cdinterface = "if=scsi";
-                if ($vars->{CDMODEL} eq "ide-cd") { $cdinterface = "if=ide"; }
-                push(@params, "-drive", "$cdinterface,id=addon_$i,file=$addoniso,media=cdrom");
+                my $addoniso = $vars->{"ISO_$i"};
+                push(@params, "-drive", "if=scsi,id=addon_$i,file=$addoniso,media=cdrom");
             }
         }
 


### PR DESCRIPTION
issue: https://openqa.suse.de/tests/138596/modules/addon_products_sle/steps/8
SLES/SLED ISO will be first in list
CDINTERFACE=ide-cd will be used without add-ons
GNOME:
http://10.100.98.90/tests/2477
SDK:
http://10.100.98.90/tests/2478
GNOME+CDINTERFACE=ide-cd:
http://10.100.98.90/tests/2479
SDK+CDINTERFACE=ide-cd:
http://10.100.98.90/tests/2480
openSUSE:
http://10.100.98.90/tests/2472
openSUSE+CDINTERFACE=ide-cd:
http://10.100.98.90/tests/2471