### PR TITLE
Fix CDMODEL ide-cd

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -533,7 +533,7 @@ sub start_qemu {
             }
         }
 
-
+        my $cdbus = $vars->{CDMODEL} ne 'ide-cd' ? ',bus=scsi0.0' : '';
         if ($iso) {
             if ($vars->{USBBOOT}) {
                 push(@params, "-drive",  "if=none,id=usbstick,file=$iso,snapshot=on");
@@ -545,7 +545,7 @@ sub start_qemu {
                 # XXX: workaround for OVMF wanting to write NVvars into first FAT partition
                 # we need to replace -bios with proper pflash drive specification
                 $params[-1] .= ',snapshot=on' if $vars->{UEFI};
-                push(@params, '-device', "$vars->{CDMODEL},drive=cd0,bus=scsi0.0");
+                push(@params, '-device', "$vars->{CDMODEL},drive=cd0" . $cdbus);
             }
         }
 
@@ -554,7 +554,7 @@ sub start_qemu {
             my $i        = $k;
             $i =~ s/^ISO_//;
             push(@params, '-drive',  "media=cdrom,if=none,id=cd$i,format=raw,file=$addoniso");
-            push(@params, '-device', "$vars->{CDMODEL},drive=cd$i,bus=scsi0.0");
+            push(@params, '-device', "$vars->{CDMODEL},drive=cd$i" . $cdbus);
         }
 
         if ($arch_supports_boot_order) {


### PR DESCRIPTION
ide-cd have broken since 4df959b8e0f118e47a358a03777c259e417ba245 and fails with QEMU: qemu-system-x86_64: -device ide-cd,drive=cd0,bus=scsi0.0: Bus 'scsi0.0' not found