### PR TITLE
don't hardcode libexecdir location in cv.pm

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,7 +57,8 @@ pkglibexec_SCRIPTS = \
 bin_SCRIPTS = isotovideo
 
 install-exec-hook:
-	sed -i -e "s,\$$installprefix = undef;,\$$installprefix = '$(pkglibexecdir)';," $(DESTDIR)$(bindir)/isotovideo
+	sed -i -e "s,\$$installprefix = undef;,\$$installprefix = '$(pkglibexecdir)';," $(DESTDIR)$(bindir)/isotovideo && \
+	sed -i -e "s,\$$sysdir = undef;,\$$sysdir = '$(pkglibexecdir)';," $(DESTDIR)$(pkglibexecdir)/cv.pm
 
 pkglibexec_FOLDERS = \
 	distri \

--- a/cv.pm
+++ b/cv.pm
@@ -12,7 +12,10 @@ sub init() {
     use Config;
     my $vendorlib = $Config{installvendorlib};
     my $libdir    = dirname(__FILE__);
-    return if ($libdir eq "/usr/lib/os-autoinst");
+    # undef is substituted with $(pkglibexecdir) in
+    # make install, in the following line. See Makefile.am
+    my $sysdir = undef;
+    return if ($sysdir && $libdir eq $sysdir);
     my @s = stat("$libdir/ppmclibs/blib/lib/tinycv.pm");
     unless (@s && -e "$libdir/ppmclibs/tinycv.pm" && $s[7] == (stat(_))[7]) {
         $| = 1;


### PR DESCRIPTION
cv.pm assumes that if it's installed it will be in
'/usr/lib/os-autoinst', but in fact it's installed to
pkglibexecdir, and that's not always /usr/lib - on Fedora it's
/usr/libexec. So on installation, substitute this path to
$(pkglibexecdir). This is done the same way as an existing
substitution in isotovideo; I don't really like this approach
(using a post-install hook) but I went with it for consistency
and minimal change.