### PR TITLE
Change the PNG compression

### DIFF
--- a/ppmclibs/tinycv_impl.cc
+++ b/ppmclibs/tinycv_impl.cc
@@ -271,7 +271,7 @@ bool image_write(Image *s, const char *filename)
   compression_params.push_back(CV_IMWRITE_PNG_COMPRESSION);
   // compression level from 0-9, default is 3 but we go lower/faster
   // and let openQA run optipng on those we want to save
-  compression_params.push_back(1);
+  compression_params.push_back(0);
 
   if (!imencode(".png", s->img, buf, compression_params)) {
     std::cerr << "Could not encode image " << filename << std::endl;


### PR DESCRIPTION
The compression (Which was basically none), is basically disabled
with this change, altough the changes are not that big, it might improve
peformance on test and reduce "Slow IO" messages, when the system is
under heavy load.

The attached file shows the time each file took to be encoded/written. 

Note that times are expressed in ms, and write time > 3ms is a lot considering that i have a m2 drive, pretty fast. 

Filename | Encoding Time | Write Time | Total time
--- | --- | --- | ---
testresults/.thumbs/consoletest_setup-2.png	|0	|97	|97
testresults/install_and_reboot-15.png	|32	|9	|42
testresults/install_and_reboot-27.png	|22	|8	|31
qemuscreenshot/shot-0000001663.png	|52	|5	|57
qemuscreenshot/shot-0000001509.png	|32	|5	|38
testresults/install_and_reboot-26.png	|21	|5	|26

[benchmarktest.txt](https://github.com/os-autoinst/os-autoinst/files/603048/benchmarktest.txt)
