### PR TITLE
Add -kernel, -initrd and -append QEMU arguments and also use AArch64 setup for ARM too

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -321,7 +321,7 @@ sub start_qemu {
     my $arch_supports_boot_order = 1;
     my $use_usb_kbd;
     my @vgaoptions;
-    if ($vars->{ARCH} eq 'aarch64') {
+    if ($vars->{ARCH} eq 'aarch64' || $vars->{ARCH} eq 'arm') {
         push @vgaoptions, '-device', 'VGA';
         $arch_supports_boot_order = 0;
         $use_usb_kbd              = 1;

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -248,13 +248,14 @@ sub start_qemu {
         $vars->{UEFI} = 1;
     }
 
-    if ($vars->{BIOS} && $vars->{BIOS} !~ /^\//) {
-        # Non-absolute paths are assumed relative to /usr/share/qemu
-        $vars->{BIOS} = '/usr/share/qemu/' . $vars->{BIOS};
-    }
-
-    if ($vars->{BIOS} && !-e $vars->{BIOS}) {
-        die "'$vars->{BIOS}' missing, check BIOS\n";
+    foreach my $attribute (qw/BIOS KERNEL INITRD/) {
+        if ($vars->{$attribute} && $vars->{$attribute} !~ /^\//) {
+            # Non-absolute paths are assumed relative to /usr/share/qemu
+            $vars->{$attribute} = '/usr/share/qemu/' . $vars->{$attribute};
+        }
+        if ($vars->{$attribute} && !-e $vars->{$attribute}) {
+            die "'$vars->{$attribute}' missing, check $attribute\n";
+        }
     }
 
     if ($vars->{UEFI} && $vars->{ARCH} eq 'x86_64' && !$vars->{BIOS}) {
@@ -551,6 +552,11 @@ sub start_qemu {
         }
         elsif ($vars->{BIOS}) {
             push(@params, "-bios", $vars->{BIOS});
+        }
+        foreach my $attribute (qw/KERNEL INITRD APPEND/) {
+            if ($vars->{$attribute}) {
+                push(@params, "-" . lc($attribute), $vars->{$attribute});
+            }
         }
         if ($vars->{MULTINET}) {
             if ($vars->{NICTYPE} eq "tap") {


### PR DESCRIPTION
This contains two commits - first adds possibility to use direct kernel boot with `-kernel`, `-initrd` and `-append` QEMU arguments (I tried to merge this with code for specifying BIOS variable to avoid code duplication). Second uses AArch64 (ARM64) options (`-device VGA` and not supporting boot order and also connecting kbd keyboard) for 32bit ARM also.