### PR TITLE
Extract baseclass for qemu+svirt to set common values

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,7 +18,8 @@ backendexec_DATA = \
 	backend/qemu.pm \
 	backend/s390x.pm \
 	backend/svirt.pm \
-	backend/pvm.pm
+	backend/pvm.pm \
+	backend/virt.pm
 
 consolesexecdir = $(pkglibexecdir)/consoles
 consolesexec_DATA = \

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -16,7 +16,7 @@
 
 package backend::qemu;
 use strict;
-use base ('backend::baseclass');
+use base ('backend::virt');
 use File::Path qw/mkpath/;
 use File::Temp ();
 use Time::HiRes qw(sleep gettimeofday);
@@ -340,7 +340,6 @@ sub start_qemu {
     }
     push(@vgaoptions, "-vga", $vars->{QEMUVGA}) if $vars->{QEMUVGA};
 
-    $vars->{QEMUCPUS} ||= 1;
     if (defined($vars->{RAIDLEVEL})) {
         $vars->{NUMDISKS} = 4;
     }
@@ -468,7 +467,7 @@ sub start_qemu {
         $SIG{__DIE__} = undef;    # overwrite the default - just exit
         my @params = ("-serial", "file:serial0", "-soundhw", "ac97", "-global", "isa-fdc.driveA=", @vgaoptions);
 
-        push(@params, '-m', $vars->{QEMURAM} || '1024');
+        push(@params, '-m', $vars->{QEMURAM});
 
         if ($vars->{QEMUMACHINE}) {
             push(@params, "-machine", $vars->{QEMUMACHINE});

--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -16,7 +16,7 @@
 
 package backend::svirt;
 use strict;
-use base ('backend::baseclass');
+use base ('backend::virt');
 use testapi qw(get_required_var check_var);
 
 use IO::Select;

--- a/backend/virt.pm
+++ b/backend/virt.pm
@@ -1,0 +1,34 @@
+# Copyright © 2016 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package backend::virt;
+use strict;
+use warnings;
+use base ('backend::baseclass');
+use testapi qw/get_var/;
+use bmwqemu;
+
+sub new {
+    my ($class) = @_;
+    my $self = $class->SUPER::new;
+    $bmwqemu::vars{QEMURAM}  //= 1024;
+    $bmwqemu::vars{QEMUCPUS} //= 1;
+    return $self;
+}
+
+
+1;
+# vim: set sw=4 et:
+

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -18,7 +18,7 @@ package consoles::sshVirtsh;
 use base 'consoles::sshXtermVt';
 use strict;
 use warnings;
-use testapi qw/get_var/;
+use testapi qw/get_var get_required_var/;
 require IPC::System::Simple;
 use autodie qw(:all);
 use XML::LibXML;
@@ -96,12 +96,12 @@ sub _init_xml {
     $root->appendChild($elem);
 
     $elem = $doc->createElement('memory');
-    $elem->appendTextNode(get_var('QEMURAM', '512'));
+    $elem->appendTextNode(get_required_var('QEMURAM'));
     $elem->setAttribute(unit => 'MiB');
     $root->appendChild($elem);
 
     $elem = $doc->createElement('vcpu');
-    $elem->appendTextNode(get_var('QEMUCPUS', '1'));
+    $elem->appendTextNode(get_required_var('QEMUCPUS'));
     $root->appendChild($elem);
 
     my $os = $doc->createElement('os');


### PR DESCRIPTION
DRY when setting - already differing - values for common settings.

Related to https://github.com/os-autoinst/os-autoinst/pull/517

Verified on qemu+svirt

Verification run on svirt: http://lord.arch/tests/1287