### PR TITLE
Even safer shutdown to get published disks

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -70,9 +70,7 @@ sub load_vars() {
     local $/;
     open(my $fh, '<', $fn) or return 0;
     eval { $ret = JSON->new->relaxed->decode(<$fh>); };
-    die                                  #
-      "parse error in vars.json:\n" .    #
-      "$@" if $@;
+    die "parse error in vars.json:\n$@" if $@;
     close($fh);
     %vars = %{$ret};
     return;

--- a/isotovideo
+++ b/isotovideo
@@ -144,8 +144,6 @@ sub signalhandler {
 
 sub signalhandler_chld {
 
-    diag("got sigchld");
-
     while ((my $child = waitpid(-1, WNOHANG)) > 0) {
         if ($child == $cpid) {
             diag("commands webserver died");
@@ -156,9 +154,7 @@ sub signalhandler_chld {
         if ($bmwqemu::backend->{backend_pid} && $child == $bmwqemu::backend->{backend_pid}) {
             diag("backend $child died");
             $bmwqemu::backend->{backend_pid} = 0;
-            $bmwqemu::backend->{to_child}    = undef;
-            $bmwqemu::backend->{from_child}  = undef;
-            $loop                            = 0;
+            $loop = 0;
             next;
         }
         if ($child == $testpid) {
@@ -489,7 +485,11 @@ if (!$r) {
         diag "BACKEND SHUTDOWN $clean_shutdown";
     };
     # don't rely on the backend in a sane state if we failed - just kill it later
-    bmwqemu::stop_vm();
+    eval { bmwqemu::stop_vm(); };
+    if ($@) {
+        diag "Error during stop_vm: $@";
+        $r = 1;
+    }
 }
 
 # read calculated variables from backend and tests


### PR DESCRIPTION
While we try to stop the backend process, we will receive a SIGCHLD.
During handling this we should make sure not to remove sockets, we're
possibly writing to. This happens all the time, but for some reason
more likely on aarch64. This wouldn't be such a big problem if this
wouldn't stop (silently) to stop isotovideo from publishing disks.

See https://progress.opensuse.org/issues/14000