### PR TITLE
Reduce self test execution time

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -419,6 +419,11 @@ sub hashed_string {
     return substr($hash, 0, $count);
 }
 
+sub wait_for_one_more_screenshot {
+    # sleeping for one second should ensure that one more screenshot is taken
+    sleep 1;
+}
+
 1;
 
 # vim: set sw=4 et:

--- a/cpanfile
+++ b/cpanfile
@@ -54,6 +54,7 @@ on 'test' => sub {
   requires 'Test::Output';
   requires 'Test::Fatal';
   requires 'Test::Pod';
+  requires 'Test::MockModule';
   requires 'Pod::Coverage';
 }
 

--- a/t/03-testapi.pl
+++ b/t/03-testapi.pl
@@ -67,9 +67,13 @@ subtest 'assert_script_run' => sub {
     }
     $autotest::current_test = t::test->new();
 
+    use Test::MockModule;
+    my $module = new Test::MockModule('bmwqemu');
+    # just save ourselves some time during testing
+    $module->mock('wait_for_one_more_screenshot', sub { sleep 0; });
+
     require distribution;
     testapi::set_distribution(distribution->new());
-    # TODO these tests call 'wait_serial' internally which causes a delay of 1 second each which is not so nice for testing
     is(assert_script_run('true'), undef, 'nothing happens on success');
     like(exception { assert_script_run 'false'; }, qr/command.*false.*failed at/, 'dies with standard message');
     like(exception { assert_script_run 'false', 0, 'my custom fail message'; }, qr/command.*false.*failed: my custom fail message at/, 'custom message on die');

--- a/testapi.pm
+++ b/testapi.pm
@@ -555,7 +555,7 @@ sub wait_serial {
     if ($expect_not_found) {
         $matched = !$matched;
     }
-    sleep 1;                               # wait for one more screenshot
+    bmwqemu::wait_for_one_more_screenshot();
 
     # to string, we need to feed string of result to
     # record_serialresult(), either 'ok' or 'fail'


### PR DESCRIPTION
By making the sleep time within wait_serial overridable the execution of the
tests in t/03-testapi.pl are reduced to near 0 instead of multiple seconds as
in before.