### PR TITLE
add small helper program to display the latest os-autoinst screenshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ _Inline
 compile
 test-driver
 videoencoder
+debugviewer/debugviewer

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 ACLOCAL_AMFLAGS = -I m4
-SUBDIRS = t
+SUBDIRS = t debugviewer
 
 doc_DATA = \
 	README.asciidoc \

--- a/configure.ac
+++ b/configure.ac
@@ -36,5 +36,6 @@ PKG_CHECK_MODULES([THEORAENC], [theoraenc >= 1.1])
 AC_CONFIG_FILES([
 	Makefile
 	t/Makefile
+	debugviewer/Makefile
 ])
 AC_OUTPUT

--- a/debugviewer/Makefile.am
+++ b/debugviewer/Makefile.am
@@ -1,0 +1,7 @@
+noinst_PROGRAMS = debugviewer
+
+debugviewer_SOURCES = debugviewer.cpp
+
+AM_CPPFLAGS = $(pkg-config --cflags opencv)
+debugviewer_LDFLAGS = $(shell pkg-config --libs opencv)
+

--- a/debugviewer/debugviewer.cpp
+++ b/debugviewer/debugviewer.cpp
@@ -1,0 +1,37 @@
+/* 
+   this is from the opencv documentation - just extended with a loop
+*/
+
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <iostream>
+
+using namespace cv;
+using namespace std;
+
+int main( int argc, char** argv )
+{
+    if( argc != 2)
+    {
+     cout <<" Usage: debugviewer qemuscreenshot/last.png" << endl;
+     return -1;
+    }
+
+    Mat image;
+    while (1) {
+      image = imread(argv[1], CV_LOAD_IMAGE_COLOR);   // Read the file
+      
+      if(! image.data )                              // Check for invalid input
+	{
+	  cout <<  "Could not open or find the image" << std::endl ;
+	  return -1;
+	}
+      
+      namedWindow( "Display window", WINDOW_AUTOSIZE );// Create a window for display.
+      imshow( "Display window", image );                   // Show our image inside it.
+      
+      if (waitKey(300) >= 0)                                          // Wait for a keystroke in the window
+	break;
+    }
+    return 0;
+}


### PR DESCRIPTION
Without openQA's live view, it's pretty hard to follow what is happening
in the backend's screen. So use this tool and point it to last.png