### PR TITLE
Foundations for directory nesting for needles

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -121,6 +121,7 @@ sub record_screenmatch {
         screenshot => $self->next_resultname('png'),
         result     => 'ok',
         properties => [@$properties],
+        file       => $h->{file},
     };
 
     # When the needle has the workaround property,
@@ -171,8 +172,9 @@ sub _serialize_match {
     my $diffcount = 0;
 
     my $name = $cand->{needle}->{name};
+    my $file = $cand->{needle}->{file};
 
-    my $h = {name => $name, error => $cand->{error}, area => []};
+    my $h = {name => $name, error => $cand->{error}, area => []}, file => $file;
     for my $a (@{$cand->{area}}) {
         my $na = {};
         for my $i (qw/x y w h result/) {

--- a/basetest.pm
+++ b/basetest.pm
@@ -121,7 +121,7 @@ sub record_screenmatch {
         screenshot => $self->next_resultname('png'),
         result     => 'ok',
         properties => [@$properties],
-        file       => $h->{file},
+        json       => $h->{json},
     };
 
     # When the needle has the workaround property,
@@ -171,10 +171,10 @@ sub _serialize_match {
     my $candidates;
     my $diffcount = 0;
 
-    my $name = $cand->{needle}->{name};
-    my $file = $cand->{needle}->{file};
+    my $name     = $cand->{needle}->{name};
+    my $jsonfile = $cand->{needle}->{file};
 
-    my $h = {name => $name, error => $cand->{error}, area => [], file => $file};
+    my $h = {name => $name, error => $cand->{error}, area => [], json => $jsonfile};
     for my $a (@{$cand->{area}}) {
         my $na = {};
         for my $i (qw/x y w h result/) {

--- a/basetest.pm
+++ b/basetest.pm
@@ -174,7 +174,7 @@ sub _serialize_match {
     my $name = $cand->{needle}->{name};
     my $file = $cand->{needle}->{file};
 
-    my $h = {name => $name, error => $cand->{error}, area => []}, file => $file;
+    my $h = {name => $name, error => $cand->{error}, area => [], file => $file};
     for my $a (@{$cand->{area}}) {
         my $na = {};
         for my $i (qw/x y w h result/) {

--- a/needle.pm
+++ b/needle.pm
@@ -37,7 +37,7 @@ sub new {
     my $json;
     if (ref $jsonfile eq 'HASH') {
         $json = $jsonfile;
-        $jsonfile = join('/', $needledir, $json->{name} . '.json');
+        $jsonfile = $json->{file} || join('/', $needledir, $json->{name} . '.json');
     }
     else {
         local $/;


### PR DESCRIPTION
This is a part of implementation (together with a patch for OpenQA <https://github.com/os-autoinst/openQA/pull/613>) that adds the foundations for directory nesting of needles. The problem is initially described in this issue: https://github.com/os-autoinst/os-autoinst/issues/426

Overall, the implementation strives to make backward-compatible changes, so although new testruns will store additional information, there should not be errors in viewing older results.

This patch adds a `file` item to the result's matchfile, which contains path to the respective needle's json file definition. This item is then used in the OpenQA's needle editor to provide the desired functionality.
