### PR TITLE
isotovideo: don't upload disks if test failed (POO #13722)

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -111,14 +111,15 @@ sub load_snapshot {
 }
 
 sub run_all {
-    my $r = 0;
-    eval { autotest::runalltests(); };
+    my $died   = 0;
+    my $passed = 0;
+    eval { $passed = autotest::runalltests(); };
     if ($@) {
         warn $@;
-        $r = 1;
+        $died = 1;    # test execution died
     }
     bmwqemu::save_vars();
-    myjsonrpc::send_json($isotovideo, {cmd => 'tests_done', ret => $r});
+    myjsonrpc::send_json($isotovideo, {cmd => 'tests_done', died => $died, passed => $passed});
     close $isotovideo;
     _exit(0);
 }

--- a/isotovideo
+++ b/isotovideo
@@ -69,6 +69,8 @@ $bmwqemu::direct_output = $opt_d;
 
 # global exit status
 my $r = 1;
+# whether tests 'passed'
+my $passed = 0;
 
 select(STDERR);
 $| = 1;
@@ -342,7 +344,8 @@ while ($loop) {
             next;
         }
         if ($rsp->{cmd} eq 'tests_done') {
-            $r = $rsp->{ret};
+            $r      = $rsp->{died};
+            $passed = $rsp->{passed};
             CORE::close($testfd);
             $testfd = undef;
             kill_autotest;
@@ -442,8 +445,8 @@ if (!$r) {
 # read calculated variables from backend and tests
 bmwqemu::load_vars();
 
-# mark hard disks for upload if test finished
-if (!$r && (my $nd = $bmwqemu::vars{NUMDISKS})) {
+# mark hard disks for upload if test finished and passed
+if (!$r && $passed && (my $nd = $bmwqemu::vars{NUMDISKS})) {
     my @toextract;
     for my $i (1 .. $nd) {
         my $dir = 'assets_private';

--- a/t/fake/tests/fatal.pm
+++ b/t/fake/tests/fatal.pm
@@ -1,0 +1,11 @@
+use strict;
+use warnings;
+use base 'basetest';
+
+sub run { }
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
At present, the "# mark hard disks for upload if test finished"
block runs even if the test *failed*: it's only skipped if
something went really wrong with test execution somehow (which
causes $r to be set to 1). This is a problem because commonly,
if the test failed, the SUT will not have been shut down
cleanly, so we'll run into the "ERROR: Machine not shut down"
case, which causes us to exit 1 (which in turn, on current
openQA git, causes the test to wind up as 'incomplete' rather
than 'failed').

`autotest::runalltests` actually returns either 0 or 1 to signal
whether a fatal test failed or not, but nothing was using this
return value at present; `run_all` only cared if `runalltests`
*died*, not if it returned 0 or 1.

So to improve things, let's have `run_all` care both whether
`runalltests` died and what it returned, and pass both bits of
information along to `isotovideo`, which can then use them both
to decide whether to run the disk upload block or not.

If anyone has a case where they want a test to upload its disk
images regardless of whether the test failed, we could tweak
this a bit more - say, if `STORE_ON_FAIL` var is set, we can
run the upload block but skip the 'is VM shut down?' check if
`$passed` is 0, or something like that.