### PR TITLE
openvswitch service fixes

### DIFF
--- a/os-autoinst-openvswitch
+++ b/os-autoinst-openvswitch
@@ -100,6 +100,7 @@ sub set_vlan {
 
     # connect tap device to given vlan
     system('ovs-vsctl', 'set', 'port', $tap, "tag=$vlan");
+    system('ip', 'link', 'set', $tap, 'up');
 }
 
 ################################################################################

--- a/systemd/os-autoinst-openvswitch.service
+++ b/systemd/os-autoinst-openvswitch.service
@@ -4,7 +4,7 @@
 [Unit]
 Description=os-autoinst openvswitch helper
 BindsTo=openvswitch.service
-After=openvswitch.service
+After=openvswitch.service network.target
 Before=openqa-worker.target
 
 [Service]

--- a/systemd/os-autoinst-openvswitch.service
+++ b/systemd/os-autoinst-openvswitch.service
@@ -12,7 +12,6 @@ Type=dbus
 BusName=org.opensuse.os_autoinst.switch
 Environment=OS_AUTOINST_USE_BRIDGE=br0
 EnvironmentFile=-/etc/sysconfig/os-autoinst-openvswitch
-ExecStartPre=/usr/sbin/ifup ${OS_AUTOINST_USE_BRIDGE}
 ExecStart=/usr/lib/os-autoinst/os-autoinst-openvswitch
 
 [Install]


### PR DESCRIPTION
ip link set $tap up is one remaining change from https://github.com/os-autoinst/os-autoinst/pull/457 which might still be useful.

Other changes fixes the boot order with the new openvswitch which starts before wicked.