### PR TITLE
Provide lib/ of the test distribution to main.pm

### DIFF
--- a/isotovideo
+++ b/isotovideo
@@ -213,7 +213,12 @@ $bmwqemu::vars{TEST_GIT_HASH} = $test_git_hash;
 # is not supposed to talk to the backend directly
 ($cpid, $cfd) = commands::start_server($bmwqemu::vars{QEMUPORT} + 1);
 
+# add lib of the test distributions - but only for main.pm not to pollute
+# further dependencies (the tests get it through autotest)
+my @oldINC = @INC;
+unshift @INC, $bmwqemu::vars{CASEDIR} . '/lib';
 require $bmwqemu::vars{PRODUCTDIR} . "/main.pm";
+@INC = @oldINC;
 
 # set a default distribution if the tests don't have one
 $testapi::distri ||= distribution->new;


### PR DESCRIPTION
This way we avoid every product's main.pm having a BEGIN clause with
hacky includes - and using functions in main.pm is handy

See https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/1452#discussion_r66057803 and https://progress.opensuse.org/issues/12258