### PR TITLE
Fix signal handler to have stable shutdown

### DIFF
--- a/backend/driver.pm
+++ b/backend/driver.pm
@@ -22,9 +22,10 @@
 package backend::driver;
 use strict;
 use Carp qw(cluck carp croak confess);
-use JSON qw( to_json );
+use JSON qw(to_json);
 use File::Path qw(remove_tree);
 use IO::Select;
+use POSIX qw(_exit);
 require IPC::System::Simple;
 use autodie qw(:all);
 
@@ -69,7 +70,7 @@ sub start {
 
     if ($pid == 0) {
         _run($self->{backend}, fileno($self->{from_parent}), fileno($self->{to_parent}));
-        exit(0);
+        _exit(0);
     }
     else {
         $self->{backend_pid} = $pid;
@@ -89,8 +90,7 @@ sub _run {
 }
 
 sub stop {
-    my $self = shift;
-    my $cmd  = shift;
+    my ($self, $cmd) = @_;
 
     return unless ($self->{backend_pid});
 
@@ -195,8 +195,8 @@ sub AUTOLOAD {
 # virtual methods end
 
 sub _send_json {
-    my $self = shift;
-    my $cmd  = shift;
+    my ($self, $cmd) = @_;
+
     # TODO: make this a class object
     # allow regular expressions to be automatically converted into
     # strings, using the Regex::TO_JSON function as defined at the end

--- a/isotovideo
+++ b/isotovideo
@@ -79,17 +79,17 @@ my $backend;
 # all so ugly ...
 sub signalhandler {
 
-    my $sig = shift;
-    print STDERR "$$: signalhandler got $sig\n";
+    my ($sig) = @_;
+    diag("$$: signalhandler got $sig");
     if ($autotest::running) {
         $autotest::running->fail_if_running();
         $autotest::running = undef;
     }
     if (defined $backend && $backend->{backend_pid}) {
-        print STDERR "killing backend process\n";
+        diag("$$: killing backend process $backend->{backend_pid}");
         kill('SIGTERM', $backend->{backend_pid});
         waitpid($backend->{backend_pid}, 0);
-        print STDERR "done with backend process\n";
+        diag("$$: done with backend process");
         $backend->{backend_pid} = 0;
     }
     # mark it as no longer working
@@ -101,10 +101,10 @@ sub signalhandler {
         $test->save_test_result();
     }
     if (defined $cpid) {
-        print STDERR "killing commands process\n";
+        diag("$$: killing commands process $cpid");
         kill('SIGTERM', $cpid);
         waitpid($cpid, 0);
-        print STDERR "done joining commands process\n";
+        diag("$$: done joining commands process");
         $cpid = 0;
     }
     _exit(1);
@@ -112,16 +112,15 @@ sub signalhandler {
 
 sub signalhandler_chld {
 
-    my $sig = shift;
-    print STDERR "$$: signalhandler_chld got $sig\n";
+    diag("$$: got sigchld");
 
     while ((my $child = waitpid(-1, WNOHANG)) > 0) {
         if ($child == $cpid) {
-            print STDERR "$$: commands webserver died\n";
+            diag("$$: commands webserver died");
             $cpid = 0;
         }
         else {
-            print STDERR "$$: backend $child died\n";
+            diag("$$: backend $child died");
             $backend->{backend_pid} = 0;
             $backend->{to_child}    = undef;
             $backend->{from_child}  = undef;
@@ -218,12 +217,12 @@ eval {
 };
 
 bmwqemu::stop_vm();
-print "killing commands process\n";
+diag "killing commands process";
 if ($cpid) {
     kill('SIGTERM', $cpid);
     waitpid($cpid, 0);
 }
-print "done joining commands process\n";
+diag "done joining commands process";
 
 # mark hard disks for upload if test finished
 if (!$r && (my $nd = $bmwqemu::vars{NUMDISKS})) {

--- a/isotovideo
+++ b/isotovideo
@@ -40,6 +40,7 @@ use testapi qw(diag);
 use Getopt::Std;
 require IPC::System::Simple;
 use autodie qw(:all);
+use POSIX qw(:sys_wait_h _exit);
 
 # avoid paranoia
 $Getopt::Std::STANDARD_HELP_VERSION = 1;
@@ -73,19 +74,24 @@ bmwqemu::clean_control_files();
 my $init = 1;
 
 my $cpid;
+my $backend;
 
 # all so ugly ...
 sub signalhandler {
 
-    # do not start a race about the results between the threads
-
     my $sig = shift;
-    diag("signalhandler $$: got $sig");
+    print STDERR "$$: signalhandler got $sig\n";
     if ($autotest::running) {
-        $autotest::running->fail_if_running();
-        $autotest::running = undef;
+	$autotest::running->fail_if_running();
+	$autotest::running = undef;
     }
-    bmwqemu::stop_vm();
+    if (defined $backend && $backend->{backend_pid}) {
+	print STDERR "killing backend process\n";
+        kill('SIGTERM', $backend->{backend_pid});
+        waitpid($backend->{backend_pid}, 0);
+        print STDERR "done with backend process\n";
+	$backend->{backend_pid} = 0;
+    }
     # mark it as no longer working
     delete $ENV{WORKERID};
     bmwqemu::save_status();
@@ -95,14 +101,32 @@ sub signalhandler {
         $test->save_test_result();
     }
     if (defined $cpid) {
-        print "killing commands process\n";
+        print STDERR "killing commands process\n";
         kill('SIGTERM', $cpid);
         waitpid($cpid, 0);
-        print "done joining commands process\n";
+        print STDERR "done joining commands process\n";
+	$cpid = 0;
     }
-    exit(1);
+    _exit(1);
 }
 
+sub signalhandler_chld {
+
+    my $sig = shift;
+    print  STDERR "$$: signalhandler_chld got $sig\n";
+
+    while ((my $child = waitpid(-1, WNOHANG)) > 0) {
+	if ($child == $cpid) {
+	    print  STDERR "$$: commands webserver died\n";
+	    $cpid = 0;
+	} else {
+	    print  STDERR "$$: backend $child died\n";
+	    $backend->{backend_pid} = 0;
+	    $backend->{to_child} = undef;
+	    $backend->{from_child} = undef;
+	}
+    }
+}
 
 $ENV{MOJO_MAX_MESSAGE_SIZE} = 107741824;
 
@@ -132,7 +156,7 @@ $cpid = commands::start_server($bmwqemu::vars{QEMUPORT} + 1);
 bmwqemu::save_vars();
 # make sure the needles are initialized before the backend thread is started
 needle::init($bmwqemu::vars{PRODUCTDIR} . "/needles");
-bmwqemu::init_backend( $bmwqemu::vars{BACKEND} );
+$backend = bmwqemu::init_backend( $bmwqemu::vars{BACKEND} );
 
 if ($init) {
     open( my $fd, ">", "os-autoinst.pid" );
@@ -158,6 +182,7 @@ $SIG{ALRM} = \&signalhandler;
 $SIG{TERM} = \&signalhandler;
 $SIG{INT}  = \&signalhandler;
 $SIG{HUP}  = \&signalhandler;
+$SIG{CHLD}  = \&signalhandler_chld;
 
 if ($ENV{RUN_VNCVIEWER}) {
   system("vncviewer -shared localhost:" . $bmwqemu::vars{VNC} . " -viewonly &");
@@ -193,8 +218,10 @@ eval {
 
 bmwqemu::stop_vm();
 print "killing commands process\n";
-kill('SIGTERM', $cpid);
-waitpid($cpid, 0);
+if ($cpid) {
+    kill('SIGTERM', $cpid);
+    waitpid($cpid, 0);
+}
 print "done joining commands process\n";
 
 # mark hard disks for upload if test finished

--- a/isotovideo
+++ b/isotovideo
@@ -21,7 +21,7 @@ use strict;
 local $Devel::Trace::TRACE;
 $Devel::Trace::TRACE = 0;
 
-my $installprefix; # $bmwqemu::scriptdir
+my $installprefix;    # $bmwqemu::scriptdir
 
 BEGIN {
     # the following line is modified during make install
@@ -46,20 +46,20 @@ use POSIX qw(:sys_wait_h _exit);
 $Getopt::Std::STANDARD_HELP_VERSION = 1;
 
 sub HELP_MESSAGE {
-  print "$0 [-d]\n";
-  print "Parses vars.json and tests the given assets/ISOS\n\n";
-  print " -d enables direct output to STDERR instead of autoinst-log.txt\n"
+    print "$0 [-d]\n";
+    print "Parses vars.json and tests the given assets/ISOS\n\n";
+    print " -d enables direct output to STDERR instead of autoinst-log.txt\n";
 }
 
 # enable debug default when started from a tty
-$bmwqemu::istty = -t 1; ## no critic
+$bmwqemu::istty = -t 1;    ## no critic
 our ($opt_d);
 getopts('d');
 $bmwqemu::direct_output = $opt_d;
 
 select(STDERR);
 $| = 1;
-select(STDOUT); # default
+select(STDOUT);            # default
 $| = 1;
 
 $bmwqemu::scriptdir = $installprefix;
@@ -82,15 +82,15 @@ sub signalhandler {
     my $sig = shift;
     print STDERR "$$: signalhandler got $sig\n";
     if ($autotest::running) {
-	$autotest::running->fail_if_running();
-	$autotest::running = undef;
+        $autotest::running->fail_if_running();
+        $autotest::running = undef;
     }
     if (defined $backend && $backend->{backend_pid}) {
-	print STDERR "killing backend process\n";
+        print STDERR "killing backend process\n";
         kill('SIGTERM', $backend->{backend_pid});
         waitpid($backend->{backend_pid}, 0);
         print STDERR "done with backend process\n";
-	$backend->{backend_pid} = 0;
+        $backend->{backend_pid} = 0;
     }
     # mark it as no longer working
     delete $ENV{WORKERID};
@@ -105,7 +105,7 @@ sub signalhandler {
         kill('SIGTERM', $cpid);
         waitpid($cpid, 0);
         print STDERR "done joining commands process\n";
-	$cpid = 0;
+        $cpid = 0;
     }
     _exit(1);
 }
@@ -113,18 +113,19 @@ sub signalhandler {
 sub signalhandler_chld {
 
     my $sig = shift;
-    print  STDERR "$$: signalhandler_chld got $sig\n";
+    print STDERR "$$: signalhandler_chld got $sig\n";
 
     while ((my $child = waitpid(-1, WNOHANG)) > 0) {
-	if ($child == $cpid) {
-	    print  STDERR "$$: commands webserver died\n";
-	    $cpid = 0;
-	} else {
-	    print  STDERR "$$: backend $child died\n";
-	    $backend->{backend_pid} = 0;
-	    $backend->{to_child} = undef;
-	    $backend->{from_child} = undef;
-	}
+        if ($child == $cpid) {
+            print STDERR "$$: commands webserver died\n";
+            $cpid = 0;
+        }
+        else {
+            print STDERR "$$: backend $child died\n";
+            $backend->{backend_pid} = 0;
+            $backend->{to_child}    = undef;
+            $backend->{from_child}  = undef;
+        }
     }
 }
 
@@ -156,24 +157,24 @@ $cpid = commands::start_server($bmwqemu::vars{QEMUPORT} + 1);
 bmwqemu::save_vars();
 # make sure the needles are initialized before the backend thread is started
 needle::init($bmwqemu::vars{PRODUCTDIR} . "/needles");
-$backend = bmwqemu::init_backend( $bmwqemu::vars{BACKEND} );
+$backend = bmwqemu::init_backend($bmwqemu::vars{BACKEND});
 
 if ($init) {
-    open( my $fd, ">", "os-autoinst.pid" );
+    open(my $fd, ">", "os-autoinst.pid");
     print $fd "$$\n";
     close $fd;
 
     # run prestart test code before VM is started
     if (-f "$bmwqemu::vars{CASEDIR}/prestart.pm") {
         diag "running prestart step";
-        eval {require $bmwqemu::vars{CASEDIR}."/prestart.pm";};
+        eval { require $bmwqemu::vars{CASEDIR} . "/prestart.pm"; };
         if ($@) {
             diag "prestart step FAIL:";
             die $@;
         }
     }
 
-    if ( !bmwqemu::alive ) {
+    if (!bmwqemu::alive) {
         bmwqemu::start_vm or die $@;
     }
 }
@@ -182,13 +183,13 @@ $SIG{ALRM} = \&signalhandler;
 $SIG{TERM} = \&signalhandler;
 $SIG{INT}  = \&signalhandler;
 $SIG{HUP}  = \&signalhandler;
-$SIG{CHLD}  = \&signalhandler_chld;
+$SIG{CHLD} = \&signalhandler_chld;
 
 if ($ENV{RUN_VNCVIEWER}) {
-  system("vncviewer -shared localhost:" . $bmwqemu::vars{VNC} . " -viewonly &");
+    system("vncviewer -shared localhost:" . $bmwqemu::vars{VNC} . " -viewonly &");
 }
 if ($ENV{RUN_DEBUGVIEWER}) {
-  system("$bmwqemu::scriptdir/debugviewer/debugviewer qemuscreenshot/last.png &");
+    system("$bmwqemu::scriptdir/debugviewer/debugviewer qemuscreenshot/last.png &");
 }
 
 require Carp;
@@ -213,7 +214,7 @@ $SIG{ALRM} = 'IGNORE';    # ignore ALRM so the readthread doesn't kill us here
 my $clean_shutdown;
 eval {
     my $status = $bmwqemu::backend->status();
-    $clean_shutdown = 1 if $status||'' eq "shutdown";
+    $clean_shutdown = 1 if $status || '' eq "shutdown";
 };
 
 bmwqemu::stop_vm();
@@ -239,7 +240,7 @@ if (!$r && (my $nd = $bmwqemu::vars{NUMDISKS})) {
         next unless $name;
         $name =~ /\.([[:alnum:]]+)$/;
         my $format = $1;
-        push @toextract, { hdd_num => $i, name => $name, dir => $dir, format => $format };
+        push @toextract, {hdd_num => $i, name => $name, dir => $dir, format => $format};
     }
     if (@toextract && !$clean_shutdown) {
         diag "ERROR: Machine not shut down when uploading disks!\n";
@@ -254,7 +255,7 @@ if (!$r && (my $nd = $bmwqemu::vars{NUMDISKS})) {
 # run postrun test code after VM is stopped
 if (-f "$bmwqemu::vars{CASEDIR}/postrun.pm") {
     diag "running postrun step";
-    eval { require "$bmwqemu::vars{CASEDIR}/postrun.pm"; }; ## no critic
+    eval { require "$bmwqemu::vars{CASEDIR}/postrun.pm"; };    ## no critic
     if ($@) {
         diag "postrun step FAIL:";
         warn $@;

--- a/tools/tidy
+++ b/tools/tidy
@@ -28,7 +28,7 @@ find -name '*.tdy' -delete
 
 find . -name '*.p[lm]' -print0 | xargs -0 perltidy $TIDY_ARGS
 
-find tools/absolutize -print0 | xargs -0 perltidy $TIDY_ARGS
+find tools/absolutize isotovideo -print0 | xargs -0 perltidy $TIDY_ARGS
 
 while read file; do
     if ! diff -u ${file%.tdy} $file; then


### PR DESCRIPTION
Do not call stop_vm through JSON but just kill the backend process
and leave the shutdown to itself