### PR TITLE
svirt: Set cache to 'unsafe'

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -359,7 +359,8 @@ sub add_disk {
             $elem->setAttribute(type => 'raw');
         }
         else {
-            $elem->setAttribute(type => 'qcow2');
+            $elem->setAttribute(type  => 'qcow2');
+            $elem->setAttribute(cache => 'unsafe');
         }
         $disk->appendChild($elem);
     }


### PR DESCRIPTION
In qemu backend disk cache type is set to 'unsafe', this commit sets
cache to 'unsafe' for disks run by svirt backend as well. Works with
QCOW2 images (KVM, Xen), not VMware as it does not support `<driver>`
property.