### PR TITLE
test creating support fixes

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -128,7 +128,7 @@ sub runalltests {
             $t->start();
 
             # avoid erasing the good vm snapshot
-            if ($snapshots_supported && ($bmwqemu::vars{SKIPTO} || '') ne $t->{fullname} && $bmwqemu::vars{MAKETESTSNAPSHOTS}) {
+            if ($snapshots_supported && (($bmwqemu::vars{SKIPTO} || '') ne $t->{fullname}) && $bmwqemu::vars{MAKETESTSNAPSHOTS}) {
                 make_snapshot($t->{fullname});
             }
 

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -46,7 +46,7 @@ ISO;filename;;Filename of ISO file to be attached to VM
 ISO_$i;filename;;Aditional ISO to be attached to VM. Up to 9
 KEEPHDDS;boolean;;Leave created HDD after test finishes. Useful for debugging tests
 LAPTOP;boolean or filename;0;If 1, loads Dell E6330 DMI. If filename, loads specified DMI
-MAKETESTSNAPSHOTS;integer;0;save snapshot for each test in qcow image
+MAKETESTSNAPSHOTS;boolean;0;Save snapshot for each test module in qcow image
 MULTINET;boolean;0;VM will have two virtual NIC. Can't be used with NICTYPE tap
 MULTIPATH;boolean;0;Add HDD drives as multipath devices. Override HDDMODEL to virtio-scsi-pci
 NICMAC;any MAC address;52:54:00:12:34:56;MAC address to be assigned to virtual network card
@@ -68,8 +68,9 @@ QEMUVGA;see qemu -device ?;cirrus;VGA device to use with VM
 QEMU_COMPRESS_QCOW2;boolean;0;compress qcow2 images intended for upload
 QEMU_NO_KVM;boolean;0;Don't use KVM acceleration.
 RAIDLEVEL;;;
-SKIPTO;name of snapshot;;Restore VM from given snapshot. Needs HDD image with snapshots present. Used for test debugging
+SKIPTO;full name of test module;;Restore VM from snapshot and continue by running specified test module. Needs HDD image with snapshots present
 TAPDEV;device name;undef;TAP device name to which virtual NIC should be connected. Usually undef so automatic matching is used
+TESTDEBUG;boolean;0;Enable test debugging: override 'milestone' and 'fatal' test flags to 1. Snapshot are created after each successful test module and each fail aborts test run
 UEFI;;;
 UEFI_BIOS;;;
 USBBOOT;boolean;0;Mount ISO as USB disk and boot VM from it


### PR DESCRIPTION
- first commit allows one to provide KEEPHDDs variable even when VM pool is empty, thus disk images has to be created yet.
- the rest changes behavior of MAKETESTSNAPHOSTS:
Instead of creating snapshot before each test it only acts as an override to 'milestone' test flag. This way snapshot is always only one, storing the latest successful test module. User than can use SKIPTO to restart failed test module.