### PR TITLE
VNC backend: add caps keycode

### DIFF
--- a/backend/VNC.pm
+++ b/backend/VNC.pm
@@ -521,6 +521,7 @@ my $keymap_x11 = {
     'minus'     => ord('-'),
     'shift'     => 0xffe1,
     'ctrl'      => 0xffe3,     # left, right is e4
+    'caps'      => 0xffe5,
     'meta'      => 0xffe7,     # left, right is e8
     'alt'       => 0xffe9,     # left one, right is ea
     'ret'       => 0xff0d,


### PR DESCRIPTION
Unless in my submissions of ensure_installed, I named the key here 'caps', as the keymap_ikvm already lists this key with a code as well... otherwise we have different names for different keys.

Of course this also needs a fix in ensure_install, to actually push the 'caps' key now (I mistakenly used the telnet interface and got confused by the namings)