### PR TITLE
Move bmwqemu functions (ab-)used in openSUSE tests to test API

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -18,7 +18,6 @@ package bmwqemu;
 use strict;
 use warnings;
 use Time::HiRes qw(sleep gettimeofday);
-use Digest::MD5;
 use IO::Socket;
 
 use ocr;
@@ -43,7 +42,6 @@ require IPC::System::Simple;
 use autodie qw(:all);
 
 use distribution;
-use Digest::MD5 qw(md5_base64);
 
 sub mydie;
 
@@ -388,7 +386,12 @@ sub scale_timeout {
     return $timeout * ($vars{TIMEOUT_SCALE} // 1);
 }
 
-# just a random string useful for pseudo security or temporary files
+=head2 random_string
+
+  random_string([$count]);
+
+Just a random string useful for pseudo security or temporary files.
+=cut
 sub random_string {
     my ($count) = @_;
     $count //= 4;
@@ -398,17 +401,9 @@ sub random_string {
     return $string;
 }
 
-# return a short string representing the given string by passing it through
-# the MD5 algorithm and taking the first characters
 sub hashed_string {
-    my ($string, $count) = @_;
-    $count //= 5;
-
-    my $hash = md5_base64($string);
-    # + and / are problematic in regexps and shell commands
-    $hash =~ s,\+,_,g;
-    $hash =~ s,/,~,g;
-    return substr($hash, 0, $count);
+    fctwarn '@DEPRECATED: Use testapi::hashed_string instead';
+    return testapi::hashed_string(@_);
 }
 
 1;

--- a/distribution.pm
+++ b/distribution.pm
@@ -105,7 +105,7 @@ sub script_run {
 
     testapi::type_string "$name";
     if ($wait > 0) {
-        my $str = bmwqemu::hashed_string("SR$name$wait");
+        my $str = hashed_string("SR$name$wait");
         testapi::type_string " ; echo $str > /dev/$testapi::serialdev\n";
         testapi::wait_serial($str);
     }
@@ -131,7 +131,7 @@ sub script_sudo {
 
     my $str;
     if ($wait > 0) {
-        $str  = bmwqemu::hashed_string("SS$prog$wait");
+        $str  = hashed_string("SS$prog$wait");
         $prog = "$prog; echo $str > /dev/$testapi::serialdev";
     }
     testapi::type_string "sudo $prog\n";


### PR DESCRIPTION
The functions 'save_vars', 'hashed_string' and 'diag' are currently used in
os-autoinst-distri-opensuse but only the testapi functions should be used. If
we need them we may as well just include them in the test API and subsequently
clean up tests (and then bmwqemu). 'random_string' sounds similar to
'hashed_string' but is only used within bmwqemu so only the doc has been
adapted but the function not moved.