### PR TITLE
Don't be too eager to shut off VNC screen

### DIFF
--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -790,9 +790,10 @@ sub send_update_request {
     # to get a defined live sign. If that doesn't help, consider
     # the framebuffer outdated
     if ($self->_framebuffer) {
-        if ($self->_last_update_requested - $self->_last_update_received > 2) {
+        if ($self->_last_update_requested - $self->_last_update_received > 4) {
             $self->_last_update_received(0);
             # return black image - screen turned off
+            bmwqemu::diag "considering VNC stalled - turning black";
             $self->_framebuffer(tinycv::new($self->width, $self->height));
         }
         if ($time_since_last_update > 2) {


### PR DESCRIPTION
The VNC stall detection didn't actually wait another 2 seconds, but would
disable the screen if there was no update in between 2 loop iterations, which
happens every 0.5 seconds. We actually *meant* to wait 2 more seconds before
disabling the screen, so add these 2 to the original 2