### PR TITLE
Travis badge should show only master branch

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,5 +1,5 @@
-os-autoinst image:https://api.travis-ci.org/os-autoinst/os-autoinst.svg[link=https://travis-ci.org/os-autoinst/os-autoinst]
-===========================================================================================================================
+os-autoinst image:https://api.travis-ci.org/os-autoinst/os-autoinst.svg?branch=master[link=https://travis-ci.org/os-autoinst/os-autoinst]
+=========================================================================================================================================
 :author: openSUSE Team at SUSE
 :toc:
 


### PR DESCRIPTION
No need to confuse people with a 'random' last PR build status.