### PR TITLE
use fputs rather than fprintf to avoid 'format not a literal'

### DIFF
--- a/snd2png/snd2png.cpp
+++ b/snd2png/snd2png.cpp
@@ -89,7 +89,7 @@ main (int argc, char *argv[])
 			   info_in.channels);
   if (!infile_data)
     {
-      fprintf (stderr, ERR_NOT_ENOUGH_MEMORY);
+      fputs (ERR_NOT_ENOUGH_MEMORY, stderr);
       sf_close (fIn);
       return 2;
     }
@@ -118,7 +118,7 @@ main (int argc, char *argv[])
   double *fftw_in = (double *) fftw_malloc (sizeof (double) * nDftSamples);
   if (!fftw_in)
     {
-      fprintf (stderr, ERR_NOT_ENOUGH_MEMORY);
+      fputs (ERR_NOT_ENOUGH_MEMORY, stderr);
       return 2;
     }
 
@@ -127,7 +127,7 @@ main (int argc, char *argv[])
     (fftw_complex *) fftw_malloc (sizeof (fftw_complex) * nDftSamples);
   if (!fftw_out)
     {
-      fprintf (stderr, ERR_NOT_ENOUGH_MEMORY);
+      fputs (ERR_NOT_ENOUGH_MEMORY, stderr);
       sf_close (fIn);
       return 2;
     }


### PR DESCRIPTION
These three identical lines cause the infamous 'format not a
string literal and no format arguments' warning in GCC. On
many distros (including Fedora) the default compile flags for
packages turn this warning into an error.

I don't think there's a real problem here, because ERR_NOT_
ENOUGH_MEMORY is a constant defined in the code. But we should
avoid triggering the warning/error in any case.

https://fedoraproject.org/wiki/Format-Security-FAQ