### PR TITLE
Use the stopwatch to detect a slow operations

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -380,8 +380,7 @@ sub enqueue_screenshot {
 
     return unless $image;
 
-    my $starttime = gettimeofday;
-    my $watch     = OpenQA::Benchmark::Stopwatch->new();
+    my $watch = OpenQA::Benchmark::Stopwatch->new();
     $watch->start();
 
     $image = $image->scale(1024, 768);
@@ -396,11 +395,9 @@ sub enqueue_screenshot {
     $sim = $lastscreenshot->similarity($image) if $lastscreenshot;
     $watch->lap("similarity");
 
-    my $mt1 = gettimeofday;
-
     # we have two different similarity levels - one (slightly higher value, based
     # t/data/user-settings-*) to determine if it's worth it to recheck needles
-    # and one (slightly lower as less signifant) determining if we write the frame
+    # and one (slightly lower as less significant) determining if we write the frame
     # into the video (and onto disk)
     # in case the filename has to be returned to the test process as result, it's
     # written out unconditionally (see write_img)
@@ -418,15 +415,14 @@ sub enqueue_screenshot {
         $self->write_encoder_frame("E $filename");
         $watch->lap("write_encoder_frame E");
     }
-    # TODO: Have the stopwatch to be able to handle this calculation. (by ading elapsed - lap)
-    my $d = gettimeofday - $starttime;
-    if ($d > $self->screenshot_interval) {
-        bmwqemu::diag sprintf("WARNING: enqueue_screenshot took %.2f seconds - slow IO? (opencv: %.2f - encoder: %.2f)", $d, $mt1 - $starttime, gettimeofday - $mt1);
-    }
 
     $watch->stop();
-    print "DEBUG_IO: for $filename\n";
-    print $watch->summary();
+    if ($watch->as_data()->{total_time} > $self->screenshot_interval) {
+        bmwqemu::diag "DEBUG_IO: for $filename\n";
+        bmwqemu::diag sprintf("WARNING: enqueue_screenshot took %.2f seconds", $watch->as_data()->{total_time});
+        bmwqemu::diag "DEBUG_IO: \n" . $watch->summary();
+    }
+
     return;
 }
 
@@ -840,9 +836,9 @@ sub check_asserted_screen {
         return;
     }
 
+    my $watch        = OpenQA::Benchmark::Stopwatch->new();
     my $img_filename = $self->_last_screenshot_name;
-
-    my $n = $self->_time_to_assert_screen_deadline;
+    my $n            = $self->_time_to_assert_screen_deadline;
 
     my $search_ratio = 0.02;
     $search_ratio = 1 if ($n % 5 == 0);
@@ -860,7 +856,7 @@ sub check_asserted_screen {
         }
     }
 
-    my $starttime = gettimeofday;
+    $watch->start();
 
     my ($foundneedle, $failed_candidates) = $img->search($self->assert_screen_needles, 0, $search_ratio);
 
@@ -869,9 +865,9 @@ sub check_asserted_screen {
         return {filename => $self->write_img($img, $img_filename), found => $foundneedle, candidates => $failed_candidates};
     }
 
-    my $d = gettimeofday - $starttime;
-    if ($d > $self->screenshot_interval) {
-        bmwqemu::diag sprintf("WARNING: check_asserted_screen took %.2f seconds - make your needles more specific", $d);
+    $watch->stop();
+    if ($watch->as_data()->{total_time} > $self->screenshot_interval) {
+        bmwqemu::diag sprintf("WARNING: check_asserted_screen took %.2f seconds - make your needles more specific", $watch->as_data()->{total_time});
     }
 
     if ($n < 0) {

--- a/basetest.pm
+++ b/basetest.pm
@@ -550,12 +550,11 @@ Optical Character Recognition matching.
 Return a listref containing hashrefs like this:
 
   {
-    screenshot=>2,		# nr of screenshot for the test to OCR
-    x=>104, y=>201,		# position
-    xs=>380, ys=>150,		# size
-    pattern=>"H ?ello",		# regex to match the OCR result
-
-    result=>"OK"		# or "fail"
+    screenshot=>2,      # nr of screenshot for the test to OCR
+    x=>104, y=>201,     # position
+    xs=>380, ys=>150,   # size
+    pattern=>"H ?ello", # regex to match the OCR result
+    result=>"OK"        # or "fail"
   }
 
 =cut

--- a/needle.pm
+++ b/needle.pm
@@ -25,7 +25,7 @@ use JSON;
 use File::Basename;
 require IPC::System::Simple;
 use autodie ':all';
-use Time::HiRes 'time';
+use OpenQA::Benchmark::Stopwatch;
 
 our %needles;
 our %tags;
@@ -145,9 +145,15 @@ sub get_image {
     my ($self, $area) = @_;
 
     if (!$self->{img}) {
-        my $start = time;
+        my $watch = OpenQA::Benchmark::Stopwatch->new();
+        $watch->start();
         $self->{img} = tinycv::read($self->{png});
-        bmwqemu::diag(sprintf("load of $self->{png} took %.2f seconds", time - $start));
+        $watch->stop();
+
+        if ($watch->as_data()->{total_time} > 0.1) {
+            bmwqemu::diag(sprintf("load of $self->{png} took %.2f seconds", $watch->as_data()->{total_time}));
+        }
+
         for my $a (@{$self->{area}}) {
             next unless $a->{type} eq 'exclude';
             $self->{img}->replacerect($a->{xpos}, $a->{ypos}, $a->{width}, $a->{height});


### PR DESCRIPTION
Change the baseclass.pm and needle.pm to use Benchmark::Stopwatch
instead of using by calculation by hand.

Fix tabs in basetest.pm