### PR TITLE
Allow to implement openQA test modules in python

### DIFF
--- a/doc/example-bootloader.py
+++ b/doc/example-bootloader.py
@@ -1,4 +1,5 @@
 import perl
+perl.use("registration")
 
 def run(self):
     print "This python code ran"
@@ -10,6 +11,7 @@ def run(self):
         perl.send_key(2 + perl.get_var("NUMDISKS"))
     perl.assert_screen("inst-bootmenu", 15)
     perl.send_key_until_needlematch('inst-oninstallation', 'down', 10, 5)
+    perl.registration.registration_bootloader_params()
     perl.type_string("qwertyuiopasdfghjkl")
     print "TODO: more code"
     perl.send_key('ret')

--- a/doc/example-bootloader.py
+++ b/doc/example-bootloader.py
@@ -1,0 +1,19 @@
+import perl
+
+def run(self):
+    print "This python code ran"
+    #perl.assert_screen("fooweiuhfiu", 1) # to test how it dies
+    if perl.get_var("USBBOOT"):
+        perl.assert_screen("boot-menu", 1)
+        perl.send_key("f12")
+        perl.assert_screen("boot-menu-usb", 4)
+        perl.send_key(2 + perl.get_var("NUMDISKS"))
+    perl.assert_screen("inst-bootmenu", 15)
+    perl.send_key_until_needlematch('inst-oninstallation', 'down', 10, 5)
+    perl.type_string("qwertyuiopasdfghjkl")
+    print "TODO: more code"
+    perl.send_key('ret')
+
+def test_flags(self):
+    return dict([("fatal", 1)])
+


### PR DESCRIPTION
    Allow to implement openQA test modules in python
    
    because some people prefer python over perl.
    The implementation uses the Inline::Python perl module
