### PR TITLE
Save machine memory dumps

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -329,6 +329,10 @@ sub is_shutdown {
     return -1;
 }
 
+sub save_state {
+    notimplemented;
+}
+
 ## MAY be overwritten:
 
 sub cpu_stat {

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -329,7 +329,11 @@ sub is_shutdown {
     return -1;
 }
 
-sub save_state {
+sub save_memory_dump {
+    notimplemented;
+}
+
+sub save_storage_drives {
     notimplemented;
 }
 

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -155,32 +155,31 @@ sub can_handle {
 sub save_state {
 
     my ($self, $args) = @_;
-    my $rsp = 0;
+    my $rsp    = 0;
     my $vmname = $args->{name};
 
     bmwqemu::diag("Trying to save a QEMU image");
 
-    $rsp = $self->_send_hmp("stop");
+    $self->freeze_vm;
 
-    diag "Sucessfully stopped our vm: $rsp";
-    die unless ($rsp eq "stop");
+    $rsp = $self->handle_qmp_command(JSON::from_json('{ "execute": "migrate_set_speed", "arguments": { "value": "4095m" } }'));
+    $rsp = $self->handle_qmp_command(JSON::from_json('{ "execute": "migrate", "arguments": { "uri": "exec:gzip -c > vmstate.gz" } }'));
 
-    $rsp    = $self->_send_hmp("migrate_set_speed 4095m");
-    die unless ($rsp eq "migrate_set_speed 4095m");
-    diag "Set up speed to: $rsp" 
+    do {
 
-    #For compression pixz was suggested, but it might add a new dependency
-    # also it would use multiple CPU's, which might be a problem in production.
-    $rsp    = $self->_send_hmp("migrate \"exec:gzip -c > vmstate.gz\"");
-    die unless ($rsp eq "migrate \"exec:gzip -c > vmstate.gz\"");
-    diag "Saved the machine state $rsp" 
+        sleep 0.5;    #We want to wait a decent amount of time, a file of 10GB will be
+                      # migrated in about 40secs with an ssd drive. and no heavy load.
 
-    $rsp    = $self->_send_hmp("cont");
-    die unless ($rsp eq "cont");
-    diag "Allowed the VM to keep running $rsp";
-    
+        $rsp = $self->handle_qmp_command({execute => "query-migrate"});
 
-    return;
+        diag "QEMU MIGRATING BYTES TOTAL:     \t" . $rsp->{return}->{ram}->{total};
+        diag "QEMU MIGRATING BYTES REMAINING:   \t" . $rsp->{return}->{ram}->{remaining};
+
+    } until ($rsp->{return}->{status} eq "completed");
+
+    diag "Migration completed.";
+    $self->cont_vm;
+
 }
 
 sub save_snapshot {

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -152,34 +152,54 @@ sub can_handle {
     return;
 }
 
-sub save_state {
-
+sub save_memory_dump {
     my ($self, $args) = @_;
-    my $rsp    = 0;
-    my $vmname = $args->{name};
+    my $rsp = 0;
 
-    bmwqemu::diag("Trying to save a QEMU image");
+    bmwqemu::diag("Migrating the machine.");
 
-    $self->freeze_vm;
+    mkpath("ulogs");
 
-    $rsp = $self->handle_qmp_command(JSON::from_json('{ "execute": "migrate_set_speed", "arguments": { "value": "4095m" } }'));
-    $rsp = $self->handle_qmp_command(JSON::from_json('{ "execute": "migrate", "arguments": { "uri": "exec:gzip -c > vmstate.gz" } }'));
+    $rsp = $self->handle_qmp_command(
+        {
+            execute   => "migrate",
+            arguments => {
+                uri => sprintf("exec:gzip -c > ulogs/%s-vm-memory-dump.gz", $args->{filename}),
+            }});
+
+    die(sprintf("Migration failed: desc: %s, class: %s, stopped", $rsp->{error}->{desc}, $rsp->{error}->{class})) if ($rsp->{error});
+
 
     do {
 
-        sleep 0.5;    #We want to wait a decent amount of time, a file of 10GB will be
+        sleep 0.5;    #We want to wait a decent amount of time, a file of 1GB will be
                       # migrated in about 40secs with an ssd drive. and no heavy load.
-
         $rsp = $self->handle_qmp_command({execute => "query-migrate"});
 
-        diag "QEMU MIGRATING BYTES TOTAL:     \t" . $rsp->{return}->{ram}->{total};
-        diag "QEMU MIGRATING BYTES REMAINING:   \t" . $rsp->{return}->{ram}->{remaining};
+        diag "Migrating total bytes:     \t" . $rsp->{return}->{ram}->{total};
+        diag "Migrating remaining bytes:   \t" . $rsp->{return}->{ram}->{remaining};
 
     } until ($rsp->{return}->{status} eq "completed");
 
     diag "Migration completed.";
-    $self->cont_vm;
+    return;
+}
 
+sub save_storage_drives {
+    my ($self, $args) = @_;
+
+    diag "Attemping to extract disk #%d.", $args->{disk};
+
+    $self->do_extract_assets(
+        {
+            hdd_num => $args->{disk},
+            name    => sprintf("%s-%d-vm_disk_file.qcow2", $args->{filename}, $args->{disk}),
+            dir     => "ulogs",
+            format  => "qcow2"
+        });
+
+    diag "Sucessfully extracted disk #%d.", $args->{disk};
+    return;
 }
 
 sub save_snapshot {

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -152,6 +152,37 @@ sub can_handle {
     return;
 }
 
+sub save_state {
+
+    my ($self, $args) = @_;
+    my $rsp = 0;
+    my $vmname = $args->{name};
+
+    bmwqemu::diag("Trying to save a QEMU image");
+
+    $rsp = $self->_send_hmp("stop");
+
+    diag "Sucessfully stopped our vm: $rsp";
+    die unless ($rsp eq "stop");
+
+    $rsp    = $self->_send_hmp("migrate_set_speed 4095m");
+    die unless ($rsp eq "migrate_set_speed 4095m");
+    diag "Set up speed to: $rsp" 
+
+    #For compression pixz was suggested, but it might add a new dependency
+    # also it would use multiple CPU's, which might be a problem in production.
+    $rsp    = $self->_send_hmp("migrate \"exec:gzip -c > vmstate.gz\"");
+    die unless ($rsp eq "migrate \"exec:gzip -c > vmstate.gz\"");
+    diag "Saved the machine state $rsp" 
+
+    $rsp    = $self->_send_hmp("cont");
+    die unless ($rsp eq "cont");
+    diag "Allowed the VM to keep running $rsp";
+    
+
+    return;
+}
+
 sub save_snapshot {
     my ($self, $args) = @_;
     my $vmname = $args->{name};

--- a/doc/memorydumps.asciidoc
+++ b/doc/memorydumps.asciidoc
@@ -1,0 +1,56 @@
+= Memory Dumps
+
+In the case that some test are failing under abnormal
+circumstances, the os-autoinst api offers the possibility to the tester to save
+a memory dump and disk image when certain conditions are met.
+
+IMPORTANT: Currently only the QEMU backend is supported.
+
+== How to use
+
+Three methods are available to the test writer, `freeze_vm`, `save_memory_dump`,
+and `save_storage_drives`
+
+The feature is enabled by calling the aforementioned methods, using
+a https://github.com/os-autoinst/openQA/blob/master/docs/WritingTests.asciidoc#how-to-write-tests[post_fail_hook] and setting the test's flags as fatal. The `save_memory_dump` method can be however
+called at any point within the test.
+
+=== save_memory_dump
+
+The method `save_memory_dump` can be called at any point, but it is recommended
+to use it within a post fail hook. Different filenames should be provided if the
+dump is being used within the test itself (or more than one memory dump is being
+created) if no filename is provided, the test's name will be used.
+
+=== save_storage_drives
+
+The method `save_storage_drives` saves all of the SUT drives using a filename
+provided by the user, if not the current test's name will be used  as part of
+the final filename, the default will be the current test's name. The  disk
+number will be always present.
+
+NOTE: Call this method to ensure memory and disk dump refer to the same machine state.
+
+=== freeze_vm
+
+If it is supported by the backend `freeze_vm` will allow the vm to be
+paused/frozen within the test. So that memory and disk dumps can be extracted
+without any risk of data changing.
+
+NOTE: Call this method to ensure memory and disk dump refer to the same machine state.
+
+== Examples
+
+A very simple way to use this helpful feature is the following:
+
+[source,perl]
+----------------------------------------
+sub post_fail_hook {
+	my $self = shift;
+	freeze_vm;
+	save_memory_dump("my-memory-dump");
+	save_storage_drives("my-disk");
+}
+
+sub test_flags { return { fatal => 1 } }
+----------------------------------------

--- a/testapi.pm
+++ b/testapi.pm
@@ -53,7 +53,7 @@ our @EXPORT = qw($realname $username $password $serialdev %cmd %vars
   upload_logs
 
   wait_idle wait_screen_change wait_still_screen wait_serial record_soft_failure
-  become_root x11_start_program ensure_installed eject_cd power
+  become_root x11_start_program ensure_installed eject_cd power save_state
 
   diag hashed_string
 );
@@ -822,6 +822,19 @@ sub eject_cd {
     query_isotovideo('backend_eject_cd');
 }
 
+=head2 save_state
+
+  save_state;
+
+if backend supports it, save machine state
+
+=cut
+
+sub save_state {
+    bmwqemu::log_call();
+    bmwqemu::diag("Trying to save machine state");
+    query_isotovideo('backend_save_state');
+}
 
 =head2 parse_junit_log
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -53,7 +53,9 @@ our @EXPORT = qw($realname $username $password $serialdev %cmd %vars
   upload_logs
 
   wait_idle wait_screen_change wait_still_screen wait_serial record_soft_failure
-  become_root x11_start_program ensure_installed eject_cd power save_state
+  become_root x11_start_program ensure_installed eject_cd power
+
+  save_memory_dump save_storage_drives freeze_vm
 
   diag hashed_string
 );
@@ -393,6 +395,7 @@ Returns true if screen is not changed for given $stilltime (in seconds) or undef
 Default timeout is 30s, default stilltime is 7s.
 
 =cut
+
 sub wait_still_screen {
     my $stilltime        = shift || 7;
     my $timeout          = shift || 30;
@@ -822,18 +825,82 @@ sub eject_cd {
     query_isotovideo('backend_eject_cd');
 }
 
-=head2 save_state
+=head2 save_memory_dump
 
-  save_state;
+  save_memory_dump([{ filename => undef, migration_speed => "4096m" }]);
 
-if backend supports it, save machine state
+Saves the SUT memory state using C<$filename> as base for the memory dump
+filename,  the default will be the current test's name.
+
+The memory dump can be created at any point, but it's recommended to use it
+within a post fail hook. Different filenames should be provided if the dump is
+being used within the test itself.
+
+I<Currently only qemu backend is supported.>
 
 =cut
 
-sub save_state {
+sub save_memory_dump {
+    my ($args) = @_;
+    $args->{filename} ||= ref($autotest::current_test);
+
     bmwqemu::log_call();
+    bmwqemu::diag "If save_memory_dump is called multiple times with the same '\$filename', it will be rewritten." unless ((caller(1))[3]) =~ /post_fail_hook/;
     bmwqemu::diag("Trying to save machine state");
-    query_isotovideo('backend_save_state');
+
+    query_isotovideo('backend_save_memory_dump', $args);
+}
+
+=head2 save_storage_drives
+
+  save_storage_drives([$filename]);
+
+Saves all of the SUT drives using C<$filename> as part of the final filename,
+the default will be the current test's name. The disk number will be always present.
+
+This method must be called within a post_fail_hook. 
+
+I<Currently only qemu backend is supported.>
+
+=cut
+
+sub save_storage_drives {
+    my $filename ||= ref($autotest::current_test);
+    die "Method should be called within a post_fail_hook" unless ((caller(1))[3]) =~ /post_fail_hook/;
+
+    bmwqemu::log_call();
+    bmwqemu::diag("Trying to save machine drives");
+    bmwqemu::load_vars();
+
+    # Right now, we're saving all the disks
+    # sometimes we might not want to. This could be improved.
+    if (my $nd = $bmwqemu::vars{NUMDISKS}) {
+        for my $i (1 .. $nd) {
+            query_isotovideo('backend_save_storage_drives', {disk => $i, filename => $filename});
+        }
+    }
+}
+
+=head2 freeze_vm
+
+  freeze_vm;
+
+If the backend supports it, freeze the vm. This will allow the vm to be
+paused/frozen within the test, but only from the post_fail_hook. So that memory
+and disk dumps can be extracted without any risk of data changing.
+
+Call this method to ensure memory and disk dump refer to the same machine state.
+
+I<Currently only qemu backend is supported.>
+
+=cut
+
+sub freeze_vm {
+    #While it might be a good idea to allow the user to stop the vm within a test
+    #we're not allowing them to do that outside a post_fail_hook.
+    die "Method should be called within a post_fail_hook" unless ((caller(1))[3]) =~ /post_fail_hook/;
+    bmwqemu::log_call();
+    query_isotovideo('backend_freeze_vm');
 }
 
 =head2 parse_junit_log


### PR DESCRIPTION
Added the necessary code to perform an online migration of the machine. 

After the vmstate.gz file has been generated, the machine can be restored or migrated by appending: **-incoming "exec: gzip -c -d vmstate.gz"** at the end of the qemu line. By grepping autoinst.txt looking for _starting qemu service:_ the line to spawn qemu can be found.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/os-autoinst/os-autoinst/621)

<!-- Reviewable:end -->
