### PR TITLE
Set iso read-only

### DIFF
--- a/backend/pvm.pm
+++ b/backend/pvm.pm
@@ -112,10 +112,12 @@ sub start_lpar {
     my $iso_present = qx/pvmctl media list -d VirtualOpticalMedia.media_name --where VirtualOpticalMedia.name=$iso/;
     if ($iso_present !~ /$iso/) {
         #copy over from nfs to VMLibrary
-        my $cmd = "sudo viosvrcmd --id 1 -r -c\" cp $source_iso /var/vio/VMLibrary/$iso\"";
-        runcmd($cmd);
-        $cmd = "sudo viosvrcmd --id 1 -r -c\" chown padmin:staff /var/vio/VMLibrary/$iso\"";
-        runcmd($cmd);
+        my @viocmd = ("sudo viosvrcmd --id 1 -r -c\"cp $source_iso /var/vio/VMLibrary/$iso\"");
+        push(@viocmd, "sudo viosvrcmd --id 1 -r -c\"chown padmin:staff /var/vio/VMLibrary/$iso\"");
+        push(@viocmd, "sudo viosvrcmd --id 1 -c\"chvopt -name $iso -access ro\"");
+        foreach my $viocmd (@viocmd) {
+            runcmd($viocmd);
+        }
     }
     $self->pvmctl('scsi', 'create', 'vopt', $iso);
 


### PR DESCRIPTION
We need to change access mode for ISO, in order to be able to
mount it multiple times.

Signed-off-by: Dinar Valeev <dvaleev@suse.com>