### PR TITLE
Output git hash of executed tests

### DIFF
--- a/isotovideo
+++ b/isotovideo
@@ -40,6 +40,7 @@ use testapi qw(diag);
 use Getopt::Std;
 require IPC::System::Simple;
 use autodie qw(:all);
+use Cwd;
 use POSIX qw(:sys_wait_h _exit);
 
 # avoid paranoia
@@ -143,6 +144,20 @@ $bmwqemu::vars{BACKEND} ||= "qemu";
 # This allows further structuring the test distribution collections with
 # multiple distributions or flavors in one repository.
 $bmwqemu::vars{PRODUCTDIR} ||= $bmwqemu::vars{CASEDIR};
+
+# as we are about to load the test modules store the git hash that has been
+# used. If it is not a git repo fail silently, i.e. store an empty variable
+
+my $dir = getcwd;
+chdir($bmwqemu::vars{CASEDIR});
+chomp(my $test_git_hash = qx{git rev-parse HEAD});
+$test_git_hash ||= "UNKNOWN";
+chdir($dir);
+diag "git hash of test distribution: $test_git_hash";
+# TODO find a better place to store hash in than vars.json, see
+# https://github.com/os-autoinst/os-autoinst/pull/393#discussion_r50143013
+$bmwqemu::vars{TEST_GIT_HASH} = $test_git_hash;
+
 require $bmwqemu::vars{PRODUCTDIR} . "/main.pm";
 
 # set a default distribution if the tests don't have one


### PR DESCRIPTION
If the test directory (CASEDIR) is a git repository the current commit hash is
saved just before the tests are loaded and output into the logs. The git
commit hash can be used for reference in later analysis, e.g. in openQA to
display the file not in the "most recent" state but the actual state the test
source was in at the time of execution.

If CASEDIR is not a git repo "UNKNOWN" is stored instead. A "dirty" state of
the repository is *not* detected.

Example output

```
12:29:34.6697 git hash of test distribution: c9421dc270a53d5f408e22607e437be8ae385349
12:29:34.6803 usingenv DESKTOP=textmode
12:29:34.6804 usingenv TEXTMODE=1
```