### PR TITLE
Add a version route to commands

### DIFF
--- a/isotovideo
+++ b/isotovideo
@@ -33,6 +33,10 @@ BEGIN {
     unshift @INC, "$installprefix";
 }
 
+# this shall be an integer increased by every change of the API
+# either to the worker or the tests
+our $INTERFACE = 6;
+
 use bmwqemu;
 use needle;
 use autotest;
@@ -126,15 +130,23 @@ sub init_backend {
     return $bmwqemu::backend;
 }
 
+our $test_git_hash;
+
+sub calculate_git_hash {
+    my $dir = getcwd;
+    chdir($bmwqemu::vars{CASEDIR});
+    chomp($test_git_hash = qx{git rev-parse HEAD});
+    $test_git_hash ||= "UNKNOWN";
+    chdir($dir);
+    diag "git hash of test distribution: $test_git_hash";
+    return $test_git_hash;
+}
+
 $SIG{ALRM} = \&signalhandler;
 $SIG{TERM} = \&signalhandler;
 $SIG{INT}  = \&signalhandler;
 $SIG{HUP}  = \&signalhandler;
 $SIG{CHLD} = \&signalhandler_chld;
-
-# start the command fork before we get into the backend, the command child
-# is not supposed to talk to the backend directly
-($cpid, $cfd) = commands::start_server($bmwqemu::vars{QEMUPORT} + 1);
 
 # Try to load the main.pm from one of the following in this order:
 #  - product dir
@@ -147,15 +159,14 @@ $bmwqemu::vars{PRODUCTDIR} ||= $bmwqemu::vars{CASEDIR};
 # as we are about to load the test modules store the git hash that has been
 # used. If it is not a git repo fail silently, i.e. store an empty variable
 
-my $dir = getcwd;
-chdir($bmwqemu::vars{CASEDIR});
-chomp(my $test_git_hash = qx{git rev-parse HEAD});
-$test_git_hash ||= "UNKNOWN";
-chdir($dir);
-diag "git hash of test distribution: $test_git_hash";
+calculate_git_hash;
 # TODO find a better place to store hash in than vars.json, see
 # https://github.com/os-autoinst/os-autoinst/pull/393#discussion_r50143013
 $bmwqemu::vars{TEST_GIT_HASH} = $test_git_hash;
+
+# start the command fork before we get into the backend, the command child
+# is not supposed to talk to the backend directly
+($cpid, $cfd) = commands::start_server($bmwqemu::vars{QEMUPORT} + 1);
 
 require $bmwqemu::vars{PRODUCTDIR} . "/main.pm";
 
@@ -300,6 +311,12 @@ while ($loop) {
             my $result = {tags => $tags, running => $current_test_name};
             $result->{interactive} = $interactive;
             $result->{needinput}   = $needinput;
+            myjsonrpc::send_json($r, $result);
+            next;
+        }
+
+        if ($rsp->{cmd} eq 'version') {
+            my $result = {test_git_hash => $test_git_hash, version => $INTERFACE};
             myjsonrpc::send_json($r, $result);
             next;
         }

--- a/t/07-commands.pl
+++ b/t/07-commands.pl
@@ -1,0 +1,78 @@
+#!/usr/bin/perl
+#
+# Copyright (c) 2016 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+
+use strict;
+use warnings;
+
+use FindBin;
+use File::Find;
+require IPC::System::Simple;
+use autodie qw(:all);
+
+
+BEGIN {
+    unshift @INC, '..';
+}
+
+use commands;
+use Mojo::IOLoop::Server;
+use Time::HiRes qw(sleep);
+use Test::More tests => 4;
+use POSIX qw(_exit);
+
+our $mojoport = Mojo::IOLoop::Server->generate_port;
+
+sub wait_for_server {
+    my ($ua) = @_;
+    for (my $counter = 0; $counter < 20; $counter++) {
+        return if (($ua->get("http://localhost:$mojoport/NEVEREVER")->res->code // 0) == 404);
+        sleep .1;
+    }
+    return 1;
+}
+
+$bmwqemu::vars{JOBTOKEN} = 'Hallo';
+
+# now this is a game of luck
+my ($cpid, $cfd) = commands::start_server($mojoport);
+
+my $spid = fork();
+if ($spid == 0) {
+    # we need to fake isotovideo here
+    my $h = myjsonrpc::read_json($cfd);
+    if ($h->{cmd} eq 'version') {
+        myjsonrpc::send_json($cfd, {VERSION => 'COOL'});
+    }
+    _exit(0);
+}
+
+my $ua = Mojo::UserAgent->new;
+if (wait_for_server($ua)) {
+    exit(0);
+}
+
+is($ua->get("http://localhost:$mojoport/NEVEREVER")->res->code,          404);
+is($ua->get("http://localhost:$mojoport/isotovideo/version")->res->code, 404);
+my $get = $ua->get("http://localhost:$mojoport/Hallo/isotovideo/version");
+is($get->res->code, 200);
+is_deeply($get->res->json, {VERSION => 'COOL'});
+
+END {
+    kill($spid);
+    kill($cpid);
+}

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,3 +1,3 @@
-TESTS = 00-compile-check-all.pl 01-test_needle.pl 02-test_ocr.pl 03-testapi.pl 04-check_vars_docu.pl 05-pod.pl 06-pod-coverage.pl
+TESTS = 00-compile-check-all.pl 01-test_needle.pl 02-test_ocr.pl 03-testapi.pl 04-check_vars_docu.pl 05-pod.pl 06-pod-coverage.pl 07-commands.pl
 
 EXTRA_DIST = $(TESTS) t/test_driver.pm


### PR DESCRIPTION
curl -s
http://localhost:20113/98Xoquw0SPu7So7v/isotovideo/version | json_pp
{
   "version" : 6,
   "test_git_hash" : "5c4b7d1bc8be0b7c4a3a5bb6bc128dd6d34ee1b7"
}

The 6 is a random number, but it will increase and the worker will
require a minium version of it.

And it can transmit the test_git_hash to the webui so it can render the
correct sources even before the final vars.json is uploaded