### PR TITLE
Fix assert_script_run with just one named argument

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -607,7 +607,7 @@ sub assert_script_run {
     if (@_ == 1) {
         %args = (timeout => $_[0]);
     }
-    elsif (@_ == 2 && $_[1] ne 'fail_message' && $_[1] ne 'timeout') {
+    elsif (@_ == 2 && $_[0] ne 'fail_message' && $_[0] ne 'timeout') {
         %args = (timeout => $_[0], fail_message => $_[1]);
     }
     else {


### PR DESCRIPTION
The error has been in travis output since like forever:

https://s3.amazonaws.com/archive.travis-ci.org/jobs/152011606/log.txt
-> Argument "fail_message" isn't numeric in multiplication (*) at
../bmwqemu.pm line 329.