### PR TITLE
enable virtio rng by default

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -461,6 +461,10 @@ sub start_qemu {
             push(@params, "-cpu", $vars->{QEMUCPU});
         }
 
+        if ($vars->{QEMU_VIRTIO_RNG}) {
+            push(@params, '-device', 'virtio-rng-pci');
+        }
+
         for (my $i = 0; $i < $num_networks; $i++) {
             if ($vars->{NICTYPE} eq "user") {
                 push(@params, '-netdev', "user,id=qanet$i");

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -59,6 +59,7 @@ QEMUTHREADS;integer;0;Number of cpu threads used by VM
 QEMUVGA;see qemu -device ?;cirrus;VGA device to use with VM
 QEMU_COMPRESS_QCOW2;boolean;0;compress qcow2 images intended for upload
 QEMU_NO_KVM;boolean;0;Don't use KVM acceleration.
+QEMU_VIRTIO_RNG;boolean;0;Enable virtio random number generator
 RAIDLEVEL;;;
 SKIPTO;full name of test module;;Restore VM from snapshot and continue by running specified test module. Needs HDD image with snapshots present
 TAPDEV;device name;undef;TAP device name to which virtual NIC should be connected. Usually undef so automatic matching is used


### PR DESCRIPTION
virtio rng is a feature introduced in qemu 1.3 resp kernel 2.6.26
already. Let's use it to avoid entropy starvation.

https://progress.opensuse.org/issues/9584