### PR TITLE
assert_shutdown: Sleep for 1 second even on svirt

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -1313,9 +1313,7 @@ sub assert_shutdown {
             $autotest::current_test->take_screenshot('ok');
             return;
         }
-        # svirt backend uses SSH in is_shutdown() so it takes around 1 second
-        # to get result anyway - no need to sleep explicitly
-        sleep 1 unless check_var('BACKEND', 'svirt');
+        sleep 1;
         --$timeout;
     }
     $autotest::current_test->take_screenshot('fail');


### PR DESCRIPTION
POO#15790

With some recent changes the assumption that with SSH the round of
checking VM status takes about 1 second and that no other sleep is
required (PR#669) is no longer valid.

Now even via SSH it takes just 0.1 second
(https://openqa.suse.de/tests/698139/file/autoinst-log.txt):
```
15:45:54.8191 8873 Connection to root@openqaw6-kvm.qa.suse.de established
15:45:54.9165 8873 Command executed: ! virsh dominfo openQA-SUT-1 | grep -w 'shut off', ret=0
15:45:55.0000 8873 Connection to root@openqaw6-kvm.qa.suse.de established
15:45:55.0992 8873 Command executed: ! virsh dominfo openQA-SUT-1 | grep -w 'shut off', ret=0
```
Hence the check for system status takes only around 10 second and some
VMs (e.g. KVM with UEFI) may not make it:
https://openqa.suse.de/tests/698139#step/shutdown/3.