### PR TITLE
WIP: Change the backend to use ppm and videoencoder to create the pngs

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -37,7 +37,6 @@ my $framecounter = 0;    # screenshot counter
 
 # should be a singleton - and only useful in backend process
 our $backend;
-our $want_png = 0;
 
 use parent 'Class::Accessor::Fast';
 __PACKAGE__->mk_accessors(
@@ -182,8 +181,6 @@ sub run_capture_loop {
 
                 last if $time_to_timeout <= 0;
             }
-
-            $want_png = (-e bmwqemu::result_dir() . "/live_log") ? 1 : 0;
 
             my $time_to_update_request = ($update_request_interval // $self->update_request_interval) - ($now - $self->last_update_request);
             if ($time_to_update_request <= 0) {
@@ -388,8 +385,7 @@ sub enqueue_screenshot {
     $framecounter++;
 
     my $filename = $bmwqemu::screenshotpath . sprintf("/shot-%010d.ppm", $framecounter);
-    my $lastlink = $bmwqemu::screenshotpath . "/last.png";
-
+    
     my $lastscreenshot = $self->last_image;
 
     # link identical files to save space
@@ -404,13 +400,6 @@ sub enqueue_screenshot {
         $self->write_img($image, $filename) || die "write $filename";
         $self->last_image($image);
         $self->_last_screenshot_name($filename);
-
-        if ($want_png) {
-            no autodie 'unlink';
-            unlink($lastlink);
-            symlink(basename($self->_last_screenshot_name), $lastlink);
-        }
-
     }
 
     if ($sim > 50) {    # we ignore smaller differences

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -406,7 +406,6 @@ sub enqueue_screenshot {
         $self->_last_screenshot_name($filename);
 
         if ($want_png) {
-            print "We want the png";
             no autodie 'unlink';
             unlink($lastlink);
             symlink(basename($self->_last_screenshot_name), $lastlink);

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -37,6 +37,7 @@ my $framecounter = 0;    # screenshot counter
 
 # should be a singleton - and only useful in backend process
 our $backend;
+our $want_png = 0;
 
 use parent 'Class::Accessor::Fast';
 __PACKAGE__->mk_accessors(
@@ -181,6 +182,8 @@ sub run_capture_loop {
 
                 last if $time_to_timeout <= 0;
             }
+
+            $want_png = (-e bmwqemu::result_dir() . "/live_log") ? 1 : 0;
 
             my $time_to_update_request = ($update_request_interval // $self->update_request_interval) - ($now - $self->last_update_request);
             if ($time_to_update_request <= 0) {
@@ -384,7 +387,7 @@ sub enqueue_screenshot {
 
     $framecounter++;
 
-    my $filename = $bmwqemu::screenshotpath . sprintf("/shot-%010d.png", $framecounter);
+    my $filename = $bmwqemu::screenshotpath . sprintf("/shot-%010d.ppm", $framecounter);
     my $lastlink = $bmwqemu::screenshotpath . "/last.png";
 
     my $lastscreenshot = $self->last_image;
@@ -401,9 +404,14 @@ sub enqueue_screenshot {
         $self->write_img($image, $filename) || die "write $filename";
         $self->last_image($image);
         $self->_last_screenshot_name($filename);
-        no autodie 'unlink';
-        unlink($lastlink);
-        symlink(basename($self->_last_screenshot_name), $lastlink);
+
+        if ($want_png) {
+            print "We want the png";
+            no autodie 'unlink';
+            unlink($lastlink);
+            symlink(basename($self->_last_screenshot_name), $lastlink);
+        }
+
     }
 
     if ($sim > 50) {    # we ignore smaller differences

--- a/ppmclibs/tinycv_impl.cc
+++ b/ppmclibs/tinycv_impl.cc
@@ -266,29 +266,7 @@ Image *image_read(const char *filename)
 
 bool image_write(Image *s, const char *filename)
 {
-  vector<uchar> buf;
-
-  if (!imencode(".ppm", s->img, buf)) {
-    std::cerr << "Could not encode image " << filename << std::endl;
-    return false;
-  }
-  string path = filename;
-  string tpath = path + ".tmp";
-  FILE *f = fopen(tpath.c_str(), "wx");
-  if (!f) {
-    std::cerr << "Could not write image " << tpath << std::endl;
-    return false;
-  }
-  if (fwrite(buf.data(), 1, buf.size(), f) != buf.size()) {
-    std::cerr << "Could not write to image " << tpath << std::endl;
-    return false;
-  }
-  fclose(f);
-  if (rename(tpath.c_str(), path.c_str())) {
-    std::cerr << "Could not rename " << tpath << errno << std::endl;
-    return false;
-  }
-  return true;
+	return imwrite(filename, s->img);
 }
 
 Image *image_copy(Image *s)

--- a/ppmclibs/tinycv_impl.cc
+++ b/ppmclibs/tinycv_impl.cc
@@ -267,13 +267,8 @@ Image *image_read(const char *filename)
 bool image_write(Image *s, const char *filename)
 {
   vector<uchar> buf;
-  vector<int> compression_params;
-  compression_params.push_back(CV_IMWRITE_PNG_COMPRESSION);
-  // compression level from 0-9, default is 3 but we go lower/faster
-  // and let openQA run optipng on those we want to save
-  compression_params.push_back(1);
 
-  if (!imencode(".png", s->img, buf, compression_params)) {
+  if (!imencode(".ppm", s->img, buf)) {
     std::cerr << "Could not encode image " << filename << std::endl;
     return false;
   }

--- a/videoencoder.cpp
+++ b/videoencoder.cpp
@@ -35,6 +35,7 @@ video.
 #include <cstdio>
 #include <ogg/ogg.h>
 #include "theora/theoraenc.h"
+#include <sys/stat.h>
 
 const char *option_input;
 const char *option_output;
@@ -336,15 +337,25 @@ main (int argc, char *argv[])
 	      return -1;
 	    }
 
-	  rgb_to_yuv (&image, ycbcr);
+    rgb_to_yuv (&image, ycbcr);
+    
+    struct stat buff;
+    std::string livelog_file = get_current_dir_name();
+    livelog_file += "/live_log";
+    bool live_view = (stat(livelog_file.c_str(), &buff) != -1);
 
-	std::string new_filename = filename;
-
-	new_filename = new_filename.replace(new_filename.end() - 4, new_filename.end(), ".png");
-
-	imwrite(new_filename, image);
-	unlink(filename);
-	link(new_filename.c_str(), filename); //tried with symlink but somehow the link is broken
+    std::cout << "Processing " << filename << std::endl;
+    std::cout << "CWD is " << get_current_dir_name() << std::endl;
+    std::cout << "livelog_file is " << livelog_file.c_str() << std::endl;
+    if(live_view){
+      std::string new_filename = filename;
+      new_filename += ".png";
+      std::cout << "Need more PNG!" << std::endl;
+    // new_filename = new_filename.replace(new_filename.end() - 4, new_filename.end(), ".png");
+      imwrite(new_filename, image);
+      unlink("last.png");
+      symlink(new_filename.c_str(), "last.png"); //tried with symlink but somehow the link is broken
+    }
 
 	}
       else if (line[0] == 'R')

--- a/videoencoder.cpp
+++ b/videoencoder.cpp
@@ -1,5 +1,3 @@
-/* Modified by Stephan Kulow <coolo@suse.de> 2014 to take the PNGs
-   from stdin and use opencv directly */
 /* Modified by Stephan Kulow <coolo@suse.de> 2016 to take the PNGs
    from external file */
 
@@ -21,23 +19,16 @@
   last mod: $Id$
              based on code from Vegard Nossum
 
+Commands can be: E src_image or R:
+  * E src_image will add src_image to the video as a new frame
+  * R will wait until a new command is recieved
+
+This program will wait until it recieves a TERM signal to complete the 
+video.
+
  ********************************************************************/
 
 #define _FILE_OFFSET_BITS 64
-
-/*
-#include <errno.h>
-#include <getopt.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
-#include <time.h>
-#include <math.h>
-#include <libgen.h>
-#include <sys/types.h>
-#include <dirent.h>
-*/
 
 #include <signal.h>
 #include <unistd.h>
@@ -346,6 +337,14 @@ main (int argc, char *argv[])
 	    }
 
 	  rgb_to_yuv (&image, ycbcr);
+
+	std::string new_filename = filename;
+
+	new_filename = new_filename.replace(new_filename.end() - 4, new_filename.end(), ".png");
+
+	imwrite(new_filename, image);
+	unlink(filename);
+	link(new_filename.c_str(), filename); //tried with symlink but somehow the link is broken
 
 	}
       else if (line[0] == 'R')


### PR DESCRIPTION
Change the backend to write ppm instead of png's,
also the `last.png` file would be written on request by a file named
`live_log` in the testresults directory on the pool.

Changed videoencoder to make it write the png when it has finished
encoding a new frame.

This PR is related to [Change the isotovideo backend to write ppm files](https://progress.opensuse.org/issues/14976)

For now png and ppm will coexist (but the ppm will be a png internally
too). The only problem so far i've encountered is that the last.png is
not updated as often as we would like to.

http://deimos.suse.de/tests/1232#live had a live execution and it
shown the problem described above, delay in the WebUI... which took at
one point almost a minute, but somehow the test results were not properly uploaded.
