### PR TITLE
JSON fixes

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -33,7 +33,6 @@ use Data::Dumper;
 use feature qw(say);
 
 my $framecounter = 0;    # screenshot counter
-our $MAGIC_PIPE_CLOSE_STRING = "xxxQUITxxx\n";
 
 # should be a singleton - and only useful in backend thread
 our $backend;
@@ -386,7 +385,7 @@ sub close_pipes {
 
     # XXX: perl does not really close the fd here due to threads!?
     print "sending magic and exit\n";
-    $self->{rsppipe}->print($MAGIC_PIPE_CLOSE_STRING);
+    $self->{rsppipe}->print('{"QUIT":1}');
     close($self->{rsppipe}) || die "close $!\n";
     threads->exit();
 }


### PR DESCRIPTION
- use incr_parse() from JSON module
- utf-8 is disabled in both _send_json and _read_json
  (the originaly used JSON::decode_json is utf-8 enabled which
  caused inconsistencies)
- write json without trailing "\n"
  parsing ends at last '}' and if the following "\n" appeared at
  the begginig of buffer, it was considered to be part of next
  command and caused _read_json to block without screen updates etc.
  until the next command really arrived
- changed MAGIC_PIPE_CLOSE_STRING to JSON format to simplify
  parsing