### PR TITLE
Enable strictures and warnings for all tests

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -24,6 +24,12 @@ use JSON;
 use POSIX;
 use testapi ();
 
+# enable strictures and warnings in all tests globaly
+sub import {
+    strict->import;
+    warnings->import;
+}
+
 sub new {
     my ($class, $category) = @_;
     $category ||= 'unknown';


### PR DESCRIPTION
Few times I noticed people doesn't import strict and warnings modules.
Especialy strictures are important for safe development so import them in
our basetest class.