### PR TITLE
Required changes for CASP VMX images

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -304,7 +304,7 @@ sub add_disk {
         $file = $args->{file};
     }
     else {
-        $file = $self->name . (($self->vmm_family eq 'vmware') ? ".vmdk" : ".img");
+        $file = $self->name . $args->{dev_id} . (($self->vmm_family eq 'vmware') ? ".vmdk" : ".img");
         if ($args->{create}) {
             my $size = $args->{size} || '4G';
             if ($self->vmm_family eq 'vmware') {

--- a/testapi.pm
+++ b/testapi.pm
@@ -94,8 +94,10 @@ Used for internal initialization, do not call from tests.
 =for stopwords xen hvc0 xvc0 ipmi ttyS
 =cut
 sub init {
-    $serialdev = get_var('SERIALDEV', 'ttyS0');
-    if (get_var('OFW') || check_var('BACKEND', 's390x')) {
+    if (get_var('SERIALDEV')) {
+        $serialdev = get_var('SERIALDEV');
+    }
+    elsif (get_var('OFW') || check_var('BACKEND', 's390x')) {
         $serialdev = "hvc0";
     }
     elsif (check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux')) {
@@ -105,6 +107,9 @@ sub init {
         else {
             $serialdev = "xvc0";
         }
+    }
+    else {
+        $serialdev = 'ttyS0';
     }
     $serialdev = 'ttyS1' if check_var('BACKEND', 'ipmi');
     return;


### PR DESCRIPTION
Enable second HDD device in sshVirsh.
Use SERIALDEV variable if set