### PR TITLE
Fix the exit code of isotovideo

### DIFF
--- a/isotovideo
+++ b/isotovideo
@@ -454,8 +454,8 @@ END {
     kill_backend;
     kill_commands;
     kill_autotest;
+    print "$$: EXIT $r\n";
+    _exit($r);
 }
 
-print "EXIT $r\n";
-exit $r;
 # vim: set sw=4 et:


### PR DESCRIPTION
The exit code of a perl script is not the one you give to exit, but is the
value of $? at the end of all END blocks (see perldoc -f exit). Interesting
caveat