### PR TITLE
Add module name to uploaded files

### DIFF
--- a/commands.pm
+++ b/commands.pm
@@ -170,11 +170,18 @@ sub upload_file {
         mkdir($target) or die "$!";
     }
 
-    my $upname = basename($self->param('filename'));
+    my $upname   = $self->param('upname');
+    my $filename = basename($self->param('filename'));
+    # Only renaming the file if upname parameter has posted ie. from upload_logs()
+    # With this it won't renamed the file in case upload_assert and autoyast profile
+    # as those are not called from upload_logs.
+    if ($upname) {
+        $filename = basename($upname);
+    }
 
-    $upload->move_to("$target/$upname");
+    $upload->move_to("$target/$filename");
 
-    return $self->render(text => "OK: $upname\n");
+    return $self->render(text => "OK: $filename\n");
 }
 
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -390,8 +390,9 @@ sub upload_logs {
     my ($file) = @_;
 
     bmwqemu::log_call('upload_logs', file => $file);
-    my $cmd      = "curl --form upload=\@$file ";
     my $basename = basename($file);
+    my $upname   = ref($autotest::current_test) . '-' . $basename;
+    my $cmd      = "curl --form upload=\@$file --form upname=$upname ";
     $cmd .= autoinst_url("/uploadlog/$basename");
     return assert_script_run($cmd);
 }


### PR DESCRIPTION
Main goal is avoding the uploaded files be overwritten. Now the uploaded files are named $modulename-$filename