### PR TITLE
don't sha1sum qcow assets (poo#13526)

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -203,8 +203,6 @@ sub do_extract_assets {
                 symlink("../raid/l$hdd_num", "$img_dir/$name");
             }
         }
-        chomp(my $sha1 = qx{sha1sum -b $img_dir/$name});
-        bmwqemu::diag "sha1sum $sha1";
     }
     else {
         bmwqemu::diag "do_extract_assets: hdd $hdd_num does not exist";


### PR DESCRIPTION
it takes a long time and blocks the worker process, preventing
it from sending status updates to the server and making it
vulnerable to the 'dead worker' check. Since we're *also*
checksumming in the worker itself, this really isn't needed.

Combined with several other changes I'm submitting for openQA,
this should address poo#13526.