### PR TITLE
missing l when creating qemu image

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -348,7 +348,7 @@ sub start_qemu() {
                 symlink($i, "$basedir/l$i") or die "$!\n";
             }
             else {
-                die "$!\n" unless runcmd($qemuimg, "create", "$basedir/$i", "-f", $vars->{HDDFORMAT}, $vars->{HDDSIZEGB} . "G") == 0;
+                die "$!\n" unless runcmd($qemuimg, "create", "$basedir/l$i", "-f", $vars->{HDDFORMAT}, $vars->{HDDSIZEGB} . "G") == 0;
                 symlink($i, "$basedir/l$i") or die "$!\n";
             }
         }


### PR DESCRIPTION
This should maybe fix multipath on ppc64le

https://openqa.suse.de/tests/148782/file/autoinst-log.txt

log:
> running /usr/bin/qemu-img create raid/1 -f raw 10G
> qemu-system-ppc64 -drive file=raid/l1
> Could not open 'raid/l1': Invalid argument