### PR TITLE
Support JeOS on VMware

### DIFF
--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -91,6 +91,14 @@ VIRSH_HOSTNAME;string;SSH Host with virtsh;
 VIRSH_PASSWORD;string;Password for root account on above host;
 VIRSH_VMM_FAMILY;string;Host's hypervisor ('kvm', 'xen');
 VIRSH_VMM_TYPE;string;Host's hypervisor type ('hvm' for full virtualization on 'kvm' and 'xen' families, 'linux' for paravirtualization on 'xen' family);
+VIRSH_GUEST;string;Where to look for VNC server (SUT or VM);
+VMWARE_USERNAME;string;Administrator's username ('@' is '%40');
+VMWARE_PASSWORD;string;Administrator's password;
+VMWARE_HOST;string;VCS server for autentication;
+VMWARE_DATACENTER;string;VMware datacenter;
+VMWARE_SERVER;string;ESX server to start VM on;
+VMWARE_DATASTORE;string;VMware datastore;
+VMWARE_SERIAL_PORT;string;TCP port where is VM's serial port stream to be expected on the ESX server;
 |====================
 
 .PVM backend


### PR DESCRIPTION
This adds support for running JeOS on VMware (net install won't work as
VMware does not support direct kernel boot).

Serial port is exposed on ESX server as `virsh console' is not supported
by esx libvirt driver, netcat is used instead.