### PR TITLE
Add Benchmark::Stopwatch and timming marks (and unlink ppm)

### DIFF
--- a/OpenQA/Benchmark/Stopwatch.pm
+++ b/OpenQA/Benchmark/Stopwatch.pm
@@ -1,0 +1,273 @@
+use strict;
+use warnings;
+
+package OpenQA::Benchmark::Stopwatch;
+
+our $VERSION = '0.05';
+
+use Time::HiRes;
+use Clone 'clone';
+
+=head1 NAME
+
+Benchmark::Stopwatch - simple timing of stages of your code.
+
+=head1 SYNOPSIS
+
+    use Benchmark::Stopwatch;
+    my $stopwatch = Benchmark::Stopwatch->new->start;
+
+    # ... code that reads from database ...
+    $stopwatch->lap('read from database');
+
+    # ... code that writes to disk ...
+    $stopwatch->lap('write to disk');
+
+    print $stopwatch->stop->summary;
+
+    # NAME                        TIME        CUMULATIVE      PERCENTAGE
+    #  read from database          0.123       0.123           34.462%
+    #  write to disk               0.234       0.357           65.530%
+    #  _stop_                      0.000       0.357           0.008%
+
+=head1 DESCRIPTION
+
+The other benchmark modules provide excellent timing for specific parts of
+your code. This module aims to allow you to easily time the progression of
+your code.
+
+The stopwatch analogy is that at some point you get a C<new> stopwatch and
+C<start> timing. Then you note certain events using C<lap>. Finally you
+C<stop> the watch and then print out a C<summary>.
+
+The summary shows all the events in order, what time they occured at, how long
+since the last lap and the percentage of the total time. Hopefully this will
+give you a good idea of where your code is spending most of its time.
+
+The times are all wallclock times in fractional seconds.
+
+That's it.
+
+=head1 METHODS
+
+=head2 new
+
+    my $stopwatch = Benchmark::Stopwatch->new;
+
+Creates a new stopwatch.
+
+=cut
+
+sub new {
+    my $class = shift;
+    my $self  = {};
+
+    $self->{events} = [];
+    $self->{_time} = sub { Time::HiRes::time() };
+
+    return bless $self, $class;
+}
+
+=head2 start
+
+    $stopwatch = $stopwatch->start;
+
+Starts the stopwatch. Returns a reference to the stopwatch so that you can
+chain.
+
+=cut
+
+sub start {
+    my $self = shift;
+    $self->{start} = $self->time;
+    return $self;
+}
+
+=head2 lap
+
+    $stopwatch = $stopwatch->lap( 'name of event' );
+
+Notes down the time at which an event occurs. This event will later appear in
+the summary.
+
+=cut
+
+sub lap {
+    my $self = shift;
+    my $name = shift;
+    my $time = $self->time;
+
+    push @{$self->{events}}, {name => $name, time => $time};
+    return $self;
+}
+
+=head2 stop
+
+    $stopwatch = $stopwatch->stop;
+
+Stops the stopwatch. Returns a reference to the stopwatch so you can chain.
+
+=cut
+
+sub stop {
+    my $self = shift;
+    $self->{stop} = $self->time;
+    return $self;
+}
+
+=head2 total_time
+
+    my $time_in_seconds = $stopwatch->total_time;
+
+Returns the time that the stopwatch ran for in fractional seconds. If the
+stopwatch has not been stopped yet then it returns time it has been running
+for.
+
+=cut
+
+sub total_time {
+    my $self = shift;
+
+    # Get the stop time or now if missing.
+    my $stop = $self->{stop} || $self->time;
+
+    return $stop - $self->{start};
+}
+
+=head2 summary
+
+    my $summary_text = $stopwatch->summary;
+
+Returns text summarizing the events that occured. Example output from a script
+that fetches the homepages of the web's five busiest sites and times how long
+each took.
+
+ NAME                        TIME        CUMULATIVE      PERCENTAGE
+  http://www.yahoo.com/       3.892       3.892           22.399%
+  http://www.google.com/      3.259       7.152           18.758%
+  http://www.msn.com/         8.412       15.564          48.411%
+  http://www.myspace.com/     0.532       16.096          3.062%
+  http://www.ebay.com/        1.281       17.377          7.370%
+  _stop_                      0.000       17.377          0.000%
+
+The final entry C<_stop_> is when the stop watch was stopped.
+
+=cut
+
+sub summary {
+    my $self          = shift;
+    my $out           = '';
+    my $header_format = "%-27.26s %-11s %-15s %s\n";
+    my $result_format = " %-27.26s %-11.3f %-15.3f %.3f%%\n";
+    my $prev_time     = $self->{start};
+
+    push @{$self->{events}}, {name => '_stop_', time => $self->{stop}};
+
+    $out .= sprintf $header_format, qw( NAME TIME CUMULATIVE PERCENTAGE);
+
+    foreach my $event (@{$self->{events}}) {
+
+        my $duration   = $event->{time} - $prev_time;
+        my $cumulative = $event->{time} - $self->{start};
+        my $percentage = ($duration / $self->total_time) * 100;
+
+        $out .= sprintf $result_format,    #
+          $event->{name},                  #
+          $duration,                       #
+          $cumulative,                     #
+          $percentage;
+
+        $prev_time = $event->{time};
+    }
+
+    pop @{$self->{events}};
+    return $out;
+}
+
+=head2 as_data
+
+  my $data_structure_hashref = $stopwatch->as_data;
+
+Returns a data structure that contains all the information that was logged.
+This is so that you can use this module to gather the data but then use your
+own code to manipulate it.
+
+The returned hashref will look like this:
+
+  {
+    start_time => 1234500,  # The time the stopwatch was started
+    stop_time  => 1234510,  # The time it was stopped or as_data called
+    total_time => 10,       # The duration of timing
+    laps       => [
+        {
+            name       => 'test', # The name of the lap
+            time       => 1,      # The time of this lap (seconds)
+            cumulative => 1,      # seconds since start to this lap
+            fraction   => 0.10,   # fraction of total time.
+        },
+        {
+            name       => '_stop_',   # created as needed
+            time       => 9,
+            cumulative => 10,
+            fraction   => 0.9,
+        },
+    ],
+  }
+
+=cut
+
+sub as_data {
+    my $self = shift;
+    my %data = ();
+
+    $data{start_time} = $self->{start};
+    $data{stop_time}  = $self->{stop} || $self->time;
+    $data{total_time} = $data{stop_time} - $data{start_time};
+
+    # Clone the events across and add the stop event.
+    $data{laps} = clone($self->{events});
+    push @{$data{laps}}, {name => '_stop_', time => $data{stop_time}};
+
+    # For each entry in laps calculate the cumulative and the fraction.
+    my $running_total = 0;
+    my $last_time     = $data{start_time};
+    foreach my $lap (@{$data{laps}}) {
+
+        my $this_time = delete $lap->{time};
+        $lap->{time} = $this_time - $last_time;
+        $last_time = $this_time;
+
+        $running_total += $lap->{time};
+        $lap->{cumulative} = $running_total;
+        $lap->{fraction}   = $lap->{time} / $data{total_time};
+    }
+
+    return \%data;
+}
+
+sub time {
+    &{$_[0]{_time}};
+}
+
+=head1 AUTHOR
+
+Edmund von der Burg C<<evdb@ecclestoad.co.uk>>
+
+L<http://www.ecclestoad.co.uk>
+
+=head1 ACKNOWLEDGMENTS
+
+Inspiration from my colleagues at L<http://www.nestoria.co.uk>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2006 Edmund von der Burg. All rights reserved.
+
+This module is free software; you can redistribute it and/or modify it under
+the same terms as Perl itself. If it breaks you get to keep both pieces.
+
+THERE IS NO WARRANTY.
+
+=cut
+
+1;

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -29,9 +29,9 @@ use IO::Select;
 require IPC::System::Simple;
 use autodie ':all';
 use myjsonrpc;
-
 use Net::SSH2;
 use feature 'say';
+use OpenQA::Benchmark::Stopwatch;
 
 my $framecounter = 0;    # screenshot counter
 
@@ -381,18 +381,20 @@ sub enqueue_screenshot {
     return unless $image;
 
     my $starttime = gettimeofday;
+    my $watch     = OpenQA::Benchmark::Stopwatch->new();
+    $watch->start();
 
     $image = $image->scale(1024, 768);
-
+    $watch->lap("scaling");
     $framecounter++;
 
     my $filename = $bmwqemu::screenshotpath . sprintf("/shot-%010d.ppm", $framecounter);
-
     my $lastscreenshot = $self->last_image;
 
     # link identical files to save space
     my $sim = 0;
     $sim = $lastscreenshot->similarity($image) if $lastscreenshot;
+    $watch->lap("similarity");
 
     my $mt1 = gettimeofday;
 
@@ -409,15 +411,22 @@ sub enqueue_screenshot {
 
     if ($sim > 50) {    # we ignore smaller differences
         $self->write_encoder_frame('R');
+        $watch->lap("write_encoder_frame R");
     }
     else {
         $self->write_img($image, $filename) || die "write $filename";
         $self->write_encoder_frame("E $filename");
+        $watch->lap("write_encoder_frame E");
     }
+    # TODO: Have the stopwatch to be able to handle this calculation. (by ading elapsed - lap)
     my $d = gettimeofday - $starttime;
     if ($d > $self->screenshot_interval) {
         bmwqemu::diag sprintf("WARNING: enqueue_screenshot took %.2f seconds - slow IO? (opencv: %.2f - encoder: %.2f)", $d, $mt1 - $starttime, gettimeofday - $mt1);
     }
+
+    $watch->stop();
+    print "DEBUG_IO: for $filename\n";
+    print $watch->summary();
     return;
 }
 

--- a/ppmclibs/tinycv_impl.cc
+++ b/ppmclibs/tinycv_impl.cc
@@ -33,6 +33,15 @@
 #define DEBUG 0
 #define DEBUG2 0
 
+#if __cplusplus >= 201112L
+// disabled by default
+#define DEBUG_IO 0
+#endif
+
+#if DEBUG_IO
+#include <chrono>
+#endif
+
 #define VERY_DIFF 0.0
 #define VERY_SIM 1000000.0
 
@@ -313,7 +322,15 @@ Image* image_read(const char* filename)
 
 bool image_write(Image* s, const char* filename)
 {
+#if DEBUG_IO
+    auto time_before_write = std::chrono::high_resolution_clock::now();
+#endif
     return imwrite(filename, s->img);
+#if DEBUG_IO
+    auto time_after_write = std::chrono::high_resolution_clock::now();
+    cout << "DEBUG_IO: "
+         << "|filename: " << filename << "|write time: " << chrono::duration_cast<chrono::milliseconds>(time_after_write - time_before_write).count() << endl flush;
+#endif
 }
 
 Image* image_copy(Image* s)

--- a/t/10-test-image-conversion-benchmark.t
+++ b/t/10-test-image-conversion-benchmark.t
@@ -1,0 +1,67 @@
+#!/usr/bin/perl
+# Do not add to makefile.am
+
+use strict;
+use warnings;
+use Test::More;
+
+use Try::Tiny;
+use File::Basename;
+use File::Path qw(make_path remove_tree);
+use String::Random;
+use Cwd;
+
+
+BEGIN {
+    unshift @INC, '..';
+}
+
+use OpenQA::Benchmark::Stopwatch;
+
+
+# optional but very useful
+eval 'use Test::More::Color';                 ## no critic
+eval 'use Test::More::Color "foreground"';    ## no critic
+my $string = new String::Random;
+
+use needle;
+use cv;
+
+cv::init();
+require tinycv;
+
+
+my ($res, $needle, $image, $cand, $img_src);
+
+my $data_dir = 't/data';
+my $result_dir = "$data_dir/results";
+
+make_path($result_dir);
+
+opendir(DIR, $data_dir) or die ("Cannot read directories: $data_dir");
+
+my @all_images = grep { /\.png$/ } readdir DIR;
+
+    my $watch = OpenQA::Benchmark::Stopwatch->new();
+    $watch->start();
+
+    foreach my $img_src (@all_images){
+
+        my $filename = "$result_dir/test-".$string->randregex('\d\d\d\d\d')."$img_src";
+        $image = tinycv::read($data_dir .'/'. $img_src);
+        if( $image ){
+                $image->write($filename);
+            }
+        ok( -e $filename, "Passed $filename");
+        $watch->lap("$img_src");
+    }
+
+remove_tree($result_dir, {verbose => 1});
+
+$watch->stop();
+print $watch->summary();
+
+
+done_testing();
+
+# vim: set sw=4 et:

--- a/t/20-openqa-benchmark-stopwatch-utils.t
+++ b/t/20-openqa-benchmark-stopwatch-utils.t
@@ -1,0 +1,31 @@
+#!/usr/bin/perl
+# Do not add to makefile.am
+
+use strict;
+use warnings;
+use Test::More;
+
+
+BEGIN {
+    unshift @INC, '..';
+}
+
+use OpenQA::Benchmark::Stopwatch;
+
+my $watch = OpenQA::Benchmark::Stopwatch->new();
+$watch->start();
+
+sleep 1;
+$watch->lap("Lap 1 sec");
+sleep 2;
+$watch->lap("Lap 2 sec");
+$watch->stop();
+
+ok($watch->as_data()->{total_time} gt 2,"Pass summary as data");
+ok($watch->as_data()->{laps}[0]{time} gt 1,"Pass 1sec lap");
+ok($watch->as_data()->{laps}[1]{time} gt 2 && $watch->as_data()->{laps}[1]{time} lt 3 ,"Pass 2sec lap");
+print $watch->summary();
+
+done_testing();
+
+# vim: set sw=4 et:

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,4 +1,4 @@
 AM_MAKEFLAGS = PERL5OPT=-MDevel::Cover
-TESTS = 00-compile-check-all.t 01-test_needle.t 02-test_ocr.t 03-testapi.t 04-check_vars_docu.t 05-pod.t 06-pod-coverage.t 07-commands.t 08-autotest.t 09-lockapi.t 10-terminal.t
+TESTS = 00-compile-check-all.t 01-test_needle.t 02-test_ocr.t 03-testapi.t 04-check_vars_docu.t 05-pod.t 06-pod-coverage.t 07-commands.t 08-autotest.t 09-lockapi.t 10-terminal.t 20-openqa-benchmark-stopwatch-utils.t
 
 EXTRA_DIST = $(TESTS) t/test_driver.pm

--- a/videoencoder.cpp
+++ b/videoencoder.cpp
@@ -345,6 +345,8 @@ int main(int argc, char* argv[])
             last_frame_converted = true;
         }
 
+        unlink(last_frame_filename.c_str());
+
         if (output_video) {
             if (theora_write_frame(ycbcr, 0)) {
                 fprintf(stderr, "Encoding error.\n");


### PR DESCRIPTION
This is still related to the task [poo#14976 #1](https://progress.opensuse.org/issues/14976) regarding timing marks and also to the task 3rd (unlinking the ppm)

Whith the last two commits we get [Benchmark::Stopwatch](https://metacpan.org/pod/Benchmark::Stopwatch).

A live run can be seen at: http://deimos.suse.de/tests/1285