### PR TITLE
support  for slepos images

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -423,11 +423,19 @@ sub start_qemu {
             runcmd("/bin/dd", "if=/dev/zero", "count=1", "of=$basedir/l1");    # for LVM
         }
         elsif ($vars->{"HDD_$i"}) {
-            runcmd($qemuimg, "create", "$basedir/$i", "-f", "qcow2", "-b", $vars->{"HDD_$i"});
+            # default: same size as the original image
+            my @sizeopt = ();
+            # HDD_$i specific size
+            @sizeopt = ($vars->{"HDDSIZEGB_$i"} . "G") if $vars->{"HDDSIZEGB_$i"};
+            runcmd($qemuimg, "create", "$basedir/$i", "-f", "qcow2", "-b", $vars->{"HDD_$i"}, @sizeopt);
             symlink($i, "$basedir/l$i") or die "$!\n";
         }
         else {
-            runcmd($qemuimg, "create", "$basedir/$i", "-f", $vars->{HDDFORMAT}, $vars->{HDDSIZEGB} . "G");
+            # default: generic hdd size
+            my @sizeopt = ($vars->{HDDSIZEGB} . "G");
+            # HDD_$i specific size
+            @sizeopt = ($vars->{"HDDSIZEGB_$i"} . "G") if $vars->{"HDDSIZEGB_$i"};
+            runcmd($qemuimg, "create", "$basedir/$i", "-f", $vars->{HDDFORMAT}, @sizeopt);
             symlink($i, "$basedir/l$i") or die "$!\n";
         }
     }

--- a/commands.pm
+++ b/commands.pm
@@ -195,6 +195,10 @@ sub current_script {
 sub run_daemon {
     my ($port) = @_;
 
+    # allow up to 20GB - hdd images
+    $ENV{MOJO_MAX_MESSAGE_SIZE}   = 1024 * 1024 * 1024 * 20;
+    $ENV{MOJO_INACTIVITY_TIMEOUT} = 300;
+
     # avoid leaking token
     app->mode('production');
 


### PR DESCRIPTION
These changes are needed for the following scenario:
- job 1 builds a hdd image with kiwi and uploads it with upload_asset
- job 2 boots with the image on HDD_1, the image is resized during boot to fit the hdd size.