### PR TITLE
svirt: Add support for UEFI, input devices configuration, and suspend/resume of VM

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -441,8 +441,8 @@ sub get_ssh_output {
         return ($stdout, $errout);
     }
     else {
-        bmwqemu::diag "Command's stdout:\n$stdout";
-        bmwqemu::diag "Command's stderr:\n$errout";
+        bmwqemu::diag "Command's stdout:\n$stdout" if length($stdout);
+        bmwqemu::diag "Command's stderr:\n$errout" if length($errout);
     }
 }
 
@@ -522,6 +522,7 @@ sub run_cmd {
 
     my $chan = $self->{ssh}->channel();
     $chan->exec($cmd);
+    bmwqemu::diag "Command executed: $cmd";
     get_ssh_output($chan);
     $chan->close();
     return $chan->exit_status();

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -411,6 +411,18 @@ sub get_ssh_output {
     }
 }
 
+sub suspend {
+    my ($self) = @_;
+    $self->{ssh}->channel()->exec("virsh suspend " . $self->name);
+    bmwqemu::diag "VM " . $self->name . " suspended";
+}
+
+sub resume {
+    my ($self) = @_;
+    $self->{ssh}->channel()->exec("virsh resume " . $self->name);
+    bmwqemu::diag "VM " . $self->name . " resumed";
+}
+
 sub define_and_start {
     my ($self) = @_;
 

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -257,6 +257,20 @@ sub add_vnc {
     return;
 }
 
+sub add_input {
+    my ($self, $args) = @_;
+
+    my $doc     = $self->{domainxml};
+    my $devices = $self->{devices_element};
+
+    my $input = $doc->createElement('input');
+    $input->setAttribute(type => $args->{type});
+    $input->setAttribute(bus  => $args->{bus});
+    $devices->appendChild($input);
+
+    return;
+}
+
 # network stuff
 sub add_interface {
     my ($self, $args) = @_;


### PR DESCRIPTION
Add UEFI support to svirt backend - This change adds UEFI support to svirt backend (depends on UEFI variable). Surrounding code was refactured.

Add support for input device configuration - `<input ...>` arguments `type` (mouse, keyboard, ...) and `bus` (e.g. virtio) can be configured in svirt backend.

Support suspend and resume of VM in svirt backend - `suspend()` and `resume()` functions of svirt backend let test to freeze and unfreeze VM.