### PR TITLE
Put temp files to /tmp instead of default temp dir

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -335,7 +335,7 @@ sub define_and_start {
 
     my $remote_vmm = "";
     if ($self->vmm_family eq 'vmware') {
-        my ($fh, $libvirtauthfilename) = tempfile();
+        my ($fh, $libvirtauthfilename) = tempfile(DIR => "/tmp/");
         my $chan = $self->{ssh}->channel();
 
         # The libvirt esx driver supports connection over HTTP(S) only. When


### PR DESCRIPTION
This puts temporary files to /tmp dir, before it put files to
/var/lib/openqa/pool/#/tmp/ which does not exist on VIRSH_HOST (does on
worker but that's not accessible).

(Well the branch should have been named as a _VMware_ fix...)