### PR TITLE
Fix remote consoles on zkvm

### DIFF
--- a/isotovideo
+++ b/isotovideo
@@ -196,9 +196,10 @@ $SIG{HUP}  = \&signalhandler;
 $SIG{CHLD} = \&signalhandler_chld;
 
 # make sure all commands coming from the backend will not be in the
-# developers's locale
-$ENV{LC_ALL} = 'C';
-$ENV{LANG}   = 'C';
+# developers's locale - but a defined english one. This is SUSE's
+# default locale
+$ENV{LC_ALL} = 'en_US.UTF-8';
+$ENV{LANG}   = 'en_US.UTF-8';
 
 # Try to load the main.pm from one of the following in this order:
 #  - product dir


### PR DESCRIPTION
The C locale is affecting ncurses font more than what I intended with
this change. it should be UTF-8 still