### PR TITLE
WIP: virtio_console

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -566,6 +566,11 @@ sub get_last_mouse_set() {
     return $self->bouncer('get_last_mouse_set', $args);
 }
 
+sub is_serial_terminal {
+    my ($self, $args) = @_;
+    return { yesorno => $self->{current_console}->is_serial_terminal };
+}
+
 sub capture_screenshot {
     my ($self) = @_;
     return unless $self->{current_screen};
@@ -640,12 +645,14 @@ sub wait_serial {
     my $matched = 0;
     my $str;
 
-    if (ref $regexp ne 'ARRAY') {
-        $regexp = [$regexp];
+    if ($self->{current_console}->is_serial_terminal) {
+        #$args->{do_while_idle} = sub { $self->run_capture_loop(undef, 0.1, 1, 10); };
+
+        return $self->{current_screen}->read_until($regexp, $timeout, %$args);
     }
 
-    if ($self->{current_console}->is_serial_terminal) {
-        return $self->{current_screen}->read_until($regexp->[0], $timeout, %$args);
+    if (ref $regexp ne 'ARRAY') {
+        $regexp = [$regexp];
     }
 
     my $initial_time = time;
@@ -669,10 +676,6 @@ sub wait_serial {
     }
     $self->set_serial_offset();
     return {matched => $matched, string => $str};
-}
-
-sub wait_terminal {
-    die 'Not implemented for this backend';
 }
 
 # set_reference_screenshot and similiarity_to_reference are necessary to

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -643,6 +643,11 @@ sub wait_serial {
     if (ref $regexp ne 'ARRAY') {
         $regexp = [$regexp];
     }
+
+    if ($self->{current_console}->is_serial_terminal) {
+        return $self->{current_screen}->read_until($regexp->[0], $timeout, %$args);
+    }
+
     my $initial_time = time;
     while (time < $initial_time + $timeout) {
         $str = $self->serial_text();

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -568,7 +568,7 @@ sub get_last_mouse_set() {
 
 sub is_serial_terminal {
     my ($self, $args) = @_;
-    return { yesorno => $self->{current_console}->is_serial_terminal };
+    return {yesorno => $self->{current_console}->is_serial_terminal};
 }
 
 sub capture_screenshot {

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -666,7 +666,7 @@ sub wait_serial {
     return {matched => $matched, string => $str};
 }
 
-sub assert_terminal {
+sub wait_terminal {
     die 'Not implemented for this backend';
 }
 

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -666,6 +666,10 @@ sub wait_serial {
     return {matched => $matched, string => $str};
 }
 
+sub assert_terminal {
+    die 'Not implemented for this backend';
+}
+
 # set_reference_screenshot and similiarity_to_reference are necessary to
 # implement wait_still and wait_changed functions in the tests without having
 # to transfer the screenshot into the test process

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -939,17 +939,6 @@ sub cont_vm {
     return $self->handle_qmp_command({execute => 'cont'});
 }
 
-sub wait_terminal {
-    my $self  = shift;
-    my %nargs = %{(shift)};
-
-    $nargs{do_while_idle} = sub {
-        $self->run_capture_loop(undef, 0.1);
-    };
-
-    return $self->{current_screen}->read_until($nargs{pattern}, $nargs{timeout}, %nargs);
-}
-
 1;
 
 # vim: set sw=4 et:

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -637,6 +637,12 @@ sub start_qemu {
             push(@params, "-k", $vars->{VNCKB}) if ($vars->{VNCKB});
         }
 
+        if ($vars->{VIRTIOCONSOLE}) {
+            push(@params, '-device', 'virtio-serial');
+            push(@params, '-chardev', "socket,path=/tmp/$vars->{VIRTIOCONSOLE},server,nowait,id=$vars->{VIRTIOCONSOLE}");
+            push(@params, '-device', "virtioconsole,chardev=/tmp/$vars->{VIRTIOCONSOLE},name=org.openqa.console.$vars->{VIRTIOCONSOLE}");
+        }
+
         push @params, '-qmp', "unix:qmp_socket,server,nowait", "-monitor", "unix:hmp_socket,server,nowait", "-S";
         my $port = $vars->{QEMUPORT};
         push @params, "-monitor", "telnet:127.0.0.1:$port,server,nowait";

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -636,7 +636,7 @@ sub start_qemu {
             push(@params, "-k", $vars->{VNCKB}) if ($vars->{VNCKB});
         }
 
-        if ($vars->{VIRTIO_CONSOLE}) {
+        {
             my $id = 'virtio_console';
             push(@params, '-device',  'virtio-serial');
             push(@params, '-chardev', "socket,path=$id,server,nowait,id=$id,logfile=$id.log");

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -943,7 +943,7 @@ sub wait_terminal {
     my $self = shift;
     my %nargs = @_;
 
-    $self->{current_screen}->read_until($nargs{pattern}, $nargs{timeout}, %nargs);
+    return $self->{current_screen}->read_until($nargs{pattern}, $nargs{timeout}, %nargs);
 }
 
 1;

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -638,9 +638,9 @@ sub start_qemu {
 
         if ($vars->{VIRTIO_CONSOLE}) {
             my $id = 'virtio_console';
-            push(@params, '-device', 'virtio-serial');
+            push(@params, '-device',  'virtio-serial');
             push(@params, '-chardev', "socket,path=$id,server,nowait,id=$id,logfile=$id.log");
-            push(@params, '-device', "virtconsole,chardev=$id,name=org.openqa.console.$id");
+            push(@params, '-device',  "virtconsole,chardev=$id,name=org.openqa.console.$id");
         }
 
         push @params, '-qmp', "unix:qmp_socket,server,nowait", "-monitor", "unix:hmp_socket,server,nowait", "-S";
@@ -940,7 +940,7 @@ sub cont_vm {
 }
 
 sub wait_terminal {
-    my $self = shift;
+    my $self  = shift;
     my %nargs = %{(shift)};
 
     return $self->{current_screen}->read_until($nargs{pattern}, $nargs{timeout}, %nargs);

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -943,6 +943,10 @@ sub wait_terminal {
     my $self  = shift;
     my %nargs = %{(shift)};
 
+    $nargs{do_while_idle} = sub {
+        $self->run_capture_loop(undef, 0.1);
+    };
+
     return $self->{current_screen}->read_until($nargs{pattern}, $nargs{timeout}, %nargs);
 }
 

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -637,10 +637,11 @@ sub start_qemu {
             push(@params, "-k", $vars->{VNCKB}) if ($vars->{VNCKB});
         }
 
-        if ($vars->{VIRTIOCONSOLE}) {
+        if ($vars->{VIRTIO_CONSOLE}) {
+            my $vioc = $vars->{VIRTIO_CONSOLE};
             push(@params, '-device', 'virtio-serial');
-            push(@params, '-chardev', "socket,path=/tmp/$vars->{VIRTIOCONSOLE},server,nowait,id=$vars->{VIRTIOCONSOLE}");
-            push(@params, '-device', "virtioconsole,chardev=/tmp/$vars->{VIRTIOCONSOLE},name=org.openqa.console.$vars->{VIRTIOCONSOLE}");
+            push(@params, '-chardev', "socket,path=/tmp/$vioc,server,nowait,id=$vioc");
+            push(@params, '-device', "virtioconsole,chardev=/tmp/$vioc,name=org.openqa.console.$vioc");
         }
 
         push @params, '-qmp', "unix:qmp_socket,server,nowait", "-monitor", "unix:hmp_socket,server,nowait", "-S";

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -18,7 +18,6 @@ package backend::qemu;
 use strict;
 use base ('backend::virt');
 use File::Path qw/mkpath/;
-use File::Temp ();
 use Time::HiRes qw(sleep gettimeofday);
 use IO::Select;
 use IO::Socket::UNIX qw( SOCK_STREAM );
@@ -638,10 +637,10 @@ sub start_qemu {
         }
 
         if ($vars->{VIRTIO_CONSOLE}) {
-            my $vioc = $vars->{VIRTIO_CONSOLE};
+            my $id = 'virtio_console';
             push(@params, '-device', 'virtio-serial');
-            push(@params, '-chardev', "socket,path=/tmp/$vioc,server,nowait,id=$vioc");
-            push(@params, '-device', "virtioconsole,chardev=/tmp/$vioc,name=org.openqa.console.$vioc");
+            push(@params, '-chardev', "socket,path=$id,server,nowait,id=$id,logfile=$id.log");
+            push(@params, '-device', "virtconsole,chardev=$id,name=org.openqa.console.$id");
         }
 
         push @params, '-qmp', "unix:qmp_socket,server,nowait", "-monitor", "unix:hmp_socket,server,nowait", "-S";

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -941,7 +941,7 @@ sub cont_vm {
 
 sub wait_terminal {
     my $self = shift;
-    my %nargs = @_;
+    my %nargs = %{(shift)};
 
     return $self->{current_screen}->read_until($nargs{pattern}, $nargs{timeout}, %nargs);
 }

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -939,6 +939,13 @@ sub cont_vm {
     return $self->handle_qmp_command({execute => 'cont'});
 }
 
+sub wait_terminal {
+    my $self = shift;
+    my %nargs = @_;
+
+    $self->{current_screen}->read_until($nargs{pattern}, $nargs{timeout}, %nargs);
+}
+
 1;
 
 # vim: set sw=4 et:

--- a/basetest.pm
+++ b/basetest.pm
@@ -380,9 +380,11 @@ sub record_serialresult {
 
     $string //= '';
 
-    # the screenshot is not the fail, it's just for documentation
     my $result = $self->record_testresult('unk');
-    $self->_result_add_screenshot($result);
+    unless (testapi::is_serial_terminal) {
+        # the screenshot is not the fail, it's just for documentation
+        $self->_result_add_screenshot($result);
+    }
 
     my $details = {result => $res};
 

--- a/consoles/console.pm
+++ b/consoles/console.pm
@@ -84,4 +84,8 @@ sub activate {
     return;
 }
 
+sub is_serial_terminal {
+    return 0;
+}
+
 1;

--- a/consoles/virtio_screen.pm
+++ b/consoles/virtio_screen.pm
@@ -2,10 +2,14 @@ package consoles::virtio_screen;
 use 5.018;
 use warnings;
 use autodie;
+use English qw( -no_match_vars );
+use Time::HiRes qw( gettimeofday );
+
+our $VERSION;
 
 sub new {
     my ($class, $socket_fd) = @_;
-    my $self = bless({class => $class}, $class);
+    my $self = bless {class => $class}, $class;
     $self->{socket_fd} = $socket_fd;
     return $self;
 }
@@ -26,10 +30,106 @@ sub type_string {
     ...
 }
 
+=head2 read_until
+
+  read_until($self, $match_expression, $timeout, [
+                     buffer_size => 4096, record_output => 0, exclude_match => 0,
+                     no_regex => 0
+  ]);
+
+Monitor the virtio console socket $file_descriptor for a character sequence which matches
+$match_expression. Bytes are read from the socket in up to $buffer_size chunks and each chunk is
+added to a ring buffer which is also up to $buffer_size long. The regular expression is tested
+against the ring buffer after each read operation.
+
+If $record_output is set then all data from the socket is stored in a separate string and returned.
+Otherwise just the contents of the ring buffer will be returned. Setting $exclude_match removes the
+matched string from the returned string. Data which was received after a matching set of characters
+is lost (although not completely, as it will be in "$socket_path.log").
+
+Setting $no_regex will cause it to do a plain string search instead using index().
+
+=cut
+sub read_until {
+    my ($self, $re, $timeout) = @_;
+    my $fd = $self->{socket_fd};
+    my %nargs = @_;
+    my $buflen = $nargs{buffer_size} || 4096;
+    my $rbuf = '';
+    my $buf = '';
+    my $data = $nargs{record_output} ? '' : undef;
+    my $sttime = gettimeofday;
+    my $loops = 0;
+    my $match = '';
+    my $prematch = '';
+
+    bmwqemu::log_call(regular_expression => $re, timeout => $timeout);
+
+  READ: {
+        $loops++;
+        if (gettimeofday() - $sttime >= $timeout) {
+            # TODO: Replace a lot of these die calls with vconsole_record_result(<title>, 'fail',...)
+            die 'Timeout exceeded on virtio console assert, read: ' . $rbuf;
+        }
+
+        my $read = sysread($fd, $buf, $buflen);
+        unless (defined $read) {
+            if ($!{EAGAIN} || $!{EWOULDBLOCK}) {
+                usleep(100);
+                next READ;
+            }
+            die "Failed to read from virtio console char device: $!";
+        }
+        if (length($rbuf) + $read > $buflen) {
+            # If there is not enough free space in the ring buffer remove the
+            # amount just read minus any free space. TODO: Test it with low buffer size
+            $rbuf = substr $rbuf, $read - ($buflen - length($rbuf));
+        }
+        $rbuf .= $buf;
+        if ($nargs{no_regex}) {
+            my $i = index($rbuf, $re);
+            if ($i >= 0) {
+                $match = substr $rbuf, $i, length($re);
+                $prematch = substr $rbuf, 0, $i;
+                last READ;
+            }
+        }
+        elsif ($rbuf =~ $re) {
+            # See perf issues: http://bit.ly/2dbGrzo
+            $match = substr $rbuf, $LAST_MATCH_START[0], $LAST_MATCH_END[0] - $LAST_MATCH_START[0];
+            $prematch = substr $rbuf, 0, $LAST_MATCH_START[0];
+            last READ;
+        }
+        if (defined $data) {
+            $data .= $buf;
+        }
+        next READ;
+    }
+
+    my $trailing;
+    unless ($nargs{exclude_match}) {
+        $trailing = $prematch . $match;
+    }else{
+        $trailing = $prematch;
+    }
+
+    if (defined $data) {
+        $data .= substr $trailing, length($rbuf) - length($buf);
+    }
+    else {
+        $data = $trailing;
+    }
+
+    my $elapsed = gettimeofday() - $sttime;
+    bmwqemu::fctinfo("Asserted output from SUT in $loops loops & $elapsed seconds: $match");
+
+    return $data;
+}
+
 sub current_screen {
     # TODO: We could generate a bitmap of the terminal text, but I think it would be misleading.
     #       Instead we should use a text terminal viewer in the browser if possible.
-    return undef;
+    return 0;
 }
 
 1;

--- a/consoles/virtio_screen.pm
+++ b/consoles/virtio_screen.pm
@@ -1,0 +1,33 @@
+package consoles::virtio_screen;
+use 5.18;
+use warnings;
+use autodie;
+
+sub new {
+    my ($class, $socket_fd) = @_;
+    my $self = bless({class => $class}, $class);
+    $self->{socket_fd} = $socket_fd;
+    return $self;
+}
+
+sub send_key {
+    ...
+}
+
+sub hold_key {
+    ...
+}
+
+sub release_key {
+    ...
+}
+
+sub type_string {
+    ...
+}
+
+sub current_screen {
+    # TODO: We could generate a bitmap of the terminal text, but I think it would be misleading.
+    #       Instead we should use a text terminal viewer in the browser if possible.
+    return undef;
+}

--- a/consoles/virtio_screen.pm
+++ b/consoles/virtio_screen.pm
@@ -28,8 +28,9 @@ sub new {
 }
 
 my $trying_to_use_keys = <<'FIN.';
-Use type_string (possibly with an ANSI/XTERM escape sequence), or switch to a
-console which sends key presses, not terminal codes.
+Virtio terminal does not support send_key. Use type_string (possibly with an
+ANSI/XTERM escape sequence), or switch to a console which sends key presses, not
+terminal codes.
 FIN.
 
 sub send_key {
@@ -57,17 +58,17 @@ than entering text. See ANSI, VT100 and XTERM escape codes.
 
 =cut
 sub type_string {
-    my ($self, $msg) = @_;
+    my ($self, $nargs) = @_;
     my $fd = $self->{socket_fd};
 
-    bmwqemu::log_call(message => $msg);
+    bmwqemu::log_call(%$nargs);
 
-    my $written = syswrite $fd, $msg;
+    my $written = syswrite $fd, $nargs->{text};
     unless (defined $written) {
         die "Error writing to virtio terminal: $ERRNO";
     }
-    if ($written < length($msg)) {
-        die "Was not able to write entire message to virtio terminal. Only $written of $msg";
+    if ($written < length($nargs->{text})) {
+        die "Was not able to write entire message to virtio terminal. Only $written of $nargs->{text}";
     }
 }
 
@@ -168,6 +169,11 @@ sub current_screen {
     # TODO: We could generate a bitmap of the terminal text, but I think it would be misleading.
     #       Instead we should use a text terminal viewer in the browser if possible.
     return 0;
+}
+
+sub request_screen_update {
+    # TODO: Forward this request to the previous VNC console
+    return;
 }
 
 1;

--- a/consoles/virtio_screen.pm
+++ b/consoles/virtio_screen.pm
@@ -171,7 +171,7 @@ sub read_until {
     my ($rbuf, $buf) = ('', '');
     my $loops = 0;
     my ($prematch, $match);
-    my $do_while_idle = $nargs{do_while_idle} || sub { usleep(100); };
+    my $do_while_idle = $nargs{do_while_idle};
 
     my $re = normalise_pattern($pattern, $nargs{no_regex});
 
@@ -189,7 +189,7 @@ sub read_until {
         my $read = sysread($fd, $buf, $buflen / 2);
         unless (defined $read) {
             if ($ERRNO{EAGAIN} || $ERRNO{EWOULDBLOCK}) {
-                &$do_while_idle();
+                &$do_while_idle() if defined $do_while_idle;
                 next READ;
             }
             die "Failed to read from virtio console char device: $ERRNO";

--- a/consoles/virtio_screen.pm
+++ b/consoles/virtio_screen.pm
@@ -1,5 +1,5 @@
 package consoles::virtio_screen;
-use 5.18;
+use 5.018;
 use warnings;
 use autodie;
 
@@ -31,3 +31,5 @@ sub current_screen {
     #       Instead we should use a text terminal viewer in the browser if possible.
     return undef;
 }
+
+1;

--- a/consoles/virtio_screen.pm
+++ b/consoles/virtio_screen.pm
@@ -105,24 +105,24 @@ and { matched => 0, string => 'text from the terminal' } on failure.
 
 =cut
 sub read_until {
-    my ($self, $re, $timeout) = @_[0..2];
-    my $fd = $self->{socket_fd};
-    my %nargs = @_[3..$#_];
-    my $buflen = $nargs{buffer_size} || 4096;
+    my ($self, $re, $timeout) = @_[0 .. 2];
+    my $fd       = $self->{socket_fd};
+    my %nargs    = @_[3 .. $#_];
+    my $buflen   = $nargs{buffer_size} || 4096;
     my $overflow = $nargs{record_output} ? '' : undef;
-    my $sttime = gettimeofday;
+    my $sttime   = gettimeofday;
     my ($rbuf, $buf) = ('', '');
     my $loops = 0;
     my ($prematch, $match);
 
     $nargs{regular_expression} = $re;
-    $nargs{timeout} = $timeout;
+    $nargs{timeout}            = $timeout;
     bmwqemu::log_call(%nargs);
 
-  READ: while(1) {
+  READ: while (1) {
         $loops++;
         if (gettimeofday() - $sttime >= $timeout) {
-            return { matched => 0, string => ($overflow || '') . $rbuf };
+            return {matched => 0, string => ($overflow || '') . $rbuf};
         }
 
         my $read = sysread($fd, $buf, $buflen);

--- a/consoles/virtio_screen.pm
+++ b/consoles/virtio_screen.pm
@@ -1,3 +1,17 @@
+# Copyright © 2016 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
 package consoles::virtio_screen;
 use 5.018;
 use warnings;

--- a/consoles/virtio_screen.pm
+++ b/consoles/virtio_screen.pm
@@ -15,7 +15,7 @@ sub new {
 }
 
 sub send_key {
-    ...
+    type_string(@_);
 }
 
 sub hold_key {

--- a/consoles/virtio_screen.pm
+++ b/consoles/virtio_screen.pm
@@ -34,7 +34,16 @@ terminal codes.
 FIN.
 
 sub send_key {
-    die $trying_to_use_keys;
+    my ($self, $nargs) = @_;
+
+    # TODO: Testapi could just use type_string("\n") instead, VNC supports it.
+    if ($nargs->{key} eq 'ret') {
+        $nargs->{text} = "\n";
+        $self->type_string($nargs);
+    }
+    else {
+        die $trying_to_use_keys;
+    }
 }
 
 sub hold_key {

--- a/consoles/virtio_screen.pm
+++ b/consoles/virtio_screen.pm
@@ -3,7 +3,6 @@ use 5.018;
 use warnings;
 use English qw( -no_match_vars );
 use Time::HiRes qw( gettimeofday usleep );
-# Do not use autodie in this module, it breaks non-blocking sockets
 
 our $VERSION;
 
@@ -14,18 +13,35 @@ sub new {
     return $self;
 }
 
+my $trying_to_use_keys = <<'FIN.';
+Use type_string (possibly with an ANSI/XTERM escape sequence), or switch to a
+console which sends key presses, not terminal codes.
+FIN.
+
 sub send_key {
-    type_string(@_);
+    die $trying_to_use_keys;
 }
 
 sub hold_key {
-    ...
+    die $trying_to_use_keys;
 }
 
 sub release_key {
-    ...
+    die $trying_to_use_keys;
 }
 
+=head2 type_string
+
+    type_string($self, $message);
+
+Writes $message to the socket which the guest's terminal is listening on. Unlike
+VNC based consoles we just send the bytes making up $message not a series of
+keystrokes. This is much faster, but means that special key combinations like
+Ctrl-Alt-Del or SysRq may not be possible. However most terminals do support
+many escape sequences for scrolling and performing various actions other
+than entering text. See ANSI, VT100 and XTERM escape codes.
+
+=cut
 sub type_string {
     my ($self, $msg) = @_;
     my $fd = $self->{socket_fd};
@@ -56,9 +72,9 @@ against the ring buffer after each read operation.
 If $record_output is set then all data from the socket is stored in a separate string and returned.
 Otherwise just the contents of the ring buffer will be returned. Setting $exclude_match removes the
 matched string from the returned string. Data which was received after a matching set of characters
-is lost (although not completely, as it will be in "$socket_path.log").
+is lost (although not completely, as it should be in "$socket_path.log").
 
-Setting $no_regex will cause it to do a plain string search instead using index().
+Setting $no_regex will cause it to do a plain string search using index().
 
 =cut
 sub read_until {
@@ -66,10 +82,9 @@ sub read_until {
     my $fd = $self->{socket_fd};
     my %nargs = @_[3..$#_];
     my $buflen = $nargs{buffer_size} || 4096;
-    my $rbuf = '';
-    my $buf = '';
-    my $data = $nargs{record_output} ? '' : undef;
+    my $overflow = $nargs{record_output} ? '' : undef;
     my $sttime = gettimeofday;
+    my ($rbuf, $buf) = ('', '');
     my $loops = 0;
     my ($prematch, $match);
 
@@ -80,7 +95,8 @@ sub read_until {
   READ: while(1) {
         $loops++;
         if (gettimeofday() - $sttime >= $timeout) {
-            # TODO: Replace a lot of these die calls with vconsole_record_result(<title>, 'fail',...)
+            # TODO: Return fail to the caller instead of dieing so that the test
+            #       can collect logs or perform a workaround
             die 'Timeout exceeded on virtio console assert, read: ' . $rbuf;
         }
 
@@ -93,13 +109,20 @@ sub read_until {
             die "Failed to read from virtio console char device: $ERRNO";
         }
 
+        # If there is not enough free space in the ring buffer; remove an amount
+        # equal to the bytes just read minus the free space in $rbuf from the
+        # begining. If we are recording all output, add the removed bytes to
+        # $overflow.
         if (length($rbuf) + $read > $buflen) {
-            # If there is not enough free space in the ring buffer remove the
-            # amount just read minus any free space. TODO: Test it with low buffer size
-            $rbuf = substr $rbuf, $read - ($buflen - length($rbuf));
+            my $remove_len = $read - ($buflen - length($rbuf));
+            if (defined $overflow) {
+                $overflow .= substr $rbuf, 0, $remove_len;
+            }
+            $rbuf = substr $rbuf, $remove_len;
         }
         $rbuf .= $buf;
 
+        # Search ring buffer for a match and exit if we find it
         if ($nargs{no_regex}) {
             my $i = index($rbuf, $re);
             if ($i >= 0) {
@@ -109,35 +132,21 @@ sub read_until {
             }
         }
         elsif ($rbuf =~ m/$re/) {
-            # See perf issues: http://bit.ly/2dbGrzo
+            # See match variable perf issues: http://bit.ly/2dbGrzo
             $prematch = substr $rbuf, 0, $LAST_MATCH_START[0];
             $match = substr $rbuf, $LAST_MATCH_START[0], $LAST_MATCH_END[0] - $LAST_MATCH_START[0];
             last READ;
         }
-
-        if (defined $data) {
-            $data .= $buf;
-        }
-    }
-
-    my $trailing;
-    unless ($nargs{exclude_match}) {
-        $trailing = $prematch . $match;
-    }else{
-        $trailing = $prematch;
-    }
-
-    if (defined $data) {
-        $data .= substr $trailing, length($rbuf) - length($buf);
-    }
-    else {
-        $data = $trailing;
     }
 
     my $elapsed = gettimeofday() - $sttime;
     bmwqemu::fctinfo("Matched output from SUT in $loops loops & $elapsed seconds: $match");
 
-    return $data;
+    $overflow ||= '';
+    if ($nargs{exclude_match}) {
+        return $overflow . $prematch;
+    }
+    return $overflow . $prematch . $match;
 }
 
 sub current_screen {

--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -1,3 +1,17 @@
+# Copyright © 2016 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
 package consoles::virtio_terminal;
 use 5.018;
 use warnings;

--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -54,7 +54,7 @@ requires a UNIX socket which inputs and outputs terminal ASCII/ANSI codes.
 sub new {
     my ($class, $testapi_console, $args) = @_;
     my $self = $class->SUPER::new($testapi_console, $args);
-    $self->{socket_fd} = 0;
+    $self->{socket_fd}   = 0;
     $self->{socket_path} = cwd() . '/virtio_console';
     return $self;
 }
@@ -69,7 +69,7 @@ sub reset {
     if ($self->{socket_fd} > 0) {
         close $self->{socket_fd};
         $self->{socket_fd} = 0;
-        $self->{screen} = undef;
+        $self->{screen}    = undef;
     }
     return $self->SUPER::reset;
 }
@@ -100,10 +100,10 @@ sub open_socket {
     bmwqemu::log_call(socket_path => $self->socket_path);
 
     (-S $self->socket_path) || die 'Could not find ' . $self->socket_path;
-    socket($fd, PF_UNIX, SOCK_STREAM|SOCK_NONBLOCK, 0)
-        || die 'Could not create Unix socket: ' . $ERRNO;
+    socket($fd, PF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0)
+      || die 'Could not create Unix socket: ' . $ERRNO;
     connect($fd, sockaddr_un($self->socket_path))
-        || die 'Could not connect to virtio-console chardev socket: ' . $ERRNO;
+      || die 'Could not connect to virtio-console chardev socket: ' . $ERRNO;
 
     return $fd;
 }
@@ -111,7 +111,7 @@ sub open_socket {
 sub activate {
     my $self = shift;
     $self->{socket_fd} = $self->open_socket;
-    $self->{screen} = consoles::virtio_screen::->new($self->{socket_fd});
+    $self->{screen}    = consoles::virtio_screen::->new($self->{socket_fd});
     return;
 }
 

--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -7,6 +7,7 @@ use Errno qw(EAGAIN EWOULDBLOCK);
 use Carp qw(cluck);
 use Scalar::Util qw(blessed);
 use Cwd;
+use consoles::virtio_screen ();
 
 use base 'consoles::console';
 
@@ -19,7 +20,7 @@ sub new {
 
 sub screen {
     my $self = shift;
-    die('Not implemented');
+    return $self->{screen};
 }
 
 sub reset {
@@ -27,6 +28,7 @@ sub reset {
     if ($self->{socket_fd} > 0) {
         close($self->{socket_fd});
         $self->{socket_fd} = 0;
+        $self->{screen} = undef;
     }
     return $self->SUPER::reset;
 }
@@ -34,11 +36,6 @@ sub reset {
 sub trigger_select {
     my $self = shift;
     die('Not imlpementd');
-}
-
-sub activate {
-    my $self = shift;
-    $self->{socket_fd} = open_socket;
 }
 
 =head2 $socket_path
@@ -74,6 +71,12 @@ sub open_socket {
         die "Could not connect to virtio-console chardev socket: $!";
     }
     return $fd;
+}
+
+sub activate {
+    my $self = shift;
+    $self->{socket_fd} = open_socket;
+    $self->{screen} = consoles::virtio_screen::->new($self->{socket_fd});
 }
 
 1;

--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -115,4 +115,8 @@ sub activate {
     return;
 }
 
+sub is_serial_terminal {
+    return 1;
+}
+
 1;

--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -60,11 +60,6 @@ sub reset {
     return $self->SUPER::reset;
 }
 
-sub trigger_select {
-    my $self = shift;
-    die 'Not imlpementd';
-}
-
 =head2 socket_path
 
 The file system path bound to a UNIX socket which will be used to transfer

--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -11,10 +11,36 @@ use consoles::virtio_screen ();
 
 use base 'consoles::console';
 
+our $VERSION;
+
+=head1 NAME
+
+consoles::virtio_terminal
+
+=head1 SYNOPSIS
+
+Provides functions to allow the testapi to interact with a text only console.
+
+=head1 DESCRIPTION
+
+This console can be requested when the backend (usually QEMU/KVM) and guest OS
+support virtio serial and virtio console. The guest also needs to be in a state
+where it can start a tty on the virtual console. By default openSUSE and SLE
+automatically start agetty when the kernel finds the virtio console device, but
+another OS may require some additional configuration.
+
+It may also be possible to use a transport other than virtio. This code just
+requires a UNIX socket which inputs and outputs terminal ASCII/ANSI codes.
+
+=head1 SUBROUTINES/METHODS
+
+=cut
+
 sub new {
     my ($class, $testapi_console, $args) = @_;
     my $self = $class->SUPER::new($testapi_console, $args);
     $self->{socket_fd} = 0;
+    $self->{socket_path} = cwd() . '/virtio_console';
     return $self;
 }
 
@@ -35,19 +61,19 @@ sub reset {
 
 sub trigger_select {
     my $self = shift;
-    die('Not imlpementd');
+    die 'Not imlpementd';
 }
 
-=head2 $socket_path
+=head2 socket_path
 
-Below is the path to a character device file created by QEMU on the host.
-This file is backed by a console/tty running on the guest assuming it
-runs agetty and the virtio console driver is in the guest's kernel. Any
-data written to the file should be interpretted as user input by the tty
-running in the guest.
+The file system path bound to a UNIX socket which will be used to transfer
+terminal data between the host and guest.
 
 =cut
-my $socket_path = cwd() . '/virtio_console';
+sub socket_path {
+    my ($self) = @_;
+    return $self->{socket_path};
+}
 
 =head2 open_socket
 

--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -1,0 +1,79 @@
+package consoles::virtio_terminal;
+use 5.018;
+use warnings;
+use autodie;
+use Socket qw(SOCK_NONBLOCK PF_UNIX SOCK_STREAM sockaddr_un);
+use Errno qw(EAGAIN EWOULDBLOCK);
+use Carp qw(cluck);
+use Scalar::Util qw(blessed);
+use Cwd;
+
+use base 'consoles::console';
+
+sub new {
+    my ($class, $testapi_console, $args) = @_;
+    my $self = $class->SUPER::new($testapi_console, $args);
+    $self->{socket_fd} = 0;
+    return $self;
+}
+
+sub screen {
+    my $self = shift;
+    die('Not implemented');
+}
+
+sub reset {
+    my $self = shift;
+    if ($self->{socket_fd} > 0) {
+        close($self->{socket_fd});
+        $self->{socket_fd} = 0;
+    }
+    return $self->SUPER::reset;
+}
+
+sub trigger_select {
+    my $self = shift;
+    die('Not imlpementd');
+}
+
+sub activate {
+    my $self = shift;
+    $self->{socket_fd} = open_socket;
+}
+
+=head2 $socket_path
+
+Below is the path to a character device file created by QEMU on the host.
+This file is backed by a console/tty running on the guest assuming it
+runs agetty and the virtio console driver is in the guest's kernel. Any
+data written to the file should be interpretted as user input by the tty
+running in the guest.
+
+=cut
+my $socket_path = cwd() . '/virtio_console';
+
+=head2 open_socket
+
+  open_socket();
+
+Opens a unix socket to the character device located at $socket_path.
+
+Returns the file descriptor for the open socket, otherwise it dies.
+
+=cut
+sub open_socket {
+    my $fd;
+    bmwqemu::log_call(socket_path => $socket_path);
+    unless (-S $socket_path) {
+        die "Could not find $socket_path";
+    }
+    unless (socket($fd, PF_UNIX, SOCK_STREAM|SOCK_NONBLOCK, 0)) {
+        die "Could not create Unix socket: $!";
+    }
+    unless (connect($fd, sockaddr_un($socket_path))) {
+        die "Could not connect to virtio-console chardev socket: $!";
+    }
+    return $fd;
+}
+
+1;

--- a/distribution.pm
+++ b/distribution.pm
@@ -36,13 +36,13 @@ sub add_console {
     my ($self, $testapi_console, $backend_console, $backend_args) = @_;
 
     my %class_names = (
-        'tty-console'  => 'ttyConsole',
-        'ssh-xterm'    => 'sshXtermVt',
-        'ssh-virtsh'   => 'sshVirtsh',
-        'vnc-base'     => 'vnc_base',
-        'local-Xvnc'   => 'localXvnc',
-        'ssh-iucvconn' => 'sshIucvconn',
-        'virtio-terminal'       => 'virtio_terminal'
+        'tty-console'     => 'ttyConsole',
+        'ssh-xterm'       => 'sshXtermVt',
+        'ssh-virtsh'      => 'sshVirtsh',
+        'vnc-base'        => 'vnc_base',
+        'local-Xvnc'      => 'localXvnc',
+        'ssh-iucvconn'    => 'sshIucvconn',
+        'virtio-terminal' => 'virtio_terminal'
     );
     my $required_type = $class_names{$backend_console} || $backend_console;
     my $location      = "consoles/$required_type.pm";

--- a/distribution.pm
+++ b/distribution.pm
@@ -110,7 +110,11 @@ sub script_run {
     testapi::type_string "$cmd";
     if ($wait > 0) {
         my $str = testapi::hashed_string("SR$cmd$wait");
-        testapi::type_string " ; echo $str-\$?- | tee /dev/$testapi::serialdev\n";
+        if (testapi::console->is_serial_terminal) {
+            testapi::type_string " ; echo $str-\$?-\n";
+        } else {
+            testapi::type_string " ; echo $str-\$?- > /dev/$testapi::serialdev\n";
+        }
         my $res = testapi::wait_serial(qr/$str-\d+-/, $wait);
         return unless $res;
         return ($res =~ /$str-(\d+)-/)[0];

--- a/distribution.pm
+++ b/distribution.pm
@@ -110,7 +110,7 @@ sub script_run {
     testapi::type_string "$cmd";
     if ($wait > 0) {
         my $str = testapi::hashed_string("SR$cmd$wait");
-        if (testapi::console->is_serial_terminal) {
+        if (testapi::is_serial_terminal) {
             testapi::type_string " ; echo $str-\$?-\n";
         } else {
             testapi::type_string " ; echo $str-\$?- > /dev/$testapi::serialdev\n";

--- a/distribution.pm
+++ b/distribution.pm
@@ -41,7 +41,8 @@ sub add_console {
         'ssh-virtsh'   => 'sshVirtsh',
         'vnc-base'     => 'vnc_base',
         'local-Xvnc'   => 'localXvnc',
-        'ssh-iucvconn' => 'sshIucvconn'
+        'ssh-iucvconn' => 'sshIucvconn',
+        'virtio-terminal'       => 'virtio_terminal'
     );
     my $required_type = $class_names{$backend_console} || $backend_console;
     my $location      = "consoles/$required_type.pm";

--- a/distribution.pm
+++ b/distribution.pm
@@ -110,7 +110,7 @@ sub script_run {
     testapi::type_string "$cmd";
     if ($wait > 0) {
         my $str = testapi::hashed_string("SR$cmd$wait");
-        testapi::type_string " ; echo $str-\$?- > /dev/$testapi::serialdev\n";
+        testapi::type_string " ; echo $str-\$?- | tee /dev/$testapi::serialdev\n";
         my $res = testapi::wait_serial(qr/$str-\d+-/, $wait);
         return unless $res;
         return ($res =~ /$str-(\d+)-/)[0];

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -25,7 +25,7 @@ sub fake_send_json {
 sub fake_read_json {
     my ($fd) = @_;
     my $lcmd = $cmds->[-1];
-    if ($lcmd->{cmd} eq 'backend_wait_serial') {
+    if ($lcmd->{cmd} eq 'backend_wait_serial' || $lcmd->{cmd} eq 'backend_wait_terminal') {
         my $str = $lcmd->{regexp};
         $str =~ s,\\d\+,$fake_exit,;
         return {ret => {matched => 1, string => $str}};
@@ -97,6 +97,18 @@ $cmds = [];
 
 type_password 'hallo';
 is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 100, text => 'hallo'}]);
+$cmds = [];
+
+wait_terminal 'pattern', exclude_match => 1;
+is_deeply($cmds, 
+          [{cmd => 'backend_wait_terminal', pattern => 'pattern', 
+            exclude_match => 1, timeout => 30}], 
+          'wait_terminal matches');
+$cmds = [];
+
+assert_terminal 'zzZZZZzzzZZZ';
+is_deeply($cmds, [{cmd => 'backend_assert_terminal', pattern => 'zzZZZZzzzZZZ', timeout => 30}],
+          'assert_terminal matches');
 $cmds = [];
 
 is($autotest::current_test->{dents}, 0, 'no soft failures so far');

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -107,7 +107,7 @@ is_deeply($cmds,
 $cmds = [];
 
 assert_terminal 'zzZZZZzzzZZZ';
-is_deeply($cmds, [{cmd => 'backend_assert_terminal', pattern => 'zzZZZZzzzZZZ', timeout => 30}],
+is_deeply($cmds, [{cmd => 'backend_wait_terminal', pattern => 'zzZZZZzzzZZZ', timeout => 30}],
           'assert_terminal matches');
 $cmds = [];
 

--- a/t/09-terminal.t
+++ b/t/09-terminal.t
@@ -212,41 +212,45 @@ sub test_terminal_directly {
     my $scrn = $term->screen;
     ok( defined($scrn), 'Create screen' );
 
+    sub type_string {
+        $scrn->type_string( { text => shift } );
+    }
+
     is_matched( $scrn->read_until( qr/$user_name_prompt_data$/, $timeout ),
                $login_prompt_data, 'direct: find login prompt' );
-    $scrn->type_string( $user_name_data );
+    type_string( $user_name_data );
 
     is_matched( $scrn->read_until( qr/$password_prompt_data$/, $timeout ),
         $user_name_data . $password_prompt_data, 'direct: find password prompt' );
-    $scrn->type_string( $password_data );
+    type_string( $password_data );
 
     is_matched( $scrn->read_until( $first_prompt_data, $timeout, no_regex => 1 ),
         $password_data . $first_prompt_data, 'direct: find first command prompt' );
-    $scrn->type_string( $set_prompt_data );
+    type_string( $set_prompt_data );
 
     is_matched( $scrn->read_until( qr/$normalised_prompt_data$/, $timeout ),
         $set_prompt_data . $normalised_prompt_data, 'direct: find normalised prompt' );
 
     # Note that a real terminal would echo this back to us causing the next test to fail
     # unless we suck up the echo.
-    $scrn->type_string( $next_test );
+    type_string( $next_test );
 
     my $result = $scrn->read_until( $stop_code_data, $timeout,
                                        no_regex => 1, buffer_size => 256 );
     is( length($result->{string}), 256, 'direct: returned data is same length as buffer' );
     like( $result->{string}, qr/\Q$US_keyboard_data\E$stop_code_data$/,
           'direct: read a large amount of data with small ring buffer' );
-    $scrn->type_string( $next_test );
+    type_string( $next_test );
 
     like( $scrn->read_until( qr/$stop_code_data$/, $timeout, record_output => 1)->{string},
           qr/^(\Q$US_keyboard_data\E){$repeat_sequence_count}$stop_code_data$/,
           'direct: record a large amount of data' );
-    $scrn->type_string( $next_test );
+    type_string( $next_test );
 
     is_deeply( $scrn->read_until( 'we timeout', 1 ),
                { matched => 0, string => $US_keyboard_data },
                'direct: timeout' );
-    $scrn->type_string( $next_test );
+    type_string( $next_test );
 }
 
 sub test_terminal_through_testapi {

--- a/t/09-terminal.t
+++ b/t/09-terminal.t
@@ -125,7 +125,7 @@ sub fake_terminal {
     # parent to fail as well
     my $tb = Test::More->builder;
     $tb->reset;
-    $tb->expected_tests(3)
+    $tb->expected_tests(3);
 
     try_write( $fd, $login_prompt_data );
     ok( try_read($fd, $user_name_data), 'fake_terminal reads: Entered user name');

--- a/t/09-terminal.t
+++ b/t/09-terminal.t
@@ -1,0 +1,79 @@
+#!/usr/bin/perl
+
+use 5.018;
+use warnings;
+use autodie;
+use Test::More;
+use consoles::virtio_terminal;
+use English qw( -no_match_vars );
+use testapi ();
+
+our $VERSION;
+
+# Set this to an amount greater than any chunk of data sent in a unit test
+my $largest_data_length = 4096;
+my $login_prompt_data = <<'FIN.';
+
+
+Welcome to SUSE Linux Enterprise Server 12 SP2 RC3 (x86_64) - Kernel 4.4.21-65-default (hvc0).
+
+
+linux-5rw7 login: 
+FIN.
+my $user_name_data = "root\n";
+my $password_prompt_data = 'Password: ';
+my $password_data = "$testapi::password\n";
+# Contains some ANSI/XTERM escape sequences
+my $first_prompt_data = "\e[1mlinux-5rw7:~ #\e[0m\e(B";
+my $set_prompt_data = qq/PS1="# "\n/;
+my $normalised_prompt_data = '# ';
+
+sub try_write {
+    my ($fd, $msg) = @_;
+
+    syswrite($fd, $msg)
+      || die "fake_terminal: Failed to write to socket $ERRNO";
+}
+
+sub try_read {
+    my ($fd) = @_;
+    my ($buf, $text);
+
+  READ: {
+        sysread($fd, my $buf, $largest_data_length) || do {
+            if ($ERRNO{EINTR}) {
+                $text .= $buf;
+                next READ;
+            }
+            die "fake_terminal: Could not read from socket: $ERRNO";
+        };
+    }
+    return $buf;
+}
+
+sub fake_terminal {
+    my ($sock_path) = @_;
+    socket( my $listen_fd, PF_UNIX, SOCK_STREAM, 0 );
+      || die "fake_terminal: Could not create socket: $ERRNO";
+    bind( $listen_fd, sockaddr_un($sock_path) )
+      || die "fake_terminal: Could not bind socket to path $sock_path: $ERRNO";
+    listen( $listen_fd, 1 )
+      || die "fake_terminal: Could not list on socket: $ERRNO";
+
+  ACCEPT: {
+        accept( my $fd, $listen_fd ) || do {
+            if ($ERRNO{EINTR}) {
+                next ACCEPT;
+            }
+            die "fake_terminal: Failed to accept connection: $ERRNO";
+        };
+    }
+
+    try_write( $fd, $login_prompt_data );
+    is( try_read($fd), 'root\n', 'Enter user name');
+    try_write( $fd, $password_prompt_data );
+    is( try_read($fd), $password_data, 'Enter password');
+    try_write( $fd, $first_prompt_data );
+    is( try_read($fd), $set_prompt_data, 'Normalise bash prompt');
+    try_write( $fd, $normalised_prompt_data );
+}

--- a/t/09-terminal.t
+++ b/t/09-terminal.t
@@ -21,8 +21,6 @@ our $VERSION;
 
 $testapi::password = 'd*97Jlk/.d';
 my $socket_path = './virtio_console';
-# Set this to an amount greater than any chunk of data sent in a unit test
-my $largest_data_length = 8192;
 my $login_prompt_data = <<'FIN.';
 
 
@@ -39,6 +37,8 @@ my $first_prompt_data = "\e[1mlinux-5rw7:~ #\e[0m\e(B";
 my $set_prompt_data = qq/PS1="# "\n/;
 my $normalised_prompt_data = '# ';
 
+# If test keeps timing out, this can be increased or you can add more calls to
+# alarm in fake terminal
 my $timeout = 5;
 
 sub try_write {
@@ -83,6 +83,7 @@ sub try_read {
     return $text eq $expected;
 }
 
+# A mock terminal which we can communicate with over a UNIX socket
 sub fake_terminal {
     my ($sock_path) = @_;
     my ($fd, $listen_fd);
@@ -102,6 +103,7 @@ sub fake_terminal {
     listen( $listen_fd, 1 )
       || confess "fake_terminal: Could not list on socket: $ERRNO";
 
+    #Signal to parent that the socket is listening
     kill 'CONT', getppid;
 
   ACCEPT: {
@@ -118,16 +120,27 @@ sub fake_terminal {
         exit(1);
     };
 
+    # Test::More does not support forking, but if these tests fail it should
+    # cause the child to return a non zero exit code which will cause the
+    # parent to fail as well
+    my $tb = Test::More->builder;
+    $tb->reset;
+    $tb->expected_tests(3)
+
     try_write( $fd, $login_prompt_data );
     ok( try_read($fd, $user_name_data), 'fake_terminal reads: Entered user name');
+
     try_write( $fd, $password_prompt_data );
     ok( try_read($fd, $password_data), 'fake_terminal reads: Entered password');
+
     try_write( $fd, $first_prompt_data );
     ok( try_read($fd, $set_prompt_data), 'fake_terminal reads: Normalised bash prompt');
+
     try_write( $fd, $normalised_prompt_data );
 
     #TODO:
     # - Send 4-8kb of data to test the ring buffer
+    # - Send data in small chunks with pauses between them
     # - Test timeout
 }
 
@@ -140,13 +153,15 @@ sub test_terminal_directly {
     is( $scrn->read_until( qr/$user_name_prompt_data$/, $timeout ),
         $login_prompt_data, 'direct: find login prompt' );
     $scrn->type_string( $user_name_data );
-    usleep(100);
+
     is( $scrn->read_until( qr/$password_prompt_data$/, $timeout ),
         $user_name_data . $password_prompt_data, 'direct: find password prompt' );
     $scrn->type_string( $password_data );
+
     is( $scrn->read_until( $first_prompt_data, $timeout, no_regex => 1 ),
         $password_data . $first_prompt_data, 'direct: find first command prompt' );
     $scrn->type_string( $set_prompt_data );
+
     is( $scrn->read_until( qr/$normalised_prompt_data$/, $timeout ),
         $set_prompt_data . $normalised_prompt_data, 'direct: find normalised prompt' );
 }
@@ -155,30 +170,42 @@ sub test_terminal_through_testapi {
     ...
 }
 
+# Called after waitpid to check child's exit
+sub report_on_fake_terminal {
+    my $exited = WIFEXITED($CHILD_ERROR);
+    my $exit_status = WEXITSTATUS($CHILD_ERROR);
+    ok($exited, 'Fake terminal process exits cleanly');
+    if ($exited) {
+        is($exit_status, 0, 'Child exit status is zero');
+    }
+    if ($exited == 0 || $exit_status != 0) {
+        return 0;
+    }
+
+    return 1;
+}
+
+# If child bails out early...
 $SIG{CHLD} = sub {
     local ($ERRNO, $CHILD_ERROR);
     if ( waitpid(-1, WNOHANG) > 0 ) {
-        my $exited = WIFEXITED($CHILD_ERROR);
-        my $exit_status = WEXITSTATUS($CHILD_ERROR);
-        ok($exited, 'Fake terminal process exits cleanly');
-        if ($exited) {
-            is($exit_status, 0, 'Child exit status is zero');
-        }
-        if ($exited == 0 || $exit_status != 0) {
-            exit 1;
-        }
+        report_on_fake_terminal || exit(1);
     }
 };
-
-$SIG{CONT} = sub { };
 
 my $pid = fork || do {
     fake_terminal( $socket_path );
     exit 0;
 };
 
+# The virtio_terminal expects the socket to be ready by the time it is activated
+# so wait for fake terminal to create socket and emit SIGCONT. Pause only
+# returns if a signal is received which has a handler set.
+$SIG{CONT} = sub { };
 pause;
 
 test_terminal_directly;
 
-pause;
+$SIG{CHLD} = sub { };
+waitpid($pid, 0);
+report_on_fake_terminal;

--- a/t/09-terminal.t
+++ b/t/09-terminal.t
@@ -1,5 +1,16 @@
 #!/usr/bin/perl
-
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
 use 5.018;
 use warnings;
 use Carp qw( confess );

--- a/t/09-terminal.t
+++ b/t/09-terminal.t
@@ -3,23 +3,34 @@
 use 5.018;
 use warnings;
 use autodie;
-use Test::More;
-use consoles::virtio_terminal;
+use Carp qw( confess );
 use English qw( -no_match_vars );
+use POSIX qw( :sys_wait_h pause );
+use Socket qw( PF_UNIX SOCK_STREAM sockaddr_un );
+
+use Test::More tests => 9;
+
+BEGIN {
+    unshift @INC, '..';
+}
+
+use consoles::virtio_terminal;
 use testapi ();
 
 our $VERSION;
 
+$testapi::password = 'd*97Jlk/.d';
+my $socket_path = './virtio_console';
 # Set this to an amount greater than any chunk of data sent in a unit test
-my $largest_data_length = 4096;
+my $largest_data_length = 8192;
 my $login_prompt_data = <<'FIN.';
 
 
 Welcome to SUSE Linux Enterprise Server 12 SP2 RC3 (x86_64) - Kernel 4.4.21-65-default (hvc0).
 
-
-linux-5rw7 login: 
 FIN.
+$login_prompt_data .= 'linux-5rw7 login: ';
+my $user_name_prompt_data = "login: ";
 my $user_name_data = "root\n";
 my $password_prompt_data = 'Password: ';
 my $password_data = "$testapi::password\n";
@@ -28,52 +39,127 @@ my $first_prompt_data = "\e[1mlinux-5rw7:~ #\e[0m\e(B";
 my $set_prompt_data = qq/PS1="# "\n/;
 my $normalised_prompt_data = '# ';
 
+my $timeout = 5;
+
 sub try_write {
     my ($fd, $msg) = @_;
 
     syswrite($fd, $msg)
-      || die "fake_terminal: Failed to write to socket $ERRNO";
+      || confess "fake_terminal: Failed to write to socket $ERRNO";
 }
 
 sub try_read {
-    my ($fd) = @_;
+    my ($fd, $expected) = shift;
     my ($buf, $text);
 
   READ: {
-        sysread($fd, my $buf, $largest_data_length) || do {
+        sysread($fd, my $buf, length($expected)) || do {
             if ($ERRNO{EINTR}) {
                 $text .= $buf;
                 next READ;
             }
-            die "fake_terminal: Could not read from socket: $ERRNO";
+            confess "fake_terminal: Could not read from socket: $ERRNO";
         };
     }
-    return $buf;
+    $text .= $buf;
+    # Echo back what we just read like a real terminal
+    try_write( $fd, $text );
+    return $text eq $expected;
 }
 
 sub fake_terminal {
     my ($sock_path) = @_;
-    socket( my $listen_fd, PF_UNIX, SOCK_STREAM, 0 );
-      || die "fake_terminal: Could not create socket: $ERRNO";
+    my ($fd, $listen_fd);
+
+    $SIG{ALRM} = sub {
+        fail('fake_terminal timed out while waiting for a connection');
+        exit(1);
+    };
+
+    alarm $timeout;
+
+    socket( $listen_fd, PF_UNIX, SOCK_STREAM, 0 )
+      || confess "fake_terminal: Could not create socket: $ERRNO";
+    unlink( $sock_path );
     bind( $listen_fd, sockaddr_un($sock_path) )
-      || die "fake_terminal: Could not bind socket to path $sock_path: $ERRNO";
+      || confess "fake_terminal: Could not bind socket to path $sock_path: $ERRNO";
     listen( $listen_fd, 1 )
-      || die "fake_terminal: Could not list on socket: $ERRNO";
+      || confess "fake_terminal: Could not list on socket: $ERRNO";
+
+    kill 'CONT', getppid;
 
   ACCEPT: {
-        accept( my $fd, $listen_fd ) || do {
+        accept( $fd, $listen_fd ) || do {
             if ($ERRNO{EINTR}) {
                 next ACCEPT;
             }
-            die "fake_terminal: Failed to accept connection: $ERRNO";
+            confess "fake_terminal: Failed to accept connection: $ERRNO";
         };
     }
 
+    $SIG{ALRM} = sub {
+        fail('fake_terminal timed out while performing IO');
+        exit(1);
+    };
+
     try_write( $fd, $login_prompt_data );
-    is( try_read($fd), 'root\n', 'Enter user name');
+    ok( try_read($fd, $user_name_data), 'fake_terminal reads: Entered user name');
     try_write( $fd, $password_prompt_data );
-    is( try_read($fd), $password_data, 'Enter password');
+    ok( try_read($fd, $password_data), 'fake_terminal reads: Entered password');
     try_write( $fd, $first_prompt_data );
-    is( try_read($fd), $set_prompt_data, 'Normalise bash prompt');
+    ok( try_read($fd, $set_prompt_data), 'fake_terminal reads: Normalised bash prompt');
     try_write( $fd, $normalised_prompt_data );
+
+    #TODO:
+    # - Send 4-8kb of data to test the ring buffer
+    # - Test timeout
 }
+
+sub test_terminal_directly {
+    my $term = consoles::virtio_terminal->new('unit-test-console', []);
+    $term->activate;
+    my $scrn = $term->screen;
+    ok( defined($scrn), 'Create screen' );
+
+    is( $scrn->read_until( qr/$user_name_prompt_data$/, $timeout ),
+        $login_prompt_data, 'direct: find login prompt' );
+    $scrn->type_string( $user_name_data );
+    is( $scrn->read_until( qr/$password_prompt_data$/, $timeout ),
+        $user_name_data . $password_prompt_data, 'direct: find password prompt' );
+    $scrn->type_string( $password_data );
+    is( $scrn->read_until( qr/$first_prompt_data$/, $timeout ),
+        $password_data . $first_prompt_data, 'direct: find first command prompt' );
+    $scrn->type_string( $set_prompt_data );
+    is( $scrn->read_until( qr/$normalised_prompt_data$/, $timeout ),
+        $set_prompt_data . $normalised_prompt_data, 'direct: find normalised prompt' );
+}
+
+sub test_terminal_through_testapi {
+    ...
+}
+
+$SIG{CHLD} = sub {
+    local ($ERRNO, $CHILD_ERROR);
+    if ( waitpid(-1, WNOHANG) > 0 ) {
+        my $exited = WIFEXITED($CHILD_ERROR);
+        my $exit_status = WEXITSTATUS($CHILD_ERROR);
+        ok($exited, 'Fake terminal process exits cleanly');
+        if ($exited) {
+            is($exit_status, 0, 'Child exit status is zero');
+        }
+        if ($exited == 0 || $exit_status != 0) {
+            exit 0;
+        }
+    }
+};
+
+$SIG{CONT} = sub { };
+
+my $pid = fork || do {
+    fake_terminal( $socket_path );
+    exit 0;
+};
+
+pause;
+
+test_terminal_directly;

--- a/t/09-terminal.t
+++ b/t/09-terminal.t
@@ -63,7 +63,7 @@ my $next_test             = "GOTO NEXT\n";
 
 # If test keeps timing out, this can be increased or you can add more calls to
 # alarm in fake terminal
-my $timeout = 5;
+my $timeout = 10;
 
 # Either write $msg to the socket or die
 sub try_write {
@@ -213,7 +213,7 @@ sub fake_terminal {
     }
 
     alarm $timeout * 2;
-    try_write($fd, ($US_keyboard_data x 200_000) . $stop_code_data);
+    try_write($fd, ($US_keyboard_data x 100_000) . $stop_code_data);
 
     alarm $timeout;
     $SIG{ALRM} = sub { fail('fake_terminal timed out first'); exit(1); };

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,4 +1,4 @@
 AM_MAKEFLAGS = PERL5OPT=-MDevel::Cover
-TESTS = 00-compile-check-all.t 01-test_needle.t 02-test_ocr.t 03-testapi.t 04-check_vars_docu.t 05-pod.t 06-pod-coverage.t 07-commands.t 08-autotest.t
+TESTS = 00-compile-check-all.t 01-test_needle.t 02-test_ocr.t 03-testapi.t 04-check_vars_docu.t 05-pod.t 06-pod-coverage.t 07-commands.t 08-autotest.t 09-terminal.t
 
 EXTRA_DIST = $(TESTS) t/test_driver.pm

--- a/testapi.pm
+++ b/testapi.pm
@@ -553,20 +553,26 @@ sub wait_serial {
     return;    # false
 }
 
-sub assert_terminal {
+sub wait_terminal {
     die 'Expecting at least one argument' unless @_ > 0;
     my $pattern = shift;
     my %named_args = @_;
-    %named_args{pattern} = $pattern;
-    $named_args{timeout} ||= bmwqemu::default_timeout;
+    $named_args{pattern} = $pattern;
+    $named_args{timeout} ||= $bmwqemu::default_timeout;
 
     bmwqemu::log_call(\%named_args);
     
-    my $ret = query_isotovideo('backend_assert_terminal', \%named_args);
+    my $ret = query_isotovideo('backend_wait_terminal', \%named_args);
     my $result = $ret->{matched} ? 'ok' : 'fail';
     $autotest::current_test->record_serialresult(bmwqemu::pp($pattern), $result, $ret->{string});
-    bwmqemu::fctres("$pattern: $matched");
+    bwmqemu::fctres("$pattern: $ret->{matched}");
     return ($ret->{matched}, $ret->{string});
+}
+
+sub assert_terminal {
+    my ($matched, $string) = wait_terminal(@_);
+    die 'Pattern not found on terminal' unless $matched;
+    return $string;
 }
 
 =head2 x11_start_program

--- a/testapi.pm
+++ b/testapi.pm
@@ -729,7 +729,8 @@ sub script_output($;$) {
         wait_serial("$cat", undef, 0, no_regex => 1);
         type_string($current_test_script, terminate_with => 'EOT');
         wait_serial("$suffix-0-");
-    } else {
+    }
+    else {
         open my $fh, ">", 'current_script' or die("Could not open file. $!");
         print $fh $current_test_script;
         close $fh;
@@ -737,11 +738,13 @@ sub script_output($;$) {
         script_run "clear";
     }
 
-    my $run_script = "/bin/bash -ex /tmp/script$suffix.sh ; echo SCRIPT_FINISHED$suffix-\$?-";
+    my $run_script = "/tmp/script$suffix.sh ; echo SCRIPT_FINISHED$suffix-\$?-";
     if (is_serial_terminal) {
-        type_string($run_script . "\n");
-    } else {
-        type_string "($run_script)| tee /dev/$serialdev\n";
+        type_string("bash -e $run_script\n");
+        wait_serial($run_script, undef, 0, no_regex => 1);
+    }
+    else {
+        type_string "(bash -ex $run_script)| tee /dev/$serialdev\n";
     }
     my $output = wait_serial("SCRIPT_FINISHED$suffix-\\d+-", $wait, 0, record_output => 1)
       || die "script timeout";

--- a/testapi.pm
+++ b/testapi.pm
@@ -510,9 +510,27 @@ sub check_var_array {
     return grep { $_ eq $val } @$vars_r;
 }
 
+=head2 is_serial_terminal
+
+  is_serial_terminal->{yesorno};
+
+Determines if communication with the guest is being performed purely over a
+serial port. When true, the guest should have a tty attached to a serial port
+and os-autoinst sends commands to it as text. This differs from when a text
+console is selected in the guest, but VNC is being used to simulate keypresses.
+
+When a serial terminal is selected you will not be able to use functions which
+rely on needles. This sub is not exported by default as most tests I<will not
+benefit> from changing their behaviour depending on if communication happens
+over serial or VNC.
+
+For more info see consoles/virtio_console.pm and consoles/virtio_screen.pm.
+
+=cut
 sub is_serial_terminal {
-    state ($ret, $last_seen);
-    if ($selected_console ne $last_seen) {
+    state $ret;
+    state $last_seen = '';
+    if (defined $selected_console && $selected_console ne $last_seen) {
         $last_seen = $selected_console;
         $ret = query_isotovideo('backend_is_serial_terminal', {});
     }

--- a/testapi.pm
+++ b/testapi.pm
@@ -555,6 +555,43 @@ sub wait_serial {
     return;    # false
 }
 
+=head2 wait_terminal
+
+  wait_terminal($pattern, timeout => 30, expect_not_found => 0, record_output => 0,
+                exclude_match => 0, no_regex => 0);
+
+This function is only valid when the console is set to a text terminal. It waits
+for the terminal to output text which matches $pattern in a similar fasion to
+C<wait_serial>. If no named arguments are provided then it will scan the output of
+the active terminal for the regex C<$pattern> until the global timeout is reached.
+
+If it cannot find the pattern then a serial failure will be recorded. On success
+a pass is recorded and in either case the function returns a tuple containing
+a boolean and a string. The boolean indicates whether the pattern was matched
+and the string will contain some output from the terminal up to and including
+the match.
+
+The named arguments modify this behaviour; setting C<record_output = 1> will ensure
+that all text read from the terminal is return in the string up to the match.
+Setting C<exclude_match = 1> will remove the match from the returned string.
+Setting C<no_regex = 1> will cause C<$pattern> to be treated as plain text and a
+simple search using C<index> will be done instead. C<timeout> and C<expect_not_found>
+are the same as in L<wait_serial>.
+
+  sub find_login {
+    select_console('root-virtio-terminal');
+    my ($matched, $output) = wait_terminal(qr/login: $/);
+  }
+
+It is important to remember that, by default, terminals echo everything you send.
+Unless the echo has been disabled, you should wait for it before sending more input.
+Terminals can also insert ANSI control codes and formatting characters in
+unexpected places causing match failures on text which looks like it should
+otherwise match.
+
+Presently wait_terminal is implemented by L<consoles::virtio_screen::read_until>.
+
+=cut
 sub wait_terminal {
     die 'Expecting at least one argument' unless @_ > 0;
     my $pattern = shift;
@@ -563,18 +600,26 @@ sub wait_terminal {
     $named_args{timeout} ||= $bmwqemu::default_timeout;
 
     bmwqemu::log_call(%named_args);
-    
+
     my $ret = query_isotovideo('backend_wait_terminal', \%named_args);
-    my $result = $ret->{matched} ? 'ok' : 'fail';
+    my $result = ($ret->{matched} xor $named_args{expect_not_found}) ? 'ok' : 'fail';
     $autotest::current_test->record_serialresult(bmwqemu::pp($pattern), $result, $ret->{string});
     bmwqemu::fctres("$pattern: $ret->{matched}");
+    if ($named_args{die_on_fail} && $result eq 'fail') {
+        die 'wait_terminal failed';
+    }
     return ($ret->{matched}, $ret->{string});
 }
 
+=head2 assert_terminal
+
+This function is identical to L<wait_terminal> except that it will cause the
+test to die on failure.
+
+=cut
 sub assert_terminal {
-    my ($matched, $string) = wait_terminal(@_);
-    die 'Pattern not found on terminal' unless $matched;
-    return $string;
+    push @_, die_on_fail => 1;
+    wait_terminal(@_);
 }
 
 =head2 x11_start_program

--- a/testapi.pm
+++ b/testapi.pm
@@ -743,7 +743,8 @@ sub script_output($;$) {
     } else {
         type_string "($run_script)| tee /dev/$serialdev\n";
     }
-    my $output = wait_serial("SCRIPT_FINISHED$suffix-\\d+-", $wait) or die "script timeout";
+    my $output = wait_serial("SCRIPT_FINISHED$suffix-\\d+-", $wait, 0, record_output => 1)
+      || die "script timeout";
 
     die "script failed" if $output !~ "SCRIPT_FINISHED$suffix-0-";
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -553,6 +553,22 @@ sub wait_serial {
     return;    # false
 }
 
+sub assert_terminal {
+    die 'Expecting at least one argument' unless @_ > 0;
+    my $pattern = shift;
+    my %named_args = @_;
+    %named_args{pattern} = $pattern;
+    $named_args{timeout} ||= bmwqemu::default_timeout;
+
+    bmwqemu::log_call(\%named_args);
+    
+    my $ret = query_isotovideo('backend_assert_terminal', \%named_args);
+    my $result = $ret->{matched} ? 'ok' : 'fail';
+    $autotest::current_test->record_serialresult(bmwqemu::pp($pattern), $result, $ret->{string});
+    bwmqemu::fctres("$pattern: $matched");
+    return ($ret->{matched}, $ret->{string});
+}
+
 =head2 x11_start_program
 
     x11_start_program($program[, $timeout, $options]);

--- a/testapi.pm
+++ b/testapi.pm
@@ -45,6 +45,8 @@ our @EXPORT = qw($realname $username $password $serialdev %cmd %vars
   script_run script_sudo script_output validate_script_output
   assert_script_run assert_script_sudo
 
+  wait_terminal assert_terminal
+
   start_audiocapture assert_recorded_sound
 
   select_console console reset_consoles
@@ -560,12 +562,12 @@ sub wait_terminal {
     $named_args{pattern} = $pattern;
     $named_args{timeout} ||= $bmwqemu::default_timeout;
 
-    bmwqemu::log_call(\%named_args);
+    bmwqemu::log_call(%named_args);
     
     my $ret = query_isotovideo('backend_wait_terminal', \%named_args);
     my $result = $ret->{matched} ? 'ok' : 'fail';
     $autotest::current_test->record_serialresult(bmwqemu::pp($pattern), $result, $ret->{string});
-    bwmqemu::fctres("$pattern: $ret->{matched}");
+    bmwqemu::fctres("$pattern: $ret->{matched}");
     return ($ret->{matched}, $ret->{string});
 }
 


### PR DESCRIPTION
This allows the user to select a 'virtio-terminal' which is a text only (serial) console. This restricts the type of input and output which can be achieved and introduces a moderate amount of extra code, but is orders of magnitude quicker than sending key presses though VNC. The primary motivation for adding this is the LTP, which is made of thousands of executables which are best started individually by the OpenQA test script.

Currently the implementation is not quite transparent and adds a couple of functions to testapi, however these can probably be removed. Systems which do not support virtio can achieve a similar speed up by using an old fasioned serial port (or SSH) piped over whatever transport, everything will probably be the same except the transport/sockets used.

A significant proportion of the additions below are made up of the unit tests and documentation. 