### PR TITLE
Improve error message on needle reading problems

### DIFF
--- a/needle.pm
+++ b/needle.pm
@@ -41,10 +41,8 @@ sub new {
     }
     else {
         local $/;
-        # TODO preserving old behaviour, why should failing read be allowed?
-        no autodie qw(open);
         open(my $fh, '<', $jsonfile);
-        eval { $json = decode_json(<$fh>) };
+        $json = decode_json(<$fh>);
         close($fh);
         if (!$json || $@) {
             warn "broken json $jsonfile: $@";


### PR DESCRIPTION
There is no use in trying to handle problems reading needle data in a custom
way. autodie provides much better details in this case.

Verified locally with a needle with wrong permissions. In before it would just
state that the needle is broken without a reason.