### PR TITLE
Fix testapi parse_junit_log

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -814,7 +814,7 @@ sub parse_junit_log {
 
     upload_logs($file);
 
-    $file = basename($file);
+    $file = ref($autotest::current_test) . '-' . basename($file);
 
     open my $fd, "<", "ulogs/$file";
     my $xml = join("", <$fd>);


### PR DESCRIPTION
parse_junit_log uses upload_logs to upload junit files, but forgets to add current test name as a prefix to the file name, causing it fails to open the junit file.
issue: https://progress.opensuse.org/issues/10552