### PR TITLE
Do not take screenshot when VNC connection is dead

### DIFF
--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -83,9 +83,9 @@ sub run_cmd {
     );
     my $chan = $self->{ssh}->channel();
     $chan->exec($cmd);
-    bmwqemu::diag "Command executed: $cmd";
     $chan->send_eof;
     $chan->close();
+    bmwqemu::diag "Command executed: $cmd";
     return $chan->exit_status();
 }
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -858,8 +858,12 @@ sub assert_shutdown {
             bmwqemu::diag("Backend does not implement is_shutdown - just sleeping");
             sleep($timeout);
         }
-        if ($is_shutdown) {    # -1 counts too
-            $autotest::current_test->take_screenshot('ok');
+        # -1 counts too
+        if ($is_shutdown) {
+            # With svirt backend the VNC connection is dead, can't take a screenshot
+            unless (check_var('BACKEND', 'svirt')) {
+                $autotest::current_test->take_screenshot('ok');
+            }
             return;
         }
         --$timeout;


### PR DESCRIPTION
POO#14618

With qemu backend we use '-no-shutdown' Qemu option which prevents qemu
process to exit after it's guest OS quits. In svirt backend we don't
have such option so after OS is shutdown, the VNC connection is
terminated with it's domain - we should not take a screenshot in such a
case.

Should fix https://openqa.suse.de/tests/654678 but there may be other occurrences.