### PR TITLE
Fix continue waitforneedle does not work

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -45,6 +45,7 @@ __PACKAGE__->mk_accessors(
       reference_screenshot interactive_mode
       assert_screen_tags assert_screen_needles assert_screen_deadline
       assert_screen_fails assert_screen_last_check stall_detected
+      reload_needles
       ));
 
 sub new {
@@ -677,8 +678,9 @@ sub wait_idle {
 
 sub set_tags_to_assert {
     my ($self, $args) = @_;
-    my $mustmatch = $args->{mustmatch};
-    my $timeout = $args->{timeout} // $bmwqemu::default_timeout;
+    my $mustmatch     = $args->{mustmatch};
+    my $timeout       = $args->{timeout} // $bmwqemu::default_timeout;
+    my $reloadneedles = $args->{reloadneedles} || 0;
 
     # get the array reference to all matching needles
     my $needles = [];
@@ -719,6 +721,7 @@ sub set_tags_to_assert {
     $self->assert_screen_needles($needles);
     $self->assert_screen_last_check(undef);
     $self->stall_detected(0);
+    $self->reload_needles($reloadneedles);
     # store them for needle reload event
     $self->assert_screen_tags(\@tags);
     return {tags => \@tags};
@@ -790,6 +793,13 @@ sub check_asserted_screen {
     my $starttime = gettimeofday;
 
     my ($foundneedle, $failed_candidates) = $img->search($self->assert_screen_needles, 0, $search_ratio);
+
+    # first time in reload_needles_and_retry, get into waiting for continuation directly and did not reload needles
+    if ($self->interactive_mode && -e $bmwqemu::control_files{stop_waitforneedle} && !$self->reload_needles) {
+        $self->freeze_vm();
+        return {waiting_for_needle => 1, filename => $self->write_img($img, $img_filename), candidates => $failed_candidates};
+    }
+
     if ($foundneedle) {
         $self->assert_screen_last_check(undef);
         return {filename => $self->write_img($img, $img_filename), found => $foundneedle, candidates => $failed_candidates};
@@ -803,7 +813,8 @@ sub check_asserted_screen {
     if ($n < 0) {
         # make sure we recheck later
         $self->assert_screen_last_check(undef);
-        if ($self->interactive_mode && -e $bmwqemu::control_files{stop_waitforneedle}) {
+        # in reload_needles_and_retry and reloaded candidate needles
+        if ($self->interactive_mode && -e $bmwqemu::control_files{stop_waitforneedle} && $self->reload_needles) {
             $self->freeze_vm();
             return {waiting_for_needle => 1, filename => $self->write_img($img, $img_filename), candidates => $failed_candidates};
         }
@@ -908,7 +919,8 @@ sub retry_assert_screen {
     # do not need to retry in 5 seconds but contining SUT if continue_waitforneedle
     if ($args->{reload_needles}) {
         # short timeout, we're already there
-        $self->set_tags_to_assert({mustmatch => $self->assert_screen_tags, timeout => 5});
+        $self->set_tags_to_assert({mustmatch => $self->assert_screen_tags, timeout => 5, reloadneedles => 1});
+
     }
     return;
 }

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -803,7 +803,7 @@ sub check_asserted_screen {
     if ($n < 0) {
         # make sure we recheck later
         $self->assert_screen_last_check(undef);
-        if ($self->interactive_mode) {
+        if ($self->interactive_mode && -e $bmwqemu::control_files{stop_waitforneedle}) {
             $self->freeze_vm();
             return {waiting_for_needle => 1, filename => $self->write_img($img, $img_filename), candidates => $failed_candidates};
         }
@@ -901,8 +901,11 @@ sub retry_assert_screen {
         needle::init();
     }
     $self->cont_vm;
-    # short timeout, we're already there
-    $self->set_tags_to_assert({mustmatch => $self->assert_screen_tags, timeout => 5});
+    # do not need to retry in 5 seconds but contining SUT if continue_waitforneedle
+    if ($args->{reload_needles}) {
+        # short timeout, we're already there
+        $self->set_tags_to_assert({mustmatch => $self->assert_screen_tags, timeout => 5});
+    }
     return;
 }
 

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -900,6 +900,10 @@ sub retry_assert_screen {
         }
         needle::init();
     }
+    # reset timeout otherwise continue wait_forneedle might just fail if stopped too long than timeout
+    if ($args->{timeout}) {
+        $self->assert_screen_deadline(time + $args->{timeout});
+    }
     $self->cont_vm;
     # do not need to retry in 5 seconds but contining SUT if continue_waitforneedle
     if ($args->{reload_needles}) {

--- a/testapi.pm
+++ b/testapi.pm
@@ -232,7 +232,7 @@ sub _check_or_assert {
             }
             $bmwqemu::waiting_for_new_needle = 0;
             bmwqemu::save_status();
-            $bmwqemu::backend->retry_assert_screen({reload_needles => $reload_needles});
+            $bmwqemu::backend->retry_assert_screen({reload_needles => $reload_needles, timeout => $timeout});
         }
         my $delta = tv_interval([$seconds, $microseconds], [gettimeofday]);
         # sleep the remains of one second

--- a/testapi.pm
+++ b/testapi.pm
@@ -144,7 +144,6 @@ sub _check_or_assert {
     while (1) {
         if (-e $bmwqemu::control_files{stop_waitforneedle}) {
             $bmwqemu::backend->stop_assert_screen;
-            unlink($bmwqemu::control_files{stop_waitforneedle});
         }
         if (-e $bmwqemu::control_files{interactive_mode}) {
             $bmwqemu::backend->interactive_assert_screen({interactive => 1});
@@ -210,11 +209,6 @@ sub _check_or_assert {
                 # do not set overall here as the result will be removed later
             );
 
-            if (!-e $bmwqemu::control_files{stop_waitforneedle}) {
-                open(my $fd, '>', $bmwqemu::control_files{stop_waitforneedle});
-                close $fd;
-            }
-
             $bmwqemu::waiting_for_new_needle = 1;
 
             bmwqemu::save_status();
@@ -223,7 +217,6 @@ sub _check_or_assert {
             bmwqemu::diag("interactive mode waiting for continuation");
             while (-e $bmwqemu::control_files{stop_waitforneedle}) {
                 if (-e $bmwqemu::control_files{reload_needles_and_retry}) {
-                    unlink($bmwqemu::control_files{stop_waitforneedle});
                     last;
                 }
                 sleep 1;


### PR DESCRIPTION
It's a regression causes worker stay in waiting_for_needle block, ie.
freezing VM and checking the same tag, won't quit  _check_or_assert()