### PR TITLE
update known UEFI firmware locations for Fedora distro package

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -255,10 +255,7 @@ sub start_qemu {
     }
 
     if ($vars->{UEFI} && $vars->{ARCH} eq 'x86_64' && !$vars->{BIOS}) {
-        # We have to try and find a firmware for UEFI. These are known
-        # locations for openSUSE and Fedora (respectively).
-        my @known = ('/usr/share/qemu/ovmf-x86_64-ms.bin', '/usr/share/edk2.git/ovmf-x64/OVMF_CODE-pure-efi.fd');
-        foreach my $firmware (@known) {
+        foreach my $firmware (@bmwqemu::ovmf_locations) {
             if (-e $firmware) {
                 $vars->{BIOS} = $firmware;
                 last;

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -59,6 +59,10 @@ our $istty;
 our $direct_output;
 our $standstillthreshold = scale_timeout(600);
 
+# Known locations of OVMF (UEFI) firmware: first is openSUSE, second is
+# the kraxel.org nightly packages, third is Fedora's edk2-ovmf package.
+our @ovmf_locations = ('/usr/share/qemu/ovmf-x86_64-ms.bin', '/usr/share/edk2.git/ovmf-x64/OVMF_CODE-pure-efi.fd', '/usr/share/edk2/ovmf/OVMF_CODE.fd');
+
 our %vars;
 
 sub load_vars() {

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -136,9 +136,7 @@ sub _init_xml {
     }
 
     if (get_var('UEFI') and check_var('ARCH', 'x86_64') and !get_var('BIOS')) {
-        # These are known locations for openSUSE and Fedora (respectively).
-        my @known = ('/usr/share/qemu/ovmf-x86_64-ms.bin', '/usr/share/edk2.git/ovmf-x64/OVMF_CODE-pure-efi.fd');
-        foreach my $firmware (@known) {
+        foreach my $firmware (@bmwqemu::ovmf_locations) {
             if (!$self->run_cmd("test -e $firmware")) {
                 set_var('BIOS', $firmware);
                 $elem = $doc->createElement('loader');


### PR DESCRIPTION
Fedora now has a distro edk2-ovmf package, so add the pure EFI
firmware from that to the two lists of known UEFI firmware file
locations (and update the comment).