### PR TITLE
Fix warnings in vnc_base for mouse pointer set and hide

### DIFF
--- a/consoles/vnc_base.pm
+++ b/consoles/vnc_base.pm
@@ -183,6 +183,7 @@ sub release_key {
 
 sub mouse_hide {
     my ($self, $args) = @_;
+    $args->{border_offset} //= 0;
 
     $self->{mouse}->{x} = $self->{vnc}->width - 1;
     $self->{mouse}->{y} = $self->{vnc}->height - 1;
@@ -199,6 +200,7 @@ sub mouse_hide {
 
 sub mouse_set {
     my ($self, $args) = @_;
+    return unless ($args->{x} && $args->{y});
 
     # TODO: for framebuffers larger than 1024x768, we need to upscale
     $self->{mouse}->{x} = int($args->{x});


### PR DESCRIPTION
Verified locally with test run of os-autoinst-distri-openSUSE, mouse cursor
can still be hidden.