### PR TITLE
Support arbitrary options for '-netdev user'

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -482,7 +482,11 @@ sub start_qemu {
 
         for (my $i = 0; $i < $num_networks; $i++) {
             if ($vars->{NICTYPE} eq "user") {
-                push(@params, '-netdev', "user,id=qanet$i");
+                my $nictype_user_options;
+                if ($vars->{NICTYPE_USER_OPTIONS}) {
+                    $nictype_user_options = ',' . $vars->{NICTYPE_USER_OPTIONS};
+                }
+                push(@params, '-netdev', "user,id=qanet$i$nictype_user_options");
             }
             elsif ($vars->{NICTYPE} eq "tap") {
                 push(@params, '-netdev', "tap,id=qanet$i,ifname=$tapdev[$i],script=$tapscript[$i],downscript=$tapdownscript[$i]");

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -47,6 +47,7 @@ NBF;boolean;0;open source network boot firmware e.g. to attach iscsi target on b
 NICMAC;any MAC address;52:54:00:12:34:56;MAC address to be assigned to virtual network card
 NICMODEL;see qemu -device ?;virtio-net;Network device virtual NIC.
 NICTYPE;user|tap|vde;user;Instruct QEMU to either use user networking or to connect virtual NIC to existin system TAP device
+NICTYPE_USER_OPTIONS;string;undef;Arbitrary options for NICTYPE
 NICVLAN;integer;undef;network (vlan) number to which the NIC should be connected, assigned by scheduler to jobs with NICTYPE != user
 NUMDISKS;integer;1;Number of disks to be created and attached to VM
 OFW;;;

--- a/doc/networking.md
+++ b/doc/networking.md
@@ -7,6 +7,9 @@ By default NICTYPE is set to "user" and MULTINET is not set. In this case, each 
 with one network device, QEMU provided DHCP configuration. "User" network mode does have a
 limitation - only TCP and UDP are supported. However no additional configuration is needed.
 
+## options for "user" mode
+If options for "user" mode are required, they can be set in NICTYPE_USER_OPTIONS variable.
+
 ## multiple network devices
 When MULTINET variable is set, only NICTYPE set to "user" is supported. In this case, each VM
 is created with two network devices using "user" network mode.


### PR DESCRIPTION
For FATE#319639 we need to test that YaST2 uses in installation hostname
from network. One way to test it is by -netdev user,hostname=MyHostName
Qemu option.

Test case:

    start qemu with -netdev user,hostname=
    start installation ifcfg=*=dhcp
    check whether hostname is set to 'myhostname1'

Verification:

    # ps aux | grep hostnameXXX
    _openqa+ 13293 13.1  0.1 5074336 45956 ?       Sl   16:35   0:00
    /usr/bin/qemu-system-x86_64 -serial file:serial0 -soundhw ac97
    -global
    isa-fdc.driveA= -vga cirrus -m 4096 -cpu qemu64 -netdev
    user,id=qanet0,hostname=myhostnameXXX