### PR TITLE
Destroy VM on do_stop_vm()

### DIFF
--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -63,6 +63,13 @@ sub do_stop_vm {
     my ($self) = @_;
 
     $self->stop_serial_grab;
+
+    unless (get_var('SVIRT_KEEP_VM_RUNNING')) {
+        my $vmname = $self->console('svirt')->name;
+        bmwqemu::diag "Destroying $vmname virtual machine";
+        $self->run_cmd("virsh destroy $vmname");
+        $self->run_cmd("virsh undefine $vmname");
+    }
     return {};
 }
 

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -509,6 +509,10 @@ sub attach_to_running {
 
     $self->name($name) if $name;
     $self->backend->start_serial_grab($self->name);
+
+    # Setting SVIRT_KEEP_VM_RUNNING variable prevents destruction of a perhaps valuable VM
+    # outside of openQA. Un-set it on your own in test should the VM be destroyed.
+    set_var('SVIRT_KEEP_VM_RUNNING', 1);
 }
 
 # Sends command to libvirt host, logs stdout and stderr of the command,


### PR DESCRIPTION
Virtual machine managed by svirt backend is now being destroyed on
do_stop_vm() call.

Verification run: http://assam.suse.cz/tests/4128