### PR TITLE
QEMU: Add QEMU_NUMA var to enable NUMA

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -689,6 +689,12 @@ sub start_qemu {
         else {
             push(@params, "-smp", $vars->{QEMUCPUS});
         }
+        if ($vars->{QEMU_NUMA}) {
+            for my $i (0 .. ($vars->{QEMUCPUS} - 1)) {
+                push(@params, '-numa', "node,nodeid=$i");
+            }
+        }
+
         push(@params, "-enable-kvm") unless $vars->{QEMU_NO_KVM};
         push(@params, "-no-shutdown");
 

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -64,6 +64,7 @@ QEMUVGA;see qemu -device ?;cirrus;VGA device to use with VM
 QEMU_COMPRESS_QCOW2;boolean;0;compress qcow2 images intended for upload
 QEMU_NO_KVM;boolean;0;Don't use KVM acceleration.
 QEMU_VIRTIO_RNG;boolean;0;Enable virtio random number generator
+QEMU_NUMA;boolean;0;Enable NUMA simulation, requires QEMUCPUS to be greater than one
 RAIDLEVEL;;;
 SKIPTO;full name of test module;;Restore VM from snapshot and continue by running specified test module. Needs HDD image with snapshots present
 TAPDEV;device name;undef;TAP device name to which virtual NIC should be connected. Usually undef so automatic matching is used


### PR DESCRIPTION
Setting QEMU_NUMA to 1 activates NUMA *simulation* so long as QEMUCPUS > 1.

This allows LTP tests to be ran which require NUMA, although it may not have the same effect as running it on actual NUMA hardware.