### PR TITLE
Fix needle loading for remote workers when cache is enabled

### DIFF
--- a/isotovideo
+++ b/isotovideo
@@ -193,7 +193,7 @@ sub init_backend {
         bmwqemu::diag(sprintf("Rsync: Synchronization of needles directory took %.2f seconds", time - $start));
 
         # make sure the needles are initialized
-        needle::init($shared_cache . "/needles");
+        needle::init($bmwqemu::vars{PRODUCTDIR} . "/needles", $shared_cache . "/needles");
     }
     else {
         needle::init($bmwqemu::vars{PRODUCTDIR} . "/needles");


### PR DESCRIPTION
The initialization of needles will set the shared_cache variable,
in this case .json files will be loaded from the original location
and the .png files will be loaded from the cache, avoiding workers
to run jobs forever.