### PR TITLE
Export autotest::loadtests to avoid helpers in main.pm

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -18,6 +18,8 @@ package autotest;
 use strict;
 use bmwqemu;
 use basetest;
+use Exporter qw/import/;
+our @EXPORT_OK = qw/loadtest $current_test/;
 
 use File::Basename;
 use File::Spec;


### PR DESCRIPTION
- without this one needs to use either
    autotest::loadtest('tests/<testname>')
  or custom helper (as we do in opensuse tests)
- export loadtest only on demand for compatibility reasons