### PR TITLE
Calculate sha1sum of qcow assets for verification

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -187,10 +187,10 @@ sub do_extract_assets {
     my $img_dir = $args->{dir};
     my $format  = $args->{format};
     if (!$format || $format !~ /^(raw|qcow2)$/) {
-        bmwqemu::diag "do_extract_assets: only raw and qcow2 formats supported $name $format\n";
+        bmwqemu::diag "do_extract_assets: only raw and qcow2 formats supported $name $format";
     }
     elsif (-f "raid/l$hdd_num") {
-        bmwqemu::diag "preparing hdd $hdd_num for upload as $name in $format\n";
+        bmwqemu::diag "preparing hdd $hdd_num for upload as $name in $format";
         mkpath($img_dir);
         my @cmd = ('nice', 'ionice', 'qemu-img', 'convert', '-O', $format, "raid/l$hdd_num", "$img_dir/$name");
         if ($format eq 'raw') {
@@ -206,9 +206,11 @@ sub do_extract_assets {
                 symlink("../raid/l$hdd_num", "$img_dir/$name");
             }
         }
+        chomp(my $sha1 = qx{sha1sum -b $img_dir/$name});
+        bmwqemu::diag "sha1sum $sha1";
     }
     else {
-        bmwqemu::diag "do_extract_assets: hdd $hdd_num does not exist\n";
+        bmwqemu::diag "do_extract_assets: hdd $hdd_num does not exist";
     }
 }
 


### PR DESCRIPTION
Output the computed sha1sum of each generated qcow asset in the diag output so
that we can check the integrity of images. SUSE QAM has some problems lately
booting the generated images so we want to make sure the images are correct.

Deleting additional '\n' on diag calls. Diag already adds newline.

Example output in logfile:

```
14:07:59.9220 sha1sum bd5a4df9d6523acd3cd31361481b8ee389047d66 *assets_public/SLES-12-SP2-x86_64-Build1644-gnome.qcow2
```

Local verification run: http://lord.arch/tests/1820