### PR TITLE
wait longer for return value from curl

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -579,7 +579,7 @@ sub script_output($;$) {
 
     my $suffix = _random_string;
     type_string "curl -f -v " . autoinst_url . "/current_script > /tmp/script$suffix.sh && echo \"curl-\$?\" > /dev/$serialdev\n";
-    wait_serial('curl-0', 2) || die "script couldn't be downloaded";
+    wait_serial('curl-0') || die "script couldn't be downloaded";
     send_key "ctrl-l";
 
     type_string "/bin/bash -ex /tmp/script$suffix.sh | tee /dev/$serialdev\n";


### PR DESCRIPTION
https://openqa.suse.de/tests/145316/modules/curl_https/steps/1

||| starting curl_https tests/console/curl_https.pm at 2015-10-14 13:00:30
Debug: /var/lib/openqa/share/tests/sle-12-SP1/tests/console/curl_https.pm:8 called testapi::validate_script_output
<<< type_string(string='curl -f -v http://10.0.2.2:20053/current_script > /tmp/scriptBGgb.sh && echo "curl-$?" > /dev/ttyS0
', max_interval=250)
Debug: /var/lib/openqa/share/tests/sle-12-SP1/tests/console/curl_https.pm:8 called testapi::validate_script_output
<<< wait_serial(regex='curl-0', timeout=2)
[Wed Oct 14 15:00:39 2015] [debug] GET "/current_script"
[Wed Oct 14 15:00:39 2015] [debug] Routing to a callback
[Wed Oct 14 15:00:39 2015] [debug] Request from 127.0.0.1.
[Wed Oct 14 15:00:39 2015] [debug] Routing to a callback
[Wed Oct 14 15:00:39 2015] [debug] 200 OK (0.000960s, 1041.667/s)
\>>> wait_serial: ARRAY(0x5155560): fail
test curl_https died: script couldn't be downloaded at /usr/lib/os-autoinst/testapi.pm line 582.
test curl_https died: script couldn't be downloaded at /usr/lib/os-autoinst/testapi.pm line 582.