### PR TITLE
reimplement the wait_(screen_still|changed_screen) functions

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -22,6 +22,14 @@ our $MAGIC_PIPE_CLOSE_STRING = "xxxQUITxxx\n";
 # should be a singleton - and only useful in backend thread
 our $backend;
 
+use parent qw(Class::Accessor::Fast);
+__PACKAGE__->mk_accessors(
+    qw(
+      update_request_interval last_update_request
+      screenshot_interval last_screenshot last_image
+      reference_screenshot)
+);
+
 sub new {
     my $class = shift;
     my $self = bless({class => $class}, $class);
@@ -51,12 +59,6 @@ sub die_handler {
 }
 
 
-use parent qw(Class::Accessor::Fast);
-__PACKAGE__->mk_accessors(
-    qw(
-      update_request_interval last_update_request
-      screenshot_interval last_screenshot)
-);
 
 sub run {
     my ($self, $cmdpipe, $rsppipe) = @_;
@@ -302,7 +304,6 @@ sub cpu_stat {
     return [];
 }
 
-my $lastscreenshot;
 my $lastscreenshotName;
 
 sub enqueue_screenshot {
@@ -317,6 +318,8 @@ sub enqueue_screenshot {
     my $filename = $bmwqemu::screenshotpath . sprintf("/shot-%010d.png", $framecounter);
     my $lastlink = $bmwqemu::screenshotpath . "/last.png";
 
+    my $lastscreenshot = $self->last_image;
+
     # link identical files to save space
     my $sim = 0;
     $sim = $lastscreenshot->similarity($image) if $lastscreenshot;
@@ -329,7 +332,7 @@ sub enqueue_screenshot {
         $image->write($filename) || die "write $filename";
         # copy new one to shared directory, remove old one and change symlink
         $bmwqemu::screenshotQueue->enqueue($filename);
-        $lastscreenshot     = $image;
+        $self->last_image($image);
         $lastscreenshotName = $filename;
         no autodie qw(unlink);
         unlink($lastlink);
@@ -584,6 +587,25 @@ sub wait_serial {
     }
     $self->set_serial_offset();
     return {matched => $matched, string => $str};
+}
+
+# set_reference_screenshot and similiarity_to_reference are necessary to
+# implement wait_still and wait_changed functions in the tests without having
+# to transfer the screenshot into the test thread
+sub set_reference_screenshot {
+    my ($self, $args) = @_;
+
+    $self->reference_screenshot($self->last_image);
+    return;
+}
+
+
+sub similiarity_to_reference {
+    my ($self, $args) = @_;
+    if (!$self->reference_screenshot || !$self->last_image) {
+        return {sim => 10000};
+    }
+    return {sim => $self->reference_screenshot->similarity($self->last_image)};
 }
 
 1;

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -608,5 +608,14 @@ sub similiarity_to_reference {
     return {sim => $self->reference_screenshot->similarity($self->last_image)};
 }
 
+sub wait_idle {
+    my ($self, $args) = @_;
+    my $timeout = $args->{timeout};
+
+    bmwqemu::diag("wait_idle sleeping for $timeout seconds");
+    $self->run_capture_loop(undef, $timeout);
+    return;
+}
+
 1;
 # vim: set sw=4 et:

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -411,45 +411,6 @@ sub get_cpu_stat() {
 
 # runtime information gathering functions end
 
-# wait functions
-
-=head2 wait_still_screen
-
-wait_still_screen($stilltime_sec, $timeout_sec, $similarity_level)
-
-Wait until the screen stops changing
-
-=cut
-
-sub wait_still_screen {
-
-    my ($stilltime, $timeout, $similarity_level) = @_;
-
-    $timeout = scale_timeout($timeout);
-
-    my $starttime      = time;
-    my $lastchangetime = [gettimeofday];
-    my $lastchangeimg  = getcurrentscreenshot();
-    while (time - $starttime < $timeout) {
-        my $img = getcurrentscreenshot();
-        my $sim = $img->similarity($lastchangeimg);
-        my $now = [gettimeofday];
-        if ($sim < $similarity_level) {
-
-            # a change
-            $lastchangetime = $now;
-            $lastchangeimg  = $img;
-        }
-        if (($now->[0] - $lastchangetime->[0]) + ($now->[1] - $lastchangetime->[1]) / 1000000. >= $stilltime) {
-            fctres('wait_still_screen', "detected same image for $stilltime seconds");
-            return 1;
-        }
-        sleep(0.5);
-    }
-    current_test->timeout_screenshot();
-    fctres('wait_still_screen', "wait_still_screen timed out after $timeout");
-    return 0;
-}
 
 =head2 wait_idle
 
@@ -592,7 +553,7 @@ sub assert_screen {
             $interactive_mode = 0;
             save_status();
         }
-        if (-e $control_files{"stop_waitforneedle"}) {
+        if (-e $control_files{stop_waitforneedle}) {
             last;
         }
         my $statstr = get_cpu_stat();

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -66,7 +66,6 @@ our $clock_ticks = POSIX::sysconf(&POSIX::_SC_CLK_TCK);
 
 our $istty;
 our $direct_output;
-our $timesidleneeded     = 1;
 our $standstillthreshold = scale_timeout(600);
 
 our %vars;
@@ -154,10 +153,9 @@ sub init {
     $testapi::distri = distribution->new unless $testapi::distri;
 
     # defaults
-    $vars{QEMUPORT}      ||= 15222;
-    $vars{VNC}           ||= 90;
-    $vars{INSTLANG}      ||= "en_US";
-    $vars{IDLETHRESHOLD} ||= 18;
+    $vars{QEMUPORT} ||= 15222;
+    $vars{VNC}      ||= 90;
+    $vars{INSTLANG} ||= "en_US";
     # openQA already sets a random string we can reuse
     $vars{JOBTOKEN} ||= random_string(10);
 
@@ -410,45 +408,6 @@ sub get_cpu_stat() {
 }
 
 # runtime information gathering functions end
-
-
-=head2 wait_idle
-
-Wait until the system becomes idle
-
-=cut
-
-sub wait_idle {
-    my ($timeout) = @_;
-    $timeout ||= $idle_timeout;
-    my $prev;
-    my $timesidle     = 0;
-    my $idlethreshold = $vars{IDLETHRESHOLD};
-
-    $timeout = scale_timeout($timeout);
-
-    for my $n (1 .. $timeout) {
-        my ($stat, $systemstat) = @{$backend->cpu_stat()};
-        sleep 1;    # sleep before skip to timeout when having no data (hw)
-        next unless $stat;
-        $stat += $systemstat;
-        if ($prev) {
-            my $diff = $stat - $prev;
-            diag("wait_idle $timesidle d=$diff");
-            if ($diff < $idlethreshold) {
-                if (++$timesidle > $timesidleneeded) {    # idle for $x sec
-                                                          #if($diff<2000000) # idle for one sec
-                    fctres('wait_idle', "idle detected");
-                    return 1;
-                }
-            }
-            else { $timesidle = 0 }
-        }
-        $prev = $stat;
-    }
-    fctres('wait_idle', "timed out after $timeout");
-    return 0;
-}
 
 sub save_needle_template {
     my ($img, $mustmatch, $tags) = @_;

--- a/distribution.pm
+++ b/distribution.pm
@@ -85,8 +85,6 @@ sub script_run {
     # start console application
     my ($self, $name, $wait) = @_;
 
-    testapi::wait_idle();
-
     testapi::type_string "$name\n";
     testapi::wait_idle($wait);
 }

--- a/testapi.pm
+++ b/testapi.pm
@@ -307,17 +307,17 @@ within the block to avoid races between the action and the screen change
 
 =cut
 
-sub wait_screen_change(&@) {
-    my ($callback) = @_;
+sub wait_screen_change(&@;$) {
+    my ($callback, $timeout) = @_;
+    $timeout ||= 10;
 
-    bmwqemu::log_call('wait_screen_change');
+    bmwqemu::log_call('wait_screen_change', timeout => $timeout);
 
     # get the initial screen
     $bmwqemu::backend->set_reference_screenshot;
     $callback->() if $callback;
 
     my $starttime        = time;
-    my $timeout          = 10;
     my $similarity_level = 50;
 
     while (time - $starttime < $timeout) {

--- a/testapi.pm
+++ b/testapi.pm
@@ -63,6 +63,8 @@ sub init {
     return;
 }
 
+## no critic (ProhibitSubroutinePrototypes)
+
 sub set_distribution {
     ($distri) = @_;
     return $distri->init();
@@ -155,9 +157,21 @@ Wait until the system becomes idle (as configured by IDLETHESHOLD)
 
 sub wait_idle {
     my $timeout = shift || $bmwqemu::idle_timeout;
+    $timeout = bmwqemu::scale_timeout($timeout);
+
     bmwqemu::log_call('wait_idle', timeout => $timeout);
 
-    return bmwqemu::wait_idle($timeout);
+    my $args = {
+        timeout   => $timeout,
+        threshold => get_var('IDLETHRESHOLD', 18)};
+    my $rsp = $bmwqemu::backend->wait_idle($args);
+    if ($rsp->{idle}) {
+        bmwqemu::fctres('wait_idle', "idle detected");
+    }
+    else {
+        bmwqemu::fctres('wait_idle', "timed out after $timeout");
+    }
+    return;
 }
 
 =head2 wait_serial


### PR DESCRIPTION
not to check the image ourselves, but to rely on the backend thread to check