### PR TITLE
Avoid growing memory over time: free needle images

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -730,6 +730,11 @@ sub set_tags_to_assert {
     my $timeout       = $args->{timeout} // $bmwqemu::default_timeout;
     my $reloadneedles = $args->{reloadneedles} || 0;
 
+    # free all needle images
+    for my $n (needle->all()) {
+        $n->{img} = undef;
+    }
+
     # get the array reference to all matching needles
     my $needles = [];
     my @tags;


### PR DESCRIPTION
The needle images are initialized whenever the needles are needed, but
they are never freed, so the backend process grows quite heavy over
time. I was from 100M to 400M when only half way through the
installation.

So now free all needle images before each assert_screen. This way we
stay reasonable sized. Actually I can't believe we noticed the problem
before