### PR TITLE
show in log default timeout instead of undef for assert_screen

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -33,6 +33,7 @@ sub mydie;
 # shared vars
 
 our $screenshotQueue = Thread::Queue->new();
+our $default_timeout //= 30;    # assert timeout, 0 is a valid timeout
 my $prestandstillwarning : shared = 0;
 
 my @ocrrect;
@@ -663,7 +664,7 @@ sub save_needle_template($$$) {
 sub assert_screen {
     my %args         = @_;
     my $mustmatch    = $args{'mustmatch'};
-    my $timeout      = $args{'timeout'} // 30;    # 0 is a valid timeout
+    my $timeout      = $args{'timeout'} // $default_timeout;
     my $check_screen = $args{'check'};
 
     $timeout = _scale_timeout($timeout);

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -34,6 +34,7 @@ sub mydie;
 
 our $screenshotQueue = Thread::Queue->new();
 our $default_timeout //= 30;    # assert timeout, 0 is a valid timeout
+our $idle_timeout ||= 19;       # wait_idle 0 makes no sense
 my $prestandstillwarning : shared = 0;
 
 my @ocrrect;
@@ -595,7 +596,7 @@ Wait until the system becomes idle
 =cut
 
 sub wait_idle($) {
-    my $timeout = shift;
+    my $timeout = shift || $idle_timeout;
     my $prev;
     my $timesidle     = 0;
     my $idlethreshold = $vars{IDLETHRESHOLD};

--- a/testapi.pm
+++ b/testapi.pm
@@ -59,13 +59,15 @@ sub record_soft_failure {
 }
 
 sub assert_screen($;$) {
-    my ($mustmatch, $timeout) = @_;
+    my $mustmatch = shift;
+    my $timeout = shift // $bmwqemu::default_timeout;
     bmwqemu::log_call('assert_screen', mustmatch => $mustmatch, timeout => $timeout);
     return $last_matched_needle = bmwqemu::assert_screen(mustmatch => $mustmatch, timeout => $timeout);
 }
 
 sub check_screen($;$) {
-    my ($mustmatch, $timeout) = @_;
+    my $mustmatch = shift;
+    my $timeout = shift // $bmwqemu::default_timeout;
     bmwqemu::log_call('check_screen', mustmatch => $mustmatch, timeout => $timeout);
     return $last_matched_needle = bmwqemu::assert_screen(mustmatch => $mustmatch, timeout => $timeout, check => 1);
 }
@@ -88,6 +90,7 @@ deprecated: assert_and_dclick($mustmatch,[$button],[$timeout],[$click_time]);
 
 sub assert_and_click($;$$$$) {
     my ($mustmatch, $button, $timeout, $clicktime, $dclick) = @_;
+    $timeout //= $bmwqemu::default_timeout;
 
     $dclick //= 0;
 
@@ -298,7 +301,6 @@ Wait for idle before  and after.
 =cut
 
 sub script_run($;$) {
-
     my ($name, $wait) = @_;
 
     bmwqemu::log_call('script_run', name => $name, wait => $wait);

--- a/testapi.pm
+++ b/testapi.pm
@@ -134,7 +134,7 @@ Wait until the system becomes idle (as configured by IDLETHESHOLD)
 =cut
 
 sub wait_idle(;$) {
-    my $timeout = shift || 19;
+    my $timeout = shift || $bmwqemu::idle_timeout;
     bmwqemu::log_call('wait_idle', timeout => $timeout);
 
     bmwqemu::wait_idle($timeout);
@@ -301,7 +301,8 @@ Wait for idle before  and after.
 =cut
 
 sub script_run($;$) {
-    my ($name, $wait) = @_;
+    my $name = shift;
+    my $wait = shift || $bmwqemu::idle_timeout;
 
     bmwqemu::log_call('script_run', name => $name, wait => $wait);
     return $distri->script_run($name, $wait);

--- a/testapi.pm
+++ b/testapi.pm
@@ -336,7 +336,8 @@ $wait_seconds
 =cut
 
 sub script_sudo($;$) {
-    my ($name, $wait) = @_;
+    my $name = shift;
+    my $wait = shift || 2;
 
     bmwqemu::log_call('script_sudo', name => $name, wait => $wait);
     return $distri->script_sudo($name, $wait);


### PR DESCRIPTION
It's a bit confusing if instead of default timeout 30 is in log undef