### PR TITLE
Use xhci usb on POWER

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -327,7 +327,9 @@ sub start_qemu {
     }
     elsif ($vars->{OFW}) {
         $vars->{QEMUVGA} ||= "std";
+        $vars->{QEMUMACHINE} = "usb=off";
         push(@vgaoptions, '-g', '1024x768');
+        $use_usb_kbd = 1;
     }
     else {
         $vars->{QEMUVGA} ||= "cirrus";
@@ -587,7 +589,7 @@ sub start_qemu {
         }
         if ($vars->{OFW}) {
             no warnings 'qw';
-            push(@params, qw/-device usb-ehci -device usb-tablet,bus=usb-bus.0/);
+            push(@params, qw/-device nec-usb-xhci -device usb-tablet/);
         }
         else {
             push(@params, qw/-device usb-ehci -device usb-tablet/);


### PR DESCRIPTION
xhci should have less CPU consumption compared to ohci and ehci

Signed-off-by: Dinar Valeev <dvaleev@suse.com>