### PR TITLE
virtualization: workaround for unstable type_string on ipmi machine by typing more slowly

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -1165,7 +1165,9 @@ sub type_string {
         %args = @_;
     }
     my $log = $args{secret} ? 'SECRET STRING' : $string;
-    my $max_interval = $args{max_interval} // 250;
+    #workaround for unstable type_string behavior on ipmi machine, so type more slowly as VERY_SLOW_TYPING_SPEED setting in lib/utils
+    my $default_max_interval = check_var('BACKEND', 'ipmi') ? 4 : 250;
+    my $max_interval = $args{max_interval} // $default_max_interval;
     bmwqemu::log_call(string => $log, max_interval => $max_interval);
     query_isotovideo('backend_type_string', {text => $string, max_interval => $max_interval});
 }


### PR DESCRIPTION
Background: type_string on ipmi is unstable which blocks virtualization test. Originally I thought the maximum interval means typing with the slowest speed, however today I found that it is the opposite. So we will need to change the type speed for type_string behavior for ipmi.
 
Solution: Why I change in the type_string function in testapi.pm is that several files called this function, and inside each file , there may be serveral calls for this function. So code change is the least if change it here. 

Verification: We can not verify it locally here because the issue is only on the ipmi worker in openqa.suse.de. So we can only see whether it solves the problem after merging the code. If it does not work, we will revert the code later, and find other solutions. I think it is worth a merge.