### PR TITLE
Add TAPDOWNSCRIPT for tap networks

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -343,11 +343,13 @@ sub start_qemu {
     my @nicvlan;
     my @tapdev;
     my @tapscript;
+    my @tapdownscript;
 
-    @nicmac    = split /\s*,\s*/, $vars->{NICMAC}    if $vars->{NICMAC};
-    @nicvlan   = split /\s*,\s*/, $vars->{NICVLAN}   if $vars->{NICVLAN};
-    @tapdev    = split /\s*,\s*/, $vars->{TAPDEV}    if $vars->{TAPDEV};
-    @tapscript = split /\s*,\s*/, $vars->{TAPSCRIPT} if $vars->{TAPSCRIPT};
+    @nicmac        = split /\s*,\s*/, $vars->{NICMAC}        if $vars->{NICMAC};
+    @nicvlan       = split /\s*,\s*/, $vars->{NICVLAN}       if $vars->{NICVLAN};
+    @tapdev        = split /\s*,\s*/, $vars->{TAPDEV}        if $vars->{TAPDEV};
+    @tapscript     = split /\s*,\s*/, $vars->{TAPSCRIPT}     if $vars->{TAPSCRIPT};
+    @tapdownscript = split /\s*,\s*/, $vars->{TAPDOWNSCRIPT} if $vars->{TAPDOWNSCRIPT};
 
     my $num_networks = 1;
     $num_networks = @nicmac  if $num_networks < @nicmac;
@@ -367,13 +369,15 @@ sub start_qemu {
 
         $nicvlan[$i] //= 0;
     }
-    push @tapscript, "no" until @tapscript >= $num_networks;    #no TAPSCRIPT by default
+    push @tapscript,     "no" until @tapscript >= $num_networks;        #no TAPSCRIPT by default
+    push @tapdownscript, "no" until @tapdownscript >= $num_networks;    #no TAPDOWNSCRIPT by default
 
     # put it back to the vars for save_vars()
-    $vars->{NICMAC}    = join ',', @nicmac;
-    $vars->{NICVLAN}   = join ',', @nicvlan;
-    $vars->{TAPDEV}    = join ',', @tapdev if $vars->{NICTYPE} eq "tap";
-    $vars->{TAPSCRIPT} = join ',', @tapscript if $vars->{NICTYPE} eq "tap";
+    $vars->{NICMAC}        = join ',', @nicmac;
+    $vars->{NICVLAN}       = join ',', @nicvlan;
+    $vars->{TAPDEV}        = join ',', @tapdev if $vars->{NICTYPE} eq "tap";
+    $vars->{TAPSCRIPT}     = join ',', @tapscript if $vars->{NICTYPE} eq "tap";
+    $vars->{TAPDOWNSCRIPT} = join ',', @tapdownscript if $vars->{NICTYPE} eq "tap";
 
 
     if ($vars->{NICTYPE} eq "vde") {
@@ -477,7 +481,7 @@ sub start_qemu {
                 push(@params, '-netdev', "user,id=qanet$i");
             }
             elsif ($vars->{NICTYPE} eq "tap") {
-                push(@params, '-netdev', "tap,id=qanet$i,ifname=$tapdev[$i],script=$tapscript[$i],downscript=no");
+                push(@params, '-netdev', "tap,id=qanet$i,ifname=$tapdev[$i],script=$tapscript[$i],downscript=$tapdownscript[$i]");
             }
             elsif ($vars->{NICTYPE} eq "vde") {
                 push(@params, '-netdev', "vde,id=qanet0,sock=$vars->{VDE_SOCKETDIR}/vde.ctl,port=$vars->{VDE_PORT}");


### PR DESCRIPTION
Sometimes (in case of using tapscript to connect tap device to OVS) network settings cannot be restored automatically, TAPDOWNSCRIPT is needed (see netdev tap, downscript in man qemu).