### PR TITLE
More timing marks

### DIFF
--- a/OpenQA/Benchmark/Stopwatch.pm
+++ b/OpenQA/Benchmark/Stopwatch.pm
@@ -4,7 +4,6 @@ use warnings;
 package OpenQA::Benchmark::Stopwatch;
 
 our $VERSION = '0.05';
-
 use Time::HiRes;
 
 =head1 NAME
@@ -62,7 +61,8 @@ sub new {
     my $self  = {};
 
     $self->{events} = [];
-    $self->{_time} = sub { Time::HiRes::time() };
+    $self->{_time}  = sub { Time::HiRes::time() };
+    $self->{length} = 26;
 
     return bless $self, $class;
 }
@@ -92,10 +92,11 @@ the summary.
 =cut
 
 sub lap {
-    my $self = shift;
-    my $name = shift;
-    my $time = $self->time;
-
+    my $self        = shift;
+    my $name        = shift;
+    my $time        = $self->time;
+    my $name_lenght = length $name;
+    $self->{length} = $name_lenght if $name_lenght > $self->{length};
     push @{$self->{events}}, {name => $name, time => $time};
     return $self;
 }
@@ -156,10 +157,9 @@ The final entry C<_stop_> is when the stop watch was stopped.
 sub summary {
     my $self          = shift;
     my $out           = '';
-    my $header_format = "%-27.26s %-11s %-15s %s\n";
-    my $result_format = " %-27.26s %-11.3f %-15.3f %.3f%%\n";
+    my $header_format = "%-$self->{length}.$self->{length}s %-11s %-15s %s\n";
+    my $result_format = " %-$self->{length}.$self->{length}s %-11.3f %-15.3f %.3f%%\n";
     my $prev_time     = $self->{start};
-
     push @{$self->{events}}, {name => '_stop_', time => $self->{stop}};
 
     $out .= sprintf $header_format, qw( NAME TIME CUMULATIVE PERCENTAGE);

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -821,9 +821,10 @@ sub check_asserted_screen {
     }
 
     $watch->start();
+    $watch->{debug} = 1;
 
-    my ($foundneedle, $failed_candidates) = $img->search($self->assert_screen_needles, 0, $search_ratio);
-
+    my ($foundneedle, $failed_candidates) = $img->search($self->assert_screen_needles, 0, $search_ratio, ($watch->{debug}? $watch : undef ));
+    $watch->lap("Needle search") unless $watch->{debug};
     if ($foundneedle) {
         $self->assert_screen_last_check(undef);
         return {
@@ -836,6 +837,9 @@ sub check_asserted_screen {
     $watch->stop();
     if ($watch->as_data()->{total_time} > $self->screenshot_interval) {
         bmwqemu::diag sprintf("WARNING: check_asserted_screen took %.2f seconds - make your needles more specific", $watch->as_data()->{total_time});
+        bmwqemu::diag "DEBUG_IO: \n" . $watch->summary();
+
+
     }
 
     if ($n < 0) {

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -823,7 +823,7 @@ sub check_asserted_screen {
     $watch->start();
     $watch->{debug} = 1;
 
-    my ($foundneedle, $failed_candidates) = $img->search($self->assert_screen_needles, 0, $search_ratio, ($watch->{debug}? $watch : undef ));
+    my ($foundneedle, $failed_candidates) = $img->search($self->assert_screen_needles, 0, $search_ratio, ($watch->{debug} ? $watch : undef));
     $watch->lap("Needle search") unless $watch->{debug};
     if ($foundneedle) {
         $self->assert_screen_last_check(undef);

--- a/ppmclibs/tinycv.pm
+++ b/ppmclibs/tinycv.pm
@@ -59,7 +59,7 @@ sub mean_square_error {
 #   ]
 # }
 sub search_ {
-    my ($self, $needle, $threshold, $search_ratio) = @_;
+    my ($self, $needle, $threshold, $search_ratio, $stopwatch) = @_;
     $threshold    ||= 0.0;
     $search_ratio ||= 0.0;
     my ($sim,     $xmatch, $ymatch);
@@ -72,6 +72,7 @@ sub search_ {
         bmwqemu::diag("SKIP($needle->{name}:missing PNG)");
         return;
     }
+    $stopwatch->lap("**++ search__: get image") if $stopwatch;
 
     my $img = $self;
     for my $a (@{$needle->{area}}) {
@@ -84,15 +85,20 @@ sub search_ {
         $img = $self->copy;
         for my $a (@exclude) {
             $img->replacerect($a->{xpos}, $a->{ypos}, $a->{width}, $a->{height});
+            $stopwatch->lap("**++-- search__: rectangle replacement") if $stopwatch;
         }
     }
-
+    $stopwatch->lap("**++ search__: areas exclusion") if $stopwatch;
     my $ret = {ok => 1, needle => $needle, area => []};
-
     for my $area (@match) {
         my $margin = int($area->{margin} + $search_ratio * (1024 - $area->{margin}));
-        ($sim, $xmatch, $ymatch) = $img->search_needle($needle_image, $area->{xpos}, $area->{ypos}, $area->{width}, $area->{height}, $margin);
 
+        ($sim, $xmatch, $ymatch) = $img->search_needle($needle_image, 
+                                                        $area->{xpos}, $area->{ypos}, 
+                                                        $area->{width}, $area->{height}, 
+                                                        $margin);
+
+        $stopwatch->lap("**++ tinycv::search_needle $area->{xpos}x$area->{ypos}x$area->{width}") if $stopwatch;
         my $ma = {
             similarity => $sim,
             x          => $xmatch,
@@ -117,15 +123,15 @@ sub search_ {
 
     $ret->{error} = mean_square_error($ret->{area});
     bmwqemu::diag(sprintf("MATCH(%s:%.2f)", $needle->{name}, 1 - sqrt($ret->{error})));
-
+    $stopwatch->lap("**++ mean_square_error") if $stopwatch;
     if ($ret->{ok}) {
         for my $a (@ocr) {
             $ret->{ocr} ||= [];
             my $ocr = ocr::tesseract($img, $a);
             push @{$ret->{ocr}}, $ocr;
         }
+        $stopwatch->lap("**++ ocr::tesseract: $needle->{name}") if $stopwatch;
     }
-
     return $ret;
 }
 
@@ -148,16 +154,18 @@ sub cmp_by_error_type_ {
 # in array context returns array with two elements. First element is best match
 # or undefined, second element are candidates that did not match.
 sub search {
-    my ($self, $needle, $threshold, $search_ratio) = @_;
+    my ($self, $needle, $threshold, $search_ratio, $stopwatch) = @_;
     return unless $needle;
+
+    $stopwatch->lap("Searching for needles") if $stopwatch;
 
     if (ref($needle) eq "ARRAY") {
         my @candidates;
-
         # try to match all needles and return the one with the highest similarity
         for my $n (@$needle) {
-            my $found = $self->search_($n, $threshold, $search_ratio);
+            my $found = $self->search_($n, $threshold, $search_ratio, $stopwatch);
             push @candidates, $found if $found;
+            $stopwatch->lap("** search_: $n->{name}") if $stopwatch;
         }
 
         @candidates = sort cmp_by_error_type_ @candidates;
@@ -166,7 +174,6 @@ sub search {
         if (@candidates && $candidates[0]->{ok}) {
             $best = shift @candidates;
         }
-
         if (wantarray) {
             return ($best, \@candidates);
         }
@@ -174,8 +181,10 @@ sub search {
             return $best;
         }
     }
+
     else {
-        my $found = $self->search_($needle, $threshold, $search_ratio);
+        my $found = $self->search_($needle, $threshold, $search_ratio, $stopwatch);
+        $stopwatch->lap("** search_: single needle: $needle->{name}") if $stopwatch;
         return unless $found;
         if (wantarray) {
             return ($found, undef) if ($found->{ok});

--- a/ppmclibs/tinycv.pm
+++ b/ppmclibs/tinycv.pm
@@ -93,10 +93,7 @@ sub search_ {
     for my $area (@match) {
         my $margin = int($area->{margin} + $search_ratio * (1024 - $area->{margin}));
 
-        ($sim, $xmatch, $ymatch) = $img->search_needle($needle_image, 
-                                                        $area->{xpos}, $area->{ypos}, 
-                                                        $area->{width}, $area->{height}, 
-                                                        $margin);
+        ($sim, $xmatch, $ymatch) = $img->search_needle($needle_image, $area->{xpos}, $area->{ypos}, $area->{width}, $area->{height}, $margin);
 
         $stopwatch->lap("**++ tinycv::search_needle $area->{xpos}x$area->{ypos}x$area->{width}") if $stopwatch;
         my $ma = {


### PR DESCRIPTION
Add more timing marks for check_assert_screen, as this is quite verbose, i decided to add a debug variable (enable by default for now), this screenshot is for the job with debug referenced below

Two sucessfull runs can be seen at [Without debug #1333](http://deimos.suse.de/tests/1333) and [With debug #1323](http://deimos.suse.de/tests/1323)

![screenshot from 2016-12-20 19-01-23](https://cloud.githubusercontent.com/assets/229240/21361993/bda61500-c6e6-11e6-893e-c49c8dd83edb.png)
