### PR TITLE
Implements ssh connections to SUT

### DIFF
--- a/backend/s390x.pm
+++ b/backend/s390x.pm
@@ -56,8 +56,6 @@ sub do_start_vm {
 sub do_stop_vm {
     my ($self) = @_;
 
-    $self->stop_serial_grab;
-
     #FIXME shutdown
     return 1;
 


### PR DESCRIPTION
For now, we need two ssh connections to the SUT
one for starting a getty and a second for starting iucvconn

removed stop_serial_grab, we don't have that implemented in s390 backend