### PR TITLE
Query vars.json of another job (POO#14306)

### DIFF
--- a/commands.pm
+++ b/commands.pm
@@ -188,6 +188,13 @@ sub upload_file {
     return $self->render(text => "OK: $filename\n");
 }
 
+sub get_vars {
+    my ($self) = @_;
+
+    bmwqemu::load_vars();
+    return $self->render(json => {vars => \%bmwqemu::vars});
+}
+
 sub current_script {
     my ($self) = @_;
     return $self->reply->asset(Mojo::Asset::File->new(path => 'current_script'));
@@ -245,6 +252,9 @@ sub run_daemon {
     # get asset
     $token_auth->get('/assets/#assettype/#assetname'          => \&get_asset);
     $token_auth->get('/assets/#assettype/#assetname/*relpath' => \&get_asset);
+
+    # get vars
+    $token_auth->get('/vars' => \&get_vars);
 
     $token_auth->get('/isotovideo/#command' => \&isotovideo_get);
     $token_auth->post('/isotovideo/#command' => \&isotovideo_post);

--- a/mmapi.pm
+++ b/mmapi.pm
@@ -83,6 +83,15 @@ sub api_call {
     return $res;
 }
 
+=head2 get_children_by_state
+
+    my $children = get_children_by_state('done');
+    print $children->[0]
+
+Returns an array ref conaining ids of children in given state.
+
+=cut
+
 sub get_children_by_state {
     my ($state) = @_;
     my $res = api_call('get', 'mm/children/' . $state);
@@ -91,6 +100,15 @@ sub get_children_by_state {
     }
     return;
 }
+
+=head2 get_children
+
+    my $childern = get_children();
+    print keys %$children;
+
+Returns a hash ref conaining { id => state } pair for each child job.
+
+=cut
 
 sub get_children {
     my $res = api_call('get', 'mm/children');
@@ -101,6 +119,15 @@ sub get_children {
     return;
 }
 
+=head2 get_parents
+
+    my $parents = get_parents
+    print $parents->[0]
+
+Returns an array ref conaining ids of parent jobs.
+
+=cut
+
 sub get_parents {
     my $res = api_call('get', 'mm/parents');
 
@@ -109,6 +136,15 @@ sub get_parents {
     }
     return;
 }
+
+=head2 get_job_info
+
+    my $info = get_job_info($target_id);
+    print $info->{settings}->{DESKTOP}
+
+Returns a hash containin job information provided by openQA server.
+
+=cut
 
 sub get_job_info {
     my ($target_id) = @_;
@@ -119,6 +155,14 @@ sub get_job_info {
     }
     return;
 }
+
+=head2 get_job_autoinst_url
+
+    my $url = get_job_autoinst_url($target_id);
+
+Returns url of os-autoinst webserver for job $target_id or C<undef> on failure.
+
+=cut
 
 sub get_job_autoinst_url {
     my ($target_id) = @_;
@@ -142,6 +186,16 @@ sub get_job_autoinst_url {
     return;
 }
 
+=head2 get_job_autoinst_vars
+
+    my $vars = get_job_autoinst_vars($target_id);
+    print $vars->{WORKER_ID};
+
+Returns hash reference containing variables of job $target_id or C<undef> on failure. The variables
+are taken from vars.json file of the corresponding worker.
+
+=cut
+
 sub get_job_autoinst_vars {
     my ($target_id) = @_;
 
@@ -162,6 +216,14 @@ sub get_job_autoinst_vars {
     return;
 }
 
+=head2 wait_for_children
+
+    wait_for_children();
+
+Wait while any running or scheduled children exist.
+
+=cut
+
 sub wait_for_children {
     while (1) {
         my $children = get_children();
@@ -177,6 +239,13 @@ sub wait_for_children {
     }
 }
 
+=head2 wait_for_children_to_start
+
+    wait_for_children_to_start();
+
+Wait while any scheduled children exist.
+
+=cut
 sub wait_for_children_to_start {
     while (1) {
         my $children = get_children();


### PR DESCRIPTION
Usage:

use mmapi;
my $parents = get_parents();
my $vars = get_job_autoinst_vars($parents->[0]);
print $vars->{WORKER_ID}


The function returns current content of vars.json. It can be updated by calling bmwqemu::save_vars() if needed.