### PR TITLE
No extra whitespace between json messages

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -422,7 +422,7 @@ sub check_socket {
             if ($self->{rsppipe}) {    # the command might have closed it
                 my $JSON = JSON->new()->convert_blessed();
                 my $json = $JSON->encode({rsp => $rsp});
-                $self->{rsppipe}->print("$json\n");
+                $self->{rsppipe}->print($json);
             }
         }
         else {


### PR DESCRIPTION
if the \n (or other whitespace char) appears at the edge of the buffer
in read_json, i.e. when the message is exactly 8000 bytes long, it is
parsed as the beggining of following message and the parser waits
forever for the rest.

BTW, it can be easily reproduced by changing buffer size from 8000 to 1 in read_json.