### PR TITLE
Fix hashed_string not to return /

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -407,8 +407,9 @@ sub hashed_string {
     $count //= 5;
 
     my $hash = md5_base64($string);
-    # plus sign is problematic in regexps
+    # + and / are problematic in regexps and shell commands
     $hash =~ s,\+,_,g;
+    $hash =~ s,/,~,g;
     return substr($hash, 0, $count);
 }
 


### PR DESCRIPTION
I didn't expect / to create a problem, but that was short sightened. As we
the return value for script names, it requires subdirs - which we don't want

Referene: https://openqa.suse.de/tests/197862/modules/autoyast_verify/steps/3