### PR TITLE
Cast the size type to match perl's to avoid warnings

### DIFF
--- a/ppmclibs/tinycv.xs
+++ b/ppmclibs/tinycv.xs
@@ -124,7 +124,7 @@ void search_needle(tinycv::Image self, tinycv::Image needle, long x, long y, lon
   PPCODE:
     double similarity = 0;
     std::vector<int> ret = image_search(self, needle, x, y, width, height, margin, similarity);
-    EXTEND(SP, ret.size() + 1);
+    EXTEND(SP, SSize_t(ret.size() + 1));
 
     PUSHs(sv_2mortal(newSVnv(similarity)));
 


### PR DESCRIPTION
from 5.24's perldelta:
 The C<EXTEND> and C<MEXTEND> macros have been improved to avoid various
 issues with integer truncation and wrapping. In particular, some casts
 formerly used within the macros have been removed. This means for example
 that passing an unsigned nitems arg is likely to raise a compiler warning
 now (it's always been documented to require a signed value; formerly int,
 lately SSize_t).