### PR TITLE
Use continue_waitforneedle file to get the proper interactive mode be…

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -71,6 +71,7 @@ our %control_files = (
     reload_needles_and_retry => "reload_needles_and_retry",
     interactive_mode         => "interactive_mode",
     stop_waitforneedle       => "stop_waitforneedle",
+    continue_waitforneedle   => "continue_waitforneedle",
 );
 
 # global vars

--- a/testapi.pm
+++ b/testapi.pm
@@ -216,7 +216,10 @@ sub _check_or_assert {
 
             bmwqemu::diag("interactive mode waiting for continuation");
             while (-e $bmwqemu::control_files{stop_waitforneedle}) {
-                if (-e $bmwqemu::control_files{reload_needles_and_retry}) {
+                if (   -e $bmwqemu::control_files{continue_waitforneedle}
+                    || -e $bmwqemu::control_files{reload_needles_and_retry})
+                {
+                    unlink($bmwqemu::control_files{stop_waitforneedle});
                     last;
                 }
                 sleep 1;


### PR DESCRIPTION
…havior

Using continue_waitforneedle control file to get the proper logic of
interactive mode.

https://progress.opensuse.org/issues/10824

require https://github.com/os-autoinst/openQA/pull/611