### PR TITLE
Add debug output to needle load

### DIFF
--- a/isotovideo
+++ b/isotovideo
@@ -50,7 +50,9 @@ no autodie qw(kill);
 use Cwd;
 use POSIX qw(:sys_wait_h _exit);
 use Carp qw(cluck);
-use Time::HiRes qw(gettimeofday tv_interval sleep);
+use Time::HiRes qw(gettimeofday tv_interval sleep time);
+use File::Spec;
+use File::Path;
 
 # avoid paranoia
 $Getopt::Std::STANDARD_HELP_VERSION = 1;
@@ -172,12 +174,31 @@ sub signalhandler_chld {
 sub init_backend {
     my ($name) = @_;
     $bmwqemu::vars{BACKEND} ||= "qemu";
-    my $dir = getcwd;
-    # make sure the needles are initialized before the backend process is started
-    no autodie qw(system);
-    my $res = system("rsync -avP --delete --exclude=.git $bmwqemu::vars{PRODUCTDIR}/needles/ $dir/needles/");
-    die "Failed to rsync needles: $@" if $res;
-    needle::init("$dir/needles");
+
+    # CACHEDIRECTORY must be defined in workers.ini either global or per worker configuration
+    if ($bmwqemu::vars{CACHEDIRECTORY}) {
+
+        no autodie qw(system);
+
+        my $needles_source = $bmwqemu::vars{PRODUCTDIR} . "/needles";
+        my $shared_cache = File::Spec->catdir($bmwqemu::vars{CACHEDIRECTORY}, $bmwqemu::vars{OPENQA_HOSTNAME}, $bmwqemu::vars{DISTRI});
+        File::Path::make_path($shared_cache);
+
+        my $start = time;
+        #Do an flock to ensure only one worker is trying to synchronize at a time.
+        my $cmd = sprintf("flock -E 999 %s/needleslock rsync -aP --delete --exclude=.git %s %s/", $shared_cache, $needles_source, $shared_cache);
+        my $res = system($cmd);
+
+        die "Failed to rsync needles: '$@' " if $res;
+        bmwqemu::diag(sprintf("Rsync: Synchronization of needles directory took %.2f seconds", time - $start));
+
+        # make sure the needles are initialized
+        needle::init($shared_cache . "/needles");
+    }
+    else {
+        needle::init($bmwqemu::vars{PRODUCTDIR} . "/needles");
+    }
+
     $bmwqemu::backend = backend::driver->new($bmwqemu::vars{BACKEND});
     return $bmwqemu::backend;
 }

--- a/isotovideo
+++ b/isotovideo
@@ -172,8 +172,12 @@ sub signalhandler_chld {
 sub init_backend {
     my ($name) = @_;
     $bmwqemu::vars{BACKEND} ||= "qemu";
+    my $dir = getcwd;
     # make sure the needles are initialized before the backend process is started
-    needle::init($bmwqemu::vars{PRODUCTDIR} . "/needles");
+    no autodie qw(system);
+    my $res = system("rsync -avP --delete --exclude=.git $bmwqemu::vars{PRODUCTDIR}/needles/ $dir/needles/");
+    die "Failed to rsync needles: $@" if $res;
+    needle::init("$dir/needles");
     $bmwqemu::backend = backend::driver->new($bmwqemu::vars{BACKEND});
     return $bmwqemu::backend;
 }

--- a/needle.pm
+++ b/needle.pm
@@ -18,13 +18,14 @@ package needle;
 
 use strict;
 use warnings;
-use Cwd qw/abs_path/;
+use Cwd qw(abs_path);
 use File::Find;
 use File::Spec;
 use JSON;
 use File::Basename;
 require IPC::System::Simple;
 use autodie qw(:all);
+use Time::HiRes qw(time);
 
 our %needles;
 our %tags;
@@ -139,7 +140,9 @@ sub get_image {
     my ($self, $area) = @_;
 
     if (!$self->{img}) {
+        my $start = time;
         $self->{img} = tinycv::read($self->{png});
+        bmwqemu::diag(sprintf("load of $self->{png} took %.2f seconds", time - $start));
         for my $a (@{$self->{area}}) {
             next unless $a->{type} eq 'exclude';
             $self->{img}->replacerect($a->{xpos}, $a->{ypos}, $a->{width}, $a->{height});


### PR DESCRIPTION
As we have an increasing number of incomplete jobs that stall during the
first iteration of assert_screen, I want to know if this is just some
kind of cache problem on the worker - or a performance problem of the NFS
the needles are coming from. Locally a needle load is less than 0.01 seconds,
but I have the suspicion we will see a factor 100 in production ;(

If we can prove this with this debug output (that we can limit to slow loads
once we know what slow is), we have to consider preload strategies