### PR TITLE
we can't timeout in the thread communication

### DIFF
--- a/backend/driver.pm
+++ b/backend/driver.pm
@@ -244,7 +244,7 @@ sub _read_json {
                 }
 
                 # wait for next read
-                my @res = $s->can_read(300);
+                my @res = $s->can_read;
                 unless (@res) {
                     my $E = $!;    # save the error
                     backend::baseclass::write_crash_file();


### PR DESCRIPTION
a wait_serial with X*1000 seconds timeout is fine to wait for 800 seconds
in the backend, so we can't timeout the reading. the test thread is just
locked till the backend is done