### PR TITLE
Run icewm-lite so xterm -fullscreen can work

### DIFF
--- a/consoles/localXvnc.pm
+++ b/consoles/localXvnc.pm
@@ -62,6 +62,12 @@ sub activate {
     $self->{DISPLAY} = $display;
     sleep 1;
 
+    # we need a window manager for fullscreen apps to work
+    # twm in its default config is useless, but SUSE systems have
+    # icewm-lite for yast, so that's a good candidate
+    # TODO: find a twm expert to avoid this SUSE specific dependency
+    system("DISPLAY=$display icewm-lite &");
+
     return;
 }
 


### PR DESCRIPTION
The window manager not only makes sure xterm gets the full screen, it also
makes sure that mouse_hide is not stealing focus from the xterm window, so
we can continue typing