### PR TITLE
Support snapshots on svirt backend

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -500,7 +500,7 @@ __END"
     # shut down possibly running previous test (just to be sure) - ignore errors
     # just making sure we continue after the command finished
     $self->run_cmd("virsh $remote_vmm destroy " . $self->name);
-    $self->run_cmd("virsh $remote_vmm undefine " . $self->name);
+    $self->run_cmd("virsh $remote_vmm undefine --snapshots-metadata " . $self->name);
 
     # define the new domain
     $self->run_cmd("virsh $remote_vmm define $xmlfilename")  && die "virsh define failed";


### PR DESCRIPTION
Via libvirt we are able to save and load snapshots on KVM and perhaps
VMware's ESXi (untested), Xen is not supported and I could not find a
way how to make snapshots via it's own tools (perhaps snapshots on Xen
are not supported?), and Hyper-V will be treated in it's own way. For
full support matrix refer to: https://libvirt.org/hvsupport.html.

```
...
14:49:15.8286 21825 Command executed: virsh  undefine
--snapshots-metadata openQA-SUT-2
14:49:15.8695 21825 Command's stdout:
Domain openQA-SUT-2 has been undefined
...
15:00:13.2116 21824 ||| finished first_boot installation at 2016-09-15
15:00:13 (28 s)
15:00:13.2120 21824 Creating a VM snapshot lastgood
15:00:14.3748 21825 Connection to root@openqaw6-kvm.qa.suse.de
established
15:00:14.6962 21825 Command executed: virsh snapshot-delete openQA-SUT-2
lastgood
15:00:15.9180 21825 Connection to root@openqaw6-kvm.qa.suse.de
established
15:00:16.2408 21825 Command executed: virsh snapshot-create-as
openQA-SUT-2 lastgood
15:00:19.3901 21825 SAVED VM "openQA-SUT-2" as "lastgood" snapshot,
return code == 0
15:00:19.3907 21824 ||| starting consoletest_setup
tests/console/consoletest_setup.pm at 2016-09-15 15:00:19
...
15:09:01.6560 21824 >>> testapi::wait_serial: bJZi9-\d+-: ok
15:09:01.6867 21824 test yast2_lan failed
15:09:01.6867 21824 Loading a VM snapshot lastgood
15:09:02.6119 21825 Connection to root@openqaw6-kvm.qa.suse.de
established
15:09:02.8679 21825 Command executed: virsh snapshot-revert openQA-SUT-2
lastgood
15:09:04.0105 21825 LOADED snapshot "lastgood" to "openQA-SUT-2", return
code == 0
...

Verification run: http://assam.suse.cz/tests/3399