### PR TITLE
Write crash file in case of watchdog hit

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -183,7 +183,8 @@ sub run_capture_loop {
             }
 
             # if we got stalled for a long time, we assume bad hardware and report it
-            if ($self->assert_screen_last_check && $now - $self->last_screenshot > $self->screenshot_interval * 10) {
+            if ($self->assert_screen_last_check && $now - $self->last_screenshot > $self->screenshot_interval * 20) {
+                backend::baseclass::write_crash_file();
                 bmwqemu::mydie sprintf("There is some problem with your environment, we detected a stall for %d seconds", $now - $self->last_screenshot);
             }
 


### PR DESCRIPTION
And increase the timeout to 10 seconds to be bit more graceful. But the
crash file will make the worker reschedule the job, so we're more likely
to continue in the situation