### PR TITLE
Save git hash of executed tests

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -62,6 +62,7 @@ share(@ocrrect);
 our $interactive_mode;
 our $waiting_for_new_needle;
 our $screenshotpath = "qemuscreenshot";
+our $test_git_hash;
 
 # shared vars end
 
@@ -371,6 +372,7 @@ sub save_status {
     $result->{needinput}   = $waiting_for_new_needle ? 1                 : 0;
     $result->{running}     = current_test            ? ref(current_test) : '';
     $result->{backend} = $backend->get_info() if $backend;
+    $result->{test_git_hash} = $test_git_hash ? $test_git_hash : 'UNKNOWN';
 
     return save_json_file($result, result_dir . "/status.json");
 }

--- a/isotovideo
+++ b/isotovideo
@@ -120,6 +120,11 @@ $bmwqemu::vars{BACKEND} ||= "qemu";
 # This allows further structuring the test distribution collections with
 # multiple distributions or flavors in one repository.
 $bmwqemu::vars{PRODUCTDIR} ||= $bmwqemu::vars{CASEDIR};
+
+# as we are about to load the test modules store the git hash that has been
+# used. If it is not a git repo fail silently, i.e. store an empty variable
+chomp($bmwqemu::test_git_hash = qx{git rev-parse HEAD});
+
 require $bmwqemu::vars{PRODUCTDIR} . "/main.pm";
 
 # set a default distribution if the tests don't have one


### PR DESCRIPTION
If the test directory (CASEDIR) is a git repository the current commit hash is
saved just before the tests are loaded and stored inside "status.json" at the
end of execution. The git commit hash can be used for reference in later
analysis, e.g. in openQA to display the file not in the "most recent" state
but the actual state the test source was in at the time of execution.

If CASEDIR is not a git repo "UNKNOWN" is stored instead. A "dirty" state of
the repository is *not* detected.