### PR TITLE
Pass optional argument to record_soft_failure for reason

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -51,5 +51,6 @@ requires 'warnings';
 
 on 'test' => sub {
   requires 'Perl::Critic';
+  requires 'Test::Output';
 }
 

--- a/t/03-testapi.pl
+++ b/t/03-testapi.pl
@@ -2,7 +2,8 @@
 
 use strict;
 use warnings;
-use Test::More tests => 9;
+use Test::More tests => 11;
+use Test::Output;
 
 BEGIN {
     unshift @INC, '..';
@@ -41,9 +42,9 @@ is_deeply($bmwqemu::backend->{cmds}, ['type_string', {max_interval => 100, text 
 $bmwqemu::backend->{cmds} = [];
 
 is($autotest::current_test->{dents}, undef, 'no soft failures so far');
-record_soft_failure;
+stderr_like(\&record_soft_failure, qr/record_soft_failure\(reason=undef\)/, 'soft failure recorded in log');
 is($autotest::current_test->{dents}, 1, 'soft failure recorded');
-record_soft_failure('workaround for bug#1234');
+stderr_like(sub { record_soft_failure('workaround for bug#1234') }, qr/record_soft_failure.*reason=.*workaround for bug#1234.*/, 'soft failure with reason');
 is($autotest::current_test->{dents}, 2, 'another');
 
 # vim: set sw=4 et:

--- a/t/03-testapi.pl
+++ b/t/03-testapi.pl
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 6;
+use Test::More tests => 9;
 
 BEGIN {
     unshift @INC, '..';
@@ -39,5 +39,11 @@ $bmwqemu::backend->{cmds} = [];
 type_password 'hallo';
 is_deeply($bmwqemu::backend->{cmds}, ['type_string', {max_interval => 100, text => 'hallo'}]);
 $bmwqemu::backend->{cmds} = [];
+
+is($autotest::current_test->{dents}, undef, 'no soft failures so far');
+record_soft_failure;
+is($autotest::current_test->{dents}, 1, 'soft failure recorded');
+record_soft_failure('workaround for bug#1234');
+is($autotest::current_test->{dents}, 2, 'another');
 
 # vim: set sw=4 et:

--- a/testapi.pm
+++ b/testapi.pm
@@ -111,13 +111,16 @@ sub save_screenshot {
 
 =head2 record_soft_failure
 
-  record_soft_failure
+  record_soft_failure([$reason]);
 
-Current test module result is success, but workarounds were used.
+Record a soft failure on the current test modules result. The result will
+still be counted as a success. Use this to mark where workarounds are applied.
+Takes an optional C<$reason> string which is recorded in the log file.
 
 =cut
 sub record_soft_failure {
-    bmwqemu::log_call('record_soft_failure');
+    my ($reason) = @_;
+    bmwqemu::log_call('record_soft_failure', reason => $reason);
     $autotest::current_test->{dents}++;
     return;
 }


### PR DESCRIPTION
If a reason is provided this is shown in the logfile and later on can also be
passed to basetest::record_serialresult.