### PR TITLE
proper shift handling with qemu

### DIFF
--- a/backend/VNC.pm
+++ b/backend/VNC.pm
@@ -76,6 +76,11 @@ my @encodings = (
         name      => 'VNC_ENCODING_POINTER_TYPE_CHANGE',
         supported => 1,
     },
+    {
+        num       => -261,
+        name      => 'VNC_ENCODING_LED_STATE',
+        supported => 1,
+    },
 );
 
 sub list_encodings {
@@ -845,6 +850,12 @@ sub _receive_update {
         elsif ($encoding_type == -257) {
             bmwqemu::diag("pointer type $x $y $w $h $encoding_type");
             $self->absolute($x);
+        }
+        elsif ($encoding_type == -261) {
+            my $led_data;
+            $socket->read($led_data, 1) || die "unexpected end of data";
+            my @bytes = unpack("C", $led_data);
+            bmwqemu::diag("led state $bytes[0] $w $h $encoding_type");
         }
         elsif ($self->ikvm) {
             $self->_receive_ikvm_encoding($encoding_type, $x, $y, $w, $h);

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -352,6 +352,10 @@ sub init_charmap($) {
 
         "\e" => "esc"
     };
+    for my $c ("A" .. "Z") {
+        $self->{charmap}->{$c} = "shift-\L$c";
+    }
+
     ## charmap end
 }
 

--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -70,15 +70,6 @@ sub restart_host {
     }
 }
 
-sub init_charmap {
-    my ($self) = @_;
-
-    $self->SUPER::init_charmap();
-    for my $c ("A" .. "Z") {
-        $self->{charmap}->{$c} = "shift-\L$c";
-    }
-}
-
 sub relogin_vnc {
     my ($self) = @_;
 

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -470,6 +470,7 @@ sub start_qemu() {
             push(@params, qw"-net nic,vlan=1,model=$vars->{NICMODEL},macaddr=52:54:00:12:34:57 -net none,vlan=1");
         }
         if ($vars->{OFW}) {
+            no warnings 'qw';
             push(@params, qw/-device usb-ehci -device usb-tablet,bus=usb-bus.0/);
         }
         else {


### PR DESCRIPTION
reading the qemu vnc code, it behaves differently if the client
supports LED State pseudo encoding. So do so - and hopefully avoid
suprising caps lock (which qemu otherwise guesses at some wild heuristic)