### PR TITLE
serial terminal: Make virtio chardev optional

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -732,6 +732,7 @@ sub start_qemu {
         if ($vars->{AUTO_INST}) {
             push(@params, "-drive", "file=$basedir/autoinst.img,index=0,if=floppy");
         }
+        bmwqemu::diag(`$qemubin -version`);
         bmwqemu::diag("starting: " . join(" ", @params));
 
         # don't try to talk to the host's PA

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -715,7 +715,7 @@ sub start_qemu {
             push(@params, "-k", $vars->{VNCKB}) if ($vars->{VNCKB});
         }
 
-        {
+        if ($vars->{VIRTIO_CONSOLE}) {
             my $id = 'virtio_console';
             push(@params, '-device',  'virtio-serial');
             push(@params, '-chardev', "socket,path=$id,server,nowait,id=$id,logfile=$id.log");

--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -23,6 +23,7 @@ use Carp qw(croak);
 use Scalar::Util qw(blessed);
 use Cwd;
 use consoles::virtio_screen ();
+use testapi qw(get_var);
 
 use base 'consoles::console';
 
@@ -110,8 +111,13 @@ sub open_socket {
 
 sub activate {
     my ($self) = @_;
-    $self->{socket_fd} = $self->open_socket;
-    $self->{screen}    = consoles::virtio_screen::->new($self->{socket_fd});
+    if (get_var('VIRTIO_CONSOLE')) {
+        $self->{socket_fd} = $self->open_socket;
+        $self->{screen}    = consoles::virtio_screen::->new($self->{socket_fd});
+    }
+    else {
+        croak 'VIRTIO_CONSOLE is not set, so no virtio-serial and virtconsole devices will be available to use with this console.';
+    }
     return;
 }
 

--- a/t/10-terminal.t
+++ b/t/10-terminal.t
@@ -238,6 +238,8 @@ sub test_terminal_directly {
     open STDERR, '>&', $errdupfd;
     STDERR->autoflush(1);
 
+    testapi::set_var('VIRTIO_CONSOLE', 1);
+
     my $term = consoles::virtio_terminal->new('unit-test-console', []);
     $term->activate;
     my $scrn = $term->screen;


### PR DESCRIPTION
Stop the error "Invalid parameter 'logfile'" by making the virtio console optional.

Possibly the log file parameter does not exist on older versions of QEMU. I need to determine if this is the case and if so how long it will take before we can use this feature. However in the mean time this patch will stop the reported error.