### PR TITLE
Fail early on empty script_run

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -102,6 +102,7 @@ sub script_run {
     # start console application
     my ($self, $name, $wait) = @_;
 
+    die "script must be non-zero" unless $name;
     testapi::type_string "$name";
     if ($wait > 0) {
         my $str = bmwqemu::hashed_string("SR$name$wait");


### PR DESCRIPTION
If "script_run" is executed without content bash will fail on an invalid
command starting with "; ...". Better die early with explicit error message
about the test being written in a wrong way.

![openqa_empty_script_run_fails](https://cloud.githubusercontent.com/assets/1693432/12783372/700f95e4-ca81-11e5-9e40-1bc103a08fea.png)