### PR TITLE
Use stack introspection for sub name in log calls

### DIFF
--- a/backend/console_proxy.pm
+++ b/backend/console_proxy.pm
@@ -52,7 +52,7 @@ sub AUTOLOAD {
 			    args => $args,
 			   };
 
-	bmwqemu::log_call($function, wrapped_call => $wrapped_call);
+	bmwqemu::log_call(wrapped_call => $wrapped_call);
 	my $wrapped_retval = $bmwqemu::backend->proxy_console_call($wrapped_call);
 
 	if (exists $wrapped_retval->{exception}) {

--- a/basetest.pm
+++ b/basetest.pm
@@ -480,7 +480,7 @@ sub capture_filename {
 sub stop_audiocapture {
     my ($self) = @_;
 
-    bmwqemu::log_call('stop_audiocapture');
+    bmwqemu::log_call();
     $bmwqemu::backend->stop_audiocapture;
 
     my $result = {

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -240,25 +240,26 @@ sub diag {
 }
 
 sub fctres {
-    my $fname   = shift;
-    my @fparams = @_;
-    print_possibly_colored ">>> $fname: @fparams", 'green';
+    my ($text, $fname) = @_;
+
+    $fname //= (caller(1))[3];
+    print_possibly_colored ">>> $fname: $text", 'green';
     return;
 }
 
 sub fctinfo {
-    my $fname   = shift;
-    my @fparams = @_;
+    my ($text, $fname) = @_;
 
-    print_possibly_colored "::: $fname: @fparams", 'yellow';
+    $fname //= (caller(1))[3];
+    print_possibly_colored "::: $fname: $text", 'yellow';
     return;
 }
 
 sub fctwarn {
-    my $fname   = shift;
-    my @fparams = @_;
+    my ($text, $fname) = @_;
 
-    print_possibly_colored "!!! $fname: @fparams", 'red';
+    $fname //= (caller(1))[3];
+    print_possibly_colored "!!! $fname: $text", 'red';
     return;
 }
 
@@ -296,7 +297,7 @@ sub pp {
 }
 
 sub log_call {
-    my $fname = shift;
+    my $fname = (caller(1))[3];
     update_line_number();
     my @result;
     while (my ($key, $value) = splice(@_, 0, 2)) {
@@ -345,7 +346,7 @@ sub stop_vm() {
 
 sub mydie {
     my ($cause_of_death) = @_;
-    log_call('mydie', cause_of_death => $cause_of_death);
+    log_call(cause_of_death => $cause_of_death);
     croak "mydie";
 }
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -133,7 +133,7 @@ Takes an optional C<$reason> string which is recorded in the log file.
 =cut
 sub record_soft_failure {
     my ($reason) = @_;
-    bmwqemu::log_call('record_soft_failure', reason => $reason);
+    bmwqemu::log_call(reason => $reason);
     $autotest::current_test->{dents}++;
     return;
 }
@@ -144,9 +144,8 @@ sub _check_or_assert {
 
     die "current_test undefined" unless $autotest::current_test;
 
-    my $rsp    = $bmwqemu::backend->set_tags_to_assert({mustmatch => $mustmatch, timeout => $timeout});
-    my $tags   = $rsp->{tags};
-    my $caller = $check ? 'check_screen' : 'assert_screen';
+    my $rsp = $bmwqemu::backend->set_tags_to_assert({mustmatch => $mustmatch, timeout => $timeout});
+    my $tags = $rsp->{tags};
 
     # we ignore timeout here as the backend might be set into interactive mode and then
     # the timeout is meaningless
@@ -179,12 +178,12 @@ sub _check_or_assert {
             my $img = tinycv::read($rsp->{filename});
             $autotest::current_test->record_screenmatch($img, $foundneedle, $tags, $rsp->{candidates});
             my $lastarea = $foundneedle->{area}->[-1];
-            bmwqemu::fctres($caller, sprintf("found %s, similarity %.2f @ %d/%d", $foundneedle->{needle}->{name}, $lastarea->{similarity}, $lastarea->{x}, $lastarea->{y}));
+            bmwqemu::fctres(sprintf("found %s, similarity %.2f @ %d/%d", $foundneedle->{needle}->{name}, $lastarea->{similarity}, $lastarea->{x}, $lastarea->{y}));
             $last_matched_needle = $foundneedle;
             return $foundneedle;
         }
         if ($rsp->{timeout}) {
-            bmwqemu::fctres($caller, "match=" . join(',', @$tags) . " timed out after $timeout");
+            bmwqemu::fctres("match=" . join(',', @$tags) . " timed out after $timeout");
             my $failed_screens = $rsp->{failed_screens};
             my $final_mismatch = $failed_screens->[-1];
             if ($check) {
@@ -267,7 +266,7 @@ Returns matched needle or throws C<NeedleFailed> exception if $timeout timeout i
 sub assert_screen {
     my ($mustmatch, $timeout) = @_;
     $timeout //= $bmwqemu::default_timeout;
-    bmwqemu::log_call('assert_screen', mustmatch => $mustmatch, timeout => $timeout);
+    bmwqemu::log_call(mustmatch => $mustmatch, timeout => $timeout);
     return _check_or_assert($mustmatch, $timeout, 0);
 }
 
@@ -284,7 +283,7 @@ Returns matched needle or C<undef> if timeout is hit. Default timeout is 30s.
 sub check_screen {
     my ($mustmatch, $timeout) = @_;
     $timeout //= $bmwqemu::default_timeout;
-    bmwqemu::log_call('check_screen', mustmatch => $mustmatch, timeout => $timeout);
+    bmwqemu::log_call(mustmatch => $mustmatch, timeout => $timeout);
     return _check_or_assert($mustmatch, $timeout, 1);
 }
 
@@ -323,7 +322,7 @@ sub assert_and_click {
 
     $last_matched_needle = assert_screen($mustmatch, $timeout);
     my $old_mouse_coords = $bmwqemu::backend->get_last_mouse_set();
-    bmwqemu::log_call('assert_and_click', mustmatch => $mustmatch, button => $button, timeout => $timeout);
+    bmwqemu::log_call(mustmatch => $mustmatch, button => $button, timeout => $timeout);
 
     # last_matched_needle has to be set, or the assert is buggy :)
     my $lastarea = $last_matched_needle->{area}->[-1];
@@ -378,7 +377,7 @@ sub wait_screen_change(&@) {
     my ($callback, $timeout) = @_;
     $timeout ||= 10;
 
-    bmwqemu::log_call('wait_screen_change', timeout => $timeout);
+    bmwqemu::log_call(timeout => $timeout);
 
     # get the initial screen
     $bmwqemu::backend->set_reference_screenshot;
@@ -391,13 +390,13 @@ sub wait_screen_change(&@) {
         my $sim = $bmwqemu::backend->similiarity_to_reference->{sim};
         print "waiting for screen change: " . (time - $starttime) . " $sim\n";
         if ($sim < $similarity_level) {
-            bmwqemu::fctres('wait_screen_change', "screen change seen at " . (time - $starttime));
+            bmwqemu::fctres("screen change seen at " . (time - $starttime));
             return 1;
         }
         sleep(0.5);
     }
     save_screenshot;
-    bmwqemu::fctres('wait_screen_change', "timed out");
+    bmwqemu::fctres("timed out");
     return 0;
 }
 
@@ -416,7 +415,7 @@ sub wait_still_screen {
     my $timeout          = shift || 30;
     my $similarity_level = shift || (get_var('HW') ? 44 : 47);
 
-    bmwqemu::log_call('wait_still_screen', stilltime => $stilltime, timeout => $timeout, simlvl => $similarity_level);
+    bmwqemu::log_call(stilltime => $stilltime, timeout => $timeout, simlvl => $similarity_level);
 
     $timeout = bmwqemu::scale_timeout($timeout);
 
@@ -434,13 +433,13 @@ sub wait_still_screen {
             $bmwqemu::backend->set_reference_screenshot;
         }
         if (($now->[0] - $lastchangetime->[0]) + ($now->[1] - $lastchangetime->[1]) / 1000000. >= $stilltime) {
-            bmwqemu::fctres('wait_still_screen', "detected same image for $stilltime seconds");
+            bmwqemu::fctres("detected same image for $stilltime seconds");
             return 1;
         }
         sleep(0.5);
     }
     $autotest::current_test->timeout_screenshot();
-    bmwqemu::fctres('wait_still_screen', "wait_still_screen timed out after $timeout");
+    bmwqemu::fctres("wait_still_screen timed out after $timeout");
     return 0;
 }
 
@@ -546,7 +545,7 @@ sub wait_serial {
     my $timeout          = shift || 90;    # seconds
     my $expect_not_found = shift || 0;     # expected can not found the term in serial output
 
-    bmwqemu::log_call('wait_serial', regex => $regexp, timeout => $timeout);
+    bmwqemu::log_call(regex => $regexp, timeout => $timeout);
     $timeout = bmwqemu::scale_timeout($timeout);
 
     my $ret = $bmwqemu::backend->wait_serial({regexp => $regexp, timeout => $timeout});
@@ -566,7 +565,7 @@ sub wait_serial {
         $matched = 'fail';
     }
     $autotest::current_test->record_serialresult(bmwqemu::pp($regexp), $matched, $ret->{string});
-    bmwqemu::fctres('wait_serial', "$regexp: $matched");
+    bmwqemu::fctres("$regexp: $matched");
     return $ret->{string} if ($matched eq "ok");
     return;    # false
 }
@@ -582,7 +581,7 @@ I<The implementation is distribution specific and not always available.>
 =cut
 sub x11_start_program {
     my ($program, $timeout, $options) = @_;
-    bmwqemu::log_call('x11_start_program', timeout => $timeout, options => $options);
+    bmwqemu::log_call(timeout => $timeout, options => $options);
     return $distri->x11_start_program($program, $timeout, $options);
 }
 
@@ -603,7 +602,7 @@ sub script_run {
     my ($name, $wait) = @_;
     $wait //= $bmwqemu::default_timeout;
 
-    bmwqemu::log_call('script_run', name => $name, wait => $wait);
+    bmwqemu::log_call(name => $name, wait => $wait);
     return $distri->script_run($name, $wait);
 }
 
@@ -645,7 +644,7 @@ sub script_sudo {
     my $name = shift;
     my $wait = shift // 2;
 
-    bmwqemu::log_call('script_sudo', name => $name, wait => $wait);
+    bmwqemu::log_call(name => $name, wait => $wait);
     return $distri->script_sudo($name, $wait);
 }
 
@@ -773,7 +772,7 @@ sub power {
 
     # params: (on), off, acpi, reset
     my ($action) = @_;
-    bmwqemu::log_call('power', action => $action);
+    bmwqemu::log_call(action => $action);
     $bmwqemu::backend->power({action => $action});
 }
 
@@ -790,7 +789,7 @@ Returns C<undef> on success, throws exception on timeout.
 sub assert_shutdown {
     my ($timeout) = @_;
     $timeout //= 60;
-    bmwqemu::log_call('assert_shutdown', timeout => $timeout);
+    bmwqemu::log_call(timeout => $timeout);
     while ($timeout >= 0) {
         my $status = $bmwqemu::backend->status() // '';
         if ($status eq 'shutdown') {
@@ -812,7 +811,7 @@ if backend supports it, eject the CD
 
 =cut
 sub eject_cd {
-    bmwqemu::log_call('eject_cd');
+    bmwqemu::log_call();
     $bmwqemu::backend->eject_cd;
 }
 
@@ -926,17 +925,17 @@ sub wait_idle {
     use Carp qw(cluck);
     cluck "Wait_idle called";
 
-    bmwqemu::log_call('wait_idle', timeout => $timeout);
+    bmwqemu::log_call(timeout => $timeout);
 
     my $args = {
         timeout   => $timeout,
         threshold => get_var('IDLETHRESHOLD', 18)};
     my $rsp = $bmwqemu::backend->wait_idle($args);
     if ($rsp->{idle}) {
-        bmwqemu::fctres('wait_idle', "idle detected");
+        bmwqemu::fctres("idle detected");
     }
     else {
-        bmwqemu::fctres('wait_idle', "timed out after $timeout");
+        bmwqemu::fctres("timed out after $timeout");
     }
     return;
 }
@@ -1018,7 +1017,7 @@ sub upload_logs {
     my %args   = @_;
     my $failok = $args{failok} || 0;
 
-    bmwqemu::log_call('upload_logs', file => $file);
+    bmwqemu::log_call(file => $file);
     my $basename = basename($file);
     my $upname   = ref($autotest::current_test) . '-' . $basename;
     my $cmd      = "curl --form upload=\@$file --form upname=$upname ";
@@ -1051,7 +1050,7 @@ replacing previous assets - useful for external users:
 sub upload_asset {
     my ($file, $public) = @_;
 
-    bmwqemu::log_call('upload_asset', file => $file);
+    bmwqemu::log_call(file => $file);
     my $cmd = "curl --form upload=\@$file ";
     $cmd .= "--form target=assets_public " if $public;
     my $basename = basename($file);
@@ -1077,7 +1076,7 @@ Special characters naming:
 sub send_key {
     my ($key, $wait) = @_;
     $wait //= 0;
-    bmwqemu::log_call('send_key', key => $key);
+    bmwqemu::log_call(key => $key);
     $bmwqemu::backend->send_key($key);
     wait_idle() if $wait;
 }
@@ -1158,7 +1157,7 @@ sub type_string {
     }
     my $log = $args{secret} ? 'SECRET STRING' : $string;
     my $max_interval = $args{max_interval} // 250;
-    bmwqemu::log_call('type_string', string => $log, max_interval => $max_interval);
+    bmwqemu::log_call(string => $log, max_interval => $max_interval);
     $bmwqemu::backend->type_string({text => $string, max_interval => $max_interval});
 }
 
@@ -1189,7 +1188,7 @@ Move mouse pointer to given coordinates
 sub mouse_set {
     my ($mx, $my) = @_;
 
-    bmwqemu::log_call('mouse_set', x => $mx, y => $my);
+    bmwqemu::log_call(x => $mx, y => $my);
     $bmwqemu::backend->mouse_set({x => $mx, y => $my});
 }
 
@@ -1204,7 +1203,7 @@ Default hold time is 1s
 sub mouse_click {
     my $button = shift || 'left';
     my $time   = shift || 0.15;
-    bmwqemu::log_call('mouse_click', button => $button, cursor_down => $time);
+    bmwqemu::log_call(button => $button, cursor_down => $time);
     $bmwqemu::backend->mouse_button($button, 1);
     # FIXME sleep resolution = 1s, use usleep
     sleep $time;
@@ -1221,7 +1220,7 @@ Same as mouse_click only for double click.
 sub mouse_dclick(;$$) {
     my $button = shift || 'left';
     my $time   = shift || 0.10;
-    bmwqemu::log_call('mouse_dclick', button => $button, cursor_down => $time);
+    bmwqemu::log_call(button => $button, cursor_down => $time);
     $bmwqemu::backend->mouse_button($button, 1);
     # FIXME sleep resolution = 1s, use usleep
     sleep $time;
@@ -1242,7 +1241,7 @@ Same as mouse_click only for tripple click.
 sub mouse_tclick(;$$) {
     my $button = shift || 'left';
     my $time   = shift || 0.10;
-    bmwqemu::log_call('mouse_tclick', button => $button, cursor_down => $time);
+    bmwqemu::log_call(button => $button, cursor_down => $time);
     $bmwqemu::backend->mouse_button($button, 1);
     sleep $time;
     $bmwqemu::backend->mouse_button($button, 0);
@@ -1265,7 +1264,7 @@ Hide mouse cursor by moving it out of screen area.
 =cut
 sub mouse_hide(;$) {
     my $border_offset = shift || 0;
-    bmwqemu::log_call('mouse_hide', border_offset => $border_offset);
+    bmwqemu::log_call(border_offset => $border_offset);
     $bmwqemu::backend->mouse_hide($border_offset);
 }
 
@@ -1324,7 +1323,7 @@ to run test code.
 =cut
 sub select_console {
     my ($testapi_console) = @_;
-    bmwqemu::log_call('select_console', testapi_console => $testapi_console);
+    bmwqemu::log_call(testapi_console => $testapi_console);
     if (!exists $testapi_console_proxies{$testapi_console}) {
         $testapi_console_proxies{$testapi_console} = backend::console_proxy->new($testapi_console);
     }
@@ -1361,7 +1360,7 @@ here.
 =cut
 sub console {
     my ($testapi_console) = @_;
-    bmwqemu::log_call('console', testapi_console => $testapi_console);
+    bmwqemu::log_call(testapi_console => $testapi_console);
     if (exists $testapi_console_proxies{$testapi_console}) {
         return $testapi_console_proxies{$testapi_console};
     }
@@ -1396,7 +1395,7 @@ I<Only supported by QEMU backend.>
 sub start_audiocapture {
     my $fn = $autotest::current_test->capture_filename;
     my $filename = join('/', bmwqemu::result_dir(), $fn);
-    bmwqemu::log_call('start_audiocapture', filename => $filename);
+    bmwqemu::log_call(filename => $filename);
     return $bmwqemu::backend->start_audiocapture({filename => $filename});
 }
 


### PR DESCRIPTION
The 'name' field was used inconsistently in calls of log_call, fctinfo and
others. To correct and further simplify the call stack can be read to gather
the current sub name without the need to explicitly specify it.

All changed subfunctions are only used within os-autoinst. Only the log output
is affected besides the simplification of code.

Like #390 but updated, correct name for "assert_screen", no logging of internal function "_check_and_assert_screen".

Log output looks like this
```
21:44:02.2060 <<< testapi::type_string(string='hallo', max_interval=250)
21:44:02.2065 <<< testapi::type_string(string='hallo', max_interval=4)
21:44:02.2068 <<< testapi::type_string(string='SECRET STRING', max_interval=250)
21:44:02.2070 <<< testapi::type_string(string='SECRET STRING', max_interval=10)
21:44:02.2073 <<< testapi::type_string(string='SECRET STRING', max_interval=100)
21:44:02.2075 <<< testapi::type_string(string='SECRET STRING', max_interval=100)
21:44:02.2082 Debug: testapi.pm:136 called bmwqemu::log_call
21:44:02.2089 Debug: testapi.pm:136 called bmwqemu::log_call
21:44:02.2095 <<< testapi::script_run(name='true; echo 5RBrb-$?- > /dev/null', wait=0)
21:44:02.2096 <<< testapi::type_string(string='true; echo 5RBrb-$?- > /dev/null', max_interval=250)
21:44:02.2097 <<< testapi::send_key(key='ret')
21:44:02.2098 <<< testapi::wait_serial(regex='5RBrb-\\d+-', timeout=90)
21:44:03.2101 >>> testapi::wait_serial: 5RBrb-\d+-: ok
21:44:03.2104 <<< testapi::script_run(name='false; echo gIdkd-$?- > /dev/null', wait=0)
21:44:03.2104 <<< testapi::type_string(string='false; echo gIdkd-$?- > /dev/null', max_interval=250)
21:44:03.2105 <<< testapi::send_key(key='ret')
21:44:03.2106 <<< testapi::wait_serial(regex='gIdkd-\\d+-', timeout=90)
21:44:04.2108 >>> testapi::wait_serial: gIdkd-\d+-: ok
21:44:04.2112 <<< testapi::script_run(name='false; echo gIdkd-$?- > /dev/null', wait=0)
21:44:04.2113 <<< testapi::type_string(string='false; echo gIdkd-$?- > /dev/null', max_interval=250)
21:44:04.2114 <<< testapi::send_key(key='ret')
21:44:04.2114 <<< testapi::wait_serial(regex='gIdkd-\\d+-', timeout=90)
21:44:05.2117 >>> testapi::wait_serial: gIdkd-\d+-: ok
21:44:05.2124 <<< testapi::assert_screen(mustmatch='foo', timeout=1)
```