### PR TITLE
Avoid warning in myjsonrpc when undef is returned

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -418,7 +418,7 @@ sub check_socket {
         my $cmd = myjsonrpc::read_json($self->{cmdpipe});
 
         if ($cmd->{cmd}) {
-            my $rsp = {rsp => $self->handle_command($cmd)};
+            my $rsp = {rsp => ($self->handle_command($cmd) // 0)};
             $rsp->{json_cmd_token} = $cmd->{json_cmd_token};
             if ($self->{rsppipe}) {    # the command might have closed it
                 my $JSON = JSON->new()->convert_blessed();

--- a/isotovideo
+++ b/isotovideo
@@ -264,7 +264,7 @@ sub check_asserted_screen {
     my ($force_timeout) = @_;
 
     my ($seconds, $microseconds) = gettimeofday;
-    my $rsp = $bmwqemu::backend->_send_json({cmd => 'check_asserted_screen'});
+    my $rsp = $bmwqemu::backend->_send_json({cmd => 'check_asserted_screen'}) || {};
     # the test needs that information
     $rsp->{tags} = $tags;
     if ($rsp->{found}) {


### PR DESCRIPTION
See the discussion in https://github.com/os-autoinst/os-autoinst/commit/41ebf9fb4198d021f3710be7e58aea3df448c0a2