### PR TITLE
Remember activated consoles and rollback too

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -71,13 +71,14 @@ sub loadtest {
 }
 
 our $current_test;
+our $last_milestone;
 
 sub set_current_test {
     ($current_test) = @_;
     bmwqemu::save_status();
 }
 
-sub write_test_order() {
+sub write_test_order {
 
     my @result;
     for my $t (@testorder) {
@@ -154,18 +155,22 @@ sub runalltests {
                     return 0;
                 }
                 elsif (!$flags->{norollback}) {
-                    load_snapshot('lastgood');
+                    if ($last_milestone) {
+                        load_snapshot('lastgood');
+                        $last_milestone->rollback_activated_consoles();
+                    }
                 }
             }
             else {
                 if ($snapshots_supported && ($flags->{milestone} || $bmwqemu::vars{TESTDEBUG})) {
                     make_snapshot('lastgood');
+                    $last_milestone = $t;
                 }
             }
         }
         else {
             bmwqemu::diag "skiping $fullname";
-            $t->skip_if_not_running;
+            $t->skip_if_not_running();
             $t->save_test_result();
         }
     }

--- a/basetest.pm
+++ b/basetest.pm
@@ -39,6 +39,7 @@ sub new {
     $self->{dents}                  = 0;
     $self->{post_fail_hook_running} = 0;
     $self->{timeoutcounter}         = 0;
+    $self->{activated_consoles}     = [];
 
     return bless $self, $class;
 }
@@ -527,6 +528,20 @@ sub standstill_detected {
     testapi::send_key('alt-sysrq-w');
     testapi::send_key('alt-sysrq-l');
     testapi::send_key('alt-sysrq-d');    # only available with CONFIG_LOCKDEP
+    return;
+}
+
+# this is called if the test failed and the framework loaded a VM
+# snapshot - all consoles activated in the test's run function loose their
+# state
+sub rollback_activated_consoles {
+    my ($self) = @_;
+    for my $console (@{$self->{activated_consoles}}) {
+        # the backend will only reset its state, and call activate
+        # the next time - the console itself might actually not be
+        # able to activate a 2nd time, but that's up to the console class
+        $bmwqemu::backend->reset_console({testapi_console => $console});
+    }
     return;
 }
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -1045,6 +1045,10 @@ sub select_console {
     my $ret = $bmwqemu::backend->select_console({testapi_console => $testapi_console});
 
     if ($ret->{activated}) {
+        # we need to store the activated consoles for rollback
+        if ($autotest::last_milestone) {
+            push(@{$autotest::last_milestone->{activated_consoles}}, $testapi_console);
+        }
         $testapi::distri->activate_console($testapi_console);
     }
     return $testapi_console_proxies{$testapi_console};


### PR DESCRIPTION
In case of tty consoles requiring console, we loose the login and need
to relogin. In case of local xterms, this is a bit more tricky - but
we cross that bridge when we come there (as local xterms aren't used
on platforms supporting rollback, that's a bit in the future)