### PR TITLE
do not add perl variables as backend variables

### DIFF
--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -1,12 +1,13 @@
 Supported variables per backend
 -------------------------------
 
-.Common
+.COMMON backend
 [grid="rows",format="csv"]
 [options="header",cols="^m,^m,^m,v",separator=";"]
 |====================
 Variable;Values allowed;Default value;Explanation
-NOVIDEO;boolean;;don't encode video if set
+NOVIDEO;boolean;0;Do not encode video if set
+SCREENSHOTINTERVAL;;;
 |====================
 
 .IPMI backend
@@ -15,17 +16,8 @@ NOVIDEO;boolean;;don't encode video if set
 |====================
 Variable;Values allowed;Default value;Explanation
 IPMI_HOSTNAME;string;Hostname/IP for IPMI interface;
-IPMI_USER;string;Username for the IPMI interface;
 IPMI_PASSWORD;string;Password for the IPMI interface;
-|====================
-
-.KVM2USB backend
-[grid="rows",format="csv"]
-[options="header",cols="^m,^m,^m,v",separator=";"]
-|====================
-Variable;Values allowed;Default value;Explanation
-HWSLOT;;;
-ISO;;;
+IPMI_USER;string;Username for the IPMI interface;
 |====================
 
 .QEMU backend
@@ -33,12 +25,12 @@ ISO;;;
 [options="header",cols="^m,^m,^m,v",separator=";"]
 |====================
 Variable;Values allowed;Default value;Explanation
-ADDONS;boolean;0;Enables use of ISO_$i variables
 ARCH;x86_64|i686|aarch64|...;depends on tested medium;Architecture of VM.
 AUTO_INST;;;
 BIOS;;;
 BOOTFROM;chars;undef;Influences order of boot devices. See qemu -boot option
 CDMODEL;see qemu -device ?;undef;Storage device for virtualized CD
+HDDFORMAT;;;
 HDDMODEL;see qemu -device ?;virtio-blk;Storage device for virtualized HDD.
 HDDSIZEGB;integer;10;Creates HDD with specified size in GiB
 HDD_$i;filename;;Filename of HDD image to be used for VM. Up to 9
@@ -70,6 +62,7 @@ QEMU_NO_KVM;boolean;0;Don't use KVM acceleration.
 RAIDLEVEL;;;
 SKIPTO;full name of test module;;Restore VM from snapshot and continue by running specified test module. Needs HDD image with snapshots present
 TAPDEV;device name;undef;TAP device name to which virtual NIC should be connected. Usually undef so automatic matching is used
+TAPSCRIPT;;;
 TESTDEBUG;boolean;0;Enable test debugging: override 'milestone' and 'fatal' test flags to 1. Snapshot are created after each successful test module and each fail aborts test run
 UEFI;;;
 UEFI_BIOS;;;

--- a/t/04-check_vars_docu.pl
+++ b/t/04-check_vars_docu.pl
@@ -30,12 +30,12 @@ use constant {
 };
 use constant VARS_DOC => DOC_DIR . '/backend_vars.asciidoc';
 
-# array of ignored "backends". Write in upper case for successful match
-my @backend_blacklist = qw/BASECLASS/;
+# array of ignored "backends"
+my @backend_blacklist = qw//;
 # blacklist of vars per backend. These vars will be ignored during vars exploration
 my %var_blacklist = (QEMU => ['WORKER_ID', 'WORKER_INSTANCE']);
 # in case we want to present backend under different name, place it here
-my %backend_renames = ();
+my %backend_renames = (BASECLASS => 'Common');
 
 my %documented_vars = ();
 my %found_vars;
@@ -99,6 +99,8 @@ EO_HEADER
 $table_header
 EO_BACKEND_HEADER
         for my $var (sort keys %{$found_vars{$backend}}) {
+            # skip perl variables i.e. $bmwqemu{$k}
+            next if ($var =~ /^\$[a-zA-Z]/);
             next if (grep { /$var/ } @{$var_blacklist{$backend}});
             unless ($documented_vars{$backend}{$var}) {
                 $error_found = 1;
@@ -118,9 +120,9 @@ EO_BACKEND_FOOTER
 sub read_backend_pm {
     my ($backend) = $_ =~ /^([^\.]+)\.pm/;
     return unless $backend;
+    return if (grep { /$backend/i } @backend_blacklist);
     $backend = uc $backend;
-    return if (grep { /$backend/ } @backend_blacklist);
-    $backend = $backend_renames{$backend} if $backend_renames{$backend};
+    $backend = uc $backend_renames{$backend} if $backend_renames{$backend};
     my $fh;
     eval { open($fh, '<', $File::Find::name) };
     if (my $E = $@) {


### PR DESCRIPTION
- update doc/backend_vars.asciidoc
- parse backend/baseclass.pm as common backend
- skip perl variables (i.e. bmwqemu::vars{$k} -> skip $k)