### PR TITLE
Disable too strict stall detection again

### DIFF
--- a/INSTALL.asciidoc
+++ b/INSTALL.asciidoc
@@ -16,9 +16,6 @@ cd os-autoinst
 3.  install the BuildRequires, as per the http://build.opensuse.org[spec
 file]
 +
------------------------------------------------------------------------------------------------------
-sudo zypper in libtheora-devel opencv-devel pkg-config libtool autoconf automake gcc-c++
------------------------------------------------------------------------------------------------------
 4.  build the beastie locally
 +
 ----------------

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -154,7 +154,8 @@ running, e.g. to do some fast or slow motion.
 
 sub run_capture_loop {
     my ($self, $select, $timeout, $update_request_interval, $screenshot_interval) = @_;
-    my $starttime = gettimeofday;
+    my $stall_timeout = 20;             # empiric value
+    my $starttime     = gettimeofday;
 
     if (!$self->last_screenshot) {
         my $now = gettimeofday;
@@ -183,9 +184,8 @@ sub run_capture_loop {
             }
 
             # if we got stalled for a long time, we assume bad hardware and report it
-            if ($self->assert_screen_last_check && $now - $self->last_screenshot > $self->screenshot_interval * 20) {
-                backend::baseclass::write_crash_file();
-                bmwqemu::mydie sprintf("There is some problem with your environment, we detected a stall for %d seconds", $now - $self->last_screenshot);
+            if ($self->assert_screen_last_check && $now - $self->last_screenshot > $self->screenshot_interval * $stall_timeout) {
+                bmwqemu::diag sprintf("WARNING: There is some problem with your environment, we detected a stall for %d seconds", $now - $self->last_screenshot);
             }
 
             my $time_to_screenshot = ($screenshot_interval // $self->screenshot_interval) - ($now - $self->last_screenshot);


### PR DESCRIPTION
7653967c704b0812ee5f08103a06601405a9da05 introduced a timeout limit with
intentional crash on hit. As it looks like we are hitting this limit more
often than expected, still. Many tests would continue fine even though a stall
is detection somewhere in between.

If it is desired to put the intentional crash back on stall it should be made
optional so that we can enable it in "development" runs but just record and
continue in "productive" runs.