### PR TITLE
Exclude particular tests by variable

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -66,6 +66,12 @@ Can eg. check vars{BIGTEST}, vars{LIVETEST}
 =cut
 
 sub is_applicable {
+    my ($self) = @_;
+    my %excluded = map { $_ => 1 } split(/\s*,\s*/, $bmwqemu::vars{EXCLUDE_MODULES});
+
+    return 0 if $excluded{$self->{class}};
+    return 0 if $excluded{$self->{fullname}};
+
     return 1;
 }
 

--- a/basetest.pm
+++ b/basetest.pm
@@ -61,6 +61,9 @@ This code is run during test.
 
 Return false if the test should be skipped.
 
+By default it check the test name and fullname against comma-separated
+blacklist in EXCLUDE_MODULES variable and returns false if it is found there.
+
 Can eg. check vars{BIGTEST}, vars{LIVETEST}
 
 =cut

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -6,6 +6,7 @@ Supported variables per backend
 [options="header",cols="^m,^m,^m,v",separator=";"]
 |====================
 Variable;Values allowed;Default value;Explanation
+EXCLUDE_MODULES;string;;comma separated names or fullnames of excluded test modules
 NOVIDEO;boolean;0;Do not encode video if set
 SCREENSHOTINTERVAL;;;
 |====================


### PR DESCRIPTION
This will be useful for example on this test:
http://openqa.suse.de/tests/203975/modules/grub_test/steps/3
This is a really minimal installation, so clone does not work because of missing packages and grub is text-only.
So I will set EXCLUDE_MODULES=clone,grub_test
