### PR TITLE
Make the string used in script_* predictable

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -421,7 +421,10 @@ sub _result_add_screenshot {
     my ($self, $result) = @_;
 
     my $img = $bmwqemu::backend->last_screenshot_name->{filename};
+    return $result unless $img;
+
     $img = tinycv::read($img);
+    return $result unless $img;
 
     $result->{screenshot} = $self->next_resultname('png');
 

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -45,6 +45,7 @@ require IPC::System::Simple;
 use autodie qw(:all);
 
 use distribution;
+use Digest::MD5 qw(md5_base64);
 
 sub mydie;
 
@@ -397,6 +398,18 @@ sub random_string {
     my @chars = ('a' .. 'z', 'A' .. 'Z');
     $string .= $chars[rand @chars] for 1 .. $count;
     return $string;
+}
+
+# return a short string representing the given string by passing it through
+# the MD5 algorithm and taking the first characters
+sub hashed_string {
+    my ($string, $count) = @_;
+    $count //= 5;
+
+    my $hash = md5_base64($string);
+    # plus sign is problematic in regexps
+    $hash =~ s,\+,_,g;
+    return substr($hash, 0, $count);
 }
 
 1;

--- a/distribution.pm
+++ b/distribution.pm
@@ -104,7 +104,7 @@ sub script_run {
 
     testapi::type_string "$name";
     if ($wait > 0) {
-        my $str = bmwqemu::random_string(5);
+        my $str = bmwqemu::hashed_string("SR$name$wait");
         testapi::type_string " ; echo $str > /dev/$testapi::serialdev\n";
         testapi::wait_serial($str);
     }
@@ -128,8 +128,9 @@ sub script_sudo {
 
     $wait //= 10;
 
-    my $str = bmwqemu::random_string(5);
+    my $str;
     if ($wait > 0) {
+        $str  = bmwqemu::hashed_string("SS$prog$wait");
         $prog = "$prog; echo $str > /dev/$testapi::serialdev";
     }
     testapi::type_string "sudo $prog\n";
@@ -137,7 +138,7 @@ sub script_sudo {
         testapi::type_password;
         testapi::send_key "ret";
     }
-    if ($wait > 0) {
+    if ($str) {
         return testapi::wait_serial($str, $wait);
     }
     return;

--- a/testapi.pm
+++ b/testapi.pm
@@ -608,7 +608,7 @@ I<Make sure the command does not write to the serial output.>
 =cut
 sub assert_script_run {
     my ($cmd, $timeout) = @_;
-    my $str = bmwqemu::random_string(5);
+    my $str = bmwqemu::hashed_string("ASR$cmd");
     # call script_run with idle_timeout 0 so we don't wait twice
     script_run("$cmd; echo $str-\$?- > /dev/$serialdev", 0);
     my $ret = wait_serial("$str-\\d+-", $timeout);
@@ -649,7 +649,7 @@ I<The implementation is distribution specific and not always available.>
 =cut
 sub assert_script_sudo {
     my ($cmd, $wait) = @_;
-    my $str = bmwqemu::random_string(5);
+    my $str = bmwqemu::hashed_string("ASS$cmd");
     script_sudo("$cmd; echo $str-\$?- > /dev/$serialdev", 0);
     my $ret = wait_serial("$str-\\d+-", $wait);
     die "command '$cmd' failed" unless (defined $ret && $ret =~ /$str-0-/);
@@ -672,7 +672,7 @@ sub script_output($;$) {
     $commands::current_test_script .= "\necho SCRIPT_FINISHED\n";
     $wait ||= 10;
 
-    my $suffix = bmwqemu::random_string();
+    my $suffix = bmwqemu::hashed_string("SO$commands::current_test_script");
     type_string "curl -f -v " . autoinst_url("/current_script") . " > /tmp/script$suffix.sh && echo \"curl-\$?\" > /dev/$serialdev\n";
     wait_serial('curl-0') || die "script couldn't be downloaded";
     send_key "ctrl-l";

--- a/testapi.pm
+++ b/testapi.pm
@@ -669,19 +669,18 @@ The default timeout for the script is 10 seconds. If you need more, pass a 2nd p
 sub script_output($;$) {
     my $wait;
     ($commands::current_test_script, $wait) = @_;
-    $commands::current_test_script .= "\necho SCRIPT_FINISHED\n";
+    my $suffix = bmwqemu::hashed_string("SO$commands::current_test_script");
+    $commands::current_test_script .= "\necho SCRIPT_FINISHED$suffix\n";
     $wait ||= 10;
 
-    my $suffix = bmwqemu::hashed_string("SO$commands::current_test_script");
-    type_string "curl -f -v " . autoinst_url("/current_script") . " > /tmp/script$suffix.sh && echo \"curl-\$?\" > /dev/$serialdev\n";
-    wait_serial('curl-0') || die "script couldn't be downloaded";
-    send_key "ctrl-l";
+    assert_script_run "curl -f -v " . autoinst_url("/current_script") . " > /tmp/script$suffix.sh";
+    script_run "clear";
 
     type_string "/bin/bash -ex /tmp/script$suffix.sh | tee /dev/$serialdev\n";
-    my $output = wait_serial('SCRIPT_FINISHED', $wait) or die "script failed";
+    my $output = wait_serial("SCRIPT_FINISHED$suffix", $wait) or die "script failed";
 
     # strip the internal exit catcher
-    $output =~ s,SCRIPT_FINISHED,,;
+    $output =~ s,SCRIPT_FINISHED$suffix,,;
 
     # trim whitespaces
     $output =~ s/^\s+|\s+$//g;


### PR DESCRIPTION
Random strings are cool, but they make needling the screen content
more dangerous. So use the first bits of md5 as base64 instead