### PR TITLE
add a new variable UEFI_PFLASH

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -244,6 +244,10 @@ sub start_qemu {
         $vars->{BIOS} //= $vars->{UEFI_BIOS};
     }
 
+    if ($vars->{UEFI_PFLASH}) {
+        $vars->{UEFI} = 1;
+    }
+
     if ($vars->{BIOS} && $vars->{BIOS} !~ /^\//) {
         # Non-absolute paths are assumed relative to /usr/share/qemu
         $vars->{BIOS} = '/usr/share/qemu/' . $vars->{BIOS};
@@ -540,7 +544,12 @@ sub start_qemu {
             }
         }
 
-        if ($vars->{BIOS}) {
+        if ($vars->{UEFI_PFLASH}) {
+            # Convert the firmware file into qcow2 format or savevm would fail
+            runcmd('qemu-img', 'convert', '-O', 'qcow2', $vars->{BIOS}, 'ovmf.bin');
+            push(@params, "-drive", "if=pflash,format=qcow2,file=ovmf.bin");
+        }
+        elsif ($vars->{BIOS}) {
             push(@params, "-bios", $vars->{BIOS});
         }
         if ($vars->{MULTINET}) {

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -65,6 +65,7 @@ TAPDEV;device name;undef;TAP device name to which virtual NIC should be connecte
 TAPSCRIPT;;;
 TESTDEBUG;boolean;0;Enable test debugging: override 'milestone' and 'fatal' test flags to 1. Snapshot are created after each successful test module and each fail aborts test run
 UEFI;;;
+UEFI_PFLASH;boolean;0;Enable the pflash mode to write the UEFI variables directly into the firmware file instead of NVvars in the EFI system partition
 UEFI_BIOS;;;
 USBBOOT;boolean;0;Mount ISO as USB disk and boot VM from it
 VDE_PORT;integer;worker instance + 10;number of vde switch port to connect


### PR DESCRIPTION
The OVMF upstream recommends to specify the firmware file with "pflash"
rather than "-bios" so the non-volatile variables can be stored in the
firmware file instead of NVvars in the ESP.