### PR TITLE
Enable postrun hook

### DIFF
--- a/isotovideo
+++ b/isotovideo
@@ -104,6 +104,9 @@ sub kill_commands {
 
 sub kill_autotest {
     return unless $testpid;
+    bmwqemu::load_vars();
+    autotest::postrun_hook();
+
     # create a copy as cpid is overwritten by SIGCHLD
     my $pid = $testpid;
     if (kill('TERM', $pid)) {


### PR DESCRIPTION
Current use-case is system de-registration (poo#11518).
Tested manually by following worker logs and:
- canceling job
- obsoleting job
- finishing job

Required by https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/1923