### PR TITLE
Add VNC to a libvirt-based VM

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -173,6 +173,30 @@ sub add_pty {
     return;
 }
 
+# this is an equivalent of QEMU's '-vnc' option for tests where we watch
+# the system from boot on (e.g. JeOS)
+sub add_vnc {
+    my ($self, $args) = @_;
+
+    my $doc     = $self->{domainxml};
+    my $devices = $self->{devices_element};
+
+    my $graphics = $doc->createElement('graphics');
+    $graphics->setAttribute(type        => 'vnc');
+    $graphics->setAttribute(port        => $args->{port});
+    $graphics->setAttribute(autoport    => 'no');
+    $graphics->setAttribute(listen      => '0.0.0.0');
+    $graphics->setAttribute(sharePolicy => 'force-shared');
+    $devices->appendChild($graphics);
+
+    my $elem = $doc->createElement('listen');
+    $elem->setAttribute(type    => 'address');
+    $elem->setAttribute(address => '0.0.0.0');
+    $graphics->appendChild($elem);
+
+    return;
+}
+
 # network stuff
 sub add_interface {
     my ($self, $args) = @_;


### PR DESCRIPTION
Port 5901 is hardcoded as is it in `lib/susedistribution.pm`. VNC is set to listen on All interfaces (i.e. 0.0.0.0) otherwise we are prevented from connecting the VNC session. "force-shared" is used with qemu backend as well.