### PR TITLE
USBinstall fix

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -451,8 +451,7 @@ sub start_qemu() {
             my $addoniso = $vars->{$k};
             my $i        = $k;
             $i =~ s/^ISO_//;
-            push(@params, '-drive',  "media=cdrom,if=none,id=cd$i,format=raw,file=$addoniso");
-            push(@params, '-device', "$vars->{CDMODEL},drive=cd$i");
+            push(@params, '-drive', "media=cdrom,if=scsi,id=cd$i,format=raw,file=$addoniso");
         }
 
         if ($arch_supports_boot_order) {


### PR DESCRIPTION
for ISO_* can be hard coded scsi, when for some reason 'scsi-cd' could not be initialized.
Jut have to increase send_key in bootloader http://10.100.98.90/tests/2756/modules/bootloader/steps/2

USBinstall:
http://10.100.98.90/tests/2756
USBinstall+UEFI:
http://10.100.98.90/tests/2757
SDK:
http://10.100.98.90/tests/2750