### PR TITLE
Easier detectable errors for non-needle failures

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -144,7 +144,11 @@ sub runalltests {
             $t->save_test_result();
 
             if ($@) {
-                bmwqemu::diag $@;
+                my $msg = $@;
+                if ($msg !~ /^test.*died/) {
+                    # avoid duplicating the message
+                    bmwqemu::diag $msg;
+                }
                 if ($flags->{fatal} || !$snapshots_supported || $bmwqemu::vars{TESTDEBUG}) {
                     bmwqemu::stop_vm();
                     return 0;

--- a/basetest.pm
+++ b/basetest.pm
@@ -296,7 +296,7 @@ sub runtest {
             print $fd "# Test died:\n$@\n";
             close $fd;
             $details->{text}  = $text_fn;
-            $details->{title} = 'DIE';
+            $details->{title} = 'Failed';
             push @{$self->{details}}, $details;
         }
         else {

--- a/testapi.pm
+++ b/testapi.pm
@@ -350,7 +350,7 @@ sub wait_serial {
     else {
         $matched = 'fail';
     }
-    $autotest::current_test->record_serialresult(bmwqemu::pp($regexp), $matched);
+    $autotest::current_test->record_serialresult(bmwqemu::pp($regexp), $matched, $ret->{string});
     bmwqemu::fctres('wait_serial', "$regexp: $matched");
     return $ret->{string} if ($matched eq "ok");
     return;    # false
@@ -959,7 +959,7 @@ sub validate_script_output($&;$) {
         bmwqemu::diag("output does not pass the code block:\n$output");
     }
     # abusing the function
-    $autotest::current_test->record_serialresult($output, $res);
+    $autotest::current_test->record_serialresult($output, $res, $output);
     if ($res eq 'fail') {
         die "output not validating";
     }


### PR DESCRIPTION
Both wait_serial and die '' were pretty hard to detect on the webui
as they only reveal themselves to the knowing as red screens with a
hint in the log file. That's very hard for beginners to grasp

So change that: In case of wait_serial and die we record a 'fail' text result
together with a screenshot.

See https://progress.opensuse.org/issues/6526

taking this test

```
sub run {
   wait_serial 'hallo', 3;
   die "No Hallo";
}

```

openQA result in master:
![before](https://cloud.githubusercontent.com/assets/1067203/12324481/13cfe4c8-bac3-11e5-82eb-0ed60ceea09e.png)

openQA result after my PR:
![before1](https://cloud.githubusercontent.com/assets/1067203/12324492/1d16a54e-bac3-11e5-9b69-e201195098e5.png)