### PR TITLE
Modify the PR 415 back, since it create hdd as *.qcow2.qcow2 name

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -186,14 +186,15 @@ sub do_extract_assets {
     my $hdd_num = $args->{hdd_num};
     my $name    = $args->{name};
     my $img_dir = $args->{dir};
-    my $format  = $args->{format};
+    $name =~ /\.([[:alnum:]]+)$/;
+    my $format  = $1;
     if (!$format || $format !~ /^(raw|qcow2)$/) {
         bmwqemu::diag "do_extract_assets: only raw and qcow2 formats supported $name $format\n";
     }
     elsif (-f "raid/l$hdd_num") {
-        bmwqemu::diag "preparing hdd $hdd_num for upload as $name in $format\n";
+        bmwqemu::diag "preparing hdd $hdd_num for upload as $name\n";
         mkpath($img_dir);
-        my @cmd = ('nice', 'ionice', 'qemu-img', 'convert', '-O', $format, "raid/l$hdd_num", "$img_dir/$name.$format");
+        my @cmd = ('nice', 'ionice', 'qemu-img', 'convert', '-O', $format, "raid/l$hdd_num", "$img_dir/$name");
         if ($format eq 'raw') {
             runcmd(@cmd);
         }
@@ -204,7 +205,7 @@ sub do_extract_assets {
                 runcmd(@cmd);
             }
             else {
-                symlink("../raid/l$hdd_num", "$img_dir/$name.$format");
+                symlink("../raid/l$hdd_num", "$img_dir/$name");
             }
         }
     }

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -187,7 +187,7 @@ sub do_extract_assets {
     my $name    = $args->{name};
     my $img_dir = $args->{dir};
     $name =~ /\.([[:alnum:]]+)$/;
-    my $format  = $1;
+    my $format = $1;
     if (!$format || $format !~ /^(raw|qcow2)$/) {
         bmwqemu::diag "do_extract_assets: only raw and qcow2 formats supported $name $format\n";
     }

--- a/isotovideo
+++ b/isotovideo
@@ -204,7 +204,9 @@ if (!$r && (my $nd = $bmwqemu::vars{NUMDISKS})) {
             $dir = 'assets_public';
         }
         next unless $name;
-        push @toextract, { hdd_num => $i, name => $name, dir => $dir };
+        $name =~ /\.([[:alnum:]]+)$/;
+        my $format = $1;
+        push @toextract, { hdd_num => $i, name => $name, dir => $dir, format => $format };
     }
     if (@toextract && !$clean_shutdown) {
         diag "ERROR: Machine not shut down when uploading disks!\n";

--- a/isotovideo
+++ b/isotovideo
@@ -204,9 +204,7 @@ if (!$r && (my $nd = $bmwqemu::vars{NUMDISKS})) {
             $dir = 'assets_public';
         }
         next unless $name;
-        $name =~ /\.([[:alnum:]]+)$/;
-        my $format = $1;
-        push @toextract, { hdd_num => $i, name => $name, dir => $dir, format => $format };
+        push @toextract, { hdd_num => $i, name => $name, dir => $dir };
     }
     if (@toextract && !$clean_shutdown) {
         diag "ERROR: Machine not shut down when uploading disks!\n";


### PR DESCRIPTION
By modify from
https://github.com/os-autoinst/os-autoinst/pull/415/files
the new created hdd will named as *.qcow2.qcow2, it will make the testscript keep use the old hdd file as the new build's hdd named as *.qcow2.qcow2 which not configured in testcase. So I suggest to modify the code back.