### PR TITLE
Extend loadtest to schedule same module multiple times

### DIFF
--- a/t/08-autotest.pl
+++ b/t/08-autotest.pl
@@ -6,6 +6,7 @@ use Test::More;
 use Test::Output;
 use Test::Fatal;
 use Test::MockModule;
+use File::Basename ();
 
 BEGIN {
     unshift @INC, '..';
@@ -13,31 +14,35 @@ BEGIN {
 
 use autotest;
 use bmwqemu;
-$bmwqemu::vars{CASEDIR} = 't/fake';
+$bmwqemu::vars{CASEDIR} = File::Basename::dirname($0) . '/fake';
 
-like(exception { autotest::runalltests}, qr/ERROR: no tests loaded/, 'runalltests needs tests loaded first');
+
+like(exception { autotest::runalltests }, qr/ERROR: no tests loaded/, 'runalltests needs tests loaded first');
 stderr_like(
-    sub { like(exception {autotest::loadtest 'does/not/match'}, qr/loadtest needs a script to match/) },
-    qr/loadtest needs a script below.*is not/);
+    sub {
+        like(exception { autotest::loadtest 'does/not/match' }, qr/loadtest needs a script to match/);
+    },
+    qr/loadtest needs a script below.*is not/
+);
 
 sub loadtest {
     my ($test, $args) = @_;
-stderr_like( sub { autotest::loadtest "tests/$test.pm" }, qr@scheduling $test tests/$test.pm@, \$args);
+    stderr_like(sub { autotest::loadtest "tests/$test.pm" }, qr@scheduling $test[0-9]? tests/$test.pm@, \$args);
 }
 
 loadtest 'start';
 loadtest 'next';
 is(keys %autotest::tests, 2);
-loadtest 'start', 'rescheduling same step later is accepted but does overwrite existing step';
-is(keys %autotest::tests, 2, 'previous start step is overwritten');
+loadtest 'start', 'rescheduling same step later';
+is(keys %autotest::tests, 3) || diag explain %autotest::tests;
 
 my $mock_jsonrpc = new Test::MockModule('myjsonrpc');
-$mock_jsonrpc->mock(send_json => sub {});
-$mock_jsonrpc->mock(read_json => sub {});
+$mock_jsonrpc->mock(send_json => sub { });
+$mock_jsonrpc->mock(read_json => sub { });
 my $mock_bmwqemu = new Test::MockModule('bmwqemu');
-$mock_bmwqemu->mock(save_json_file => sub {});
+$mock_bmwqemu->mock(save_json_file => sub { });
 my $mock_basetest = new Test::MockModule('basetest');
-$mock_basetest->mock(_result_add_screenshot => sub {});
+$mock_basetest->mock(_result_add_screenshot => sub { });
 
 ok(autotest::runalltests);
 

--- a/t/08-autotest.pl
+++ b/t/08-autotest.pl
@@ -1,0 +1,46 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More;
+use Test::Output;
+use Test::Fatal;
+use Test::MockModule;
+
+BEGIN {
+    unshift @INC, '..';
+}
+
+use autotest;
+use bmwqemu;
+$bmwqemu::vars{CASEDIR} = 't/fake';
+
+like(exception { autotest::runalltests}, qr/ERROR: no tests loaded/, 'runalltests needs tests loaded first');
+stderr_like(
+    sub { like(exception {autotest::loadtest 'does/not/match'}, qr/loadtest needs a script to match/) },
+    qr/loadtest needs a script below.*is not/);
+
+sub loadtest {
+    my ($test, $args) = @_;
+stderr_like( sub { autotest::loadtest "tests/$test.pm" }, qr@scheduling $test tests/$test.pm@, \$args);
+}
+
+loadtest 'start';
+loadtest 'next';
+is(keys %autotest::tests, 2);
+loadtest 'start', 'rescheduling same step later is accepted but does overwrite existing step';
+is(keys %autotest::tests, 2, 'previous start step is overwritten');
+
+my $mock_jsonrpc = new Test::MockModule('myjsonrpc');
+$mock_jsonrpc->mock(send_json => sub {});
+$mock_jsonrpc->mock(read_json => sub {});
+my $mock_bmwqemu = new Test::MockModule('bmwqemu');
+$mock_bmwqemu->mock(save_json_file => sub {});
+my $mock_basetest = new Test::MockModule('basetest');
+$mock_basetest->mock(_result_add_screenshot => sub {});
+
+ok(autotest::runalltests);
+
+done_testing();
+
+# vim: set sw=4 et:

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,3 +1,3 @@
-TESTS = 00-compile-check-all.pl 01-test_needle.pl 02-test_ocr.pl 03-testapi.pl 04-check_vars_docu.pl 05-pod.pl 06-pod-coverage.pl 07-commands.pl
+TESTS = 00-compile-check-all.pl 01-test_needle.pl 02-test_ocr.pl 03-testapi.pl 04-check_vars_docu.pl 05-pod.pl 06-pod-coverage.pl 07-commands.pl 08-autotest.pl
 
 EXTRA_DIST = $(TESTS) t/test_driver.pm

--- a/t/fake/tests/next.pm
+++ b/t/fake/tests/next.pm
@@ -1,0 +1,1 @@
+start.pm

--- a/t/fake/tests/start.pm
+++ b/t/fake/tests/start.pm
@@ -2,5 +2,5 @@ use strict;
 use warnings;
 use base 'basetest';
 
-sub run {}
+sub run { }
 1;

--- a/t/fake/tests/start.pm
+++ b/t/fake/tests/start.pm
@@ -1,0 +1,6 @@
+use strict;
+use warnings;
+use base 'basetest';
+
+sub run {}
+1;


### PR DESCRIPTION
Previously `loadtest` would trigger a test module only once as a latter call
to `loadtest` with same argument overwrites a previous call. This prevents
reuse of test modules which should appear multiple times in the same schedule.
An example where one would like to apply this is to call a test module in a
system, then upgrade the system and call the same previous test module again.

Example output when called from isotovideo context:

scheduling consoletest_setup tests/console/consoletest_setup.pm
scheduling check_console_font tests/console/check_console_font.pm
scheduling textinfo tests/console/textinfo.pm
scheduling hostname tests/console/hostname.pm
console-check_console_font already scheduled
scheduling check_console_font1 tests/console/check_console_font.pm
scheduling zypper_lr tests/console/zypper_lr.pm

If this approach works depends on how the test modules are written of course.