### PR TITLE
Remove hardcoded worker IP from NBF variable

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -497,7 +497,7 @@ sub start_qemu {
 
         if ($vars->{NBF}) {
             push(@params, '-kernel', '/usr/share/qemu/ipxe.lkrn');
-            push(@params, '-append', "dhcp && sanhook $vars->{NBF}");
+            push(@params, '-append', "dhcp && sanhook iscsi:$vars->{WORKER_HOSTNAME}::3260:1:$vars->{NBF}");
         }
 
         if ($virtio_scsi_controller) {


### PR DESCRIPTION
http://10/100.98.90/tests/1568
@sysrich salt all workers with iSCSI target for iBFT ^^
btw right now it's broken, openqaworker3 has worker class qemu_x86_64_ipxe_firmware instead of openqaworker2 and openqaworker2 has /usr/share/qemu/ipxe.lkrn instead of openqaworker3