### PR TITLE
Accept positional and named arguments for assert_script_run

### DIFF
--- a/t/03-testapi.pl
+++ b/t/03-testapi.pl
@@ -75,8 +75,10 @@ subtest 'script_run' => sub {
     require distribution;
     testapi::set_distribution(distribution->new());
     is(assert_script_run('true'), undef, 'nothing happens on success');
-    like(exception { assert_script_run 'false'; }, qr/command.*false.*failed at/, 'dies with standard message');
-    like(exception { assert_script_run 'false', 0, 'my custom fail message'; }, qr/command.*false.*failed: my custom fail message at/, 'custom message on die');
+    like(exception { assert_script_run 'false', 42; }, qr/command.*false.*failed at/, 'with timeout option (deprecated mode)');
+    like(exception { assert_script_run 'false', 0, 'my custom fail message'; }, qr/command.*false.*failed: my custom fail message at/, 'custom message on die (deprecated mode)');
+    like(exception { assert_script_run('false', fail_message => 'my custom fail message'); }, qr/command.*false.*failed: my custom fail message at/, 'using named arguments');
+    like(exception { assert_script_run('false', timeout => 0, fail_message => 'my custom fail message'); }, qr/command.*false.*failed: my custom fail message at/, 'using two named arguments');
     is(script_run('true'), '5RBrb-0-', 'script_run with no check of success, returns "hashed_string"');
 };
 


### PR DESCRIPTION
Using no hash ref as a more modern approach, compare to type_string.

Related discussion:
os-autoinst/os-autoinst-distri-opensuse#1069

Verification test run: http://lord.arch/tests/760