### PR TITLE
Don't use obsoleted cv header.

### DIFF
--- a/snd2png/snd2png.cpp
+++ b/snd2png/snd2png.cpp
@@ -11,7 +11,7 @@
 #include <math.h>
 #include <sndfile.h>
 #include <fftw3.h>
-#include <cv.h>
+#include <opencv2/opencv.hpp>
 #include <highgui.h>
 
 using namespace cv;


### PR DESCRIPTION
According to [0] all headers have been moved to opencv2/<module>. This fixes
compilation for TW after opencv was updated to v3.1. In additional modules repo
we still link to older version 2.4.9. This version already contains moved header
files so building should not be an issue.

0: http://docs.opencv.org/3.1.0/db/dfa/tutorial_transition_guide.html#tutorial_transition_overview