### PR TITLE
Add hold_key and release_key to support alt+tab switcher

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -541,6 +541,16 @@ sub send_key() {
     return $self->bouncer('send_key', $args);
 }
 
+sub hold_key() {
+    my ($self, $args) = @_;
+    return $self->bouncer('hold_key', $args);
+}
+
+sub release_key() {
+    my ($self, $args) = @_;
+    return $self->bouncer('release_key', $args);
+}
+
 sub type_string() {
     my ($self, $args) = @_;
     return $self->bouncer('type_string', $args);

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -686,7 +686,7 @@ sub init_ikvm_keymap {
 
 
 sub map_and_send_key {
-    my ($self, $keys) = @_;
+    my ($self, $keys, $down_flag) = @_;
 
     if ($self->ikvm) {
         $self->init_ikvm_keymap;
@@ -717,12 +717,16 @@ sub map_and_send_key {
         return;
     }
 
-    for my $key (@events) {
-        $self->send_key_event_down($key);
+    if (!defined $down_flag || $down_flag == 1) {
+        for my $key (@events) {
+            $self->send_key_event_down($key);
+        }
     }
     usleep(50);    # just a brief moment
-    for my $key (@events) {
-        $self->send_key_event_up($key);
+    if (!defined $down_flag || $down_flag == 0) {
+        for my $key (@events) {
+            $self->send_key_event_up($key);
+        }
     }
 }
 

--- a/consoles/vnc_base.pm
+++ b/consoles/vnc_base.pm
@@ -160,6 +160,20 @@ sub send_key {
     return {};
 }
 
+sub hold_key {
+    my ($self, $args) = @_;
+    $self->{vnc}->map_and_send_key($args->{key}, 1);
+    $self->backend->run_capture_loop(undef, .2, .19);
+    return {};
+}
+
+sub release_key {
+    my ($self, $args) = @_;
+    $self->{vnc}->map_and_send_key($args->{key}, 0);
+    $self->backend->run_capture_loop(undef, .2, .19);
+    return {};
+}
+
 sub mouse_hide {
     my ($self, $args) = @_;
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -34,6 +34,7 @@ our @EXPORT = qw($realname $username $password $serialdev %cmd %vars
   get_var get_required_var check_var set_var get_var_array check_var_array autoinst_url
 
   send_key send_key_until_needlematch type_string type_password
+  hold_key release_key
 
   assert_screen check_screen assert_and_dclick save_screenshot
   assert_and_click mouse_hide mouse_set mouse_click
@@ -1060,6 +1061,32 @@ sub send_key {
     bmwqemu::log_call('send_key', key => $key);
     $bmwqemu::backend->send_key($key);
     wait_idle() if $wait;
+}
+
+=head2 hold_key
+
+  hold_key($key);
+
+Hold one C<$key> until release it
+
+=cut
+sub hold_key {
+    my ($key) = @_;
+    bmwqemu::log_call('hold_key', key => $key);
+    $bmwqemu::backend->hold_key({key => $key});
+}
+
+=head2 release_key
+
+  release_key($key);
+
+Release one C<$key> which is kept holding
+
+=cut
+sub release_key {
+    my $key = shift;
+    bmwqemu::log_call('release_key', key => $key);
+    $bmwqemu::backend->release_key({key => $key});
 }
 
 =head2 send_key_until_needlematch


### PR DESCRIPTION
follow send_key to implement the hold_key and release_key to support alt+tab 
this request came from https://progress.opensuse.org/issues/11326
and the test result:
http://147.2.207.208/tests/1038