### PR TITLE
Add SATA controller when SATA disk is present

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -584,6 +584,11 @@ sub start_qemu {
             }
         }
 
+        if ($vars->{ATACONTROLLER}) {
+            # SATA devices need SATA controller
+            push(@params, "-device", "$vars->{ATACONTROLLER},id=ahci0");
+        }
+
         for my $i (1 .. $vars->{NUMDISKS}) {
             if ($vars->{MULTIPATH}) {
                 for my $c (1 .. $vars->{PATHCNT}) {

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -28,6 +28,7 @@ IPMI_USER;string;Username for the IPMI interface;
 Variable;Values allowed;Default value;Explanation
 ARCH;x86_64|i686|aarch64|...;depends on tested medium;Architecture of VM.
 AUTO_INST;;;
+ATACONTROLLER;see qemu -device ?, e. g. for SATA: ich9-ahci;;Controller for ATA devices, needed for connecting disks as SATA.
 BIOS;;;
 BOOT_HDD_IMAGE;boolean;;enables boot from HDD_1 (BOOTFROM has higher priority)
 BOOTFROM;chars;undef;Influences order of boot devices. See qemu -boot option


### PR DESCRIPTION
This adds Intel's ich9-ahci bus when `ide-drive` is specified as HDDMODEL (this looks like it is preferred way [when testing SATA](https://rubenerd.com/sata-on-qemu/)).

It has unfortunate side effect - it's not possible to connect CD via PATA and HDD via SATA at the same time, because when ich9-ahci is present, `CDMODEL=ide-cd` makes QEMU connect it via SATA, not PATA.

We need this when we want to test whether Fedora works on SATA.