### PR TITLE
Add a flock together with the rsync in a shared needle directory for needle caching

### DIFF
--- a/isotovideo
+++ b/isotovideo
@@ -50,7 +50,7 @@ no autodie qw(kill);
 use Cwd;
 use POSIX qw(:sys_wait_h _exit);
 use Carp qw(cluck);
-use Time::HiRes qw(gettimeofday tv_interval sleep);
+use Time::HiRes qw(gettimeofday tv_interval sleep time);
 
 # avoid paranoia
 $Getopt::Std::STANDARD_HELP_VERSION = 1;
@@ -172,12 +172,24 @@ sub signalhandler_chld {
 sub init_backend {
     my ($name) = @_;
     $bmwqemu::vars{BACKEND} ||= "qemu";
-    my $dir = getcwd;
-    # make sure the needles are initialized before the backend process is started
     no autodie qw(system);
-    my $res = system("rsync -avP --delete --exclude=.git $bmwqemu::vars{PRODUCTDIR}/needles/ $dir/needles/");
-    die "Failed to rsync needles: $@" if $res;
-    needle::init("$dir/needles");
+
+    #We want to use the pool directory instead of the
+    # cwd (which would be the worker's directory)
+    # to be able to share the needles between workers
+    my $shared_needle_dir = getcwd() . "/..";
+    my $source_needles = $bmwqemu::vars{SOURCENEEDLES} || $bmwqemu::vars{PRODUCTDIR} . "/needles";
+
+    my $start = time;
+    my $cmd   = sprintf("flock -E 999 %s/needleslock rsync -avP --delete --exclude=.git %s %s/", $shared_needle_dir, $source_needles, $shared_needle_dir);
+    my $res   = system($cmd);
+
+    die "Failed to rsync needles: '$@' " if $res;
+    bmwqemu::diag(sprintf("Rsync: Synchronization of needles directory took %.2f seconds", time - $start));
+
+    bmwqemu::diag "Needle directory is ${shared_needle_dir}/needles";
+    # make sure the needles are initialized before the backend process is started
+    needle::init("${shared_needle_dir}/needles");
     $bmwqemu::backend = backend::driver->new($bmwqemu::vars{BACKEND});
     return $bmwqemu::backend;
 }

--- a/isotovideo
+++ b/isotovideo
@@ -51,6 +51,8 @@ use Cwd;
 use POSIX qw(:sys_wait_h _exit);
 use Carp qw(cluck);
 use Time::HiRes qw(gettimeofday tv_interval sleep time);
+use File::Spec;
+use File::Path;
 
 # avoid paranoia
 $Getopt::Std::STANDARD_HELP_VERSION = 1;
@@ -172,24 +174,31 @@ sub signalhandler_chld {
 sub init_backend {
     my ($name) = @_;
     $bmwqemu::vars{BACKEND} ||= "qemu";
-    no autodie qw(system);
 
-    #We want to use the pool directory instead of the
-    # cwd (which would be the worker's directory)
-    # to be able to share the needles between workers
-    my $shared_needle_dir = getcwd() . "/..";
-    my $source_needles = $bmwqemu::vars{SOURCENEEDLES} || $bmwqemu::vars{PRODUCTDIR} . "/needles";
+    # CACHEDIRECTORY must be defined in workers.ini either global or per worker configuration
+    if ($bmwqemu::vars{CACHEDIRECTORY}) {
 
-    my $start = time;
-    my $cmd   = sprintf("flock -E 999 %s/needleslock rsync -avP --delete --exclude=.git %s %s/", $shared_needle_dir, $source_needles, $shared_needle_dir);
-    my $res   = system($cmd);
+        no autodie qw(system);
 
-    die "Failed to rsync needles: '$@' " if $res;
-    bmwqemu::diag(sprintf("Rsync: Synchronization of needles directory took %.2f seconds", time - $start));
+        my $needles_source = $bmwqemu::vars{PRODUCTDIR} . "/needles";
+        my $shared_cache = File::Spec->catdir($bmwqemu::vars{CACHEDIRECTORY}, $bmwqemu::vars{OPENQA_HOSTNAME}, $bmwqemu::vars{DISTRI});
+        File::Path::make_path($shared_cache);
 
-    bmwqemu::diag "Needle directory is ${shared_needle_dir}/needles";
-    # make sure the needles are initialized before the backend process is started
-    needle::init("${shared_needle_dir}/needles");
+        my $start = time;
+        #Do an flock to ensure only one worker is trying to synchronize at a time.
+        my $cmd = sprintf("flock -E 999 %s/needleslock rsync -aP --delete --exclude=.git %s %s/", $shared_cache, $needles_source, $shared_cache);
+        my $res = system($cmd);
+
+        die "Failed to rsync needles: '$@' " if $res;
+        bmwqemu::diag(sprintf("Rsync: Synchronization of needles directory took %.2f seconds", time - $start));
+
+        # make sure the needles are initialized
+        needle::init($shared_cache . "/needles");
+    }
+    else {
+        needle::init($bmwqemu::vars{PRODUCTDIR} . "/needles");
+    }
+
     $bmwqemu::backend = backend::driver->new($bmwqemu::vars{BACKEND});
     return $bmwqemu::backend;
 }


### PR DESCRIPTION
The needles are being copied form SOURCENEEDLES or PRODUCTDIR/needles
to a shared directory just one level above the current working
directory, allowing all of the workers share needles and using the
blocking flock to ensure that only one worker at a time is tyring to
rsync through isotovideo

Error code 999 will be triggered when the
lock can't be obtained.