### PR TITLE
assert_and_click: handle undefined previous mouse position

### DIFF
--- a/consoles/vnc_base.pm
+++ b/consoles/vnc_base.pm
@@ -188,9 +188,11 @@ sub mouse_hide {
     $self->{mouse}->{x} = $self->{vnc}->width - 1;
     $self->{mouse}->{y} = $self->{vnc}->height - 1;
 
-    my $border_offset = int($args->{border_offset});
-    $self->{mouse}->{x} -= $border_offset;
-    $self->{mouse}->{y} -= $border_offset;
+    if (defined $args->{border_offset}) {
+        my $border_offset = int($args->{border_offset});
+        $self->{mouse}->{x} -= $border_offset;
+        $self->{mouse}->{y} -= $border_offset;
+    }
 
     bmwqemu::diag "mouse_move $self->{mouse}->{x}, $self->{mouse}->{y}";
     $self->{vnc}->mouse_move_to($self->{mouse}->{x}, $self->{mouse}->{y});

--- a/testapi.pm
+++ b/testapi.pm
@@ -311,8 +311,14 @@ sub assert_and_click {
     }
     # We can't just move the mouse, or we end up in a click-and-drag situation
     sleep 1;
-    # move mouse back to where it was before we clicked
-    return mouse_set($old_mouse_coords->{x}, $old_mouse_coords->{y});
+    # move mouse back to where it was before we clicked, or to the 'hidden'
+    # position if it had never been positioned
+    if (defined $old_mouse_coords->{x} && defined $old_mouse_coords->{y}) {
+        return mouse_set($old_mouse_coords->{x}, $old_mouse_coords->{y});
+    }
+    else {
+        return mouse_hide();
+    }
 }
 
 =head2 assert_and_dclick


### PR DESCRIPTION
assert_and_click tries to record the previous mouse cursor
position and return the cursor there after clicking. However if
the mouse has never been explicitly positioned anywhere before,
`backend_get_last_mouse_set` returns undefined for each
co-ordinate, which results in a couple of 'use of uninitialized
value in int' warnings and the cursor being set to 0,0, which
may trigger the GNOME overview under Wayland. So catch when the
values are undefined and in this case, call mouse_hide() - which
puts the cursor at bottom-right - instead. This avoids both the
warnings and the overview trigger.