### PR TITLE
drop unused `$standstillthreshold` from bmwqemu

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -57,7 +57,6 @@ our $logfd;
 
 our $istty;
 our $direct_output;
-our $standstillthreshold = scale_timeout(600);
 
 our %vars;
 


### PR DESCRIPTION
AFAICT, nothing uses this.