### PR TITLE
rename `$passed` to `$completed`, test 'important' failure

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -111,15 +111,15 @@ sub load_snapshot {
 }
 
 sub run_all {
-    my $died   = 0;
-    my $passed = 0;
-    eval { $passed = autotest::runalltests(); };
+    my $died      = 0;
+    my $completed = 0;
+    eval { $completed = autotest::runalltests(); };
     if ($@) {
         warn $@;
         $died = 1;    # test execution died
     }
     bmwqemu::save_vars();
-    myjsonrpc::send_json($isotovideo, {cmd => 'tests_done', died => $died, passed => $passed});
+    myjsonrpc::send_json($isotovideo, {cmd => 'tests_done', died => $died, completed => $completed});
     close $isotovideo;
     _exit(0);
 }

--- a/isotovideo
+++ b/isotovideo
@@ -69,8 +69,8 @@ $bmwqemu::direct_output = $opt_d;
 
 # global exit status
 my $r = 1;
-# whether tests 'passed'
-my $passed = 0;
+# whether tests completed (or we bailed due to a failed 'fatal' test)
+my $completed = 0;
 
 select(STDERR);
 $| = 1;
@@ -344,8 +344,8 @@ while ($loop) {
             next;
         }
         if ($rsp->{cmd} eq 'tests_done') {
-            $r      = $rsp->{died};
-            $passed = $rsp->{passed};
+            $r         = $rsp->{died};
+            $completed = $rsp->{completed};
             CORE::close($testfd);
             $testfd = undef;
             kill_autotest;
@@ -445,8 +445,8 @@ if (!$r) {
 # read calculated variables from backend and tests
 bmwqemu::load_vars();
 
-# mark hard disks for upload if test finished and passed
-if (!$r && $passed && (my $nd = $bmwqemu::vars{NUMDISKS})) {
+# mark hard disks for upload if test finished
+if (!$r && $completed && (my $nd = $bmwqemu::vars{NUMDISKS})) {
     my @toextract;
     for my $i (1 .. $nd) {
         my $dir = 'assets_private';

--- a/t/fake/tests/important.pm
+++ b/t/fake/tests/important.pm
@@ -1,0 +1,11 @@
+use strict;
+use warnings;
+use base 'basetest';
+
+sub run { }
+
+sub test_flags {
+    return {important => 1};
+}
+
+1;


### PR DESCRIPTION
Inspired by aaannz's comment on #597, this renames the `passed`
var to `completed` - which is a more accurate characterization
of both what we're actually checking and what we *want* to
check - and adds a test that makes sure `$completed` is 1 when
an 'important' test fails but no 'fatal' tests fail.