### PR TITLE
Do not use eatmydata anymore in qemu.pm backend

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -726,7 +726,6 @@ sub start_qemu {
         push @params, "-monitor", "telnet:127.0.0.1:$port,server,nowait";
 
         unshift(@params, $qemubin);
-        unshift(@params, "/usr/bin/eatmydata") if (-e "/usr/bin/eatmydata");
 
         if ($vars->{AUTO_INST}) {
             push(@params, "-drive", "file=$basedir/autoinst.img,index=0,if=floppy");


### PR DESCRIPTION
This is related to problem identified by bug
https://bugzilla.suse.com/show_bug.cgi?id=1009472#c16

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>