### PR TITLE
Fix crash if last_image is not yet set

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -914,6 +914,7 @@ sub cont_vm {
 
 sub last_screenshot_data {
     my ($self, $args) = @_;
+    return {} unless $self->last_image;
     return {image => encode_base64($self->last_image->ppm_data)};
 }
 


### PR DESCRIPTION
we used to return an empty filename from within write_img, now
we need to take extra care