### PR TITLE
testapi: Delete unused clear_console

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -508,16 +508,6 @@ sub wait_still_screen {
     return 0;
 }
 
-sub clear_console {
-    bmwqemu::log_call('clear_console');
-    send_key "ctrl-c";
-    sleep 1;
-    send_key "ctrl-c";
-    type_string "reset\n";
-    sleep 2;
-    return;
-}
-
 =head2 get_var
 
   get_var($variable [, $default ])


### PR DESCRIPTION
clear_console is not exported by the testapi and is unused since it was
introduced with
b048feb5457fbec6e20dc079abb2ce7bd6676717.