### PR TITLE
Don't leave the commands server when it can't react

### DIFF
--- a/commands.pm
+++ b/commands.pm
@@ -263,7 +263,7 @@ sub run_daemon {
         $daemon->run;
     }
     catch {
-        print "failed to run daemon\n";
+        print "failed to run daemon $_\n";
         _exit(1);
     };
 }

--- a/isotovideo
+++ b/isotovideo
@@ -417,6 +417,10 @@ while ($loop) {
     }
 }
 
+# don't leave the commands server open - it will no longer react anyway
+# as most of it ends up in the loop above
+kill_commands;
+
 if ($testfd) {
     $r = 1;    # unusual shutdown
     CORE::close $testfd;


### PR DESCRIPTION
This lead to the openqa worker hanging while trying to get status
updates. This mainly was a problem for jobs publishing hdds