### PR TITLE
Support 8 bit VNC

### DIFF
--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -21,6 +21,7 @@ __PACKAGE__->mk_accessors(
     qw(hostname port username password socket name width height depth save_bandwidth
       no_endian_conversion  _pixinfo _colourmap _framebuffer _rfb_version screen_on
       _bpp _true_colour _do_endian_conversion absolute ikvm keymap _last_update_request
+      vncinfo
       ));
 our $VERSION = '0.40';
 
@@ -61,6 +62,16 @@ my %supported_depths = (
         green_shift => 5,
         blue_shift  => 0,
     },
+    8 => {
+        bpp         => 8,
+        true_colour => 0,
+        red_max     => 8,
+        green_max   => 8,
+        blue_max    => 4,
+        red_shift   => 5,
+        green_shift => 2,
+        blue_shift  => 0,
+    },
 );
 
 my @encodings = (
@@ -72,22 +83,10 @@ my @encodings = (
         supported => 1,
     },
     {
-        num       => 2,
-        name      => 'RRE',
-        supported => 1,
-    },
-    {
-        num       => 6,
-        name      => 'Zlib',
-        supported => 0,        # would be easy though
-    },
-
-    {
         num       => 16,
         name      => 'ZRLE',
         supported => 1,
     },
-
     {
         num       => -223,
         name      => 'DesktopSize',
@@ -151,7 +150,7 @@ sub _handshake_protocol_version {
     my $socket = $self->socket;
     $socket->read(my $protocol_version, 12) || die 'unexpected end of data';
 
-    bmwqemu::diag "prot: $protocol_version";
+    #bmwqemu::diag "prot: $protocol_version";
 
     my $protocol_pattern = qr/\A RFB [ ] (\d{3}\.\d{3}) \s* \z/xms;
     if ($protocol_version !~ m/$protocol_pattern/xms) {
@@ -362,7 +361,7 @@ sub _server_initialization {
 
     #bmwqemu::diag "FW $framebuffer_width x $framebuffer_height";
 
-    #bmwqemu::diag "$bits_per_pixel bpp / depth $depth / $big_endian_flag be / $true_colour_flag tc / $pixinfo{red_max},$pixinfo{green_max},$pixinfo{blue_max} / $pixinfo{red_shift},$pixinfo{green_shift},$pixinfo{blue_shift}";
+    #bmwqemu::diag "$bits_per_pixel bpp / depth $depth / $server_is_big_endian be / $true_colour_flag tc / $pixinfo{red_max},$pixinfo{green_max},$pixinfo{blue_max} / $pixinfo{red_shift},$pixinfo{green_shift},$pixinfo{blue_shift}";
 
     #bmwqemu::diag $name_length;
 
@@ -417,6 +416,9 @@ sub _server_initialization {
         die "Can't use keyboard and mouse.  Is another ipmi vnc viewer logged in?" unless $ikvm_km_enable;
         return;    # the rest is kindly ignored by ikvm anyway
     }
+
+    my $info = tinycv::new_vncinfo($self->_do_endian_conversion, $self->_true_colour, $self->_bpp / 8, $pixinfo{red_max}, $pixinfo{red_shift}, $pixinfo{green_max}, $pixinfo{green_shift}, $pixinfo{blue_max}, $pixinfo{blue_shift});
+    $self->vncinfo($info);
 
     # setpixelformat
     $socket->print(
@@ -841,25 +843,7 @@ sub _receive_update {
             # splat raw pixels into the image
             my $img = tinycv::new($w, $h);
 
-            if ($self->_bpp == 32 && !$do_endian_conversion) {
-                $img->map_raw_data($data);
-            }
-            elsif ($self->_bpp == 16 || ($self->_bpp == 32 && $do_endian_conversion)) {
-                my $pi = $self->_pixinfo;
-                $img->map_raw_data_full($data, $do_endian_conversion, $bytes_per_pixel, $pi->{red_max}, $pi->{red_shift}, $pi->{green_max}, $pi->{green_shift}, $pi->{blue_max}, $pi->{blue_shift});
-            }
-            else {
-                die "unknown bpp" . $self->_bpp;
-            }
-            $image->blend($img, $x, $y);
-        }
-        elsif ($encoding_type == 2) {
-            $socket->read(my $num_sub_rects, 4)
-              || die 'unexpected end of data';
-            $num_sub_rects = unpack 'N', $num_sub_rects;
-            $socket->read(my $data, $bytes_per_pixel + $num_sub_rects * ($bytes_per_pixel + 8));
-            my $pi = $self->_pixinfo;
-            $image->map_raw_data_rre($x, $y, $w, $h, $data, $num_sub_rects, $do_endian_conversion, $bytes_per_pixel, $pi->{red_max}, $pi->{red_shift}, $pi->{green_max}, $pi->{green_shift}, $pi->{blue_max}, $pi->{blue_shift});
+            $image->map_raw_data($data, $x, $y, $w, $h, $self->vncinfo);
         }
         elsif ($encoding_type == 16) {
             $self->_receive_zlre_encoding($x, $y, $w, $h);
@@ -916,7 +900,6 @@ sub _receive_zlre_encoding {
     my $image  = $self->_framebuffer;
 
     my $pi = $self->_pixinfo;
-    my $info = tinycv::new_vncinfo($self->_do_endian_conversion, $self->_bpp, $pi->{red_max}, $pi->{red_shift}, $pi->{green_max}, $pi->{green_shift}, $pi->{blue_max}, $pi->{blue_shift});
 
     my $stime = time;
     $socket->read(my $data, 4)
@@ -939,7 +922,7 @@ sub _receive_zlre_encoding {
     if ($status != Z_OK) {
         die "inflation failed $status";
     }
-    my $res = $image->map_raw_data_zrle($x, $y, $w, $h, $info, $out, $self->{_inflater}->total_out - $old_total_out);
+    my $res = $image->map_raw_data_zrle($x, $y, $w, $h, $self->vncinfo, $out, $self->{_inflater}->total_out - $old_total_out);
     die "not read enough data" unless $old_total_out + $res == $self->{_inflater}->total_out;
     return $res;
 }
@@ -1025,7 +1008,15 @@ sub _receive_ikvm_encoding {
 sub _receive_colour_map {
     my $self = shift;
 
-    die 'we do not support color maps';
+    $self->socket->read(my $map_infos, 5);
+    my ($padding, $first_colour, $number_of_colours) = unpack('Cnn', $map_infos);
+
+    for (my $i = 0; $i < $number_of_colours; $i++) {
+        $self->socket->read(my $colour, 6);
+        my ($red, $green, $blue) = unpack('nnn', $colour);
+        tinycv::set_colour($self->vncinfo, $first_colour + $i, $red / 256, $green / 256, $blue / 256);
+    }
+    #die "we do not support color maps $first_colour $number_of_colours";
 
     return 1;
 }

--- a/ppmclibs/tinycv.h
+++ b/ppmclibs/tinycv.h
@@ -31,35 +31,18 @@ Image *image_absdiff(Image *a, Image*b);
 class VNCInfo;
 
 VNCInfo *image_vncinfo(bool do_endian_conversion,
+		       bool true_color,
 		       unsigned int bytes_per_pixel,
 		       unsigned int red_mask,   unsigned int red_shift,
 		       unsigned int green_mask, unsigned int green_shift,
 		       unsigned int blue_mask,  unsigned int blue_shift);
+void image_set_vnc_color(VNCInfo *info, unsigned int index, unsigned int red, unsigned int green, unsigned int blue);
 
-// this is for VNC support - get RGB tripels out of 32bit data for already set
-// width and height
-void image_map_raw_data(Image *a, const unsigned char *data);
+// this is for VNC support - RAW encoding
+void image_map_raw_data(Image *a, const unsigned char *data, unsigned int x, unsigned int y, unsigned int width, unsigned int height, VNCInfo *info);
 
 // this is for IPMI support - RGB555 is 16bits, the rest is like above
 void image_map_raw_data_rgb555(Image *a, const unsigned char *data);
-
-// this is for stupidly listening to what the VNC server says support
-void image_map_raw_data_full(Image* a, unsigned char *data,
-			     bool do_endian_conversion,
-			     unsigned int bytes_per_pixel,
-			     unsigned int red_mask,   unsigned int red_shift,
-			     unsigned int green_mask, unsigned int green_shift,
-			     unsigned int blue_mask,  unsigned int blue_shift);
-
-// RRE encoding for VNC
-void image_map_raw_data_rre(Image* a, long x, long y, long w, long h,
-			    unsigned char *data,
-			    unsigned int num_of_rects,
-			    bool do_endian_conversion,
-			    unsigned int bytes_per_pixel,
-			    unsigned int red_mask,   unsigned int red_shift,
-			    unsigned int green_mask, unsigned int green_shift,
-			    unsigned int blue_mask,  unsigned int blue_shift);
 
 // ZLRE encoding for VNC
 long image_map_raw_data_zlre(Image* a, long x, long y, long w, long h,

--- a/ppmclibs/tinycv.xs
+++ b/ppmclibs/tinycv.xs
@@ -28,17 +28,22 @@ tinycv::Image read(const char *file)
   OUTPUT:
     RETVAL
 
-tinycv::VNCInfo new_vncinfo(bool do_endian_conversion, unsigned int bytes_per_pixel, unsigned int red_mask, unsigned int red_shift, unsigned int green_mask, unsigned int green_shift, unsigned int blue_mask, unsigned int blue_shift)
+tinycv::VNCInfo new_vncinfo(bool do_endian_conversion, bool true_color, unsigned int bytes_per_pixel, unsigned int red_mask, unsigned int red_shift, unsigned int green_mask, unsigned int green_shift, unsigned int blue_mask, unsigned int blue_shift)
    CODE:
      RETVAL = image_vncinfo(do_endian_conversion,
-                      bytes_per_pixel,
-                      red_mask, red_shift,
-                      green_mask, green_shift,
-                      blue_mask, blue_shift);
+			    true_color,
+			    bytes_per_pixel,
+			    red_mask, red_shift,
+			    green_mask, green_shift,
+			    blue_mask, blue_shift);
 
    OUTPUT:
      RETVAL
 
+void set_colour(tinycv::VNCInfo info, unsigned int index, unsigned red, unsigned green, unsigned blue)
+   CODE:
+     image_set_vnc_color(info, index, red, green, blue);
+     
 MODULE = tinycv     PACKAGE = tinycv::Image  PREFIX = Image
 
 bool write(tinycv::Image self, const char *file)
@@ -80,31 +85,13 @@ tinycv::Image copyrect(tinycv::Image self, long x, long y, long width, long heig
   OUTPUT:
     RETVAL
 
-void map_raw_data(tinycv::Image self, unsigned char *data)
+void map_raw_data(tinycv::Image self, unsigned char *data, unsigned int x, unsigned int y, unsigned int w, unsigned h, tinycv::VNCInfo info)
   CODE:
-    image_map_raw_data(self, data);
+    image_map_raw_data(self, data, x, y, w, h, info);
 
 void map_raw_data_rgb555(tinycv::Image self, unsigned char *data)
   CODE:
     image_map_raw_data_rgb555(self, data);
-
-void map_raw_data_rre(tinycv::Image self, long x, long y, long w, long h, unsigned char *data, unsigned int num_of_rects,  bool do_endian_conversion, unsigned int bytes_per_pixel, unsigned int red_mask,   unsigned int red_shift, unsigned int green_mask, unsigned int green_shift, unsigned int blue_mask,  unsigned int blue_shift)
-  CODE:
-   image_map_raw_data_rre(self, x, y, w, h, data, num_of_rects,
-			  do_endian_conversion,
-			  bytes_per_pixel,
-			  red_mask, red_shift,
-			  green_mask, green_shift,
-			  blue_mask, blue_shift);
-
-void map_raw_data_full(tinycv::Image self, unsigned char *data, bool do_endian_conversion, unsigned int bytes_per_pixel, unsigned int red_mask, unsigned int red_shift, unsigned int green_mask, unsigned int green_shift, unsigned int blue_mask, unsigned int blue_shift)
-  CODE:
-    image_map_raw_data_full(self, data,
-			    do_endian_conversion,
-			    bytes_per_pixel,
-			    red_mask, red_shift,
-			    green_mask, green_shift,
-			    blue_mask, blue_shift);
 
 long map_raw_data_zrle(tinycv::Image self, long x, long y, long w, long h, tinycv::VNCInfo info, unsigned char *data, size_t len)
   CODE:


### PR DESCRIPTION
Some (otherwise headless) Power blades can show their serial console through
VNC, but it's 256 colours in a colour map only. So far we only supported true
colour (e.g. rgb555 in 16 bits or rgb888 in 32 bits). To support indexed colours
I had to rework the VNC logic quite a bit, but I had it already prepared

I removed RRE support because it's basically unused now that we have ZLRE (which
has RRE as subtype, but adds zlib compression on top)