### PR TITLE
Prevent warning about uninitialized variable in script_run

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -103,6 +103,7 @@ sub script_run {
     # start console application
     my ($self, $name, $wait) = @_;
 
+    $wait //= $bmwqemu::default_timeout;
     testapi::type_string "$name";
     if ($wait > 0) {
         my $str = bmwqemu::hashed_string("SR$name$wait");


### PR DESCRIPTION
As observed in https://openqa.suse.de/tests/395751/file/autoinst-log.txt