### PR TITLE
[WIP] Add log4perl to os-autoinst

### DIFF
--- a/OpenQA/Log.pm
+++ b/OpenQA/Log.pm
@@ -1,0 +1,63 @@
+package OpenQA::Log;
+use strict;
+use warnings;
+
+use base qw(Exporter);
+our @EXPORT = qw(get_logger trace debug info warn error fatal);
+our @ISA    = qw(Log::Log4perl);
+
+use Log::Log4perl qw(:no_extra_logdie_message);
+use Log::Log4perl::Level;
+
+our $logger;
+our $configuration;
+
+sub setup {
+
+    unless (Log::Log4perl->initialized) {
+        Log::Log4perl->init($configuration . "/etc/os-autoinst/log4perl.conf");
+        $Log::Log4perl::caller_depth = 1;
+        $logger                      = Log::Log4perl->get_logger(__PACKAGE__);
+        warn("Hardcoded line $configuration/etc/os-autoinst/log4perl.conf");
+    }
+
+}
+
+sub trace {
+    my ($message) = @_;
+    $logger->trace($message);
+}
+
+sub debug {
+    my ($message) = @_;
+    $logger->debug($message);
+}
+
+sub info {
+    my ($message) = @_;
+    $logger->info($message);
+}
+
+sub warn {
+    my ($message) = @_;
+    $logger->warn($message);
+}
+
+sub error {
+    my ($message) = @_;
+    $logger->error($message);
+}
+
+sub fatal {
+    my ($message) = @_;
+    $logger->fatal($message);
+}
+
+sub die {
+    my ($message) = @_;
+    $logger->logdie($message);
+}
+
+1;
+
+# vim: set sw=4 et:

--- a/OpenQA/Log.pm
+++ b/OpenQA/Log.pm
@@ -2,9 +2,8 @@ package OpenQA::Log;
 use strict;
 use warnings;
 
-use base qw(Exporter);
+use base qw(Exporter Log::Log4perl);
 our @EXPORT = qw(get_logger trace debug info warn error fatal);
-our @ISA    = qw(Log::Log4perl);
 
 use Log::Log4perl qw(:no_extra_logdie_message);
 use Log::Log4perl::Level;

--- a/OpenQA/Log.pm
+++ b/OpenQA/Log.pm
@@ -14,10 +14,10 @@ our $configuration;
 sub setup {
 
     unless (Log::Log4perl->initialized) {
-        Log::Log4perl->init($configuration . "log4perl.conf");
+        Log::Log4perl->init($configuration . "/log4perl.conf");
         $Log::Log4perl::caller_depth = 1;
-        $logger                      = Log::Log4perl->get_logger(__PACKAGE__);
-        warn("Hardcoded line $configuration/etc/os-autoinst/log4perl.conf");
+        Log::Log4perl::wrapper_register(__PACKAGE__);
+        $logger = Log::Log4perl->get_logger(__PACKAGE__);
     }
 
 }
@@ -56,6 +56,7 @@ sub die {
     my ($message) = @_;
     $logger->logdie($message);
 }
+
 
 1;
 

--- a/OpenQA/Log.pm
+++ b/OpenQA/Log.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 
 use base qw(Exporter Log::Log4perl);
-our @EXPORT = qw(get_logger trace debug info warn error fatal);
+our @EXPORT = qw(get_logger trace debug info warn error fatal die);
 
 use Log::Log4perl qw(:no_extra_logdie_message);
 use Log::Log4perl::Level;
@@ -14,7 +14,7 @@ our $configuration;
 sub setup {
 
     unless (Log::Log4perl->initialized) {
-        Log::Log4perl->init($configuration . "/etc/os-autoinst/log4perl.conf");
+        Log::Log4perl->init($configuration . "log4perl.conf");
         $Log::Log4perl::caller_depth = 1;
         $logger                      = Log::Log4perl->get_logger(__PACKAGE__);
         warn("Hardcoded line $configuration/etc/os-autoinst/log4perl.conf");

--- a/autotest.pm
+++ b/autotest.pm
@@ -40,7 +40,7 @@ sub loadtest {
         $script = File::Spec->abs2rel($script, $bmwqemu::vars{CASEDIR});
     }
     unless ($script =~ m,(\w+)/([^/]+)\.pm$,) {
-        bmwqemu::logdie "loadtest needs a script to match \\w+/[^/]+.pm\n";
+        OpenQA::Log::die "loadtest needs a script to match \\w+/[^/]+.pm\n";
     }
     my $category = $1;
     my $name     = $2;
@@ -170,7 +170,7 @@ sub prestart_hook {
         OpenQA::Log::debug "running prestart step";
         eval { require $bmwqemu::vars{CASEDIR} . "/prestart.pm"; };
         if ($@) {
-            bmwqemu::logdie "prestart step FAIL:" . $@;
+            OpenQA::Log::die "prestart step FAIL:" . $@;
         }
     }
 }

--- a/autotest.pm
+++ b/autotest.pm
@@ -155,7 +155,7 @@ sub start_process {
     if (!$line) {
         _exit(0);
     }
-    bmwqemu::fctdbg "GOT $line";
+    OpenQA::Log::debug "GOT $line";
     # the backend process might have added some defaults for the backend
     bmwqemu::load_vars();
 
@@ -209,7 +209,7 @@ sub runalltests {
     my $firsttest           = $bmwqemu::vars{SKIPTO} || $testorder[0]->{fullname};
     my $vmloaded            = 0;
     my $snapshots_supported = query_isotovideo('backend_can_handle', {function => 'snapshots'});
-    bmwqemu::fctdbg "Snapshots are " . ($snapshots_supported ? '' : 'not ') . "supported";
+    OpenQA::Log::info "Snapshots are " . ($snapshots_supported ? '' : 'not ') . "supported";
 
     write_test_order();
 

--- a/autotest.pm
+++ b/autotest.pm
@@ -26,6 +26,7 @@ use Socket;
 use IO::Handle;
 use POSIX '_exit';
 use cv;
+use OpenQA::Log;
 
 our %tests;        # scheduled or run tests
 our @testorder;    # for keeping them in order

--- a/autotest.pm
+++ b/autotest.pm
@@ -155,7 +155,7 @@ sub start_process {
     if (!$line) {
         _exit(0);
     }
-    print "GOT $line\n";
+    bmwqemu::fctdbg "GOT $line";
     # the backend process might have added some defaults for the backend
     bmwqemu::load_vars();
 

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -33,6 +33,7 @@ use Net::SSH2;
 use feature 'say';
 use OpenQA::Benchmark::Stopwatch;
 use MIME::Base64 'encode_base64';
+use OpenQA::Log;
 
 # should be a singleton - and only useful in backend process
 our $backend;

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -885,7 +885,7 @@ sub check_asserted_screen {
             _reduce_to_biggest_changes($failed_screens, 20);
         }
     }
-    OpenQA::Log::warn("no match $n");
+    OpenQA::Log::debug("no match $n");
     $self->assert_screen_last_check([$img, $search_ratio]);
     return;
 }

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -693,7 +693,7 @@ sub wait_idle {
     my ($self, $args) = @_;
     my $timeout = $args->{timeout};
 
-    bmwqemu::fctdbg("wait_idle sleeping for $timeout seconds");
+    OpenQA::Log::debug("wait_idle sleeping for $timeout seconds");
     $self->run_capture_loop($timeout);
     return;
 }
@@ -822,7 +822,7 @@ sub check_asserted_screen {
     }
     else {
         if ($oldimg && $oldimg eq $img && $old_search_ratio >= $search_ratio) {
-            bmwqemu::fctdbg("no change $n");
+            OpenQA::Log::debug("no change $n");
             return;
         }
     }

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -912,13 +912,13 @@ sub _reduce_to_biggest_changes {
 
 sub freeze_vm {
     my ($self) = @_;
-    bmwqemu::fcterr("ignored freeze_vm");
+    OpenQA::Log::error("ignored freeze_vm");
     return;
 }
 
 sub cont_vm {
     my ($self) = @_;
-    bmwqemu::fcterr("ignored cont_vm");
+    OpenQA::Log::error("ignored cont_vm");
     return;
 }
 
@@ -986,7 +986,7 @@ sub new_ssh_connection {
                 # this relies on agent to be set up correctly
                 $ssh->auth_agent($args{username});
             }
-            bmwqemu::fctinfo("Connection to $args{username}\@$args{hostname} established") if $ssh->auth_ok;
+            OpenQA::Log::info("Connection to $args{username}\@$args{hostname} established") if $ssh->auth_ok;
             last;
         }
         else {

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -386,8 +386,8 @@ sub enqueue_screenshot {
 
     $watch->stop();
     if ($watch->as_data()->{total_time} > $self->screenshot_interval) {
-        my $encoder_warining = sprintf("Enqueue_screenshot took %.2f seconds", $watch->as_data()->{total_time});
-        OpenQA::Log::warn($encoder_warining);
+        my $encoder_warning = sprintf("Enqueue_screenshot took %.2f seconds", $watch->as_data()->{total_time});
+        OpenQA::Log::warn($encoder_warning);
         # Stopwatch data can be safely handled as a trace message
         OpenQA::Log::trace("\n" . $watch->summary());
     }

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -100,8 +100,7 @@ sub run {
     $io->autoflush(1);
     $self->{rsppipe} = $io;
 
-    printf STDERR "$$: cmdpipe %d, rsppipe %d\n", fileno($self->{cmdpipe}), fileno($self->{rsppipe});
-
+    bmwqemu::fctwarn sprintf "$$: cmdpipe %d, rsppipe %d\n", fileno($self->{cmdpipe}), fileno($self->{rsppipe});
     bmwqemu::diag "started mgmt loop with pid $$";
 
     $self->{select} = IO::Select->new();

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -189,7 +189,7 @@ sub run_capture_loop {
             if (grep { $_ == $self->{encoder_pipe} } @$write_set) {
                 my $fdata        = shift @{$self->{video_frame_data}};
                 my $data_written = $self->{encoder_pipe}->syswrite($fdata);
-                bmwqemu::logdie("Encoder not accepting data") unless defined $data_written;
+                OpenQA::Log::die("Encoder not accepting data") unless defined $data_written;
                 if ($data_written != length($fdata)) {
                     # put it back into the queue
                     unshift @{$self->{video_frame_data}}, substr($fdata, $data_written);
@@ -398,7 +398,7 @@ sub close_pipes {
     my ($self) = @_;
 
     if ($self->{cmdpipe}) {
-        close($self->{cmdpipe}) || bmwqemu::logdie("close $!\n");
+        close($self->{cmdpipe}) || OpenQA::Log::die("close $!\n");
         $self->{cmdpipe} = undef;
     }
 
@@ -406,7 +406,7 @@ sub close_pipes {
 
     OpenQA::Log::debug("sending magic and exit");
     $self->{rsppipe}->print('{"QUIT":1}');
-    close($self->{rsppipe}) || bmwqemu::logdie("close $!\n");
+    close($self->{rsppipe}) || OpenQA::Log::die("close $!\n");
     Devel::Cover::report() if Devel::Cover->can('report');
     _exit(0);
 }
@@ -430,7 +430,7 @@ sub check_socket {
         }
         else {
             use Data::Dumper;
-            bmwqemu::logdie("no command in " . Dumper($cmd));
+            OpenQA::Log::die("no command in " . Dumper($cmd));
         }
         return 1;
     }
@@ -995,7 +995,7 @@ sub new_ssh_connection {
             next;
         }
     }
-    bmwqemu::logdie("Failed to login to $args{username}\@$args{hostname}") unless $ssh->auth_ok;
+    OpenQA::Log::die("Failed to login to $args{username}\@$args{hostname}") unless $ssh->auth_ok;
 
     return $ssh;
 }
@@ -1008,7 +1008,7 @@ sub start_ssh_serial {
 
     $self->{serial} = $self->new_ssh_connection(%args);
     my $chan = $self->{serial}->channel();
-    bmwqemu::logdie("No channel found") unless $chan;
+    OpenQA::Log::die("No channel found") unless $chan;
     $self->{serial_chan} = $chan;
     $chan->blocking(0);
     $chan->pty(1);

--- a/backend/console_proxy.pm
+++ b/backend/console_proxy.pm
@@ -22,6 +22,8 @@
 
 package backend::console_proxy;
 use strict;
+use warnings;
+use OpenQA::Log;
 
 sub new {
     my ($class, $console) = @_;

--- a/backend/driver.pm
+++ b/backend/driver.pm
@@ -28,7 +28,6 @@ use IO::Select;
 use POSIX '_exit';
 require IPC::System::Simple;
 use autodie ':all';
-use bmwqemu qw(fctwarn  );
 use myjsonrpc;
 
 

--- a/backend/driver.pm
+++ b/backend/driver.pm
@@ -28,7 +28,7 @@ use IO::Select;
 use POSIX '_exit';
 require IPC::System::Simple;
 use autodie ':all';
-use bmwqemu qw(:DEFAULT);
+use bmwqemu qw(fctwarn logdie fctdbg);
 use myjsonrpc;
 
 

--- a/backend/driver.pm
+++ b/backend/driver.pm
@@ -29,7 +29,7 @@ use POSIX '_exit';
 require IPC::System::Simple;
 use autodie ':all';
 use myjsonrpc;
-
+use OpenQA::Log;
 
 sub new {
     my ($class, $name) = @_;

--- a/backend/driver.pm
+++ b/backend/driver.pm
@@ -59,7 +59,7 @@ sub start {
     $self->{to_parent}  = $p2;
     $self->{from_child} = $p1;
 
-    bmwqemu::fctwarn sprintf "$$: to_child %d, from_child %d\n", fileno($self->{to_child}), fileno($self->{from_child});
+    OpenQA::Log::warn sprintf "$$: to_child %d, from_child %d\n", fileno($self->{to_child}), fileno($self->{from_child});
 
     my $pid = fork();
     bmwqemu::logdie "fork failed" unless defined $pid;

--- a/backend/driver.pm
+++ b/backend/driver.pm
@@ -48,20 +48,20 @@ sub start {
     my ($self) = @_;
 
     my $p1, my $p2;
-    pipe($p1, $p2) or OpenQA::Log::die("pipe: $!");
+    pipe($p1, $p2) or die("pipe: $!");
     $self->{from_parent} = $p1;
     $self->{to_child}    = $p2;
 
     $p1 = undef;
     $p2 = undef;
-    pipe($p1, $p2) or OpenQA::Log::die("pipe: $!");
+    pipe($p1, $p2) or die("pipe: $!");
     $self->{to_parent}  = $p2;
     $self->{from_child} = $p1;
 
-    OpenQA::Log::warn sprintf "$$: to_child %d, from_child %d\n", fileno($self->{to_child}), fileno($self->{from_child});
+    warn sprintf "$$: to_child %d, from_child %d\n", fileno($self->{to_child}), fileno($self->{from_child});
 
     my $pid = fork();
-    OpenQA::Log::die "fork failed" unless defined $pid;
+    die "fork failed" unless defined $pid;
 
     if ($pid == 0) {
         $SIG{TERM} = 'DEFAULT';
@@ -115,11 +115,11 @@ sub start_vm {
     close $runf;
 
     # remove old screenshots
-    OpenQA::Log::debug "remove_tree $bmwqemu::screenshotpath\n";
+    debug "remove_tree $bmwqemu::screenshotpath\n";
     remove_tree($bmwqemu::screenshotpath);
     mkdir $bmwqemu::screenshotpath;
 
-    $self->_send_json({cmd => 'start_vm'}) || OpenQA::Log::die "failed to start VM";
+    $self->_send_json({cmd => 'start_vm'}) || die "failed to start VM";
     return 1;
 }
 

--- a/backend/driver.pm
+++ b/backend/driver.pm
@@ -49,20 +49,20 @@ sub start {
     my ($self) = @_;
 
     my $p1, my $p2;
-    pipe($p1, $p2) or bmwqemu::logdie("pipe: $!");
+    pipe($p1, $p2) or OpenQA::Log::die("pipe: $!");
     $self->{from_parent} = $p1;
     $self->{to_child}    = $p2;
 
     $p1 = undef;
     $p2 = undef;
-    pipe($p1, $p2) or bmwqemu::logdie("pipe: $!");
+    pipe($p1, $p2) or OpenQA::Log::die("pipe: $!");
     $self->{to_parent}  = $p2;
     $self->{from_child} = $p1;
 
     OpenQA::Log::warn sprintf "$$: to_child %d, from_child %d\n", fileno($self->{to_child}), fileno($self->{from_child});
 
     my $pid = fork();
-    bmwqemu::logdie "fork failed" unless defined $pid;
+    OpenQA::Log::die "fork failed" unless defined $pid;
 
     if ($pid == 0) {
         $SIG{TERM} = 'DEFAULT';
@@ -120,7 +120,7 @@ sub start_vm {
     remove_tree($bmwqemu::screenshotpath);
     mkdir $bmwqemu::screenshotpath;
 
-    $self->_send_json({cmd => 'start_vm'}) || bmwqemu::logdie "failed to start VM";
+    $self->_send_json({cmd => 'start_vm'}) || OpenQA::Log::die "failed to start VM";
     return 1;
 }
 

--- a/backend/driver.pm
+++ b/backend/driver.pm
@@ -28,7 +28,7 @@ use IO::Select;
 use POSIX '_exit';
 require IPC::System::Simple;
 use autodie ':all';
-use bmwqemu qw(fctwarn logdie fctdbg);
+use bmwqemu qw(fctwarn  );
 use myjsonrpc;
 
 
@@ -116,7 +116,7 @@ sub start_vm {
     close $runf;
 
     # remove old screenshots
-    bmwqemu::fctdbg "remove_tree $bmwqemu::screenshotpath\n";
+    OpenQA::Log::debug "remove_tree $bmwqemu::screenshotpath\n";
     remove_tree($bmwqemu::screenshotpath);
     mkdir $bmwqemu::screenshotpath;
 

--- a/backend/generalhw.pm
+++ b/backend/generalhw.pm
@@ -57,7 +57,7 @@ sub run_cmd {
     chomp $stderr;
 
     die $cmd . ": $stderr" unless ($ret);
-    bmwqemu::diag("IPMI: $stdout");
+    OpenQA::Log::debug("IPMI: $stdout");
     return $stdout;
 }
 

--- a/backend/generalhw.pm
+++ b/backend/generalhw.pm
@@ -38,12 +38,12 @@ sub get_cmd {
 
     my $dir = get_required_var('GENERAL_HW_CMD_DIR');
     if (!-d $dir) {
-        OpenQA::Log::die "GENERAL_HW_CMD_DIR is not pointing to a directory";
+        die "GENERAL_HW_CMD_DIR is not pointing to a directory";
     }
     $cmd = get_required_var($cmd);
     $cmd = "$dir/" . basename($cmd);
     if (!-x $cmd) {
-        OpenQA::Log::die "CMD $cmd is not an executable";
+        die "CMD $cmd is not an executable";
     }
     return $cmd;
 }
@@ -56,8 +56,8 @@ sub run_cmd {
     chomp $stdout;
     chomp $stderr;
 
-    OpenQA::Log::die $cmd . ": $stderr" unless ($ret);
-    OpenQA::Log::debug("IPMI: $stdout");
+    die $cmd . ": $stderr" unless ($ret);
+    debug("IPMI: $stdout");
     return $stdout;
 }
 
@@ -130,7 +130,7 @@ sub start_serial_grab {
         open(STDOUT,     ">&", $serial);
         open(STDERR,     ">&", $serial);
         exec($self->get_cmd('GENERAL_HW_SOL_CMD'));
-        OpenQA::Log::die "exec failed $!";
+        die "exec failed $!";
     }
     return;
 }

--- a/backend/generalhw.pm
+++ b/backend/generalhw.pm
@@ -24,6 +24,7 @@ use IPC::Run ();
 require IPC::System::Simple;
 use autodie ':all';
 use File::Basename 'basename';
+use OpenQA::Log;
 
 sub new {
     my $class = shift;

--- a/backend/generalhw.pm
+++ b/backend/generalhw.pm
@@ -19,7 +19,6 @@
 package backend::generalhw;
 use strict;
 use base 'backend::baseclass';
-use bmwqemu 'diag';
 use testapi qw(get_required_var get_var);
 use IPC::Run ();
 require IPC::System::Simple;
@@ -38,12 +37,12 @@ sub get_cmd {
 
     my $dir = get_required_var('GENERAL_HW_CMD_DIR');
     if (!-d $dir) {
-        die "GENERAL_HW_CMD_DIR is not pointing to a directory";
+        OpenQA::Log::die "GENERAL_HW_CMD_DIR is not pointing to a directory";
     }
     $cmd = get_required_var($cmd);
     $cmd = "$dir/" . basename($cmd);
     if (!-x $cmd) {
-        die "CMD $cmd is not an executable";
+        OpenQA::Log::die "CMD $cmd is not an executable";
     }
     return $cmd;
 }
@@ -56,7 +55,7 @@ sub run_cmd {
     chomp $stdout;
     chomp $stderr;
 
-    die $cmd . ": $stderr" unless ($ret);
+    OpenQA::Log::die $cmd . ": $stderr" unless ($ret);
     OpenQA::Log::debug("IPMI: $stdout");
     return $stdout;
 }
@@ -130,7 +129,7 @@ sub start_serial_grab {
         open(STDOUT,     ">&", $serial);
         open(STDERR,     ">&", $serial);
         exec($self->get_cmd('GENERAL_HW_SOL_CMD'));
-        die "exec failed $!";
+        OpenQA::Log::die "exec failed $!";
     }
     return;
 }

--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -28,7 +28,7 @@ use POSIX qw(strftime :sys_wait_h);
 use JSON;
 require Carp;
 use Fcntl;
-use bmwqemu qw(fileContent diag save_vars diag);
+use bmwqemu qw(fileContent save_vars);
 use testapi 'get_required_var';
 use IPC::Run ();
 require IPC::System::Simple;
@@ -59,7 +59,7 @@ sub ipmitool {
 
     $self->dell_sleep;
 
-    die join(' ', @cmd) . ": $stderr" unless ($ret);
+    OpenQA::Log::die join(' ', @cmd) . ": $stderr" unless ($ret);
     OpenQA::Log::debug("IPMI: $stdout");
     return $stdout;
 }
@@ -163,7 +163,7 @@ sub start_serial_grab {
         push(@cmd, qw(-W nochecksumcheck));
 
         exec(@cmd);
-        die "exec failed $!";
+        OpenQA::Log::die "exec failed $!";
     }
     return;
 }

--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -60,8 +60,8 @@ sub ipmitool {
 
     $self->dell_sleep;
 
-    OpenQA::Log::die join(' ', @cmd) . ": $stderr" unless ($ret);
-    OpenQA::Log::debug("IPMI: $stdout");
+    die join(' ', @cmd) . ": $stderr" unless ($ret);
+    debug("IPMI: $stdout");
     return $stdout;
 }
 
@@ -164,7 +164,7 @@ sub start_serial_grab {
         push(@cmd, qw(-W nochecksumcheck));
 
         exec(@cmd);
-        OpenQA::Log::die "exec failed $!";
+        die "exec failed $!";
     }
     return;
 }

--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -33,6 +33,7 @@ use testapi 'get_required_var';
 use IPC::Run ();
 require IPC::System::Simple;
 use autodie ':all';
+use OpenQA::Log;
 
 sub new {
     my $class = shift;

--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -60,7 +60,7 @@ sub ipmitool {
     $self->dell_sleep;
 
     die join(' ', @cmd) . ": $stderr" unless ($ret);
-    bmwqemu::diag("IPMI: $stdout");
+    OpenQA::Log::debug("IPMI: $stdout");
     return $stdout;
 }
 

--- a/backend/pvm.pm
+++ b/backend/pvm.pm
@@ -16,12 +16,13 @@
 package backend::pvm;
 use strict;
 use base 'backend::baseclass';
-use bmwqemu qw(fileContent diag save_vars);
+use bmwqemu qw(fileContent save_vars);
 use File::Path 'mkpath';
 require IPC::System::Simple;
 use autodie ':all';
 use File::Basename;
 use Digest::MD5 'md5_hex';
+use OpenQA::Log;
 
 sub new {
     my $class      = shift;
@@ -45,7 +46,7 @@ sub do_start_vm {
 }
 
 sub runcmd {
-    diag "running " . join(' ', @_);
+    info "running " . join(' ', @_);
     return system(@_);
 }
 
@@ -62,7 +63,7 @@ sub do_extract_assets {
     $cmd = $cmd . " VirtualDisk.name=$disk";
     $cmd = $cmd . " -d VirtualDisk.udid --hide-label";
     #attach disk
-    diag "Attaching $disk to $lpar";
+    debug "Attaching $disk to $lpar";
     $self->pvmctl("scsi", "create", "lv", $disk, $lpar);
 
     my $prefix = "/dev/disk/by-id/scsi-SAIX_VDASD_";
@@ -71,7 +72,7 @@ sub do_extract_assets {
     my $device = $prefix . substr($id, 2);
 
     if (!$format || $format !~ /^raw$/) {
-        diag "do_extract_assets: Image will be saved as raw eitherway";
+        debug "do_extract_assets: Image will be saved as raw eitherway";
     }
 
     #rescan scsi for newly attached disk
@@ -132,7 +133,7 @@ sub attach_console {
     $vncport =~ /([0-9]+)/;
     chomp($vncport);
     $vars->{VNC} = $vncport;
-    diag "VNC is $vars->{VNC}";
+    debug "VNC is $vars->{VNC}";
 }
 
 sub image_exists {
@@ -182,7 +183,7 @@ sub start_lpar {
 
     #we copy isos from nfs mount on VIO side to VMLibrary
     my $source_iso = '/iso/' . basename($vars->{ISO});
-    diag "source_iso: $source_iso, vio iso: $iso";
+    debug "source_iso: $source_iso, vio iso: $iso";
     my $iso_present = qx/pvmctl media list -d VirtualOpticalMedia.media_name --where VirtualOpticalMedia.name=$iso/;
     if ($iso_present !~ /$iso/) {
         #copy over from nfs to VMLibrary

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -806,7 +806,7 @@ sub start_qemu {
 
     # retrieve welcome
     my $line = $self->_read_hmp;
-    bmwqemu::fctinfo "WELCOME $line\n";
+    OpenQA::Log::info "WELCOME $line\n";
 
     my $init = myjsonrpc::read_json($self->{qmpsocket});
     my $hash = $self->handle_qmp_command({execute => 'qmp_capabilities'});

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -745,7 +745,7 @@ sub start_qemu {
         if ($vars->{AUTO_INST}) {
             push(@params, "-drive", "file=$basedir/autoinst.img,index=0,if=floppy");
         }
-	# We are using system somwhere else, why not here too?
+        # We are using system somwhere else, why not here too?
         OpenQA::Log::info(`$qemubin -version`);
         OpenQA::Log::info("starting: " . join(" ", @params));
 

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -931,9 +931,8 @@ sub read_qemupipe {
     my $bytes = sysread($self->{qemupipe}, $buffer, 1000);
     chomp $buffer;
     for my $line (split(/\n/, $buffer)) {
-==== BASE ====
         bmwqemu::diag "QEMU: $line";
-==== BASE ====
+        bmwqemu::logdie "QEMU: Shutting down the job" if $line =~ m/key event queue full/;
     }
     return $bytes;
 }

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -30,6 +30,7 @@ use Net::DBus;
 use bmwqemu qw(fileContent save_vars);
 require IPC::System::Simple;
 use autodie ':all';
+use OpenQA::Log;
 
 sub new {
     my $class = shift;

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -798,7 +798,7 @@ sub start_qemu {
     $flags = fcntl($self->{qmpsocket}, Fcntl::F_GETFL, 0) or OpenQA::Log::die "can't getfl(): $!\n";
     $flags = fcntl($self->{qmpsocket}, Fcntl::F_SETFL, $flags | Fcntl::O_NONBLOCK) or OpenQA::Log::die "can't setfl(): $!\n";
 
-    bmwqemu::fctdbg(sprintf("hmpsocket %d, qmpsocket %d", fileno($self->{hmpsocket}), fileno($self->{qmpsocket})));
+    OpenQA::Log::debug(sprintf("hmpsocket %d, qmpsocket %d", fileno($self->{hmpsocket}), fileno($self->{qmpsocket})));
 
     fcntl($self->{qemupipe}, Fcntl::F_SETFL, Fcntl::O_NONBLOCK) or OpenQA::Log::die "can't setfl(): $!\n";
 
@@ -916,7 +916,7 @@ sub handle_qmp_command {
     while (!$hash) {
         $hash = myjsonrpc::read_json($self->{qmpsocket});
         if ($hash->{event}) {
-            bmwqemu::fctdbg("EVENT " . JSON::to_json($hash));
+            OpenQA::Log::debug("EVENT " . JSON::to_json($hash));
             # ignore
             $hash = undef;
         }

--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -20,6 +20,7 @@ use base ('backend::virt');
 use testapi qw(get_var get_required_var check_var);
 
 use IO::Select;
+use OpenQA::Log;
 
 # this is a fake backend to some extend. We don't start VMs, but provide ssh access
 # to a libvirt running host (KVM for System Z in mind)

--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -67,7 +67,7 @@ sub do_stop_vm {
 
     unless (get_var('SVIRT_KEEP_VM_RUNNING')) {
         my $vmname = $self->console('svirt')->name;
-        OpenQA::Log::debug "Destroying $vmname virtual machine";
+        debug "Destroying $vmname virtual machine";
         $self->run_cmd("virsh destroy $vmname");
         $self->run_cmd("virsh undefine $vmname");
     }
@@ -86,7 +86,7 @@ sub run_cmd {
     $chan->exec($cmd);
     $chan->send_eof;
     my $ret = $chan->exit_status();
-    OpenQA::Log::debug "Command executed: $cmd, ret=$ret";
+    debug "Command executed: $cmd, ret=$ret";
     $chan->close();
     return $ret;
 }
@@ -117,7 +117,7 @@ sub save_snapshot {
     my $vmname   = $self->console('svirt')->name;
     $self->run_cmd("virsh snapshot-delete $vmname $snapname");
     my $rsp = $self->run_cmd("virsh snapshot-create-as $vmname $snapname");
-    OpenQA::Log::debug "SAVED VM \"$vmname\" as \"$snapname\" snapshot, $rsp";
+    debug "SAVED VM \"$vmname\" as \"$snapname\" snapshot, $rsp";
     die unless ($rsp == 0);
     return;
 }
@@ -127,7 +127,7 @@ sub load_snapshot {
     my $snapname = $args->{name};
     my $vmname   = $self->console('svirt')->name;
     my $rsp      = $self->run_cmd("virsh snapshot-revert $vmname $snapname");
-    OpenQA::Log::debug "LOADED snapshot \"$snapname\" to \"$vmname\", $rsp";
+    debug "LOADED snapshot \"$snapname\" to \"$vmname\", $rsp";
     die unless ($rsp == 0);
     return $rsp;
 }

--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -66,7 +66,7 @@ sub do_stop_vm {
 
     unless (get_var('SVIRT_KEEP_VM_RUNNING')) {
         my $vmname = $self->console('svirt')->name;
-        bmwqemu::diag "Destroying $vmname virtual machine";
+        OpenQA::Log::debug "Destroying $vmname virtual machine";
         $self->run_cmd("virsh destroy $vmname");
         $self->run_cmd("virsh undefine $vmname");
     }
@@ -85,7 +85,7 @@ sub run_cmd {
     $chan->exec($cmd);
     $chan->send_eof;
     my $ret = $chan->exit_status();
-    bmwqemu::diag "Command executed: $cmd, ret=$ret";
+    OpenQA::Log::debug "Command executed: $cmd, ret=$ret";
     $chan->close();
     return $ret;
 }
@@ -116,7 +116,7 @@ sub save_snapshot {
     my $vmname   = $self->console('svirt')->name;
     $self->run_cmd("virsh snapshot-delete $vmname $snapname");
     my $rsp = $self->run_cmd("virsh snapshot-create-as $vmname $snapname");
-    bmwqemu::diag "SAVED VM \"$vmname\" as \"$snapname\" snapshot, $rsp";
+    OpenQA::Log::debug "SAVED VM \"$vmname\" as \"$snapname\" snapshot, $rsp";
     die unless ($rsp == 0);
     return;
 }
@@ -126,7 +126,7 @@ sub load_snapshot {
     my $snapname = $args->{name};
     my $vmname   = $self->console('svirt')->name;
     my $rsp      = $self->run_cmd("virsh snapshot-revert $vmname $snapname");
-    bmwqemu::diag "LOADED snapshot \"$snapname\" to \"$vmname\", $rsp";
+    OpenQA::Log::debug "LOADED snapshot \"$snapname\" to \"$vmname\", $rsp";
     die unless ($rsp == 0);
     return $rsp;
 }

--- a/basetest.pm
+++ b/basetest.pm
@@ -134,7 +134,7 @@ sub record_screenmatch {
     if ($foundneedle->has_property('workaround')) {
         $result->{dent} = 1;
         $self->{dents}++;
-        OpenQA::Log::debug("needle '$h->{name}' is a workaround");
+        OpenQA::Log::info("needle '$h->{name}' is a workaround");
     }
 
     # Hack to make it obvious that some test passed by applying a hack
@@ -296,7 +296,7 @@ sub run_post_fail {
     my ($self, $msg) = @_;
     $self->{post_fail_hook_running} = 1;
     eval { $self->post_fail_hook; };
-    OpenQA::Log::debug("post_fail_hook failed: $@") if $@;
+    OpenQA::Log::error("post_fail_hook failed: $@") if $@;
     $self->{post_fail_hook_running} = 0;
     $self->fail_if_running();
     die $msg . "\n";
@@ -326,7 +326,7 @@ sub runtest {
         # show a text result with the die message unless the die was internally generated
         if (!$internal) {
             my $msg = "# Test died: $@";
-            OpenQA::Log::debug($msg);
+            OpenQA::Log::warn($msg);
             my $details = {result => 'fail'};
             my $text_fn = $self->next_resultname('txt');
             open my $fd, ">", bmwqemu::result_dir() . "/$text_fn";

--- a/basetest.pm
+++ b/basetest.pm
@@ -390,7 +390,7 @@ sub record_serialresult {
     my $details = {result => $res};
 
     my $text_fn = $self->next_resultname('txt');
-    debug("Can't open ".bmwqemu::result_dir() . "/$text_fn") unless open my $fd, ">", bmwqemu::result_dir() . "/$text_fn";
+    debug("Can't open " . bmwqemu::result_dir() . "/$text_fn") unless open my $fd, ">", bmwqemu::result_dir() . "/$text_fn";
     print $fd "# wait_serial expected: $ref\n\n";
     print $fd "# Result:\n";
     print $fd "$string\n";

--- a/basetest.pm
+++ b/basetest.pm
@@ -134,7 +134,7 @@ sub record_screenmatch {
     if ($foundneedle->has_property('workaround')) {
         $result->{dent} = 1;
         $self->{dents}++;
-        bmwqemu::diag("needle '$h->{name}' is a workaround");
+        OpenQA::Log::debug("needle '$h->{name}' is a workaround");
     }
 
     # Hack to make it obvious that some test passed by applying a hack
@@ -296,7 +296,7 @@ sub run_post_fail {
     my ($self, $msg) = @_;
     $self->{post_fail_hook_running} = 1;
     eval { $self->post_fail_hook; };
-    bmwqemu::diag("post_fail_hook failed: $@") if $@;
+    OpenQA::Log::debug("post_fail_hook failed: $@") if $@;
     $self->{post_fail_hook_running} = 0;
     $self->fail_if_running();
     die $msg . "\n";
@@ -326,7 +326,7 @@ sub runtest {
         # show a text result with the die message unless the die was internally generated
         if (!$internal) {
             my $msg = "# Test died: $@";
-            bmwqemu::diag($msg);
+            OpenQA::Log::debug($msg);
             my $details = {result => 'fail'};
             my $text_fn = $self->next_resultname('txt');
             open my $fd, ">", bmwqemu::result_dir() . "/$text_fn";
@@ -343,7 +343,7 @@ sub runtest {
         $self->run_post_fail("test $name failed");
     }
     $self->done();
-    bmwqemu::diag(sprintf("||| finished %s %s at %s (%d s)", $name, $self->{category}, POSIX::strftime('%F %T', gmtime), time - $starttime));
+    OpenQA::Log::debug(sprintf("||| finished %s %s at %s (%d s)", $name, $self->{category}, POSIX::strftime('%F %T', gmtime), time - $starttime));
     return $ret;
 }
 

--- a/basetest.pm
+++ b/basetest.pm
@@ -135,7 +135,7 @@ sub record_screenmatch {
     if ($foundneedle->has_property('workaround')) {
         $result->{dent} = 1;
         $self->{dents}++;
-        OpenQA::Log::info("needle '$h->{name}' is a workaround");
+        info("needle '$h->{name}' is a workaround");
     }
 
     # Hack to make it obvious that some test passed by applying a hack
@@ -297,7 +297,7 @@ sub run_post_fail {
     my ($self, $msg) = @_;
     $self->{post_fail_hook_running} = 1;
     eval { $self->post_fail_hook; };
-    OpenQA::Log::error("post_fail_hook failed: $@") if $@;
+    error("post_fail_hook failed: $@") if $@;
     $self->{post_fail_hook_running} = 0;
     $self->fail_if_running();
     die $msg . "\n";
@@ -327,7 +327,7 @@ sub runtest {
         # show a text result with the die message unless the die was internally generated
         if (!$internal) {
             my $msg = "# Test died: $@";
-            OpenQA::Log::warn($msg);
+            warn($msg);
             my $details = {result => 'fail'};
             my $text_fn = $self->next_resultname('txt');
             open my $fd, ">", bmwqemu::result_dir() . "/$text_fn";
@@ -344,7 +344,7 @@ sub runtest {
         $self->run_post_fail("test $name failed");
     }
     $self->done();
-    OpenQA::Log::debug(sprintf("||| finished %s %s at %s (%d s)", $name, $self->{category}, POSIX::strftime('%F %T', gmtime), time - $starttime));
+    debug(sprintf("||| finished %s %s at %s (%d s)", $name, $self->{category}, POSIX::strftime('%F %T', gmtime), time - $starttime));
     return $ret;
 }
 

--- a/basetest.pm
+++ b/basetest.pm
@@ -25,6 +25,7 @@ use POSIX;
 use testapi  ();
 use autotest ();
 use MIME::Base64 'decode_base64';
+use OpenQA::Log;
 
 # enable strictures and warnings in all tests globaly
 sub import {
@@ -389,7 +390,7 @@ sub record_serialresult {
     my $details = {result => $res};
 
     my $text_fn = $self->next_resultname('txt');
-    open my $fd, ">", bmwqemu::result_dir() . "/$text_fn";
+    debug("Can't open ".bmwqemu::result_dir() . "/$text_fn") unless open my $fd, ">", bmwqemu::result_dir() . "/$text_fn";
     print $fd "# wait_serial expected: $ref\n\n";
     print $fd "# Result:\n";
     print $fd "$string\n";

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -36,7 +36,6 @@ our $VERSION;
 our @EXPORT    = qw(fileContent save_vars);
 our @EXPORT_OK = qw(diag fctres fctinfo fctwarn fctdbg fcterr logdie);
 
-use backend::driver;
 require IPC::System::Simple;
 use autodie ':all';
 use Log::Log4perl;
@@ -288,11 +287,17 @@ sub pp {
     return $value_with_trailing_newline;
 }
 
+=head2 log_call
+
+    log_call method will write the name of the fuction that actually triggered the call in testapi,
+    calls that are using log_call from testapi, will have the following syntax on logfiles: B<::: <<<>
+
+
+=cut
+
 sub log_call {
     my $fname = (caller(1))[3];
-
-    local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
-
+    local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 2;
     update_line_number();
 
     my @result;
@@ -302,7 +307,6 @@ sub log_call {
 
     my $params = join(", ", @result);
     fctinfo('<<< ' . $fname . "($params)");
-
     return;
 }
 

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -34,7 +34,6 @@ use Exporter;
 
 our $VERSION;
 our @EXPORT    = qw(fileContent save_vars);
-our @EXPORT_OK = qw(diag fctres fctinfo fctOpenQA::Log::warn  fcterr );
 
 use backend::driver;
 require IPC::System::Simple;
@@ -70,9 +69,9 @@ sub load_vars() {
     my $fn  = "vars.json";
     my $ret = {};
     local $/;
-    open(my $fh, '<', $fn) or OpenQA::Log::die("Can't open '$fn'");
+    open(my $fh, '<', $fn) or die("Can't open '$fn'");
     eval { $ret = JSON->new->relaxed->decode(<$fh>); };
-    OpenQA::Log::die("parse error in vars.json: $@") if $@;
+    die("parse error in vars.json: $@") if $@;
     close($fh);
     %vars = %{$ret};
     return;
@@ -82,8 +81,8 @@ sub save_vars() {
     my $fn = "vars.json";
     unlink "vars.json" if -e "vars.json";
     open(my $fd, ">", $fn);
-    flock($fd, LOCK_EX) or OpenQA::Log::die("cannot lock vars.json: $!");
-    truncate($fd, 0) or OpenQA::Log::die("cannot truncate vars.json: $!");
+    flock($fd, LOCK_EX) or die("cannot lock vars.json: $!");
+    truncate($fd, 0) or die("cannot truncate vars.json: $!");
 
     # make sure the JSON is sorted
     my $json = JSON->new->pretty->canonical;
@@ -126,7 +125,7 @@ sub init {
     select($oldfh);
 
     unless ($vars{CASEDIR}) {
-        OpenQA::Log::die("DISTRI undefined\n" . pp(\%vars)) unless $vars{DISTRI};
+        die("DISTRI undefined\n" . pp(\%vars)) unless $vars{DISTRI};
         my @dirs = ("$scriptdir/distri/$vars{DISTRI}");
         unshift @dirs, $dirs[-1] . "-" . $vars{VERSION} if ($vars{VERSION});
         for my $d (@dirs) {
@@ -135,7 +134,7 @@ sub init {
                 last;
             }
         }
-        OpenQA::Log::die("can't determine test directory for $vars{DISTRI}'") unless $vars{CASEDIR};
+        die("can't determine test directory for $vars{DISTRI}'") unless $vars{CASEDIR};
     }
 
     # defaults
@@ -159,7 +158,7 @@ sub init {
     }
     if ($vars{SUSEMIRROR} && $vars{SUSEMIRROR} =~ s{^(\w+)://}{}) {    # strip & check proto
         if ($1 ne "http") {
-            OpenQA::Log::die("only http mirror URLs are currently supported but found '$1'");
+            die("only http mirror URLs are currently supported but found '$1'");
         }
     }
 
@@ -188,54 +187,54 @@ sub set_ocr_rect {
 
 # sub  {
 #     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
-#     OpenQA::Log::(@_);
+#     (@_);
 # }
 
 # sub diag {
 #     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
-#     OpenQA::Log::info(@_);
+#     info(@_);
 #     return;
 # }
 
 # sub  {
 #     my ($text) = @_;
 #     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
-#     OpenQA::Log::debug("$text");
+#     debug("$text");
 #     return;
 # }
 
 # sub fctres {
 #     my ($text) = @_;
 #     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
-#     OpenQA::Log::info(">>> $text");
+#     info(">>> $text");
 #     return;
 # }
 
 # sub fctinfo {
 #     my ($text) = @_;
 #     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
-#     OpenQA::Log::info("::: $text");
+#     info("::: $text");
 #     return;
 # }
 
-# sub fctOpenQA::Log::warn {
+# sub fctwarn {
 #     my ($text) = @_;
 #     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
-#     OpenQA::Log::OpenQA::Log::warn("!!! $text");
+#     OpenQA::Log::warn("!!! $text");
 #     return;
 # }
 
 # sub fcterr {
 #     my ($text) = @_;
 #     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
-#     OpenQA::Log::error("EEE $text");
+#     error("EEE $text");
 #     return;
 # }
 
 sub modstart {
     my $text = sprintf "Test module: %s at %s", join(' ', @_), POSIX::strftime("%F %T", gmtime);
     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
-    OpenQA::Log::info($text);
+    info($text);
     return;
 }
 
@@ -252,7 +251,7 @@ sub update_line_number {
         my ($package, $filename, $line, $subroutine, $hasargs, $wantarray, $evaltext, $is_require, $hints, $bitmask, $hinthash) = caller($i);
         last unless $filename;
         next unless $filename =~ m/$ending$/;
-        OpenQA::Log::debug("$filename:$line called $subroutine");
+        debug("$filename:$line called $subroutine");
         last;
     }
     return;
@@ -282,7 +281,7 @@ sub log_call {
     }
 
     my $params = join(", ", @result);
-    OpenQA::Log::info('<<< ' . $fname . "($params)");
+    info('<<< ' . $fname . "($params)");
     return;
 }
 
@@ -344,7 +343,7 @@ sub random_string {
 }
 
 sub hashed_string {
-    OpenQA::Log::OpenQA::Log::warn('@DEPRECATED: Use testapi::hashed_string instead');
+    OpenQA::Log::warn('@DEPRECATED: Use testapi::hashed_string instead');
     return testapi::hashed_string(@_);
 }
 

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -33,7 +33,7 @@ use base 'Exporter';
 use Exporter;
 
 our $VERSION;
-our @EXPORT    = qw(fileContent save_vars);
+our @EXPORT = qw(fileContent save_vars);
 
 use backend::driver;
 require IPC::System::Simple;

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -38,9 +38,7 @@ our @EXPORT_OK = qw(diag fctres fctinfo fctwarn fctdbg fcterr logdie);
 
 require IPC::System::Simple;
 use autodie ':all';
-use Log::Log4perl;
-
-our $log = Log::Log4perl->get_logger('os-autoinst');
+use OpenQA::Log;
 
 sub mydie;
 
@@ -84,8 +82,8 @@ sub save_vars() {
     my $fn = "vars.json";
     unlink "vars.json" if -e "vars.json";
     open(my $fd, ">", $fn);
-    flock($fd, LOCK_EX) or $log->logdie("cannot lock vars.json: $!");
-    truncate($fd, 0) or $log->logdie("cannot truncate vars.json: $!");
+    flock($fd, LOCK_EX) or OpenQA::Log::logdie("cannot lock vars.json: $!");
+    truncate($fd, 0) or OpenQA::Log::logdie("cannot truncate vars.json: $!");
 
     # make sure the JSON is sorted
     my $json = JSON->new->pretty->canonical;
@@ -207,56 +205,56 @@ sub print_possibly_colored {
     return;
 }
 
-sub logdie {
-    local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
-    $log->logdie(@_);
-}
+# sub logdie {
+#     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
+#     OpenQA::Log::logdie(@_);
+# }
 
-sub diag {
-    local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
-    $log->info(@_);
-    return;
-}
+# sub diag {
+#     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
+#     OpenQA::Log::info(@_);
+#     return;
+# }
 
-sub fctdbg {
-    my ($text) = @_;
-    local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
-    $log->debug("$text");
-    return;
-}
+# sub fctdbg {
+#     my ($text) = @_;
+#     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
+#     OpenQA::Log::debug("$text");
+#     return;
+# }
 
-sub fctres {
-    my ($text) = @_;
-    local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
-    $log->info(">>> $text");
-    return;
-}
+# sub fctres {
+#     my ($text) = @_;
+#     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
+#     OpenQA::Log::info(">>> $text");
+#     return;
+# }
 
-sub fctinfo {
-    my ($text) = @_;
-    local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
-    $log->info("::: $text");
-    return;
-}
+# sub fctinfo {
+#     my ($text) = @_;
+#     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
+#     OpenQA::Log::info("::: $text");
+#     return;
+# }
 
-sub fctwarn {
-    my ($text) = @_;
-    local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
-    $log->warn("!!! $text");
-    return;
-}
+# sub fctwarn {
+#     my ($text) = @_;
+#     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
+#     OpenQA::Log::warn("!!! $text");
+#     return;
+# }
 
-sub fcterr {
-    my ($text) = @_;
-    local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
-    $log->error("EEE $text");
-    return;
-}
+# sub fcterr {
+#     my ($text) = @_;
+#     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
+#     OpenQA::Log::error("EEE $text");
+#     return;
+# }
 
 sub modstart {
     my $text = sprintf "||| %s at %s", join(' ', @_), POSIX::strftime("%F %T", gmtime);
     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
-    $log->info($text);
+    OpenQA::Log::info($text);
     return;
 }
 
@@ -374,7 +372,7 @@ sub random_string {
 }
 
 sub hashed_string {
-    fctwarn '@DEPRECATED: Use testapi::hashed_string instead';
+    OpenQA::Log::warn('@DEPRECATED: Use testapi::hashed_string instead');
     return testapi::hashed_string(@_);
 }
 

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -34,7 +34,7 @@ use Exporter;
 
 our $VERSION;
 our @EXPORT    = qw(fileContent save_vars);
-our @EXPORT_OK = qw(diag fctres fctinfo fctwarn fctdbg fcterr logdie);
+our @EXPORT_OK = qw(diag fctres fctinfo fctwarn  fcterr );
 
 require IPC::System::Simple;
 use autodie ':all';
@@ -70,9 +70,9 @@ sub load_vars() {
     my $fn  = "vars.json";
     my $ret = {};
     local $/;
-    open(my $fh, '<', $fn) or logdie("Can't open '$fn'");
+    open(my $fh, '<', $fn) or ("Can't open '$fn'");
     eval { $ret = JSON->new->relaxed->decode(<$fh>); };
-    logdie("parse error in vars.json: $@") if $@;
+    ("parse error in vars.json: $@") if $@;
     close($fh);
     %vars = %{$ret};
     return;
@@ -82,8 +82,8 @@ sub save_vars() {
     my $fn = "vars.json";
     unlink "vars.json" if -e "vars.json";
     open(my $fd, ">", $fn);
-    flock($fd, LOCK_EX) or OpenQA::Log::logdie("cannot lock vars.json: $!");
-    truncate($fd, 0) or OpenQA::Log::logdie("cannot truncate vars.json: $!");
+    flock($fd, LOCK_EX) or OpenQA::Log::("cannot lock vars.json: $!");
+    truncate($fd, 0) or OpenQA::Log::("cannot truncate vars.json: $!");
 
     # make sure the JSON is sorted
     my $json = JSON->new->pretty->canonical;
@@ -128,7 +128,7 @@ sub init {
     select($oldfh);
 
     unless ($vars{CASEDIR}) {
-        logdie("DISTRI undefined\n" . pp(\%vars)) unless $vars{DISTRI};
+        ("DISTRI undefined\n" . pp(\%vars)) unless $vars{DISTRI};
         my @dirs = ("$scriptdir/distri/$vars{DISTRI}");
         unshift @dirs, $dirs[-1] . "-" . $vars{VERSION} if ($vars{VERSION});
         for my $d (@dirs) {
@@ -137,7 +137,7 @@ sub init {
                 last;
             }
         }
-        logdie("can't determine test directory for $vars{DISTRI}'") unless $vars{CASEDIR};
+        ("can't determine test directory for $vars{DISTRI}'") unless $vars{CASEDIR};
     }
 
     # defaults
@@ -161,7 +161,7 @@ sub init {
     }
     if ($vars{SUSEMIRROR} && $vars{SUSEMIRROR} =~ s{^(\w+)://}{}) {    # strip & check proto
         if ($1 ne "http") {
-            logdie("only http mirror URLs are currently supported but found '$1'");
+            ("only http mirror URLs are currently supported but found '$1'");
         }
     }
 
@@ -205,9 +205,9 @@ sub print_possibly_colored {
     return;
 }
 
-# sub logdie {
+# sub  {
 #     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
-#     OpenQA::Log::logdie(@_);
+#     OpenQA::Log::(@_);
 # }
 
 # sub diag {
@@ -216,7 +216,7 @@ sub print_possibly_colored {
 #     return;
 # }
 
-# sub fctdbg {
+# sub  {
 #     my ($text) = @_;
 #     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
 #     OpenQA::Log::debug("$text");

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -275,7 +275,6 @@ sub pp {
 
 sub log_call {
     my $fname = (caller(1))[3];
-    local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 2;
     update_line_number();
     my @result;
     while (my ($key, $value) = splice(@_, 0, 2)) {

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -82,8 +82,8 @@ sub save_vars() {
     my $fn = "vars.json";
     unlink "vars.json" if -e "vars.json";
     open(my $fd, ">", $fn);
-    flock($fd, LOCK_EX) or OpenQA::Log::("cannot lock vars.json: $!");
-    truncate($fd, 0) or OpenQA::Log::("cannot truncate vars.json: $!");
+    flock($fd, LOCK_EX) or OpenQA::Log::die("cannot lock vars.json: $!");
+    truncate($fd, 0) or OpenQA::Log::die("cannot truncate vars.json: $!");
 
     # make sure the JSON is sorted
     my $json = JSON->new->pretty->canonical;

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -34,7 +34,7 @@ use Exporter;
 
 our $VERSION;
 our @EXPORT    = qw(fileContent save_vars);
-our @EXPORT_OK = qw(diag fctres fctinfo fctwarn  fcterr );
+our @EXPORT_OK = qw(diag fctres fctinfo fctOpenQA::Log::warn  fcterr );
 
 use backend::driver;
 require IPC::System::Simple;
@@ -218,10 +218,10 @@ sub set_ocr_rect {
 #     return;
 # }
 
-# sub fctwarn {
+# sub fctOpenQA::Log::warn {
 #     my ($text) = @_;
 #     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
-#     OpenQA::Log::warn("!!! $text");
+#     OpenQA::Log::OpenQA::Log::warn("!!! $text");
 #     return;
 # }
 
@@ -233,7 +233,7 @@ sub set_ocr_rect {
 # }
 
 sub modstart {
-    my $text = sprintf "||| %s at %s", join(' ', @_), POSIX::strftime("%F %T", gmtime);
+    my $text = sprintf "Test module: %s at %s", join(' ', @_), POSIX::strftime("%F %T", gmtime);
     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
     OpenQA::Log::info($text);
     return;
@@ -345,7 +345,7 @@ sub random_string {
 }
 
 sub hashed_string {
-    OpenQA::Log::warn('@DEPRECATED: Use testapi::hashed_string instead');
+    OpenQA::Log::OpenQA::Log::warn('@DEPRECATED: Use testapi::hashed_string instead');
     return testapi::hashed_string(@_);
 }
 

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -15,6 +15,7 @@ use Compress::Raw::Zlib;
 use Carp qw(confess cluck carp croak);
 use Data::Dumper 'Dumper';
 use feature 'say';
+use OpenQA::Log;
 
 __PACKAGE__->mk_accessors(
     qw(hostname port username password socket name width height depth save_bandwidth

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -159,7 +159,7 @@ sub login {
 
         # clean up so socket can be garbage collected
         $self->socket(undef);
-        bmwqemu::logdie $error;
+        OpenQA::Log::die $error;
     }
 }
 
@@ -167,13 +167,13 @@ sub _handshake_protocol_version {
     my ($self) = @_;
 
     my $socket = $self->socket;
-    $socket->read(my $protocol_version, 12) || bmwqemu::logdie 'unexpected end of data';
+    $socket->read(my $protocol_version, 12) || OpenQA::Log::die 'unexpected end of data';
 
     #OpenQA::Log::debug "prot: $protocol_version";
 
     my $protocol_pattern = qr/\A RFB [ ] (\d{3}\.\d{3}) \s* \z/xms;
     if ($protocol_version !~ m/$protocol_pattern/xms) {
-        bmwqemu::logdie 'Malformed RFB protocol: ' . $protocol_version;
+        OpenQA::Log::die 'Malformed RFB protocol: ' . $protocol_version;
     }
     $self->_rfb_version($1);
 
@@ -182,13 +182,13 @@ sub _handshake_protocol_version {
 
         # Repeat with the changed version
         if ($protocol_version !~ m/$protocol_pattern/xms) {
-            bmwqemu::logdie 'Malformed RFB protocol';
+            OpenQA::Log::die 'Malformed RFB protocol';
         }
         $self->_rfb_version($1);
     }
 
     if ($self->_rfb_version lt '003.003') {
-        bmwqemu::logdie 'RFB protocols earlier than v3.3 are not supported';
+        OpenQA::Log::die 'RFB protocols earlier than v3.3 are not supported';
     }
 
     # let's use the same version of the protocol, or the max, whichever's lower
@@ -204,17 +204,17 @@ sub _handshake_security {
     my $security_type;
     if ($self->_rfb_version ge '003.007') {
         $socket->read(my $number_of_security_types, 1)
-          || bmwqemu::logdie 'unexpected end of data';
+          || OpenQA::Log::die 'unexpected end of data';
         $number_of_security_types = unpack('C', $number_of_security_types);
 
         if ($number_of_security_types == 0) {
-            bmwqemu::logdie 'Error authenticating';
+            OpenQA::Log::die 'Error authenticating';
         }
 
         my @security_types;
         foreach (1 .. $number_of_security_types) {
             $socket->read(my $security_type, 1)
-              || bmwqemu::logdie 'unexpected end of data';
+              || OpenQA::Log::die 'unexpected end of data';
             $security_type = unpack('C', $security_type);
 
             push @security_types, $security_type;
@@ -234,7 +234,7 @@ sub _handshake_security {
     else {
 
         # In RFB 3.3, the server dictates the security type
-        $socket->read($security_type, 4) || bmwqemu::logdie 'unexpected end of data';
+        $socket->read($security_type, 4) || OpenQA::Log::die 'unexpected end of data';
         $security_type = unpack('N', $security_type);
     }
 
@@ -263,7 +263,7 @@ sub _handshake_security {
 
 
         $socket->read(my $challenge, 16)
-          || bmwqemu::logdie 'unexpected end of data';
+          || OpenQA::Log::die 'unexpected end of data';
 
         # the RFB protocol only uses the first 8 characters of a password
         my $key = substr($self->password, 0, 8);
@@ -310,7 +310,7 @@ sub _handshake_security {
         else {
             $self->old_ikvm(0);
         }
-        $socket->read(my $ikvm_session, 20) || bmwqemu::logdie 'unexpected end of data';
+        $socket->read(my $ikvm_session, 20) || OpenQA::Log::die 'unexpected end of data';
         my @bytes = unpack("C20", $ikvm_session);
         print "Session info: ";
         for my $b (@bytes) {
@@ -323,15 +323,15 @@ sub _handshake_security {
         # af f9 bf bc 08 03 02 00 20 a3 00 00 84 4c e3 be 00 80 41 40 d0 24 01 00
         # af f9 ff bd 40 19 02 00 b0 a4 00 00 84 8c b1 be 00 60 43 40 f0 29 01 00
         # ab f9 1f be 08 13 02 00 e0 a5 00 00 74 a8 82 be 00 00 4b 40 d8 2d 01 00
-        $socket->read(my $security_result, 4) || bmwqemu::logdie 'Failed to login';
+        $socket->read(my $security_result, 4) || OpenQA::Log::die 'Failed to login';
         $security_result = unpack('C', $security_result);
         print "Security Result: $security_result\n";
         if ($security_result != 0) {
-            bmwqemu::logdie 'Failed to login';
+            OpenQA::Log::die 'Failed to login';
         }
     }
     else {
-        bmwqemu::logdie 'VNC Server wants security, but we have no password';
+        OpenQA::Log::die 'VNC Server wants security, but we have no password';
     }
 
     # the RFB protocol always returns a result for type 2,
@@ -340,13 +340,13 @@ sub _handshake_security {
         || $security_type == 2)
     {
         $socket->read(my $security_result, 4)
-          || bmwqemu::logdie 'unexpected end of data';
+          || OpenQA::Log::die 'unexpected end of data';
         $security_result = unpack('N', $security_result);
 
-        bmwqemu::logdie 'login failed' if $security_result;
+        OpenQA::Log::die 'login failed' if $security_result;
     }
     elsif (!$socket->connected) {
-        bmwqemu::logdie 'login failed';
+        OpenQA::Log::die 'login failed';
     }
 }
 
@@ -373,7 +373,7 @@ sub _server_initialization {
     my $self = shift;
 
     my $socket = $self->socket;
-    $socket->read(my $server_init, 24) || bmwqemu::logdie 'unexpected end of data';
+    $socket->read(my $server_init, 24) || OpenQA::Log::die 'unexpected end of data';
 
     #<<< tidy off
     my ( $framebuffer_width, $framebuffer_height,
@@ -392,17 +392,17 @@ sub _server_initialization {
 
         # client did not express a depth preference, so check if the server's preference is OK
         if (!$supported_depths{$depth}) {
-            bmwqemu::logdie 'Unsupported depth ' . $depth;
+            OpenQA::Log::die 'Unsupported depth ' . $depth;
         }
         if ($bits_per_pixel != $supported_depths{$depth}->{bpp}) {
-            bmwqemu::logdie 'Unsupported bits-per-pixel value ' . $bits_per_pixel;
+            OpenQA::Log::die 'Unsupported bits-per-pixel value ' . $bits_per_pixel;
         }
         if (
             $true_colour_flag ?
             !$supported_depths{$depth}->{true_colour}
             : $supported_depths{$depth}->{true_colour})
         {
-            bmwqemu::logdie 'Unsupported true colour flag';
+            OpenQA::Log::die 'Unsupported true colour flag';
         }
         $self->depth($depth);
 
@@ -429,16 +429,16 @@ sub _server_initialization {
 
     if ($name_length) {
         $socket->read(my $name_string, $name_length)
-          || bmwqemu::logdie 'unexpected end of data';
+          || OpenQA::Log::die 'unexpected end of data';
         $self->name($name_string);
     }
 
     if ($self->ikvm) {
-        $socket->read(my $ikvm_init, 12) || bmwqemu::logdie 'unexpected end of data';
+        $socket->read(my $ikvm_init, 12) || OpenQA::Log::die 'unexpected end of data';
 
         my ($current_thread, $ikvm_video_enable, $ikvm_km_enable, $ikvm_kick_enable, $v_usb_enable) = unpack 'x4NCCCC', $ikvm_init;
         print "IKVM specifics: $current_thread $ikvm_video_enable $ikvm_km_enable $ikvm_kick_enable $v_usb_enable\n";
-        bmwqemu::logdie "Can't use keyboard and mouse.  Is another ipmi vnc viewer logged in?" unless $ikvm_km_enable;
+        OpenQA::Log::die "Can't use keyboard and mouse.  Is another ipmi vnc viewer logged in?" unless $ikvm_km_enable;
         return;    # the rest is kindly ignored by ikvm anyway
     }
 
@@ -669,7 +669,7 @@ sub init_x11_keymap {
     }
     # VNC doesn't use the unshifted values, only prepends a shift key
     for my $key (keys %{shift_keys()}) {
-        bmwqemu::logdie "no map for $key" unless $keymap{$key};
+        OpenQA::Log::die "no map for $key" unless $keymap{$key};
         $keymap{$key} = [$keymap{shift}, $keymap{$key}];
     }
     $self->keymap(\%keymap);
@@ -693,7 +693,7 @@ sub init_ikvm_keymap {
     }
     my %map = %{shift_keys()};
     while (my ($key, $shift) = each %map) {
-        bmwqemu::logdie "no map for $key" unless $keymap{$shift};
+        OpenQA::Log::die "no map for $key" unless $keymap{$shift};
         $keymap{$key} = [$keymap{shift}, $keymap{$shift}];
     }
     $self->keymap(\%keymap);
@@ -723,7 +723,7 @@ sub map_and_send_key {
             next;
         }
         else {
-            bmwqemu::logdie "No map for '$key'";
+            OpenQA::Log::die "No map for '$key'";
         }
     }
 
@@ -859,7 +859,7 @@ sub _receive_message {
     }
     $self->_vnc_stalled(0);
 
-    bmwqemu::logdie "socket closed: $ret\n${\Dumper $self}" unless $ret > 0;
+    OpenQA::Log::die "socket closed: $ret\n${\Dumper $self}" unless $ret > 0;
 
     $message_type = unpack('C', $message_type);
     #print "receive message $message_type\n";
@@ -867,7 +867,7 @@ sub _receive_message {
     #<<< tidy off
     # This result is unused.  It's meaning is different for the different methods
     my $result
-      = !defined $message_type ? bmwqemu::logdie 'bad message type received'
+      = !defined $message_type ? OpenQA::Log::die 'bad message type received'
       : $message_type == 0     ? $self->_receive_update()
       : $message_type == 1     ? $self->_receive_colour_map()
       : $message_type == 2     ? $self->_receive_bell()
@@ -878,7 +878,7 @@ sub _receive_message {
       : $message_type == 0x33 ? $self->_discard_ikvm_message($message_type, 4)
       : $message_type == 0x37 ? $self->_discard_ikvm_message($message_type, $self->old_ikvm ? 2 : 3)
       : $message_type == 0x3c ? $self->_discard_ikvm_message($message_type, 8)
-      :                         bmwqemu::logdie 'unsupported message type received';
+      :                         OpenQA::Log::die 'unsupported message type received';
     #>>> tidy on
     return $message_type;
 }
@@ -894,7 +894,7 @@ sub _receive_update {
     }
 
     my $socket               = $self->socket;
-    my $hlen                 = $socket->read(my $header, 3) || bmwqemu::logdie 'unexpected end of data';
+    my $hlen                 = $socket->read(my $header, 3) || OpenQA::Log::die 'unexpected end of data';
     my $number_of_rectangles = unpack('xn', $header);
 
     #OpenQA::Log::debug "NOR $number_of_rectangles";
@@ -904,7 +904,7 @@ sub _receive_update {
     my $do_endian_conversion = $self->_do_endian_conversion;
 
     foreach (1 .. $number_of_rectangles) {
-        $socket->read(my $data, 12) || bmwqemu::logdie 'unexpected end of data';
+        $socket->read(my $data, 12) || OpenQA::Log::die 'unexpected end of data';
         my ($x, $y, $w, $h, $encoding_type) = unpack 'nnnnN', $data;
 
         # unsigned -> signed conversion
@@ -920,7 +920,7 @@ sub _receive_update {
         ### Raw encoding ###
         if ($encoding_type == 0 && !$self->ikvm) {
 
-            $socket->read(my $data, $w * $h * $bytes_per_pixel) || bmwqemu::logdie 'unexpected end of data';
+            $socket->read(my $data, $w * $h * $bytes_per_pixel) || OpenQA::Log::die 'unexpected end of data';
 
             # splat raw pixels into the image
             my $img = tinycv::new($w, $h);
@@ -942,7 +942,7 @@ sub _receive_update {
         }
         elsif ($encoding_type == -261) {
             my $led_data;
-            $socket->read($led_data, 1) || bmwqemu::logdie "unexpected end of data";
+            $socket->read($led_data, 1) || OpenQA::Log::die "unexpected end of data";
             my @bytes = unpack("C", $led_data);
             bmwqemu::fcterr("led state $bytes[0] $w $h $encoding_type");
         }
@@ -950,7 +950,7 @@ sub _receive_update {
             $self->_receive_ikvm_encoding($encoding_type, $x, $y, $w, $h);
         }
         else {
-            bmwqemu::logdie 'unsupported update encoding ' . $encoding_type;
+            OpenQA::Log::die 'unsupported update encoding ' . $encoding_type;
         }
     }
 
@@ -985,12 +985,12 @@ sub _receive_zlre_encoding {
 
     my $stime = time;
     $socket->read(my $data, 4)
-      or bmwqemu::logdie "short read for length";
+      or OpenQA::Log::die "short read for length";
     my ($data_len) = unpack('N', $data);
     my $read_len = 0;
     while ($read_len < $data_len) {
         my $len = read($socket, $data, $data_len - $read_len, $read_len);
-        bmwqemu::logdie "short read for zlre data $read_len - $data_len" unless $len;
+        OpenQA::Log::die "short read for zlre data $read_len - $data_len" unless $len;
         $read_len += $len;
     }
     if (time - $stime > 0.1) {
@@ -1002,10 +1002,10 @@ sub _receive_zlre_encoding {
     my $old_total_out = $self->{_inflater}->total_out;
     my $status = $self->{_inflater}->inflate($data, $out, 1);
     if ($status != Z_OK) {
-        bmwqemu::logdie "inflation failed $status";
+        OpenQA::Log::die "inflation failed $status";
     }
     my $res = $image->map_raw_data_zrle($x, $y, $w, $h, $self->vncinfo, $out, $self->{_inflater}->total_out - $old_total_out);
-    bmwqemu::logdie "not read enough data" unless $old_total_out + $res == $self->{_inflater}->total_out;
+    OpenQA::Log::die "not read enough data" unless $old_total_out + $res == $self->{_inflater}->total_out;
     return $res;
 }
 
@@ -1049,7 +1049,7 @@ sub _receive_ikvm_encoding {
         my $data;
         print "Additional Bytes: ";
         while ($data_len > $required_data) {
-            $socket->read($data, 1) || bmwqemu::logdie "unexpected end of data";
+            $socket->read($data, 1) || OpenQA::Log::die "unexpected end of data";
             $data_len--;
             my @bytes = unpack("C", $data);
             printf "%02x ", $bytes[0];
@@ -1063,12 +1063,12 @@ sub _receive_ikvm_encoding {
     }
     elsif ($encoding_type == 0) {
         # ikvm manages to redeclare raw to be something completely different ;(
-        $socket->read(my $data, 10) || bmwqemu::logdie "unexpected end of data";
+        $socket->read(my $data, 10) || OpenQA::Log::die "unexpected end of data";
         my ($type, $segments, $length) = unpack('CxNN', $data);
         while ($segments--) {
-            $socket->read(my $data, 6) || bmwqemu::logdie "unexpected end of data";
+            $socket->read(my $data, 6) || OpenQA::Log::die "unexpected end of data";
             my ($dummy_a, $dummy_b, $y, $x) = unpack('nnCC', $data);
-            $socket->read($data, 512) || bmwqemu::logdie "unexpected end of data";
+            $socket->read($data, 512) || OpenQA::Log::die "unexpected end of data";
             my $img = tinycv::new(16, 16);
             $img->map_raw_data_rgb555($data);
 
@@ -1089,7 +1089,7 @@ sub _receive_ikvm_encoding {
     elsif ($encoding_type == 87) {
         return if $data_len == 0;
         if ($self->old_ikvm) {
-            bmwqemu::logdie "we guessed wrong - this is a new board!";
+            OpenQA::Log::die "we guessed wrong - this is a new board!";
         }
         $socket->read(my $data, $data_len);
         # enforce high quality to simplify our decoder
@@ -1110,7 +1110,7 @@ sub _receive_ikvm_encoding {
         }
     }
     else {
-        bmwqemu::logdie "unsupported encoding $encoding_type\n";
+        OpenQA::Log::die "unsupported encoding $encoding_type\n";
     }
 }
 
@@ -1152,10 +1152,10 @@ sub _receive_cut_text {
     my $self = shift;
 
     my $socket = $self->socket;
-    $socket->read(my $cut_msg, 7) || bmwqemu::logdie 'unexpected end of data';
+    $socket->read(my $cut_msg, 7) || OpenQA::Log::die 'unexpected end of data';
     my $cut_length = unpack 'xxxN', $cut_msg;
     $socket->read(my $cut_string, $cut_length)
-      || bmwqemu::logdie 'unexpected end of data';
+      || OpenQA::Log::die 'unexpected end of data';
 
     # And discard it...
 

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -4,7 +4,7 @@ use warnings;
 use base 'Class::Accessor::Fast';
 use IO::Socket::INET;
 use bytes;
-use bmwqemu qw( diag  fcterr fctwarn);
+use bmwqemu qw();
 use Time::HiRes qw( usleep gettimeofday time );
 use Carp;
 use List::Util 'min';
@@ -944,7 +944,8 @@ sub _receive_update {
             my $led_data;
             $socket->read($led_data, 1) || OpenQA::Log::die "unexpected end of data";
             my @bytes = unpack("C", $led_data);
-            bmwqemu::fcterr("led state $bytes[0] $w $h $encoding_type");
+            # Not an error, but if seen many times, means kernel panic :)
+            OpenQA::Log::info("led state $bytes[0] $w $h $encoding_type");
         }
         elsif ($self->ikvm) {
             $self->_receive_ikvm_encoding($encoding_type, $x, $y, $w, $h);

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -4,7 +4,7 @@ use warnings;
 use base 'Class::Accessor::Fast';
 use IO::Socket::INET;
 use bytes;
-use bmwqemu qw(logdie diag fctdbg fcterr fctwarn);
+use bmwqemu qw( diag  fcterr fctwarn);
 use Time::HiRes qw( usleep gettimeofday time );
 use Carp;
 use List::Util 'min';
@@ -937,7 +937,7 @@ sub _receive_update {
             $self->_framebuffer($image);
         }
         elsif ($encoding_type == -257) {
-            bmwqemu::fctdbg("pointer type $x $y $w $h $encoding_type");
+            OpenQA::Log::debug("pointer type $x $y $w $h $encoding_type");
             $self->absolute($x);
         }
         elsif ($encoding_type == -261) {
@@ -994,7 +994,7 @@ sub _receive_zlre_encoding {
         $read_len += $len;
     }
     if (time - $stime > 0.1) {
-        bmwqemu::fctdbg sprintf("read $data_len in %fs\n", time - $stime);
+        OpenQA::Log::debug sprintf("read $data_len in %fs\n", time - $stime);
     }
     # the zlib header is only sent once per session
     $self->{_inflater} ||= new Compress::Raw::Zlib::Inflate();

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -4,7 +4,7 @@ use warnings;
 use base 'Class::Accessor::Fast';
 use IO::Socket::INET;
 use bytes;
-use bmwqemu 'diag';
+use bmwqemu qw(logdie diag fctdbg fcterr fctwarn);
 use Time::HiRes qw( usleep gettimeofday time );
 use Carp;
 use List::Util 'min';
@@ -159,7 +159,7 @@ sub login {
 
         # clean up so socket can be garbage collected
         $self->socket(undef);
-        die $error;
+        bmwqemu::logdie $error;
     }
 }
 
@@ -167,13 +167,13 @@ sub _handshake_protocol_version {
     my ($self) = @_;
 
     my $socket = $self->socket;
-    $socket->read(my $protocol_version, 12) || die 'unexpected end of data';
+    $socket->read(my $protocol_version, 12) || bmwqemu::logdie 'unexpected end of data';
 
     #bmwqemu::diag "prot: $protocol_version";
 
     my $protocol_pattern = qr/\A RFB [ ] (\d{3}\.\d{3}) \s* \z/xms;
     if ($protocol_version !~ m/$protocol_pattern/xms) {
-        die 'Malformed RFB protocol: ' . $protocol_version;
+        bmwqemu::logdie 'Malformed RFB protocol: ' . $protocol_version;
     }
     $self->_rfb_version($1);
 
@@ -182,13 +182,13 @@ sub _handshake_protocol_version {
 
         # Repeat with the changed version
         if ($protocol_version !~ m/$protocol_pattern/xms) {
-            die 'Malformed RFB protocol';
+            bmwqemu::logdie 'Malformed RFB protocol';
         }
         $self->_rfb_version($1);
     }
 
     if ($self->_rfb_version lt '003.003') {
-        die 'RFB protocols earlier than v3.3 are not supported';
+        bmwqemu::logdie 'RFB protocols earlier than v3.3 are not supported';
     }
 
     # let's use the same version of the protocol, or the max, whichever's lower
@@ -203,19 +203,18 @@ sub _handshake_security {
     # Retrieve list of security options
     my $security_type;
     if ($self->_rfb_version ge '003.007') {
-        my $number_of_security_types = 0;
-        my $r = $socket->read($number_of_security_types, 1);
-        if ($r) {
-            $number_of_security_types = unpack('C', $number_of_security_types);
-        }
+        $socket->read(my $number_of_security_types, 1)
+          || bmwqemu::logdie 'unexpected end of data';
+        $number_of_security_types = unpack('C', $number_of_security_types);
+
         if ($number_of_security_types == 0) {
-            die 'Error authenticating';
+            bmwqemu::logdie 'Error authenticating';
         }
 
         my @security_types;
         foreach (1 .. $number_of_security_types) {
             $socket->read(my $security_type, 1)
-              || die 'unexpected end of data';
+              || bmwqemu::logdie 'unexpected end of data';
             $security_type = unpack('C', $security_type);
 
             push @security_types, $security_type;
@@ -235,7 +234,7 @@ sub _handshake_security {
     else {
 
         # In RFB 3.3, the server dictates the security type
-        $socket->read($security_type, 4) || die 'unexpected end of data';
+        $socket->read($security_type, 4) || bmwqemu::logdie 'unexpected end of data';
         $security_type = unpack('N', $security_type);
     }
 
@@ -264,7 +263,7 @@ sub _handshake_security {
 
 
         $socket->read(my $challenge, 16)
-          || die 'unexpected end of data';
+          || bmwqemu::logdie 'unexpected end of data';
 
         # the RFB protocol only uses the first 8 characters of a password
         my $key = substr($self->password, 0, 8);
@@ -311,7 +310,7 @@ sub _handshake_security {
         else {
             $self->old_ikvm(0);
         }
-        $socket->read(my $ikvm_session, 20) || die 'unexpected end of data';
+        $socket->read(my $ikvm_session, 20) || bmwqemu::logdie 'unexpected end of data';
         my @bytes = unpack("C20", $ikvm_session);
         print "Session info: ";
         for my $b (@bytes) {
@@ -324,15 +323,15 @@ sub _handshake_security {
         # af f9 bf bc 08 03 02 00 20 a3 00 00 84 4c e3 be 00 80 41 40 d0 24 01 00
         # af f9 ff bd 40 19 02 00 b0 a4 00 00 84 8c b1 be 00 60 43 40 f0 29 01 00
         # ab f9 1f be 08 13 02 00 e0 a5 00 00 74 a8 82 be 00 00 4b 40 d8 2d 01 00
-        $socket->read(my $security_result, 4) || die 'Failed to login';
+        $socket->read(my $security_result, 4) || bmwqemu::logdie 'Failed to login';
         $security_result = unpack('C', $security_result);
         print "Security Result: $security_result\n";
         if ($security_result != 0) {
-            die 'Failed to login';
+            bmwqemu::logdie 'Failed to login';
         }
     }
     else {
-        die 'VNC Server wants security, but we have no password';
+        bmwqemu::logdie 'VNC Server wants security, but we have no password';
     }
 
     # the RFB protocol always returns a result for type 2,
@@ -341,13 +340,13 @@ sub _handshake_security {
         || $security_type == 2)
     {
         $socket->read(my $security_result, 4)
-          || die 'unexpected end of data';
+          || bmwqemu::logdie 'unexpected end of data';
         $security_result = unpack('N', $security_result);
 
-        die 'login failed' if $security_result;
+        bmwqemu::logdie 'login failed' if $security_result;
     }
     elsif (!$socket->connected) {
-        die 'login failed';
+        bmwqemu::logdie 'login failed';
     }
 }
 
@@ -374,7 +373,7 @@ sub _server_initialization {
     my $self = shift;
 
     my $socket = $self->socket;
-    $socket->read(my $server_init, 24) || die 'unexpected end of data';
+    $socket->read(my $server_init, 24) || bmwqemu::logdie 'unexpected end of data';
 
     #<<< tidy off
     my ( $framebuffer_width, $framebuffer_height,
@@ -393,17 +392,17 @@ sub _server_initialization {
 
         # client did not express a depth preference, so check if the server's preference is OK
         if (!$supported_depths{$depth}) {
-            die 'Unsupported depth ' . $depth;
+            bmwqemu::logdie 'Unsupported depth ' . $depth;
         }
         if ($bits_per_pixel != $supported_depths{$depth}->{bpp}) {
-            die 'Unsupported bits-per-pixel value ' . $bits_per_pixel;
+            bmwqemu::logdie 'Unsupported bits-per-pixel value ' . $bits_per_pixel;
         }
         if (
             $true_colour_flag ?
             !$supported_depths{$depth}->{true_colour}
             : $supported_depths{$depth}->{true_colour})
         {
-            die 'Unsupported true colour flag';
+            bmwqemu::logdie 'Unsupported true colour flag';
         }
         $self->depth($depth);
 
@@ -430,16 +429,16 @@ sub _server_initialization {
 
     if ($name_length) {
         $socket->read(my $name_string, $name_length)
-          || die 'unexpected end of data';
+          || bmwqemu::logdie 'unexpected end of data';
         $self->name($name_string);
     }
 
     if ($self->ikvm) {
-        $socket->read(my $ikvm_init, 12) || die 'unexpected end of data';
+        $socket->read(my $ikvm_init, 12) || bmwqemu::logdie 'unexpected end of data';
 
         my ($current_thread, $ikvm_video_enable, $ikvm_km_enable, $ikvm_kick_enable, $v_usb_enable) = unpack 'x4NCCCC', $ikvm_init;
         print "IKVM specifics: $current_thread $ikvm_video_enable $ikvm_km_enable $ikvm_kick_enable $v_usb_enable\n";
-        die "Can't use keyboard and mouse.  Is another ipmi vnc viewer logged in?" unless $ikvm_km_enable;
+        bmwqemu::logdie "Can't use keyboard and mouse.  Is another ipmi vnc viewer logged in?" unless $ikvm_km_enable;
         return;    # the rest is kindly ignored by ikvm anyway
     }
 
@@ -670,7 +669,7 @@ sub init_x11_keymap {
     }
     # VNC doesn't use the unshifted values, only prepends a shift key
     for my $key (keys %{shift_keys()}) {
-        die "no map for $key" unless $keymap{$key};
+        bmwqemu::logdie "no map for $key" unless $keymap{$key};
         $keymap{$key} = [$keymap{shift}, $keymap{$key}];
     }
     $self->keymap(\%keymap);
@@ -694,7 +693,7 @@ sub init_ikvm_keymap {
     }
     my %map = %{shift_keys()};
     while (my ($key, $shift) = each %map) {
-        die "no map for $key" unless $keymap{$shift};
+        bmwqemu::logdie "no map for $key" unless $keymap{$shift};
         $keymap{$key} = [$keymap{shift}, $keymap{$shift}];
     }
     $self->keymap(\%keymap);
@@ -724,7 +723,7 @@ sub map_and_send_key {
             next;
         }
         else {
-            die "No map for '$key'";
+            bmwqemu::logdie "No map for '$key'";
         }
     }
 
@@ -860,7 +859,7 @@ sub _receive_message {
     }
     $self->_vnc_stalled(0);
 
-    die "socket closed: $ret\n${\Dumper $self}" unless $ret > 0;
+    bmwqemu::logdie "socket closed: $ret\n${\Dumper $self}" unless $ret > 0;
 
     $message_type = unpack('C', $message_type);
     #print "receive message $message_type\n";
@@ -868,7 +867,7 @@ sub _receive_message {
     #<<< tidy off
     # This result is unused.  It's meaning is different for the different methods
     my $result
-      = !defined $message_type ? die 'bad message type received'
+      = !defined $message_type ? bmwqemu::logdie 'bad message type received'
       : $message_type == 0     ? $self->_receive_update()
       : $message_type == 1     ? $self->_receive_colour_map()
       : $message_type == 2     ? $self->_receive_bell()
@@ -879,7 +878,7 @@ sub _receive_message {
       : $message_type == 0x33 ? $self->_discard_ikvm_message($message_type, 4)
       : $message_type == 0x37 ? $self->_discard_ikvm_message($message_type, $self->old_ikvm ? 2 : 3)
       : $message_type == 0x3c ? $self->_discard_ikvm_message($message_type, 8)
-      :                         die 'unsupported message type received';
+      :                         bmwqemu::logdie 'unsupported message type received';
     #>>> tidy on
     return $message_type;
 }
@@ -895,7 +894,7 @@ sub _receive_update {
     }
 
     my $socket               = $self->socket;
-    my $hlen                 = $socket->read(my $header, 3) || die 'unexpected end of data';
+    my $hlen                 = $socket->read(my $header, 3) || bmwqemu::logdie 'unexpected end of data';
     my $number_of_rectangles = unpack('xn', $header);
 
     #bmwqemu::diag "NOR $number_of_rectangles";
@@ -905,7 +904,7 @@ sub _receive_update {
     my $do_endian_conversion = $self->_do_endian_conversion;
 
     foreach (1 .. $number_of_rectangles) {
-        $socket->read(my $data, 12) || die 'unexpected end of data';
+        $socket->read(my $data, 12) || bmwqemu::logdie 'unexpected end of data';
         my ($x, $y, $w, $h, $encoding_type) = unpack 'nnnnN', $data;
 
         # unsigned -> signed conversion
@@ -921,7 +920,7 @@ sub _receive_update {
         ### Raw encoding ###
         if ($encoding_type == 0 && !$self->ikvm) {
 
-            $socket->read(my $data, $w * $h * $bytes_per_pixel) || die 'unexpected end of data';
+            $socket->read(my $data, $w * $h * $bytes_per_pixel) || bmwqemu::logdie 'unexpected end of data';
 
             # splat raw pixels into the image
             my $img = tinycv::new($w, $h);
@@ -938,20 +937,20 @@ sub _receive_update {
             $self->_framebuffer($image);
         }
         elsif ($encoding_type == -257) {
-            bmwqemu::diag("pointer type $x $y $w $h $encoding_type");
+            bmwqemu::fctdbg("pointer type $x $y $w $h $encoding_type");
             $self->absolute($x);
         }
         elsif ($encoding_type == -261) {
             my $led_data;
-            $socket->read($led_data, 1) || die "unexpected end of data";
+            $socket->read($led_data, 1) || bmwqemu::logdie "unexpected end of data";
             my @bytes = unpack("C", $led_data);
-            bmwqemu::diag("led state $bytes[0] $w $h $encoding_type");
+            bmwqemu::fcterr("led state $bytes[0] $w $h $encoding_type");
         }
         elsif ($self->ikvm) {
             $self->_receive_ikvm_encoding($encoding_type, $x, $y, $w, $h);
         }
         else {
-            die 'unsupported update encoding ' . $encoding_type;
+            bmwqemu::logdie 'unsupported update encoding ' . $encoding_type;
         }
     }
 
@@ -986,16 +985,16 @@ sub _receive_zlre_encoding {
 
     my $stime = time;
     $socket->read(my $data, 4)
-      or die "short read for length";
+      or bmwqemu::logdie "short read for length";
     my ($data_len) = unpack('N', $data);
     my $read_len = 0;
     while ($read_len < $data_len) {
         my $len = read($socket, $data, $data_len - $read_len, $read_len);
-        die "short read for zlre data $read_len - $data_len" unless $len;
+        bmwqemu::logdie "short read for zlre data $read_len - $data_len" unless $len;
         $read_len += $len;
     }
     if (time - $stime > 0.1) {
-        diag sprintf("read $data_len in %fs\n", time - $stime);
+        bmwqemu::fctdbg sprintf("read $data_len in %fs\n", time - $stime);
     }
     # the zlib header is only sent once per session
     $self->{_inflater} ||= new Compress::Raw::Zlib::Inflate();
@@ -1003,10 +1002,10 @@ sub _receive_zlre_encoding {
     my $old_total_out = $self->{_inflater}->total_out;
     my $status = $self->{_inflater}->inflate($data, $out, 1);
     if ($status != Z_OK) {
-        die "inflation failed $status";
+        bmwqemu::logdie "inflation failed $status";
     }
     my $res = $image->map_raw_data_zrle($x, $y, $w, $h, $self->vncinfo, $out, $self->{_inflater}->total_out - $old_total_out);
-    die "not read enough data" unless $old_total_out + $res == $self->{_inflater}->total_out;
+    bmwqemu::logdie "not read enough data" unless $old_total_out + $res == $self->{_inflater}->total_out;
     return $res;
 }
 
@@ -1050,7 +1049,7 @@ sub _receive_ikvm_encoding {
         my $data;
         print "Additional Bytes: ";
         while ($data_len > $required_data) {
-            $socket->read($data, 1) || die "unexpected end of data";
+            $socket->read($data, 1) || bmwqemu::logdie "unexpected end of data";
             $data_len--;
             my @bytes = unpack("C", $data);
             printf "%02x ", $bytes[0];
@@ -1064,12 +1063,12 @@ sub _receive_ikvm_encoding {
     }
     elsif ($encoding_type == 0) {
         # ikvm manages to redeclare raw to be something completely different ;(
-        $socket->read(my $data, 10) || die "unexpected end of data";
+        $socket->read(my $data, 10) || bmwqemu::logdie "unexpected end of data";
         my ($type, $segments, $length) = unpack('CxNN', $data);
         while ($segments--) {
-            $socket->read(my $data, 6) || die "unexpected end of data";
+            $socket->read(my $data, 6) || bmwqemu::logdie "unexpected end of data";
             my ($dummy_a, $dummy_b, $y, $x) = unpack('nnCC', $data);
-            $socket->read($data, 512) || die "unexpected end of data";
+            $socket->read($data, 512) || bmwqemu::logdie "unexpected end of data";
             my $img = tinycv::new(16, 16);
             $img->map_raw_data_rgb555($data);
 
@@ -1090,7 +1089,7 @@ sub _receive_ikvm_encoding {
     elsif ($encoding_type == 87) {
         return if $data_len == 0;
         if ($self->old_ikvm) {
-            die "we guessed wrong - this is a new board!";
+            bmwqemu::logdie "we guessed wrong - this is a new board!";
         }
         $socket->read(my $data, $data_len);
         # enforce high quality to simplify our decoder
@@ -1111,7 +1110,7 @@ sub _receive_ikvm_encoding {
         }
     }
     else {
-        die "unsupported encoding $encoding_type\n";
+        bmwqemu::logdie "unsupported encoding $encoding_type\n";
     }
 }
 
@@ -1145,7 +1144,7 @@ sub _receive_ikvm_session {
     $self->socket->read(my $ikvm_session_infos, 264);
 
     my ($msg1, $msg2, $str) = unpack('NNZ256', $ikvm_session_infos);
-    print "IKVM Session Message: $msg1 $msg2 $str\n";
+    fctwarn "IKVM Session Message: $msg1 $msg2 $str\n";
     return 1;
 }
 
@@ -1153,10 +1152,10 @@ sub _receive_cut_text {
     my $self = shift;
 
     my $socket = $self->socket;
-    $socket->read(my $cut_msg, 7) || die 'unexpected end of data';
+    $socket->read(my $cut_msg, 7) || bmwqemu::logdie 'unexpected end of data';
     my $cut_length = unpack 'xxxN', $cut_msg;
     $socket->read(my $cut_string, $cut_length)
-      || die 'unexpected end of data';
+      || bmwqemu::logdie 'unexpected end of data';
 
     # And discard it...
 

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -140,7 +140,7 @@ sub login {
         );
         if (!$socket) {
             return if (time > $endtime);
-            bmwqemu::diag "Error connecting to host <$hostname>: $@";
+            OpenQA::Log::debug "Error connecting to host <$hostname>: $@";
             sleep 1;
             next;
         }
@@ -169,7 +169,7 @@ sub _handshake_protocol_version {
     my $socket = $self->socket;
     $socket->read(my $protocol_version, 12) || bmwqemu::logdie 'unexpected end of data';
 
-    #bmwqemu::diag "prot: $protocol_version";
+    #OpenQA::Log::debug "prot: $protocol_version";
 
     my $protocol_pattern = qr/\A RFB [ ] (\d{3}\.\d{3}) \s* \z/xms;
     if ($protocol_version !~ m/$protocol_pattern/xms) {
@@ -747,7 +747,7 @@ sub map_and_send_key {
 
 sub send_pointer_event {
     my ($self, $button_mask, $x, $y) = @_;
-    bmwqemu::diag "send_pointer_event $button_mask, $x, $y, " . $self->absolute;
+    OpenQA::Log::debug "send_pointer_event $button_mask, $x, $y, " . $self->absolute;
 
     my $template = 'CCnn';
     $template = 'CxCnnx11' if ($self->ikvm);
@@ -805,7 +805,7 @@ sub send_update_request {
         if (($self->_vnc_stalled == 1) && ($self->_last_update_requested - $self->_last_update_received > 4)) {
             $self->_last_update_received(0);
             # return black image - screen turned off
-            bmwqemu::diag "considering VNC stalled - turning black";
+            OpenQA::Log::debug "considering VNC stalled - turning black";
             $self->_framebuffer(tinycv::new($self->width, $self->height));
             $self->_vnc_stalled(2);
         }
@@ -897,7 +897,7 @@ sub _receive_update {
     my $hlen                 = $socket->read(my $header, 3) || bmwqemu::logdie 'unexpected end of data';
     my $number_of_rectangles = unpack('xn', $header);
 
-    #bmwqemu::diag "NOR $number_of_rectangles";
+    #OpenQA::Log::debug "NOR $number_of_rectangles";
 
     my $depth = $self->depth;
 
@@ -910,7 +910,7 @@ sub _receive_update {
         # unsigned -> signed conversion
         $encoding_type = unpack 'l', pack 'L', $encoding_type;
 
-        #bmwqemu::diag "UP $x,$y $w x $h $encoding_type";
+        #OpenQA::Log::debug "UP $x,$y $w x $h $encoding_type";
 
         # work around buggy addrlink VNC
         next if ($w * $h == 0);

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -1,6 +1,6 @@
 package consoles::VNC;
 use strict;
-use warnings;
+use OpenQA::Log::warnings;
 use base 'Class::Accessor::Fast';
 use IO::Socket::INET;
 use bytes;
@@ -1146,7 +1146,7 @@ sub _receive_ikvm_session {
     $self->socket->read(my $ikvm_session_infos, 264);
 
     my ($msg1, $msg2, $str) = unpack('NNZ256', $ikvm_session_infos);
-    fctwarn "IKVM Session Message: $msg1 $msg2 $str\n";
+    fctOpenQA::Log::warn "IKVM Session Message: $msg1 $msg2 $str\n";
     return 1;
 }
 

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -1,6 +1,6 @@
 package consoles::VNC;
 use strict;
-use OpenQA::Log::warnings;
+use warnings;
 use base 'Class::Accessor::Fast';
 use IO::Socket::INET;
 use bytes;
@@ -1146,7 +1146,7 @@ sub _receive_ikvm_session {
     $self->socket->read(my $ikvm_session_infos, 264);
 
     my ($msg1, $msg2, $str) = unpack('NNZ256', $ikvm_session_infos);
-    fctOpenQA::Log::warn "IKVM Session Message: $msg1 $msg2 $str\n";
+    OpenQA::Log::warn "IKVM Session Message: $msg1 $msg2 $str\n";
     return 1;
 }
 

--- a/consoles/console.pm
+++ b/consoles/console.pm
@@ -47,7 +47,7 @@ sub reset {
 
 sub screen {
     my ($self) = @_;
-    OpenQA::Log::die "screen needs to be implemented in subclasses - $self->{class} does not\n";
+    die "screen needs to be implemented in subclasses - $self->{class} does not\n";
     return;
 }
 

--- a/consoles/console.pm
+++ b/consoles/console.pm
@@ -22,6 +22,7 @@ use autodie ':all';
 
 use Class::Accessor 'antlers';
 has backend => (is => "rw");
+use bmwqemu qw(logdie diag fctdbg fcterr fctwarn);
 
 sub new {
     my ($class, $testapi_console, $args) = @_;
@@ -46,7 +47,7 @@ sub reset {
 
 sub screen {
     my ($self) = @_;
-    die "screen needs to be implemented in subclasses - $self->{class} does not\n";
+    bmwqemu::logdie "screen needs to be implemented in subclasses - $self->{class} does not\n";
     return;
 }
 

--- a/consoles/console.pm
+++ b/consoles/console.pm
@@ -22,7 +22,7 @@ use autodie ':all';
 
 use Class::Accessor 'antlers';
 has backend => (is => "rw");
-use bmwqemu qw(logdie diag fctdbg fcterr fctwarn);
+use bmwqemu qw( diag  fcterr fctwarn);
 
 sub new {
     my ($class, $testapi_console, $args) = @_;

--- a/consoles/console.pm
+++ b/consoles/console.pm
@@ -47,7 +47,7 @@ sub reset {
 
 sub screen {
     my ($self) = @_;
-    bmwqemu::logdie "screen needs to be implemented in subclasses - $self->{class} does not\n";
+    OpenQA::Log::die "screen needs to be implemented in subclasses - $self->{class} does not\n";
     return;
 }
 

--- a/consoles/console.pm
+++ b/consoles/console.pm
@@ -22,7 +22,6 @@ use autodie ':all';
 
 use Class::Accessor 'antlers';
 has backend => (is => "rw");
-use bmwqemu qw( diag  fcterr fctwarn);
 
 sub new {
     my ($class, $testapi_console, $args) = @_;

--- a/consoles/console.pm
+++ b/consoles/console.pm
@@ -22,6 +22,7 @@ use autodie ':all';
 
 use Class::Accessor 'antlers';
 has backend => (is => "rw");
+use OpenQA::Log;
 
 sub new {
     my ($class, $testapi_console, $args) = @_;

--- a/consoles/localXvnc.pm
+++ b/consoles/localXvnc.pm
@@ -33,13 +33,13 @@ sub activate {
 
     my $tcpproto = getprotobyname('tcp');
     my $s;
-    socket($s, PF_INET, SOCK_STREAM, $tcpproto) || bmwqemu::logdie "socket: $!\n";
+    socket($s, PF_INET, SOCK_STREAM, $tcpproto) || OpenQA::Log::die "socket: $!\n";
     bind($s, sockaddr_in(0, INADDR_ANY));
     my ($port) = sockaddr_in(getsockname($s));
 
     my $display = ":$port";
     my $pid     = fork();
-    bmwqemu::logdie unless defined $pid;
+    OpenQA::Log::die unless defined $pid;
     if (!$pid) {
         listen($s, 1);
         my $peer;

--- a/consoles/localXvnc.pm
+++ b/consoles/localXvnc.pm
@@ -25,6 +25,7 @@ use autodie ':all';
 use Socket;
 use strict;
 use warnings;
+use OpenQA::Log;
 
 sub activate {
     my ($self) = @_;

--- a/consoles/localXvnc.pm
+++ b/consoles/localXvnc.pm
@@ -33,13 +33,13 @@ sub activate {
 
     my $tcpproto = getprotobyname('tcp');
     my $s;
-    socket($s, PF_INET, SOCK_STREAM, $tcpproto) || die "socket: $!\n";
+    socket($s, PF_INET, SOCK_STREAM, $tcpproto) || bmwqemu::logdie "socket: $!\n";
     bind($s, sockaddr_in(0, INADDR_ANY));
     my ($port) = sockaddr_in(getsockname($s));
 
     my $display = ":$port";
     my $pid     = fork();
-    die unless defined $pid;
+    bmwqemu::logdie unless defined $pid;
     if (!$pid) {
         listen($s, 1);
         my $peer;

--- a/consoles/localXvnc.pm
+++ b/consoles/localXvnc.pm
@@ -34,13 +34,13 @@ sub activate {
 
     my $tcpproto = getprotobyname('tcp');
     my $s;
-    socket($s, PF_INET, SOCK_STREAM, $tcpproto) || OpenQA::Log::die "socket: $!\n";
+    socket($s, PF_INET, SOCK_STREAM, $tcpproto) || die "socket: $!\n";
     bind($s, sockaddr_in(0, INADDR_ANY));
     my ($port) = sockaddr_in(getsockname($s));
 
     my $display = ":$port";
     my $pid     = fork();
-    OpenQA::Log::die unless defined $pid;
+    die unless defined $pid;
     if (!$pid) {
         listen($s, 1);
         my $peer;

--- a/consoles/s3270.pm
+++ b/consoles/s3270.pm
@@ -235,7 +235,7 @@ sub expect_3270() {
                   . $status_line;
             }
 
-            bmwqemu::logdie "status line must match 'buffer_ready'" unless ($status_line =~ /$arg{buffer_ready}/);
+            OpenQA::Log::die "status line must match 'buffer_ready'" unless ($status_line =~ /$arg{buffer_ready}/);
         }
 
         # No more host output is pending. We have some output in the raw_expect_queue,
@@ -459,7 +459,7 @@ sub connect_and_login() {
                 sleep 7;
             }
             elsif ($count == 3) {
-                bmwqemu::logdie "Could not reclaim guest despite hard_shutdown and retrying multiple times. this is odd.\n"
+                OpenQA::Log::die "Could not reclaim guest despite hard_shutdown and retrying multiple times. this is odd.\n"
                   . "Is this machine possibly connected on another terminal?";
             }
 

--- a/consoles/s3270.pm
+++ b/consoles/s3270.pm
@@ -235,7 +235,7 @@ sub expect_3270() {
                   . $status_line;
             }
 
-            die "status line must match 'buffer_ready'" unless ($status_line =~ /$arg{buffer_ready}/);
+            bmwqemu::logdie "status line must match 'buffer_ready'" unless ($status_line =~ /$arg{buffer_ready}/);
         }
 
         # No more host output is pending. We have some output in the raw_expect_queue,
@@ -459,13 +459,13 @@ sub connect_and_login() {
                 sleep 7;
             }
             elsif ($count == 3) {
-                die "Could not reclaim guest despite hard_shutdown and retrying multiple times. this is odd.\n"
-                  . "Is this machine possibly connected on another terminal?\n";
+                bmwqemu::logdie "Could not reclaim guest despite hard_shutdown and retrying multiple times. this is odd.\n"
+                  . "Is this machine possibly connected on another terminal?";
             }
 
             last if $reconnect_ok;
 
-            carp "trying hard shutdown and reconnect...\n";
+            carp "trying hard shutdown and reconnect...";
             $self->cp_logoff_disconnect();
             next;
         }

--- a/consoles/s3270.pm
+++ b/consoles/s3270.pm
@@ -19,6 +19,7 @@ package consoles::s3270;
 use base 'consoles::localXvnc';
 use strict;
 use warnings;
+use OpenQA::Log;
 
 use Class::Accessor 'antlers';
 has zVM_host    => (is => "rw");

--- a/consoles/s3270.pm
+++ b/consoles/s3270.pm
@@ -235,7 +235,7 @@ sub expect_3270() {
                   . $status_line;
             }
 
-            OpenQA::Log::die "status line must match 'buffer_ready'" unless ($status_line =~ /$arg{buffer_ready}/);
+            die "status line must match 'buffer_ready'" unless ($status_line =~ /$arg{buffer_ready}/);
         }
 
         # No more host output is pending. We have some output in the raw_expect_queue,
@@ -459,13 +459,13 @@ sub connect_and_login() {
                 sleep 7;
             }
             elsif ($count == 3) {
-                OpenQA::Log::die "Could not reclaim guest despite hard_shutdown and retrying multiple times. this is odd.\n"
+                die "Could not reclaim guest despite hard_shutdown and retrying multiple times. this is odd.\n"
                   . "Is this machine possibly connected on another terminal?";
             }
 
             last if $reconnect_ok;
 
-            OpenQA::Log::error "trying hard shutdown and reconnect...";
+            error "trying hard shutdown and reconnect...";
             $self->cp_logoff_disconnect();
             next;
         }

--- a/consoles/s3270.pm
+++ b/consoles/s3270.pm
@@ -465,7 +465,7 @@ sub connect_and_login() {
 
             last if $reconnect_ok;
 
-            carp "trying hard shutdown and reconnect...";
+            OpenQA::Log::error "trying hard shutdown and reconnect...";
             $self->cp_logoff_disconnect();
             next;
         }

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -23,6 +23,7 @@ require IPC::System::Simple;
 use autodie ':all';
 use XML::LibXML;
 use File::Temp 'tempfile';
+use OpenQA::Log;
 
 use Class::Accessor 'antlers';
 has instance   => (is => "rw", isa => "Num");

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -449,21 +449,21 @@ sub get_ssh_output {
         return ($stdout, $errout);
     }
     else {
-        OpenQA::Log::debug "Command's stdout:\n$stdout" if length($stdout);
-        OpenQA::Log::debug "Command's stderr:\n$errout" if length($errout);
+        debug "Command's stdout:\n$stdout" if length($stdout);
+        debug "Command's stderr:\n$errout" if length($errout);
     }
 }
 
 sub suspend {
     my ($self) = @_;
     $self->run_cmd("virsh suspend " . $self->name) && die "Can't suspend VM ";
-    OpenQA::Log::debug "VM " . $self->name . " suspended";
+    debug "VM " . $self->name . " suspended";
 }
 
 sub resume {
     my ($self) = @_;
     $self->run_cmd("virsh resume " . $self->name) && die "Can't resume VM ";
-    OpenQA::Log::debug "VM " . $self->name . " resumed";
+    debug "VM " . $self->name . " resumed";
 }
 
 sub define_and_start {
@@ -542,7 +542,7 @@ sub run_cmd {
     my $chan = $self->{ssh}->channel();
     $chan->exec($cmd);
     $chan->send_eof;
-    OpenQA::Log::debug "Command executed: $cmd";
+    debug "Command executed: $cmd";
     get_ssh_output($chan);
     my $ret = $chan->exit_status();
     $chan->close();

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -449,21 +449,21 @@ sub get_ssh_output {
         return ($stdout, $errout);
     }
     else {
-        bmwqemu::diag "Command's stdout:\n$stdout" if length($stdout);
-        bmwqemu::diag "Command's stderr:\n$errout" if length($errout);
+        OpenQA::Log::debug "Command's stdout:\n$stdout" if length($stdout);
+        OpenQA::Log::debug "Command's stderr:\n$errout" if length($errout);
     }
 }
 
 sub suspend {
     my ($self) = @_;
     $self->run_cmd("virsh suspend " . $self->name) && die "Can't suspend VM ";
-    bmwqemu::diag "VM " . $self->name . " suspended";
+    OpenQA::Log::debug "VM " . $self->name . " suspended";
 }
 
 sub resume {
     my ($self) = @_;
     $self->run_cmd("virsh resume " . $self->name) && die "Can't resume VM ";
-    bmwqemu::diag "VM " . $self->name . " resumed";
+    OpenQA::Log::debug "VM " . $self->name . " resumed";
 }
 
 sub define_and_start {
@@ -542,7 +542,7 @@ sub run_cmd {
     my $chan = $self->{ssh}->channel();
     $chan->exec($cmd);
     $chan->send_eof;
-    bmwqemu::diag "Command executed: $cmd";
+    OpenQA::Log::debug "Command executed: $cmd";
     get_ssh_output($chan);
     my $ret = $chan->exit_status();
     $chan->close();

--- a/consoles/sshX3270.pm
+++ b/consoles/sshX3270.pm
@@ -19,6 +19,7 @@ use base 'consoles::localXvnc';
 use strict;
 use warnings;
 use testapi 'get_var';
+use OpenQA::Log;
 
 sub activate {
     my ($self) = @_;

--- a/consoles/sshX3270.pm
+++ b/consoles/sshX3270.pm
@@ -40,7 +40,7 @@ sub activate {
         my $co = $r->{command_output};
         CORE::say bmwqemu::pp($co);
         last if grep { /[Pp]assword:/ } @$co;
-        OpenQA::Log::die "ssh password prompt timeout" unless $i;
+        die "ssh password prompt timeout" unless $i;
         sleep 1;
     }
     $s3270->send_3270("String(\"$sshpassword\")");

--- a/consoles/sshX3270.pm
+++ b/consoles/sshX3270.pm
@@ -39,7 +39,7 @@ sub activate {
         my $co = $r->{command_output};
         CORE::say bmwqemu::pp($co);
         last if grep { /[Pp]assword:/ } @$co;
-        bmwqemu::logdie "ssh password prompt timeout" unless $i;
+        OpenQA::Log::die "ssh password prompt timeout" unless $i;
         sleep 1;
     }
     $s3270->send_3270("String(\"$sshpassword\")");

--- a/consoles/sshX3270.pm
+++ b/consoles/sshX3270.pm
@@ -39,7 +39,7 @@ sub activate {
         my $co = $r->{command_output};
         CORE::say bmwqemu::pp($co);
         last if grep { /[Pp]assword:/ } @$co;
-        die "ssh password prompt timeout" unless $i;
+        bmwqemu::logdie "ssh password prompt timeout" unless $i;
         sleep 1;
     }
     $s3270->send_3270("String(\"$sshpassword\")");

--- a/consoles/sshXtermVt.pm
+++ b/consoles/sshXtermVt.pm
@@ -31,7 +31,7 @@ sub fullscreen {
     my $window_name = $args->{window_name};
 
     my $xdotool = which "xdotool";
-    OpenQA::Log::die "Missing 'xdotool'" unless $xdotool;
+    die "Missing 'xdotool'" unless $xdotool;
     # search for YaST Window and grab the id
     my $window_id = qx"DISPLAY=$display $xdotool search --sync --limit 1 --name $window_name";
     $window_id =~ s/\D//g;
@@ -58,11 +58,11 @@ sub activate {
 
     $sshcommand = "TERM=xterm " . $sshcommand;
     my $xterm_vt_cmd = which "xterm-console";
-    OpenQA::Log::die "Missing 'xterm-console'" unless $xterm_vt_cmd;
+    die "Missing 'xterm-console'" unless $xterm_vt_cmd;
     my $window_name = "ssh:$testapi_console";
     eval { system("DISPLAY=$display $xterm_vt_cmd -title $window_name -e bash -c '$sshcommand' & echo \$!") };
     if (my $E = $@) {
-        OpenQA::Log::die "cant' start xterm on $display (err: $! retval: $?)";
+        die "cant' start xterm on $display (err: $! retval: $?)";
     }
 
     # FIXME: assert_screen('xterm_password');

--- a/consoles/sshXtermVt.pm
+++ b/consoles/sshXtermVt.pm
@@ -22,7 +22,7 @@ use testapi 'get_var';
 require IPC::System::Simple;
 use autodie ':all';
 use File::Which;
-
+use OpenQA::Log;
 
 sub fullscreen {
     my ($self, $args) = @_;

--- a/consoles/sshXtermVt.pm
+++ b/consoles/sshXtermVt.pm
@@ -31,7 +31,7 @@ sub fullscreen {
     my $window_name = $args->{window_name};
 
     my $xdotool = which "xdotool";
-    bmwqemu::logdie "Missing 'xdotool'" unless $xdotool;
+    OpenQA::Log::die "Missing 'xdotool'" unless $xdotool;
     # search for YaST Window and grab the id
     my $window_id = qx"DISPLAY=$display $xdotool search --sync --limit 1 --name $window_name";
     $window_id =~ s/\D//g;
@@ -58,11 +58,11 @@ sub activate {
 
     $sshcommand = "TERM=xterm " . $sshcommand;
     my $xterm_vt_cmd = which "xterm-console";
-    bmwqemu::logdie "Missing 'xterm-console'" unless $xterm_vt_cmd;
+    OpenQA::Log::die "Missing 'xterm-console'" unless $xterm_vt_cmd;
     my $window_name = "ssh:$testapi_console";
     eval { system("DISPLAY=$display $xterm_vt_cmd -title $window_name -e bash -c '$sshcommand' & echo \$!") };
     if (my $E = $@) {
-        bmwqemu::logdie "cant' start xterm on $display (err: $! retval: $?)";
+        OpenQA::Log::die "cant' start xterm on $display (err: $! retval: $?)";
     }
 
     # FIXME: assert_screen('xterm_password');

--- a/consoles/sshXtermVt.pm
+++ b/consoles/sshXtermVt.pm
@@ -31,7 +31,7 @@ sub fullscreen {
     my $window_name = $args->{window_name};
 
     my $xdotool = which "xdotool";
-    die "Missing 'xdotool'" unless $xdotool;
+    bmwqemu::logdie "Missing 'xdotool'" unless $xdotool;
     # search for YaST Window and grab the id
     my $window_id = qx"DISPLAY=$display $xdotool search --sync --limit 1 --name $window_name";
     $window_id =~ s/\D//g;
@@ -58,11 +58,11 @@ sub activate {
 
     $sshcommand = "TERM=xterm " . $sshcommand;
     my $xterm_vt_cmd = which "xterm-console";
-    die "Missing 'xterm-console'" unless $xterm_vt_cmd;
+    bmwqemu::logdie "Missing 'xterm-console'" unless $xterm_vt_cmd;
     my $window_name = "ssh:$testapi_console";
     eval { system("DISPLAY=$display $xterm_vt_cmd -title $window_name -e bash -c '$sshcommand' & echo \$!") };
     if (my $E = $@) {
-        die "cant' start xterm on $display (err: $! retval: $?)";
+        bmwqemu::logdie "cant' start xterm on $display (err: $! retval: $?)";
     }
 
     # FIXME: assert_screen('xterm_password');

--- a/consoles/virtio_screen.pm
+++ b/consoles/virtio_screen.pm
@@ -232,7 +232,7 @@ sub read_until {
     }
 
     my $elapsed = get_elapsed($sttime);
-    bmwqemu::fctinfo("Matched output from SUT in $loops loops & $elapsed seconds: $match");
+    OpenQA::Log::info("Matched output from SUT in $loops loops & $elapsed seconds: $match");
 
     $overflow ||= '';
     if ($nargs{exclude_match}) {

--- a/consoles/virtio_screen.pm
+++ b/consoles/virtio_screen.pm
@@ -232,7 +232,7 @@ sub read_until {
     }
 
     my $elapsed = get_elapsed($sttime);
-    OpenQA::Log::info("Matched output from SUT in $loops loops & $elapsed seconds: $match");
+    info("Matched output from SUT in $loops loops & $elapsed seconds: $match");
 
     $overflow ||= '';
     if ($nargs{exclude_match}) {

--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -24,6 +24,7 @@ use Scalar::Util 'blessed';
 use Cwd;
 use consoles::virtio_screen ();
 use testapi 'get_var';
+use OpenQA::Log;
 
 use base 'consoles::console';
 

--- a/consoles/vnc_base.pm
+++ b/consoles/vnc_base.pm
@@ -55,7 +55,7 @@ sub connect_vnc {
 
     $self->{mouse} = {x => undef, y => undef};
 
-    OpenQA::Log::info "Setting up a connection to VNC console". bmwqemu::pp($args);
+    OpenQA::Log::info "Setting up a connection to VNC console" . bmwqemu::pp($args);
     $self->{vnc} = consoles::VNC->new($args);
     my $endtime = time + ($args->{connect_timeout} || 10);
 

--- a/consoles/vnc_base.pm
+++ b/consoles/vnc_base.pm
@@ -62,7 +62,7 @@ sub connect_vnc {
     while (1) {
         my @connection_error;
         my $vnc = try {
-            bmwqemu::fctdbg "trying to login\n";
+            OpenQA::Log::debug "trying to login\n";
             local $SIG{__DIE__};
             $self->{vnc}->login();
             CORE::say __FILE__. ":" . __LINE__ . ":done\n";
@@ -71,7 +71,7 @@ sub connect_vnc {
         catch {
             push @connection_error, $@;
             if (time > $endtime) {
-                bmwqemu::fctdbg sprintf "%d $endtime\n", time;
+                OpenQA::Log::debug sprintf "%d $endtime\n", time;
                 $self->disable();
                 OpenQA::Log::die(@connection_error);
             }
@@ -205,7 +205,7 @@ sub _mouse_move {
     $self->{mouse}->{x} = $x;
     $self->{mouse}->{y} = $y;
 
-    bmwqemu::fctdbg "mouse_move $x, $y";
+    OpenQA::Log::debug "mouse_move $x, $y";
     $self->{vnc}->mouse_move_to($x, $y);
     return;
 }
@@ -252,7 +252,7 @@ sub mouse_button {
     elsif ($button eq 'middle') {
         $mask = $bstate << 1;
     }
-    bmwqemu::fctdbg "pointer_event $mask $self->{mouse}->{x}, $self->{mouse}->{y}";
+    OpenQA::Log::debug "pointer_event $mask $self->{mouse}->{x}, $self->{mouse}->{y}";
     $self->{vnc}->send_pointer_event($mask, $self->{mouse}->{x}, $self->{mouse}->{y});
     return {};
 }

--- a/consoles/vnc_base.pm
+++ b/consoles/vnc_base.pm
@@ -26,6 +26,7 @@ use feature 'say';
 use Data::Dumper 'Dumper';
 use Carp qw(confess cluck carp croak);
 use Try::Tiny;
+use OpenQA::Log;
 
 sub screen {
     my ($self) = @_;

--- a/consoles/vnc_base.pm
+++ b/consoles/vnc_base.pm
@@ -54,7 +54,7 @@ sub connect_vnc {
 
     $self->{mouse} = {x => undef, y => undef};
 
-    CORE::say __FILE__. ":" . __LINE__ . ":" . bmwqemu::pp($args);
+    OpenQA::Log::info "Setting up a connection to VNC console". bmwqemu::pp($args);
     $self->{vnc} = consoles::VNC->new($args);
     my $endtime = time + ($args->{connect_timeout} || 10);
 
@@ -62,10 +62,10 @@ sub connect_vnc {
     while (1) {
         my @connection_error;
         my $vnc = try {
-            OpenQA::Log::debug "trying to login\n";
+            OpenQA::Log::debug "trying to login to VNC\n";
             local $SIG{__DIE__};
             $self->{vnc}->login();
-            CORE::say __FILE__. ":" . __LINE__ . ":done\n";
+            OpenQA::Log::info ":Sucessfully loged into VNC\n";
             return $self->{vnc};
         }
         catch {
@@ -188,7 +188,7 @@ sub release_key {
 
 sub _mouse_move {
     my ($self, $x, $y) = @_;
-    OpenQA::Log::die "need parameter \$x and \$y" unless (defined $x and defined $y);
+    OpenQA::Log::die 'need parameter $x and $y' unless (defined $x and defined $y);
 
     if ($self->{mouse}->{x} == $x && $self->{mouse}->{y} == $y) {
         # in case the mouse is moved twice to the same position
@@ -205,7 +205,7 @@ sub _mouse_move {
     $self->{mouse}->{x} = $x;
     $self->{mouse}->{y} = $y;
 
-    OpenQA::Log::debug "mouse_move $x, $y";
+    OpenQA::Log::trace "mouse_move $x, $y";
     $self->{vnc}->mouse_move_to($x, $y);
     return;
 }

--- a/consoles/vnc_base.pm
+++ b/consoles/vnc_base.pm
@@ -73,7 +73,7 @@ sub connect_vnc {
             if (time > $endtime) {
                 bmwqemu::fctdbg sprintf "%d $endtime\n", time;
                 $self->disable();
-                bmwqemu::logdie(@connection_error);
+                OpenQA::Log::die(@connection_error);
             }
             sleep 1;
             return;
@@ -188,7 +188,7 @@ sub release_key {
 
 sub _mouse_move {
     my ($self, $x, $y) = @_;
-    bmwqemu::logdie "need parameter \$x and \$y" unless (defined $x and defined $y);
+    OpenQA::Log::die "need parameter \$x and \$y" unless (defined $x and defined $y);
 
     if ($self->{mouse}->{x} == $x && $self->{mouse}->{y} == $y) {
         # in case the mouse is moved twice to the same position
@@ -229,7 +229,7 @@ sub mouse_hide {
 
 sub mouse_set {
     my ($self, $args) = @_;
-    bmwqemu::logdie "Need x/y arguments" unless (defined $args->{x} && defined $args->{y});
+    OpenQA::Log::die "Need x/y arguments" unless (defined $args->{x} && defined $args->{y});
 
     # TODO: for framebuffers larger than 1024x768, we need to upscale
     $self->_mouse_move(int($args->{x}), int($args->{y}));

--- a/consoles/vnc_base.pm
+++ b/consoles/vnc_base.pm
@@ -73,7 +73,7 @@ sub connect_vnc {
             if (time > $endtime) {
                 bmwqemu::fctdbg sprintf "%d $endtime\n", time;
                 $self->disable();
-                bmwqemu::logdie join("\n", @connection_error);
+                bmwqemu::logdie(@connection_error);
             }
             sleep 1;
             return;

--- a/consoles/vnc_base.pm
+++ b/consoles/vnc_base.pm
@@ -55,7 +55,7 @@ sub connect_vnc {
 
     $self->{mouse} = {x => undef, y => undef};
 
-    OpenQA::Log::info "Setting up a connection to VNC console" . bmwqemu::pp($args);
+    info "Setting up a connection to VNC console" . bmwqemu::pp($args);
     $self->{vnc} = consoles::VNC->new($args);
     my $endtime = time + ($args->{connect_timeout} || 10);
 
@@ -63,18 +63,18 @@ sub connect_vnc {
     while (1) {
         my @connection_error;
         my $vnc = try {
-            OpenQA::Log::debug "trying to login to VNC\n";
+            debug "trying to login to VNC\n";
             local $SIG{__DIE__};
             $self->{vnc}->login();
-            OpenQA::Log::info ":Sucessfully loged into VNC\n";
+            info ":Sucessfully loged into VNC\n";
             return $self->{vnc};
         }
         catch {
             push @connection_error, $@;
             if (time > $endtime) {
-                OpenQA::Log::debug sprintf "%d $endtime\n", time;
+                debug sprintf "%d $endtime\n", time;
                 $self->disable();
-                OpenQA::Log::die(@connection_error);
+                die(@connection_error);
             }
             sleep 1;
             return;
@@ -189,7 +189,7 @@ sub release_key {
 
 sub _mouse_move {
     my ($self, $x, $y) = @_;
-    OpenQA::Log::die 'need parameter $x and $y' unless (defined $x and defined $y);
+    die 'need parameter $x and $y' unless (defined $x and defined $y);
 
     if ($self->{mouse}->{x} == $x && $self->{mouse}->{y} == $y) {
         # in case the mouse is moved twice to the same position
@@ -206,7 +206,7 @@ sub _mouse_move {
     $self->{mouse}->{x} = $x;
     $self->{mouse}->{y} = $y;
 
-    OpenQA::Log::trace "mouse_move $x, $y";
+    trace "mouse_move $x, $y";
     $self->{vnc}->mouse_move_to($x, $y);
     return;
 }
@@ -230,7 +230,7 @@ sub mouse_hide {
 
 sub mouse_set {
     my ($self, $args) = @_;
-    OpenQA::Log::die "Need x/y arguments" unless (defined $args->{x} && defined $args->{y});
+    die "Need x/y arguments" unless (defined $args->{x} && defined $args->{y});
 
     # TODO: for framebuffers larger than 1024x768, we need to upscale
     $self->_mouse_move(int($args->{x}), int($args->{y}));
@@ -253,7 +253,7 @@ sub mouse_button {
     elsif ($button eq 'middle') {
         $mask = $bstate << 1;
     }
-    OpenQA::Log::debug "pointer_event $mask $self->{mouse}->{x}, $self->{mouse}->{y}";
+    debug "pointer_event $mask $self->{mouse}->{x}, $self->{mouse}->{y}";
     $self->{vnc}->send_pointer_event($mask, $self->{mouse}->{x}, $self->{mouse}->{y});
     return {};
 }

--- a/cpanfile
+++ b/cpanfile
@@ -47,6 +47,7 @@ requires 'base';
 requires 'constant';
 requires 'strict';
 requires 'warnings';
+requires 'Log::Log4perl';
 
 on 'test' => sub {
   requires 'Perl::Critic';

--- a/etc/os-autoinst/log4perl.conf
+++ b/etc/os-autoinst/log4perl.conf
@@ -2,7 +2,7 @@
 # A simple root logger with a Log::Log4perl::Appender::File 
 # file appender in Perl.
 ############################################################
-log4perl.rootLogger=DEBUG, Screen
+log4perl.rootLogger=INFO, Screen
 log4perl.appender.Screen        = Log::Log4perl::Appender::Screen
 log4perl.appender.Screen.stderr = 0
 log4perl.appender.Screen.layout = \

--- a/etc/os-autoinst/log4perl.conf
+++ b/etc/os-autoinst/log4perl.conf
@@ -3,16 +3,8 @@
 # file appender in Perl.
 ############################################################
 log4perl.rootLogger=DEBUG, Screen
-log4perl.appender.Screen        = Log::Log4perl::Appender::ScreenColoredLevels
+log4perl.appender.Screen        = Log::Log4perl::Appender::Screen
 log4perl.appender.Screen.stderr = 0
 log4perl.appender.Screen.layout = \
 Log::Log4perl::Layout::PatternLayout
 log4perl.appender.Screen.layout.ConversionPattern = [%r] %p %d{ISO8601} %c %M (%L) - %m%n
-
-# log4perl.logger  =DEBUG, LOGFILE
-log4perl.appender.LOGFILE=Log::Log4perl::Appender::File
-log4perl.appender.LOGFILE.filename=rootappender.log
-log4perl.appender.LOGFILE.mode=append
-log4perl.appender.LOGFILE.layout=PatternLayout
-log4perl.appender.LOGFILE.layout.ConversionPattern= [%r] %p %d{ISO8601} %c %M (%L) - %m%n
-

--- a/etc/os-autoinst/log4perl.conf
+++ b/etc/os-autoinst/log4perl.conf
@@ -1,0 +1,18 @@
+############################################################
+# A simple root logger with a Log::Log4perl::Appender::File 
+# file appender in Perl.
+############################################################
+log4perl.rootLogger=DEBUG, Screen
+log4perl.appender.Screen        = Log::Log4perl::Appender::ScreenColoredLevels
+log4perl.appender.Screen.stderr = 0
+log4perl.appender.Screen.layout = \
+Log::Log4perl::Layout::PatternLayout
+log4perl.appender.Screen.layout.ConversionPattern = [%r] %p %d{ISO8601} %c %M (%L) - %m%n
+
+# log4perl.logger  =DEBUG, LOGFILE
+log4perl.appender.LOGFILE=Log::Log4perl::Appender::File
+log4perl.appender.LOGFILE.filename=rootappender.log
+log4perl.appender.LOGFILE.mode=append
+log4perl.appender.LOGFILE.layout=PatternLayout
+log4perl.appender.LOGFILE.layout.ConversionPattern= [%r] %p %d{ISO8601} %c %M (%L) - %m%n
+

--- a/etc/os-autoinst/log4perl.conf
+++ b/etc/os-autoinst/log4perl.conf
@@ -2,7 +2,7 @@
 # A simple root logger with a Log::Log4perl::Appender::File 
 # file appender in Perl.
 ############################################################
-log4perl.rootLogger=INFO, Screen
+log4perl.rootLogger=TRACE, Screen
 log4perl.appender.Screen        = Log::Log4perl::Appender::Screen
 log4perl.appender.Screen.stderr = 0
 log4perl.appender.Screen.layout = \

--- a/isotovideo
+++ b/isotovideo
@@ -166,7 +166,7 @@ sub signalhandler_chld {
             $loop    = 0;
             next;
         }
-        bmwqemu::fcterr("unknown child $child died");
+        OpenQA::Log::error("unknown child $child died");
     }
 }
 
@@ -388,7 +388,7 @@ while ($loop) {
             next;
         }
         if ($rsp->{cmd} =~ m/^backend_(.*)/) {
-            bmwqemu::fcterr("we need to implement a backend queue") if $backend_requester;
+            OpenQA::Log::error("we need to implement a backend queue") if $backend_requester;
             $backend_requester = $r;
             my $cmd = $1;
             delete $rsp->{cmd};
@@ -499,7 +499,7 @@ if (!$r) {
     # don't rely on the backend in a sane state if we failed - just kill it later
     eval { bmwqemu::stop_vm(); };
     if ($@) {
-        bmwqemu::fcterr("Error during stop_vm: $@");
+        OpenQA::Log::error("Error during stop_vm: $@");
         $r = 1;
     }
 }
@@ -523,7 +523,7 @@ if (!$r && $completed && (my $nd = $bmwqemu::vars{NUMDISKS}) && ($bmwqemu::vars{
         push @toextract, {hdd_num => $i, name => $name, dir => $dir, format => $format};
     }
     if (@toextract && !$clean_shutdown) {
-        bmwqemu::fcterr("ERROR: Machine not shut down when uploading disks!\n");
+        OpenQA::Log::error("ERROR: Machine not shut down when uploading disks!\n");
         $r = 1;
     }
     else {

--- a/isotovideo
+++ b/isotovideo
@@ -54,6 +54,8 @@ use Time::HiRes qw(gettimeofday tv_interval sleep time);
 use File::Spec;
 use File::Path;
 
+use Log::Log4perl;
+
 # avoid paranoia
 $Getopt::Std::STANDARD_HELP_VERSION = 1;
 
@@ -79,12 +81,17 @@ $| = 1;
 select(STDOUT);            # default
 $| = 1;
 
+
+Log::Log4perl->init($installprefix."/etc/os-autoinst/log4perl.conf");
+my $log = Log::Log4perl->get_logger("openqa.os-autoinst.isotovideo");
+$log->info("Isotovideo logger initialized");
+
 $bmwqemu::scriptdir = $installprefix;
 bmwqemu::init();
 
 # Sanity checks
-die "CASEDIR environment variable not set, unknown test case directory" if !defined $bmwqemu::vars{CASEDIR};
-die "No scripts in $bmwqemu::vars{CASEDIR}" if !-e "$bmwqemu::vars{CASEDIR}";
+$log->logdie("CASEDIR environment variable not set, unknown test case directory") if !defined $bmwqemu::vars{CASEDIR};
+$log->logdie("No scripts in $bmwqemu::vars{CASEDIR}") if !-e "$bmwqemu::vars{CASEDIR}";
 
 my $cpid;
 my $testpid;
@@ -209,6 +216,7 @@ sub calculate_git_hash {
     diag "git hash of test distribution: $test_git_hash";
     return $test_git_hash;
 }
+
 
 $SIG{TERM} = \&signalhandler;
 $SIG{INT}  = \&signalhandler;

--- a/isotovideo
+++ b/isotovideo
@@ -42,7 +42,6 @@ use needle;
 use autotest;
 use commands;
 use distribution;
-use testapi 'diag';
 use Getopt::Std;
 require IPC::System::Simple;
 use autodie ':all';
@@ -54,7 +53,8 @@ use Time::HiRes qw(gettimeofday tv_interval sleep time);
 use File::Spec;
 use File::Path;
 use backend::driver;
-use Log::Log4perl;
+
+use OpenQA::Log;
 
 # avoid paranoia
 $Getopt::Std::STANDARD_HELP_VERSION = 1;
@@ -82,16 +82,15 @@ select(STDOUT);            # default
 $| = 1;
 
 
-Log::Log4perl->init($installprefix . "/etc/os-autoinst/log4perl.conf");
-my $log = Log::Log4perl->get_logger("openqa.os-autoinst.isotovideo");
-$log->info("Isotovideo logger initialized");
+$OpenQA::Log::configuration = $installprefix;
+OpenQA::Log::setup();
 
 $bmwqemu::scriptdir = $installprefix;
 bmwqemu::init();
 
 # Sanity checks
-bmwqemu::logdie("CASEDIR environment variable not set, unknown test case directory") if !defined $bmwqemu::vars{CASEDIR};
-bmwqemu::logdie("No scripts in $bmwqemu::vars{CASEDIR}") if !-e "$bmwqemu::vars{CASEDIR}";
+OpenQA::Log::logdie("CASEDIR environment variable not set, unknown test case directory") if !defined $bmwqemu::vars{CASEDIR};
+OpenQA::Log::logdie("No scripts in $bmwqemu::vars{CASEDIR}") if !-e "$bmwqemu::vars{CASEDIR}";
 
 my $cpid;
 my $testpid;
@@ -104,9 +103,9 @@ sub kill_commands {
     # create a copy as cpid is overwritten by SIGCHLD
     my $pid = $cpid;
     if (kill('TERM', $pid)) {
-        diag "awaiting death of commands process";
+        OpenQA::Log::info("awaiting death of commands process");
         my $ret = waitpid($pid, 0);
-        diag "commands process exited: $ret";
+        OpenQA::Log::info("commands process exited: $ret");
     }
     $cpid = 0;
 }
@@ -116,9 +115,9 @@ sub kill_autotest {
     # create a copy as cpid is overwritten by SIGCHLD
     my $pid = $testpid;
     if (kill('TERM', $pid)) {
-        diag "awaiting death of testpid $pid";
+        OpenQA::Log::debug "awaiting death of testpid $pid";
         my $ret = waitpid($pid, 0);
-        diag "test process exited: $ret";
+        OpenQA::Log::debug "test process exited: $ret";
     }
     $testpid = 0;
 }
@@ -127,10 +126,10 @@ sub kill_backend {
     if (defined $bmwqemu::backend && $bmwqemu::backend->{backend_pid}) {
         # save the pid in a scalar - signal handlers will reset it
         my $bpid = $bmwqemu::backend->{backend_pid};
-        diag "killing backend process $bpid";
+        OpenQA::Log::debug("killing backend process $bpid");
         kill('TERM', $bpid);
         waitpid($bpid, 0);
-        diag("done with backend process");
+        OpenQA::Log::debug("done with backend process");
         $bmwqemu::backend->{backend_pid} = 0;
     }
 }
@@ -138,7 +137,7 @@ sub kill_backend {
 sub signalhandler {
 
     my ($sig) = @_;
-    diag("signalhandler got $sig - loop $loop");
+    OpenQA::Log::debug("signalhandler got $sig - loop $loop");
     if ($loop) {
         $loop = 0;
         return;
@@ -153,19 +152,19 @@ sub signalhandler_chld {
 
     while ((my $child = waitpid(-1, WNOHANG)) > 0) {
         if ($child == $cpid) {
-            bmwqemu::fctwarn("commands webserver died");
+            OpenQA::Log::warn("commands webserver died");
             $loop = 0;
             $cpid = 0;
             next;
         }
         if ($bmwqemu::backend->{backend_pid} && $child == $bmwqemu::backend->{backend_pid}) {
-            bmwqemu::fctwarn("backend $child died");
+            OpenQA::Log::warn("backend $child died");
             $bmwqemu::backend->{backend_pid} = 0;
             $loop = 0;
             next;
         }
         if ($child == $testpid) {
-            bmwqemu::fctwarn("tests died");
+            OpenQA::Log::warn("tests died");
             $testpid = 0;
             $loop    = 0;
             next;
@@ -188,7 +187,7 @@ sub sync_needles_to_cache {
     my $res = system($cmd);
 
     bmwqemu::logdie("Failed to rsync needles: '$@' ") if $res;
-    bmwqemu::diag(sprintf("Rsync: Synchronization of needles directory took %.2f seconds", time - $start));
+    OpenQA::Log::debug(sprintf("Rsync: Synchronization of needles directory took %.2f seconds", time - $start));
     return $shared_cache;
 }
 
@@ -213,7 +212,7 @@ sub calculate_git_hash {
     chomp($test_git_hash = qx{git rev-parse HEAD});
     $test_git_hash ||= "UNKNOWN";
     chdir($dir);
-    bmwqemu::fctwarn("git hash of test distribution: $test_git_hash");
+    OpenQA::Log::warn("git hash of test distribution: $test_git_hash");
     return $test_git_hash;
 }
 
@@ -382,7 +381,7 @@ while ($loop) {
     for my $r (@$reads) {
         my $rsp = myjsonrpc::read_json($r);
         if (!defined $rsp) {
-            bmwqemu::fctwarn(sprintf("THERE IS NOTHING TO READ %d %d %d", fileno($r), fileno($testfd), fileno($cfd)));
+            OpenQA::Log::warn(sprintf("THERE IS NOTHING TO READ %d %d %d", fileno($r), fileno($testfd), fileno($cfd)));
             $r    = 1;
             $loop = 0;
             last;
@@ -493,13 +492,13 @@ if ($testfd) {
     kill_autotest;
 }
 
-bmwqemu::diag("isotovideo " . ($r ? 'failed' : 'done'));
+OpenQA::Log::debug("isotovideo " . ($r ? 'failed' : 'done'));
 
 my $clean_shutdown;
 if (!$r) {
     eval {
         $clean_shutdown = $bmwqemu::backend->_send_json({cmd => 'is_shutdown'});
-        bmwqemu::diag("BACKEND SHUTDOWN $clean_shutdown");
+        OpenQA::Log::debug("BACKEND SHUTDOWN $clean_shutdown");
     };
     # don't rely on the backend in a sane state if we failed - just kill it later
     eval { bmwqemu::stop_vm(); };

--- a/isotovideo
+++ b/isotovideo
@@ -82,7 +82,7 @@ select(STDOUT);            # default
 $| = 1;
 
 
-Log::Log4perl->init($installprefix."/etc/os-autoinst/log4perl.conf");
+Log::Log4perl->init($installprefix . "/etc/os-autoinst/log4perl.conf");
 my $log = Log::Log4perl->get_logger("openqa.os-autoinst.isotovideo");
 $log->info("Isotovideo logger initialized");
 
@@ -90,8 +90,8 @@ $bmwqemu::scriptdir = $installprefix;
 bmwqemu::init();
 
 # Sanity checks
-$log->logdie("CASEDIR environment variable not set, unknown test case directory") if !defined $bmwqemu::vars{CASEDIR};
-$log->logdie("No scripts in $bmwqemu::vars{CASEDIR}") if !-e "$bmwqemu::vars{CASEDIR}";
+bmwqemu::logdie("CASEDIR environment variable not set, unknown test case directory") if !defined $bmwqemu::vars{CASEDIR};
+bmwqemu::logdie("No scripts in $bmwqemu::vars{CASEDIR}") if !-e "$bmwqemu::vars{CASEDIR}";
 
 my $cpid;
 my $testpid;
@@ -153,24 +153,24 @@ sub signalhandler_chld {
 
     while ((my $child = waitpid(-1, WNOHANG)) > 0) {
         if ($child == $cpid) {
-            diag("commands webserver died");
+            bmwqemu::fctwarn("commands webserver died");
             $loop = 0;
             $cpid = 0;
             next;
         }
         if ($bmwqemu::backend->{backend_pid} && $child == $bmwqemu::backend->{backend_pid}) {
-            diag("backend $child died");
+            bmwqemu::fctwarn("backend $child died");
             $bmwqemu::backend->{backend_pid} = 0;
             $loop = 0;
             next;
         }
         if ($child == $testpid) {
-            diag("tests died");
+            bmwqemu::fctwarn("tests died");
             $testpid = 0;
             $loop    = 0;
             next;
         }
-        diag("unknown child $child died");
+        bmwqemu::fcterr("unknown child $child died");
     }
 }
 
@@ -187,7 +187,7 @@ sub sync_needles_to_cache {
     my $cmd = sprintf("flock -E 999 %s/needleslock rsync -aP --delete --exclude=.git %s %s/", $shared_cache, $needles_source, $shared_cache);
     my $res = system($cmd);
 
-    die "Failed to rsync needles: '$@' " if $res;
+    bmwqemu::logdie("Failed to rsync needles: '$@' ") if $res;
     bmwqemu::diag(sprintf("Rsync: Synchronization of needles directory took %.2f seconds", time - $start));
     return $shared_cache;
 }
@@ -213,7 +213,7 @@ sub calculate_git_hash {
     chomp($test_git_hash = qx{git rev-parse HEAD});
     $test_git_hash ||= "UNKNOWN";
     chdir($dir);
-    diag "git hash of test distribution: $test_git_hash";
+    bmwqemu::fctwarn("git hash of test distribution: $test_git_hash");
     return $test_git_hash;
 }
 
@@ -382,7 +382,7 @@ while ($loop) {
     for my $r (@$reads) {
         my $rsp = myjsonrpc::read_json($r);
         if (!defined $rsp) {
-            diag sprintf("THERE IS NOTHING TO READ %d %d %d", fileno($r), fileno($testfd), fileno($cfd));
+            bmwqemu::fctwarn(sprintf("THERE IS NOTHING TO READ %d %d %d", fileno($r), fileno($testfd), fileno($cfd)));
             $r    = 1;
             $loop = 0;
             last;
@@ -393,7 +393,7 @@ while ($loop) {
             next;
         }
         if ($rsp->{cmd} =~ m/^backend_(.*)/) {
-            die "we need to implement a backend queue" if $backend_requester;
+            bmwqemu::fcterr("we need to implement a backend queue") if $backend_requester;
             $backend_requester = $r;
             my $cmd = $1;
             delete $rsp->{cmd};
@@ -475,7 +475,7 @@ while ($loop) {
             check_asserted_screen(1, $no_wait);
             next;
         }
-        die "Unknown command $rsp->{cmd}";
+        bmwqemu::logdie("Unknown command $rsp->{cmd}");
     }
 
     if (defined $tags && !$needinput) {
@@ -493,18 +493,18 @@ if ($testfd) {
     kill_autotest;
 }
 
-diag "isotovideo " . ($r ? 'failed' : 'done');
+bmwqemu::diag("isotovideo " . ($r ? 'failed' : 'done'));
 
 my $clean_shutdown;
 if (!$r) {
     eval {
         $clean_shutdown = $bmwqemu::backend->_send_json({cmd => 'is_shutdown'});
-        diag "BACKEND SHUTDOWN $clean_shutdown";
+        bmwqemu::diag("BACKEND SHUTDOWN $clean_shutdown");
     };
     # don't rely on the backend in a sane state if we failed - just kill it later
     eval { bmwqemu::stop_vm(); };
     if ($@) {
-        diag "Error during stop_vm: $@";
+        bmwqemu::fcterr("Error during stop_vm: $@");
         $r = 1;
     }
 }
@@ -528,7 +528,7 @@ if (!$r && $completed && (my $nd = $bmwqemu::vars{NUMDISKS}) && ($bmwqemu::vars{
         push @toextract, {hdd_num => $i, name => $name, dir => $dir, format => $format};
     }
     if (@toextract && !$clean_shutdown) {
-        diag "ERROR: Machine not shut down when uploading disks!\n";
+        bmwqemu::fcterr("ERROR: Machine not shut down when uploading disks!\n");
         $r = 1;
     }
     else {

--- a/isotovideo
+++ b/isotovideo
@@ -53,7 +53,7 @@ use Carp 'cluck';
 use Time::HiRes qw(gettimeofday tv_interval sleep time);
 use File::Spec;
 use File::Path;
-
+use backend::driver;
 use Log::Log4perl;
 
 # avoid paranoia

--- a/isotovideo
+++ b/isotovideo
@@ -52,8 +52,6 @@ use Carp 'cluck';
 use Time::HiRes qw(gettimeofday tv_interval sleep time);
 use File::Spec;
 use File::Path;
-use backend::driver;
-
 use OpenQA::Log;
 
 # avoid paranoia
@@ -81,7 +79,6 @@ $| = 1;
 select(STDOUT);            # default
 $| = 1;
 
-
 $OpenQA::Log::configuration = $installprefix;
 OpenQA::Log::setup();
 
@@ -89,8 +86,8 @@ $bmwqemu::scriptdir = $installprefix;
 bmwqemu::init();
 
 # Sanity checks
-OpenQA::Log::("CASEDIR environment variable not set, unknown test case directory") if !defined $bmwqemu::vars{CASEDIR};
-OpenQA::Log::("No scripts in $bmwqemu::vars{CASEDIR}") if !-e "$bmwqemu::vars{CASEDIR}";
+OpenQA::Log::die("CASEDIR environment variable not set, unknown test case directory") if !defined $bmwqemu::vars{CASEDIR};
+OpenQA::Log::die("No scripts in $bmwqemu::vars{CASEDIR}") if !-e "$bmwqemu::vars{CASEDIR}";
 
 my $cpid;
 my $testpid;
@@ -215,7 +212,6 @@ sub calculate_git_hash {
     OpenQA::Log::warn("git hash of test distribution: $test_git_hash");
     return $test_git_hash;
 }
-
 
 $SIG{TERM} = \&signalhandler;
 $SIG{INT}  = \&signalhandler;

--- a/isotovideo
+++ b/isotovideo
@@ -79,7 +79,7 @@ $| = 1;
 select(STDOUT);            # default
 $| = 1;
 
-$OpenQA::Log::configuration = $installprefix;
+$OpenQA::Log::configuration = $installprefix."/etc/os-autoinst/";
 OpenQA::Log::setup();
 
 $bmwqemu::scriptdir = $installprefix;

--- a/isotovideo
+++ b/isotovideo
@@ -186,7 +186,7 @@ sub sync_needles_to_cache {
     my $cmd = sprintf("flock -E 999 %s/needleslock rsync -aP --delete --exclude=.git %s %s/", $shared_cache, $needles_source, $shared_cache);
     my $res = system($cmd);
 
-    bmwqemu::logdie("Failed to rsync needles: '$@' ") if $res;
+    OpenQA::Log::die("Failed to rsync needles: '$@' ") if $res;
     OpenQA::Log::debug(sprintf("Rsync: Synchronization of needles directory took %.2f seconds", time - $start));
     return $shared_cache;
 }
@@ -474,7 +474,7 @@ while ($loop) {
             check_asserted_screen(1, $no_wait);
             next;
         }
-        bmwqemu::logdie("Unknown command $rsp->{cmd}");
+        OpenQA::Log::die("Unknown command $rsp->{cmd}");
     }
 
     if (defined $tags && !$needinput) {

--- a/isotovideo
+++ b/isotovideo
@@ -79,8 +79,8 @@ $| = 1;
 select(STDOUT);            # default
 $| = 1;
 
-$configuration = $installprefix."/etc/os-autoinst/";
-setup();
+$OpenQA::Log::configuration = $installprefix . "/etc/os-autoinst/";
+OpenQA::Log::setup();
 
 $bmwqemu::scriptdir = $installprefix;
 bmwqemu::init();

--- a/isotovideo
+++ b/isotovideo
@@ -79,15 +79,15 @@ $| = 1;
 select(STDOUT);            # default
 $| = 1;
 
-$OpenQA::Log::configuration = $installprefix."/etc/os-autoinst/";
-OpenQA::Log::setup();
+$configuration = $installprefix."/etc/os-autoinst/";
+setup();
 
 $bmwqemu::scriptdir = $installprefix;
 bmwqemu::init();
 
 # Sanity checks
-OpenQA::Log::die("CASEDIR environment variable not set, unknown test case directory") if !defined $bmwqemu::vars{CASEDIR};
-OpenQA::Log::die("No scripts in $bmwqemu::vars{CASEDIR}") if !-e "$bmwqemu::vars{CASEDIR}";
+die("CASEDIR environment variable not set, unknown test case directory") if !defined $bmwqemu::vars{CASEDIR};
+die("No scripts in $bmwqemu::vars{CASEDIR}") if !-e "$bmwqemu::vars{CASEDIR}";
 
 my $cpid;
 my $testpid;
@@ -100,9 +100,9 @@ sub kill_commands {
     # create a copy as cpid is overwritten by SIGCHLD
     my $pid = $cpid;
     if (kill('TERM', $pid)) {
-        OpenQA::Log::info("awaiting death of commands process");
+        info("awaiting death of commands process");
         my $ret = waitpid($pid, 0);
-        OpenQA::Log::info("commands process exited: $ret");
+        info("commands process exited: $ret");
     }
     $cpid = 0;
 }
@@ -112,9 +112,9 @@ sub kill_autotest {
     # create a copy as cpid is overwritten by SIGCHLD
     my $pid = $testpid;
     if (kill('TERM', $pid)) {
-        OpenQA::Log::debug "awaiting death of testpid $pid";
+        debug "awaiting death of testpid $pid";
         my $ret = waitpid($pid, 0);
-        OpenQA::Log::debug "test process exited: $ret";
+        debug "test process exited: $ret";
     }
     $testpid = 0;
 }
@@ -123,10 +123,10 @@ sub kill_backend {
     if (defined $bmwqemu::backend && $bmwqemu::backend->{backend_pid}) {
         # save the pid in a scalar - signal handlers will reset it
         my $bpid = $bmwqemu::backend->{backend_pid};
-        OpenQA::Log::debug("killing backend process $bpid");
+        debug("killing backend process $bpid");
         kill('TERM', $bpid);
         waitpid($bpid, 0);
-        OpenQA::Log::debug("done with backend process");
+        debug("done with backend process");
         $bmwqemu::backend->{backend_pid} = 0;
     }
 }
@@ -134,7 +134,7 @@ sub kill_backend {
 sub signalhandler {
 
     my ($sig) = @_;
-    OpenQA::Log::debug("signalhandler got $sig - loop $loop");
+    debug("signalhandler got $sig - loop $loop");
     if ($loop) {
         $loop = 0;
         return;
@@ -149,24 +149,24 @@ sub signalhandler_chld {
 
     while ((my $child = waitpid(-1, WNOHANG)) > 0) {
         if ($child == $cpid) {
-            OpenQA::Log::warn("commands webserver died");
+            warn("commands webserver died");
             $loop = 0;
             $cpid = 0;
             next;
         }
         if ($bmwqemu::backend->{backend_pid} && $child == $bmwqemu::backend->{backend_pid}) {
-            OpenQA::Log::warn("backend $child died");
+            warn("backend $child died");
             $bmwqemu::backend->{backend_pid} = 0;
             $loop = 0;
             next;
         }
         if ($child == $testpid) {
-            OpenQA::Log::warn("tests died");
+            warn("tests died");
             $testpid = 0;
             $loop    = 0;
             next;
         }
-        OpenQA::Log::error("unknown child $child died");
+        error("unknown child $child died");
     }
 }
 
@@ -183,8 +183,8 @@ sub sync_needles_to_cache {
     my $cmd = sprintf("flock -E 999 %s/needleslock rsync -aP --delete --exclude=.git %s %s/", $shared_cache, $needles_source, $shared_cache);
     my $res = system($cmd);
 
-    OpenQA::Log::die("Failed to rsync needles: '$@' ") if $res;
-    OpenQA::Log::debug(sprintf("Rsync: Synchronization of needles directory took %.2f seconds", time - $start));
+    die("Failed to rsync needles: '$@' ") if $res;
+    debug(sprintf("Rsync: Synchronization of needles directory took %.2f seconds", time - $start));
     return $shared_cache;
 }
 
@@ -209,7 +209,7 @@ sub calculate_git_hash {
     chomp($test_git_hash = qx{git rev-parse HEAD});
     $test_git_hash ||= "UNKNOWN";
     chdir($dir);
-    OpenQA::Log::warn("git hash of test distribution: $test_git_hash");
+    warn("git hash of test distribution: $test_git_hash");
     return $test_git_hash;
 }
 
@@ -377,7 +377,7 @@ while ($loop) {
     for my $r (@$reads) {
         my $rsp = myjsonrpc::read_json($r);
         if (!defined $rsp) {
-            OpenQA::Log::warn(sprintf("THERE IS NOTHING TO READ %d %d %d", fileno($r), fileno($testfd), fileno($cfd)));
+            warn(sprintf("THERE IS NOTHING TO READ %d %d %d", fileno($r), fileno($testfd), fileno($cfd)));
             $r    = 1;
             $loop = 0;
             last;
@@ -388,7 +388,7 @@ while ($loop) {
             next;
         }
         if ($rsp->{cmd} =~ m/^backend_(.*)/) {
-            OpenQA::Log::error("we need to implement a backend queue") if $backend_requester;
+            error("we need to implement a backend queue") if $backend_requester;
             $backend_requester = $r;
             my $cmd = $1;
             delete $rsp->{cmd};
@@ -470,7 +470,7 @@ while ($loop) {
             check_asserted_screen(1, $no_wait);
             next;
         }
-        OpenQA::Log::die("Unknown command $rsp->{cmd}");
+        die("Unknown command $rsp->{cmd}");
     }
 
     if (defined $tags && !$needinput) {
@@ -488,18 +488,18 @@ if ($testfd) {
     kill_autotest;
 }
 
-OpenQA::Log::debug("isotovideo " . ($r ? 'failed' : 'done'));
+debug("isotovideo " . ($r ? 'failed' : 'done'));
 
 my $clean_shutdown;
 if (!$r) {
     eval {
         $clean_shutdown = $bmwqemu::backend->_send_json({cmd => 'is_shutdown'});
-        OpenQA::Log::debug("BACKEND SHUTDOWN $clean_shutdown");
+        debug("BACKEND SHUTDOWN $clean_shutdown");
     };
     # don't rely on the backend in a sane state if we failed - just kill it later
     eval { bmwqemu::stop_vm(); };
     if ($@) {
-        OpenQA::Log::error("Error during stop_vm: $@");
+        error("Error during stop_vm: $@");
         $r = 1;
     }
 }
@@ -523,7 +523,7 @@ if (!$r && $completed && (my $nd = $bmwqemu::vars{NUMDISKS}) && ($bmwqemu::vars{
         push @toextract, {hdd_num => $i, name => $name, dir => $dir, format => $format};
     }
     if (@toextract && !$clean_shutdown) {
-        OpenQA::Log::error("ERROR: Machine not shut down when uploading disks!\n");
+        error("ERROR: Machine not shut down when uploading disks!\n");
         $r = 1;
     }
     else {

--- a/isotovideo
+++ b/isotovideo
@@ -89,8 +89,8 @@ $bmwqemu::scriptdir = $installprefix;
 bmwqemu::init();
 
 # Sanity checks
-OpenQA::Log::logdie("CASEDIR environment variable not set, unknown test case directory") if !defined $bmwqemu::vars{CASEDIR};
-OpenQA::Log::logdie("No scripts in $bmwqemu::vars{CASEDIR}") if !-e "$bmwqemu::vars{CASEDIR}";
+OpenQA::Log::("CASEDIR environment variable not set, unknown test case directory") if !defined $bmwqemu::vars{CASEDIR};
+OpenQA::Log::("No scripts in $bmwqemu::vars{CASEDIR}") if !-e "$bmwqemu::vars{CASEDIR}";
 
 my $cpid;
 my $testpid;

--- a/lockapi.pm
+++ b/lockapi.pm
@@ -32,7 +32,7 @@ sub _lock_action {
     my $res = api_call('post', "mutex/$name", $param)->code;
     return 1 if ($res == 200);
 
-    bmwqemu::mydie "mutex lock '$name': lock owner already finished" if $res == 410;
+    OpenQA::Log::die "mutex lock '$name': lock owner already finished" if $res == 410;
 
     if ($res != 409) {
         OpenQA::Log::warn("Unknown return code $res for lock api");
@@ -42,7 +42,7 @@ sub _lock_action {
 
 sub mutex_lock {
     my ($name, $where) = @_;
-    bmwqemu::mydie('missing lock name') unless $name;
+    OpenQA::Log::die('missing lock name') unless $name;
     OpenQA::Log::debug("mutex lock '$name'");
     while (1) {
         my $res = _lock_action($name, $where);
@@ -54,14 +54,14 @@ sub mutex_lock {
 
 sub mutex_try_lock {
     my ($name, $where) = @_;
-    bmwqemu::mydie('missing lock name') unless $name;
+    OpenQA::Log::die('missing lock name') unless $name;
     OpenQA::Log::debug("mutex try lock '$name'");
     return _lock_action($name, $where);
 }
 
 sub mutex_unlock {
     my ($name) = @_;
-    bmwqemu::mydie('missing lock name') unless $name;
+    OpenQA::Log::die('missing lock name') unless $name;
     OpenQA::Log::debug("mutex unlock '$name'");
     my $res = api_call('post', "mutex/$name", {action => 'unlock'})->code;
     return 1 if ($res == 200);
@@ -82,8 +82,8 @@ sub mutex_create {
 ## Barriers
 sub barrier_create {
     my ($name, $tasks) = @_;
-    bmwqemu::mydie('missing barrier name')           unless $name;
-    bmwqemu::mydie('missing number of barrier task') unless $tasks;
+    OpenQA::Log::die('missing barrier name')           unless $name;
+    OpenQA::Log::die('missing number of barrier task') unless $tasks;
     OpenQA::Log::debug("barrier create '$name' for $tasks tasks");
     my $res = api_call('post', 'barrier', {name => $name, tasks => $tasks})->code;
     return 1 if ($res == 200);
@@ -98,7 +98,7 @@ sub _wait_action {
     my $res = api_call('post', "barrier/$name", $param)->code;
     return 1 if ($res == 200);
 
-    bmwqemu::mydie "barrier_wait '$name': barrier owner already finished" if $res == 410;
+    OpenQA::Log::die "barrier_wait '$name': barrier owner already finished" if $res == 410;
 
     if ($res != 409) {
         OpenQA::Log::warn("Unknown return code $res for lock api");
@@ -109,14 +109,14 @@ sub _wait_action {
 # Reason to include this is to be able to unit test _wait_action without blocking
 sub barrier_try_wait {
     my ($name, $where) = @_;
-    bmwqemu::mydie('missing barrier name') unless $name;
+    OpenQA::Log::die('missing barrier name') unless $name;
     OpenQA::Log::debug("barrier try wait '$name'");
     return _wait_action($name, $where);
 }
 
 sub barrier_wait {
     my ($name, $where) = @_;
-    bmwqemu::mydie('missing barrier name') unless $name;
+    OpenQA::Log::die('missing barrier name') unless $name;
     OpenQA::Log::debug("barrier wait '$name'");
     while (1) {
         my $res = _wait_action($name, $where);
@@ -129,7 +129,7 @@ sub barrier_wait {
 
 sub barrier_destroy {
     my ($name, $where) = @_;
-    bmwqemu::mydie('missing barrier name') unless $name;
+    OpenQA::Log::die('missing barrier name') unless $name;
     OpenQA::Log::debug("barrier destroy '$name'");
     my $param;
     $param->{where} = $where if $where;

--- a/lockapi.pm
+++ b/lockapi.pm
@@ -71,7 +71,7 @@ sub mutex_unlock {
 
 sub mutex_create {
     my ($name) = @_;
-    bmwqemu::mydie('missing lock name') unless $name;
+    OpenQA::Log::die('missing lock name') unless $name;
     OpenQA::Log::debug("mutex create '$name'");
     my $res = api_call('post', "mutex", {name => $name})->code;
     return 1 if ($res == 200);

--- a/lockapi.pm
+++ b/lockapi.pm
@@ -35,7 +35,7 @@ sub _lock_action {
     bmwqemu::mydie "mutex lock '$name': lock owner already finished" if $res == 410;
 
     if ($res != 409) {
-        bmwqemu::fctwarn("Unknown return code $res for lock api");
+        OpenQA::Log::warn("Unknown return code $res for lock api");
     }
     return 0;
 }
@@ -43,11 +43,11 @@ sub _lock_action {
 sub mutex_lock {
     my ($name, $where) = @_;
     bmwqemu::mydie('missing lock name') unless $name;
-    bmwqemu::diag("mutex lock '$name'");
+    OpenQA::Log::debug("mutex lock '$name'");
     while (1) {
         my $res = _lock_action($name, $where);
         return 1 if $res;
-        bmwqemu::diag("mutex lock '$name' unavailable, sleeping 5s");
+        OpenQA::Log::debug("mutex lock '$name' unavailable, sleeping 5s");
         sleep(5);
     }
 }
@@ -55,27 +55,27 @@ sub mutex_lock {
 sub mutex_try_lock {
     my ($name, $where) = @_;
     bmwqemu::mydie('missing lock name') unless $name;
-    bmwqemu::diag("mutex try lock '$name'");
+    OpenQA::Log::debug("mutex try lock '$name'");
     return _lock_action($name, $where);
 }
 
 sub mutex_unlock {
     my ($name) = @_;
     bmwqemu::mydie('missing lock name') unless $name;
-    bmwqemu::diag("mutex unlock '$name'");
+    OpenQA::Log::debug("mutex unlock '$name'");
     my $res = api_call('post', "mutex/$name", {action => 'unlock'})->code;
     return 1 if ($res == 200);
-    bmwqemu::fctwarn("Unknown return code $res for lock api") if ($res != 409);
+    OpenQA::Log::warn("Unknown return code $res for lock api") if ($res != 409);
     return 0;
 }
 
 sub mutex_create {
     my ($name) = @_;
     bmwqemu::mydie('missing lock name') unless $name;
-    bmwqemu::diag("mutex create '$name'");
+    OpenQA::Log::debug("mutex create '$name'");
     my $res = api_call('post', "mutex", {name => $name})->code;
     return 1 if ($res == 200);
-    bmwqemu::fctwarn("Unknown return code $res for lock api") if ($res != 409);
+    OpenQA::Log::warn("Unknown return code $res for lock api") if ($res != 409);
     return 0;
 }
 
@@ -84,10 +84,10 @@ sub barrier_create {
     my ($name, $tasks) = @_;
     bmwqemu::mydie('missing barrier name')           unless $name;
     bmwqemu::mydie('missing number of barrier task') unless $tasks;
-    bmwqemu::diag("barrier create '$name' for $tasks tasks");
+    OpenQA::Log::debug("barrier create '$name' for $tasks tasks");
     my $res = api_call('post', 'barrier', {name => $name, tasks => $tasks})->code;
     return 1 if ($res == 200);
-    bmwqemu::fctwarn("Unknown return code $res for lock api") if ($res != 409);
+    OpenQA::Log::warn("Unknown return code $res for lock api") if ($res != 409);
     return 0;
 }
 
@@ -101,7 +101,7 @@ sub _wait_action {
     bmwqemu::mydie "barrier_wait '$name': barrier owner already finished" if $res == 410;
 
     if ($res != 409) {
-        bmwqemu::fctwarn("Unknown return code $res for lock api");
+        OpenQA::Log::warn("Unknown return code $res for lock api");
         return 0;
     }
 }
@@ -110,19 +110,19 @@ sub _wait_action {
 sub barrier_try_wait {
     my ($name, $where) = @_;
     bmwqemu::mydie('missing barrier name') unless $name;
-    bmwqemu::diag("barrier try wait '$name'");
+    OpenQA::Log::debug("barrier try wait '$name'");
     return _wait_action($name, $where);
 }
 
 sub barrier_wait {
     my ($name, $where) = @_;
     bmwqemu::mydie('missing barrier name') unless $name;
-    bmwqemu::diag("barrier wait '$name'");
+    OpenQA::Log::debug("barrier wait '$name'");
     while (1) {
         my $res = _wait_action($name, $where);
         return 1 if $res;
 
-        bmwqemu::diag("barrier '$name' not released, sleeping 5s");
+        OpenQA::Log::debug("barrier '$name' not released, sleeping 5s");
         sleep(5);
     }
 }
@@ -130,12 +130,12 @@ sub barrier_wait {
 sub barrier_destroy {
     my ($name, $where) = @_;
     bmwqemu::mydie('missing barrier name') unless $name;
-    bmwqemu::diag("barrier destroy '$name'");
+    OpenQA::Log::debug("barrier destroy '$name'");
     my $param;
     $param->{where} = $where if $where;
     my $res = api_call('delete', "barrier/$name", $param)->code;
     return 1 if ($res == 200);
-    bmwqemu::fctwarn("Unknown return code $res for lock api");
+    OpenQA::Log::warn("Unknown return code $res for lock api");
 }
 
 1;

--- a/lockapi.pm
+++ b/lockapi.pm
@@ -32,62 +32,62 @@ sub _lock_action {
     my $res = api_call('post', "mutex/$name", $param)->code;
     return 1 if ($res == 200);
 
-    OpenQA::Log::die "mutex lock '$name': lock owner already finished" if $res == 410;
+    die "mutex lock '$name': lock owner already finished" if $res == 410;
 
     if ($res != 409) {
-        OpenQA::Log::warn("Unknown return code $res for lock api");
+        warn("Unknown return code $res for lock api");
     }
     return 0;
 }
 
 sub mutex_lock {
     my ($name, $where) = @_;
-    OpenQA::Log::die('missing lock name') unless $name;
-    OpenQA::Log::debug("mutex lock '$name'");
+    die('missing lock name') unless $name;
+    debug("mutex lock '$name'");
     while (1) {
         my $res = _lock_action($name, $where);
         return 1 if $res;
-        OpenQA::Log::debug("mutex lock '$name' unavailable, sleeping 5s");
+        debug("mutex lock '$name' unavailable, sleeping 5s");
         sleep(5);
     }
 }
 
 sub mutex_try_lock {
     my ($name, $where) = @_;
-    OpenQA::Log::die('missing lock name') unless $name;
-    OpenQA::Log::debug("mutex try lock '$name'");
+    die('missing lock name') unless $name;
+    debug("mutex try lock '$name'");
     return _lock_action($name, $where);
 }
 
 sub mutex_unlock {
     my ($name) = @_;
-    OpenQA::Log::die('missing lock name') unless $name;
-    OpenQA::Log::debug("mutex unlock '$name'");
+    die('missing lock name') unless $name;
+    debug("mutex unlock '$name'");
     my $res = api_call('post', "mutex/$name", {action => 'unlock'})->code;
     return 1 if ($res == 200);
-    OpenQA::Log::warn("Unknown return code $res for lock api") if ($res != 409);
+    warn("Unknown return code $res for lock api") if ($res != 409);
     return 0;
 }
 
 sub mutex_create {
     my ($name) = @_;
-    OpenQA::Log::die('missing lock name') unless $name;
-    OpenQA::Log::debug("mutex create '$name'");
+    die('missing lock name') unless $name;
+    debug("mutex create '$name'");
     my $res = api_call('post', "mutex", {name => $name})->code;
     return 1 if ($res == 200);
-    OpenQA::Log::warn("Unknown return code $res for lock api") if ($res != 409);
+    warn("Unknown return code $res for lock api") if ($res != 409);
     return 0;
 }
 
 ## Barriers
 sub barrier_create {
     my ($name, $tasks) = @_;
-    OpenQA::Log::die('missing barrier name')           unless $name;
-    OpenQA::Log::die('missing number of barrier task') unless $tasks;
-    OpenQA::Log::debug("barrier create '$name' for $tasks tasks");
+    die('missing barrier name')           unless $name;
+    die('missing number of barrier task') unless $tasks;
+    debug("barrier create '$name' for $tasks tasks");
     my $res = api_call('post', 'barrier', {name => $name, tasks => $tasks})->code;
     return 1 if ($res == 200);
-    OpenQA::Log::warn("Unknown return code $res for lock api") if ($res != 409);
+    warn("Unknown return code $res for lock api") if ($res != 409);
     return 0;
 }
 
@@ -98,10 +98,10 @@ sub _wait_action {
     my $res = api_call('post', "barrier/$name", $param)->code;
     return 1 if ($res == 200);
 
-    OpenQA::Log::die "barrier_wait '$name': barrier owner already finished" if $res == 410;
+    die "barrier_wait '$name': barrier owner already finished" if $res == 410;
 
     if ($res != 409) {
-        OpenQA::Log::warn("Unknown return code $res for lock api");
+        warn("Unknown return code $res for lock api");
         return 0;
     }
 }
@@ -109,33 +109,33 @@ sub _wait_action {
 # Reason to include this is to be able to unit test _wait_action without blocking
 sub barrier_try_wait {
     my ($name, $where) = @_;
-    OpenQA::Log::die('missing barrier name') unless $name;
-    OpenQA::Log::debug("barrier try wait '$name'");
+    die('missing barrier name') unless $name;
+    debug("barrier try wait '$name'");
     return _wait_action($name, $where);
 }
 
 sub barrier_wait {
     my ($name, $where) = @_;
-    OpenQA::Log::die('missing barrier name') unless $name;
-    OpenQA::Log::debug("barrier wait '$name'");
+    die('missing barrier name') unless $name;
+    debug("barrier wait '$name'");
     while (1) {
         my $res = _wait_action($name, $where);
         return 1 if $res;
 
-        OpenQA::Log::debug("barrier '$name' not released, sleeping 5s");
+        debug("barrier '$name' not released, sleeping 5s");
         sleep(5);
     }
 }
 
 sub barrier_destroy {
     my ($name, $where) = @_;
-    OpenQA::Log::die('missing barrier name') unless $name;
-    OpenQA::Log::debug("barrier destroy '$name'");
+    die('missing barrier name') unless $name;
+    debug("barrier destroy '$name'");
     my $param;
     $param->{where} = $where if $where;
     my $res = api_call('delete', "barrier/$name", $param)->code;
     return 1 if ($res == 200);
-    OpenQA::Log::warn("Unknown return code $res for lock api");
+    warn("Unknown return code $res for lock api");
 }
 
 1;

--- a/mmapi.pm
+++ b/mmapi.pm
@@ -184,7 +184,7 @@ sub get_job_autoinst_url {
         }
     }
     else {
-        bmwqemu::diag("get_job_autoinst_url: code: " . $res->code);
+        OpenQA::Log::debug("get_job_autoinst_url: code: " . $res->code);
     }
     return;
 }
@@ -214,7 +214,7 @@ sub get_job_autoinst_vars {
         return $res->json('/vars');
     }
     else {
-        bmwqemu::diag("get_job_autoinst_vars: code: " . $res->code);
+        OpenQA::Log::debug("get_job_autoinst_vars: code: " . $res->code);
     }
     return;
 }
@@ -236,7 +236,7 @@ sub wait_for_children {
             $n++;
         }
 
-        bmwqemu::diag("Waiting for $n jobs to finish");
+        OpenQA::Log::debug("Waiting for $n jobs to finish");
         last unless $n;
         sleep 1;
     }
@@ -258,7 +258,7 @@ sub wait_for_children_to_start {
             $n++;
         }
 
-        bmwqemu::diag("Waiting for $n jobs to start");
+        OpenQA::Log::debug("Waiting for $n jobs to start");
         last unless $n;
         sleep 1;
     }

--- a/mmapi.pm
+++ b/mmapi.pm
@@ -66,7 +66,7 @@ sub _init {
 sub api_call {
     my ($method, $action, $params, $expected_codes) = @_;
     _init unless $ua;
-    OpenQA::Log::die('Missing mandatory options') unless $method && $action && $ua;
+    die('Missing mandatory options') unless $method && $action && $ua;
 
     my $ua_url = $url->clone;
     $ua_url->path($action);
@@ -184,7 +184,7 @@ sub get_job_autoinst_url {
         }
     }
     else {
-        OpenQA::Log::debug("get_job_autoinst_url: code: " . $res->code);
+        debug("get_job_autoinst_url: code: " . $res->code);
     }
     return;
 }
@@ -214,7 +214,7 @@ sub get_job_autoinst_vars {
         return $res->json('/vars');
     }
     else {
-        OpenQA::Log::debug("get_job_autoinst_vars: code: " . $res->code);
+        debug("get_job_autoinst_vars: code: " . $res->code);
     }
     return;
 }
@@ -236,7 +236,7 @@ sub wait_for_children {
             $n++;
         }
 
-        OpenQA::Log::debug("Waiting for $n jobs to finish");
+        debug("Waiting for $n jobs to finish");
         last unless $n;
         sleep 1;
     }
@@ -258,7 +258,7 @@ sub wait_for_children_to_start {
             $n++;
         }
 
-        OpenQA::Log::debug("Waiting for $n jobs to start");
+        debug("Waiting for $n jobs to start");
         last unless $n;
         sleep 1;
     }

--- a/mmapi.pm
+++ b/mmapi.pm
@@ -66,7 +66,7 @@ sub _init {
 sub api_call {
     my ($method, $action, $params, $expected_codes) = @_;
     _init unless $ua;
-    bmwqemu::mydie('Missing mandatory options') unless $method && $action && $ua;
+    OpenQA::Log::die('Missing mandatory options') unless $method && $action && $ua;
 
     my $ua_url = $url->clone;
     $ua_url->path($action);

--- a/myjsonrpc.pm
+++ b/myjsonrpc.pm
@@ -94,8 +94,8 @@ sub read_json {
 
         my $qbuffer;
         my $bytes = sysread($socket, $qbuffer, 8000);
-        #OpenQA::Log::debug("sysread $qbuffer");
-        if (!$bytes) { OpenQA::Log::debug("sysread failed: $!"); return; }
+        #OpenQA::Log::trace("sysread $qbuffer");
+        if (!$bytes) { OpenQA::Log::warn("sysread failed: $!"); return; }
         $JSON->incr_parse($qbuffer);
     }
 

--- a/myjsonrpc.pm
+++ b/myjsonrpc.pm
@@ -33,7 +33,7 @@ sub send_json {
     $cmdcopy{json_cmd_token} = bmwqemu::random_string(8);
     my $json = $JSON->encode(\%cmdcopy);
 
-    #OpenQA::Log::debug("send_json $json");
+    #debug("send_json $json");
     my $wb = syswrite($to_fd, "$json");
     confess "syswrite failed $!" unless ($wb && $wb == length($json));
     return $cmdcopy{json_cmd_token};
@@ -69,7 +69,7 @@ sub read_json {
             # remember the trailing text
             $sockets->{$fd} = $JSON->incr_text();
             if ($hash->{QUIT}) {
-                OpenQA::Log::debug("received magic close");
+                debug("received magic close");
                 return;
             }
             if ($cmd_token && ($hash->{json_cmd_token} || '') ne $cmd_token) {
@@ -86,7 +86,7 @@ sub read_json {
                 confess "ERROR: timeout reading JSON reply: $E\n";
             }
             else {
-                OpenQA::Log::die("can_read received kill signal");
+                die("can_read received kill signal");
             }
             close($socket);
             return;
@@ -94,8 +94,8 @@ sub read_json {
 
         my $qbuffer;
         my $bytes = sysread($socket, $qbuffer, 8000);
-        #OpenQA::Log::trace("sysread $qbuffer");
-        if (!$bytes) { OpenQA::Log::warn("sysread failed: $!"); return; }
+        #trace("sysread $qbuffer");
+        if (!$bytes) { warn("sysread failed: $!"); return; }
         $JSON->incr_parse($qbuffer);
     }
 

--- a/myjsonrpc.pm
+++ b/myjsonrpc.pm
@@ -20,6 +20,7 @@ use warnings;
 use Carp qw(cluck confess);
 use bmwqemu ();
 use Errno;
+use OpenQA::Log;
 
 sub send_json {
     my ($to_fd, $cmd) = @_;

--- a/myjsonrpc.pm
+++ b/myjsonrpc.pm
@@ -86,7 +86,7 @@ sub read_json {
                 confess "ERROR: timeout reading JSON reply: $E\n";
             }
             else {
-                bmwqemu::logdie("can_read received kill signal");
+                OpenQA::Log::die("can_read received kill signal");
             }
             close($socket);
             return;

--- a/myjsonrpc.pm
+++ b/myjsonrpc.pm
@@ -33,7 +33,7 @@ sub send_json {
     $cmdcopy{json_cmd_token} = bmwqemu::random_string(8);
     my $json = $JSON->encode(\%cmdcopy);
 
-    #bmwqemu::diag("send_json $json");
+    #OpenQA::Log::debug("send_json $json");
     my $wb = syswrite($to_fd, "$json");
     confess "syswrite failed $!" unless ($wb && $wb == length($json));
     return $cmdcopy{json_cmd_token};
@@ -69,7 +69,7 @@ sub read_json {
             # remember the trailing text
             $sockets->{$fd} = $JSON->incr_text();
             if ($hash->{QUIT}) {
-                bmwqemu::diag("received magic close");
+                OpenQA::Log::debug("received magic close");
                 return;
             }
             if ($cmd_token && ($hash->{json_cmd_token} || '') ne $cmd_token) {
@@ -94,8 +94,8 @@ sub read_json {
 
         my $qbuffer;
         my $bytes = sysread($socket, $qbuffer, 8000);
-        #bmwqemu::diag("sysread $qbuffer");
-        if (!$bytes) { bmwqemu::diag("sysread failed: $!"); return; }
+        #OpenQA::Log::debug("sysread $qbuffer");
+        if (!$bytes) { OpenQA::Log::debug("sysread failed: $!"); return; }
         $JSON->incr_parse($qbuffer);
     }
 

--- a/myjsonrpc.pm
+++ b/myjsonrpc.pm
@@ -86,7 +86,7 @@ sub read_json {
                 confess "ERROR: timeout reading JSON reply: $E\n";
             }
             else {
-                die("can_read received kill signal");
+                bmwqemu::logdie("can_read received kill signal");
             }
             close($socket);
             return;

--- a/needle.pm
+++ b/needle.pm
@@ -25,6 +25,7 @@ use File::Basename;
 require IPC::System::Simple;
 use autodie ':all';
 use OpenQA::Benchmark::Stopwatch;
+use OpenQA::Log;
 
 our %needles;
 our %tags;

--- a/needle.pm
+++ b/needle.pm
@@ -148,7 +148,7 @@ sub register {
     my %check_dups;
     for my $g (@{$self->{tags}}) {
         if ($check_dups{$g}) {
-            bmwqemu::diag("$self->{name} contains $g twice");
+            OpenQA::Log::debug("$self->{name} contains $g twice");
             next;
         }
         $check_dups{$g} = 1;
@@ -167,7 +167,7 @@ sub get_image {
         $watch->stop();
 
         if ($watch->as_data()->{total_time} > 0.1) {
-            bmwqemu::diag(sprintf("load of $self->{png} took %.2f seconds", $watch->as_data()->{total_time}));
+            OpenQA::Log::debug(sprintf("load of $self->{png} took %.2f seconds", $watch->as_data()->{total_time}));
         }
 
         for my $a (@{$self->{area}}) {
@@ -225,13 +225,13 @@ sub init {
     ($needledir, $shared_cache) = @_;
 
     $needledir //= "$bmwqemu::vars{PRODUCTDIR}/needles/";
-    $needledir = abs_path($needledir) // bmwqemu::logdie("needledir not found: $needledir (check vars.json?)");
+    -d $needledir || die "needledir not found: $needledir (check vars.json?)";
 
     %needles = ();
     %tags    = ();
-    bmwqemu::diag("init needles from $needledir");
+    OpenQA::Log::debug("init needles from $needledir");
     find({no_chdir => 1, wanted => \&wanted_, follow => 1}, $needledir);
-    bmwqemu::diag(sprintf("loaded %d needles", scalar keys %needles));
+    OpenQA::Log::debug(sprintf("loaded %d needles", scalar keys %needles));
 
     if ($cleanuphandler) {
         &$cleanuphandler();

--- a/needle.pm
+++ b/needle.pm
@@ -148,7 +148,7 @@ sub register {
     my %check_dups;
     for my $g (@{$self->{tags}}) {
         if ($check_dups{$g}) {
-            OpenQA::Log::debug("$self->{name} contains $g twice");
+            debug("$self->{name} contains $g twice");
             next;
         }
         $check_dups{$g} = 1;
@@ -167,7 +167,7 @@ sub get_image {
         $watch->stop();
 
         if ($watch->as_data()->{total_time} > 0.1) {
-            OpenQA::Log::debug(sprintf("load of $self->{png} took %.2f seconds", $watch->as_data()->{total_time}));
+            debug(sprintf("load of $self->{png} took %.2f seconds", $watch->as_data()->{total_time}));
         }
 
         for my $a (@{$self->{area}}) {
@@ -229,9 +229,9 @@ sub init {
 
     %needles = ();
     %tags    = ();
-    OpenQA::Log::debug("init needles from $needledir");
+    debug("init needles from $needledir");
     find({no_chdir => 1, wanted => \&wanted_, follow => 1}, $needledir);
-    OpenQA::Log::debug(sprintf("loaded %d needles", scalar keys %needles));
+    debug(sprintf("loaded %d needles", scalar keys %needles));
 
     if ($cleanuphandler) {
         &$cleanuphandler();

--- a/needle.pm
+++ b/needle.pm
@@ -225,7 +225,7 @@ sub init {
     ($needledir, $shared_cache) = @_;
 
     $needledir //= "$bmwqemu::vars{PRODUCTDIR}/needles/";
-    -d $needledir || die "needledir not found: $needledir (check vars.json?)";
+    $needledir = abs_path($needledir) // bmwqemu::logdie("needledir not found: $needledir (check vars.json?)");
 
     %needles = ();
     %tags    = ();

--- a/ppmclibs/tinycv.pm
+++ b/ppmclibs/tinycv.pm
@@ -69,7 +69,7 @@ sub search_ {
 
     my $needle_image = $needle->get_image;
     unless ($needle_image) {
-        bmwqemu::diag("SKIP($needle->{name}:missing PNG)");
+        OpenQA::Log::debug("SKIP($needle->{name}:missing PNG)");
         return;
     }
     $stopwatch->lap("**++ search__: get image") if $stopwatch;
@@ -119,7 +119,7 @@ sub search_ {
     }
 
     $ret->{error} = mean_square_error($ret->{area});
-    bmwqemu::diag(sprintf("MATCH(%s:%.2f)", $needle->{name}, 1 - sqrt($ret->{error})));
+    OpenQA::Log::debug(sprintf("MATCH(%s:%.2f)", $needle->{name}, 1 - sqrt($ret->{error})));
     $stopwatch->lap("**++ mean_square_error") if $stopwatch;
     if ($ret->{ok}) {
         for my $a (@ocr) {

--- a/ppmclibs/tinycv.pm
+++ b/ppmclibs/tinycv.pm
@@ -69,7 +69,7 @@ sub search_ {
 
     my $needle_image = $needle->get_image;
     unless ($needle_image) {
-        OpenQA::Log::debug("SKIP ($needle->{name}:missing PNG)");
+        debug("SKIP ($needle->{name}:missing PNG)");
         return;
     }
     $stopwatch->lap("**++ search__: get image") if $stopwatch;
@@ -119,7 +119,7 @@ sub search_ {
     }
 
     $ret->{error} = mean_square_error($ret->{area});
-    OpenQA::Log::debug(sprintf("MATCH(%s:%.2f)", $needle->{name}, 1 - sqrt($ret->{error})));
+    debug(sprintf("MATCH(%s:%.2f)", $needle->{name}, 1 - sqrt($ret->{error})));
     $stopwatch->lap("**++ mean_square_error") if $stopwatch;
     if ($ret->{ok}) {
         for my $a (@ocr) {

--- a/ppmclibs/tinycv.pm
+++ b/ppmclibs/tinycv.pm
@@ -19,8 +19,6 @@ package tinycv;
 use strict;
 use warnings;
 
-use bmwqemu 'diag';
-
 use File::Basename;
 use Math::Complex 'sqrt';
 
@@ -35,6 +33,7 @@ our $VERSION = '1.0';
 bootstrap tinycv $VERSION;
 
 package tinycv::Image;
+use OpenQA::Log;
 
 sub mean_square_error {
     my ($areas) = @_;

--- a/ppmclibs/tinycv.pm
+++ b/ppmclibs/tinycv.pm
@@ -69,7 +69,7 @@ sub search_ {
 
     my $needle_image = $needle->get_image;
     unless ($needle_image) {
-        OpenQA::Log::debug("SKIP($needle->{name}:missing PNG)");
+        OpenQA::Log::debug("SKIP ($needle->{name}:missing PNG)");
         return;
     }
     $stopwatch->lap("**++ search__: get image") if $stopwatch;

--- a/t/01-test_needle.t
+++ b/t/01-test_needle.t
@@ -30,8 +30,8 @@ cv::init();
 require tinycv;
 
 use OpenQA::Log;
-$OpenQA::Log::configuration = dirname(__FILE__).'/data/';
-OpenQA::Log::setup();
+$configuration = dirname(__FILE__).'/data/';
+setup();
 
 my ($res, $needle, $img1, $cand);
 

--- a/t/01-test_needle.t
+++ b/t/01-test_needle.t
@@ -9,7 +9,6 @@ use File::Basename;
 use File::Path 'make_path';
 use File::Temp 'tempdir';
 
-
 # optional but very useful
 eval 'use Test::More::Color';                 ## no critic
 eval 'use Test::More::Color "foreground"';    ## no critic
@@ -30,8 +29,8 @@ cv::init();
 require tinycv;
 
 use OpenQA::Log;
-$configuration = dirname(__FILE__).'/data/';
-setup();
+$OpenQA::Log::configuration = dirname(__FILE__) . '/data/';
+OpenQA::Log::setup();
 
 my ($res, $needle, $img1, $cand);
 
@@ -309,8 +308,7 @@ ok(-f $needle->{png}, 'png file is accessible');
 ok($needle = needle->new('out-of-def-prj/test/data/other-desktop-dvd-20140904.json'), 'needle object created with relpath');
 is($needle->{file}, 'out-of-def-prj/test/data/other-desktop-dvd-20140904.json', 'needle json file path is left intact');
 
-eval { $needle = needle->new('out-of-prj/test/data/some-needle.json') };
-ok($@, 'died when accessing needle outside of prjdir');
+dies_ok { $needle = needle->new('out-of-prj/test/data/some-needle.json') } 'died when accessing needle outside of prjdir';
 
 done_testing();
 

--- a/t/01-test_needle.t
+++ b/t/01-test_needle.t
@@ -9,6 +9,7 @@ use File::Basename;
 use File::Path 'make_path';
 use File::Temp 'tempdir';
 
+
 # optional but very useful
 eval 'use Test::More::Color';                 ## no critic
 eval 'use Test::More::Color "foreground"';    ## no critic
@@ -20,11 +21,17 @@ BEGIN {
     $bmwqemu::vars{PRJDIR}  = dirname(__FILE__);
 }
 
+
+
 use needle;
 use cv;
 
 cv::init();
 require tinycv;
+
+use OpenQA::Log;
+$OpenQA::Log::configuration = dirname(__FILE__).'/data/';
+OpenQA::Log::setup();
 
 my ($res, $needle, $img1, $cand);
 
@@ -38,8 +45,9 @@ is($needle->has_tag('foobar'),        0, "tag not found");
 
 is($needle->has_property('glossy'), 1, "property found");
 is($needle->has_property('dull'),   0, "property not found");
-
+print "Here";
 $res = $img1->search($needle);
+print "There";
 
 ok(defined $res, "match with exclude area");
 

--- a/t/02-test_ocr.t
+++ b/t/02-test_ocr.t
@@ -16,6 +16,11 @@ use needle;
 use cv;
 use ocr;
 
+
+use OpenQA::Log;
+$OpenQA::Log::configuration = dirname(__FILE__).'/data/';
+OpenQA::Log::setup();
+
 cv::init();
 require tinycv;
 

--- a/t/02-test_ocr.t
+++ b/t/02-test_ocr.t
@@ -18,8 +18,8 @@ use ocr;
 
 
 use OpenQA::Log;
-$configuration = dirname(__FILE__).'/data/';
-setup();
+$OpenQA::Log::configuration = dirname(__FILE__) . '/data/';
+OpenQA::Log::setup();
 
 cv::init();
 require tinycv;

--- a/t/02-test_ocr.t
+++ b/t/02-test_ocr.t
@@ -18,8 +18,8 @@ use ocr;
 
 
 use OpenQA::Log;
-$OpenQA::Log::configuration = dirname(__FILE__).'/data/';
-OpenQA::Log::setup();
+$configuration = dirname(__FILE__).'/data/';
+setup();
 
 cv::init();
 require tinycv;

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -13,8 +13,8 @@ BEGIN {
 }
 
 use OpenQA::Log;
-$configuration = dirname(__FILE__).'/data/';
-setup();
+$OpenQA::Log::configuration = dirname(__FILE__) . '/data/';
+OpenQA::Log::setup();
 
 require bmwqemu;
 

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -13,8 +13,8 @@ BEGIN {
 }
 
 use OpenQA::Log;
-$OpenQA::Log::configuration = dirname(__FILE__).'/data/';
-OpenQA::Log::setup();
+$configuration = dirname(__FILE__).'/data/';
+setup();
 
 require bmwqemu;
 

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -5,10 +5,16 @@ use warnings;
 use Test::More;
 use Test::Output;
 use Test::Fatal;
+use File::Basename;
+
 
 BEGIN {
     unshift @INC, '..';
 }
+
+use OpenQA::Log;
+$OpenQA::Log::configuration = dirname(__FILE__).'/data/';
+OpenQA::Log::setup();
 
 require bmwqemu;
 
@@ -106,9 +112,9 @@ is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 5, text => 'hal
 $cmds = [];
 
 is($autotest::current_test->{dents}, 0, 'no soft failures so far');
-stderr_like(\&record_soft_failure, qr/record_soft_failure\(reason=undef\)/, 'soft failure recorded in log');
+stdout_like(\&record_soft_failure, qr/record_soft_failure\(reason=undef\)/, 'soft failure recorded in log');
 is($autotest::current_test->{dents}, 1, 'soft failure recorded');
-stderr_like(sub { record_soft_failure('workaround for bug#1234') }, qr/record_soft_failure.*reason=.*workaround for bug#1234.*/, 'soft failure with reason');
+stdout_like(sub { record_soft_failure('workaround for bug#1234') }, qr/record_soft_failure.*reason=.*workaround for bug#1234.*/, 'soft failure with reason');
 is($autotest::current_test->{dents}, 2, 'another');
 my $details = $autotest::current_test->{details}[-1];
 is($details->{title}, 'Soft Failed', 'title for soft failure added');

--- a/t/06-pod-coverage.t
+++ b/t/06-pod-coverage.t
@@ -18,5 +18,5 @@ my $pc = Pod::Coverage->new(
     package  => 'testapi',
     pod_from => 'testapi.pm',
 );
-is($pc->coverage, 1, 'Everything in testapi covered') || diag('Uncovered: ', join(', ', $pc->uncovered), "\n");
+is($pc->coverage, 1, 'Everything in testapi covered') || OpenQA::Log::debug('Uncovered: ', join(', ', $pc->uncovered), "\n");
 done_testing();

--- a/t/06-pod-coverage.t
+++ b/t/06-pod-coverage.t
@@ -18,5 +18,5 @@ my $pc = Pod::Coverage->new(
     package  => 'testapi',
     pod_from => 'testapi.pm',
 );
-is($pc->coverage, 1, 'Everything in testapi covered') || OpenQA::Log::debug('Uncovered: ', join(', ', $pc->uncovered), "\n");
+is($pc->coverage, 1, 'Everything in testapi covered') || die('Uncovered: ', join(', ', $pc->uncovered), "\n");
 done_testing();

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -13,10 +13,9 @@ BEGIN {
     unshift @INC, '..';
 }
 
-
 use OpenQA::Log;
-$configuration = dirname(__FILE__).'/data/';
-setup();
+$OpenQA::Log::configuration = dirname(__FILE__) . '/data/';
+OpenQA::Log::setup();
 
 use autotest;
 use bmwqemu;

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -15,8 +15,8 @@ BEGIN {
 
 
 use OpenQA::Log;
-$OpenQA::Log::configuration = dirname(__FILE__).'/data/';
-OpenQA::Log::setup();
+$configuration = dirname(__FILE__).'/data/';
+setup();
 
 use autotest;
 use bmwqemu;

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -6,11 +6,17 @@ use Test::More;
 use Test::Output;
 use Test::Fatal;
 use Test::MockModule;
-use File::Basename ();
+use File::Basename;
+
 
 BEGIN {
     unshift @INC, '..';
 }
+
+
+use OpenQA::Log;
+$OpenQA::Log::configuration = dirname(__FILE__).'/data/';
+OpenQA::Log::setup();
 
 use autotest;
 use bmwqemu;
@@ -20,7 +26,7 @@ my @sent;
 
 
 like(exception { autotest::runalltests }, qr/ERROR: no tests loaded/, 'runalltests needs tests loaded first');
-stderr_like(
+stdout_like(
     sub {
         like(exception { autotest::loadtest 'does/not/match' }, qr/loadtest needs a script to match/);
     },
@@ -29,7 +35,7 @@ stderr_like(
 
 sub loadtest {
     my ($test, $args) = @_;
-    stderr_like(sub { autotest::loadtest "tests/$test.pm" }, qr@scheduling $test[0-9]? tests/$test.pm@, \$args);
+    stdout_like(sub { autotest::loadtest "tests/$test.pm" }, qr@scheduling $test[0-9]? tests/$test.pm@, \$args);
 }
 
 sub fake_send {

--- a/t/09-lockapi.t
+++ b/t/09-lockapi.t
@@ -4,12 +4,19 @@ use strict;
 use warnings;
 use Test::More;
 use Test::MockModule;
+use File::Basename;
+
 
 BEGIN {
     unshift @INC, '..';
 }
 
 use lockapi;
+
+
+use OpenQA::Log;
+$OpenQA::Log::configuration = dirname(__FILE__).'/data/';
+OpenQA::Log::setup();
 
 # mock api_call return value
 my $api_call_return;

--- a/t/09-lockapi.t
+++ b/t/09-lockapi.t
@@ -15,8 +15,8 @@ use lockapi;
 
 
 use OpenQA::Log;
-$OpenQA::Log::configuration = dirname(__FILE__).'/data/';
-OpenQA::Log::setup();
+$configuration = dirname(__FILE__).'/data/';
+setup();
 
 # mock api_call return value
 my $api_call_return;

--- a/t/09-lockapi.t
+++ b/t/09-lockapi.t
@@ -15,8 +15,8 @@ use lockapi;
 
 
 use OpenQA::Log;
-$configuration = dirname(__FILE__).'/data/';
-setup();
+$OpenQA::Log::configuration = dirname(__FILE__) . '/data/';
+OpenQA::Log::setup();
 
 # mock api_call return value
 my $api_call_return;

--- a/t/10-terminal.t
+++ b/t/10-terminal.t
@@ -30,8 +30,8 @@ BEGIN {
 
 
 use OpenQA::Log;
-$OpenQA::Log::configuration = dirname(__FILE__).'/data/';
-OpenQA::Log::setup();
+$configuration = dirname(__FILE__).'/data/';
+setup();
 
 use consoles::virtio_terminal;
 use testapi ();

--- a/t/10-terminal.t
+++ b/t/10-terminal.t
@@ -30,8 +30,8 @@ BEGIN {
 
 
 use OpenQA::Log;
-$configuration = dirname(__FILE__).'/data/';
-setup();
+$OpenQA::Log::configuration = dirname(__FILE__) . '/data/';
+OpenQA::Log::setup();
 
 use consoles::virtio_terminal;
 use testapi ();

--- a/t/10-terminal.t
+++ b/t/10-terminal.t
@@ -19,12 +19,19 @@ use POSIX qw( :sys_wait_h sigprocmask sigsuspend );
 use Socket qw( PF_UNIX SOCK_STREAM sockaddr_un );
 use Time::HiRes 'usleep';
 use File::Temp 'tempfile';
+use File::Basename;
+
 
 use Test::More;
 
 BEGIN {
     unshift @INC, '..';
 }
+
+
+use OpenQA::Log;
+$OpenQA::Log::configuration = dirname(__FILE__).'/data/';
+OpenQA::Log::setup();
 
 use consoles::virtio_terminal;
 use testapi ();

--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -39,6 +39,6 @@ open($var, '>', 'live_log');
 close($var);
 system("perl $toplevel_dir/isotovideo -d 2>&1 | tee autoinst-log.txt");
 is(system('grep -q "\d*: EXIT 0" autoinst-log.txt'),     0,   'test executed fine');
-is(system("grep -q 'test \w* failed' autoinst-log.txt"), 256, 'no test moduled failed');
+is(system("grep -q 'test \\w* failed' autoinst-log.txt"), 256, 'no test moduled failed');
 
 done_testing();

--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -38,7 +38,7 @@ close($var);
 open($var, '>', 'live_log');
 close($var);
 system("perl $toplevel_dir/isotovideo -d 2>&1 | tee autoinst-log.txt");
-is(system('grep -q "\d*: EXIT 0" autoinst-log.txt'),     0,   'test executed fine');
+is(system('grep -q "\d*: EXIT 0" autoinst-log.txt'),      0,   'test executed fine');
 is(system("grep -q 'test \\w* failed' autoinst-log.txt"), 256, 'no test moduled failed');
 
 done_testing();

--- a/testapi.pm
+++ b/testapi.pm
@@ -193,13 +193,13 @@ sub _check_backend_response {
         my $img = tinycv::from_ppm(decode_base64($rsp->{image}));
         $autotest::current_test->record_screenmatch($img, $foundneedle, $tags, $rsp->{candidates});
         my $lastarea = $foundneedle->{area}->[-1];
-        OpenQA::Log::debug(
+        debug(
             sprintf("found %s, similarity %.2f @ %d/%d", $foundneedle->{needle}->{name}, $lastarea->{similarity}, $lastarea->{x}, $lastarea->{y}));
         $last_matched_needle = $foundneedle;
         return $foundneedle;
     }
     elsif ($rsp->{timeout}) {
-        OpenQA::Log::debug("match=" . join(',', @$tags) . " timed out after $timeout");
+        debug("match=" . join(',', @$tags) . " timed out after $timeout");
         my $failed_screens = $rsp->{failed_screens};
         my $final_mismatch = $failed_screens->[-1];
         if ($check) {
@@ -362,7 +362,7 @@ sub assert_and_click {
     my $ry       = 1;                                                  # $origy / $img->yres();
     my $x        = int(($lastarea->{x} + $lastarea->{w} / 2) * $rx);
     my $y        = int(($lastarea->{y} + $lastarea->{h} / 2) * $ry);
-    OpenQA::Log::debug("clicking at $x/$y");
+    debug("clicking at $x/$y");
     mouse_set($x, $y);
     if ($dclick) {
         mouse_dclick($button, $clicktime);
@@ -428,15 +428,15 @@ sub wait_screen_change(&@) {
 
     while (time - $starttime < $timeout) {
         my $sim = query_isotovideo('backend_similiarity_to_reference')->{sim};
-        OpenQA::Log::debug "waiting for screen change: " . (time - $starttime) . " $sim\n";
+        debug "waiting for screen change: " . (time - $starttime) . " $sim\n";
         if ($sim < $similarity_level) {
-            OpenQA::Log::debug("screen change seen at " . (time - $starttime));
+            debug("screen change seen at " . (time - $starttime));
             return 1;
         }
         sleep(0.5);
     }
     save_screenshot;
-    OpenQA::Log::debug("timed out");
+    debug("timed out");
     return 0;
 }
 
@@ -494,13 +494,13 @@ sub wait_still_screen {
             query_isotovideo('backend_set_reference_screenshot');
         }
         if (($now->[0] - $lastchangetime->[0]) + ($now->[1] - $lastchangetime->[1]) / 1000000. >= $stilltime) {
-            OpenQA::Log::debug("detected same image for $stilltime seconds");
+            debug("detected same image for $stilltime seconds");
             return 1;
         }
         sleep(0.5);
     }
     $autotest::current_test->timeout_screenshot();
-    OpenQA::Log::debug("wait_still_screen timed out after $timeout");
+    debug("wait_still_screen timed out after $timeout");
     return 0;
 }
 
@@ -666,7 +666,7 @@ sub wait_serial {
         $matched = 'fail';
     }
     $autotest::current_test->record_serialresult(bmwqemu::pp($regexp), $matched, $ret->{string});
-    OpenQA::Log::debug("$regexp: $matched");
+    debug("$regexp: $matched");
     return $ret->{string} if ($matched eq "ok");
     return;    # false
 }
@@ -880,12 +880,12 @@ sub validate_script_output($&;$) {
     $_ = $output;
     if (!$code->()) {
         $res = 'fail';
-        OpenQA::Log::warn("output does not pass the code block:\n$output");
+        warn("output does not pass the code block:\n$output");
     }
     # abusing the function
     $autotest::current_test->record_serialresult($output, $res, $output);
     if ($res eq 'fail') {
-        OpenQA::Log::warn("output not validating");
+        warn("output not validating");
     }
 }
 
@@ -1378,7 +1378,7 @@ sub assert_shutdown {
     while ($timeout >= 0) {
         my $is_shutdown = query_isotovideo('backend_is_shutdown') || 0;
         if ($is_shutdown < 0) {
-            OpenQA::Log::debug("Backend does not implement is_shutdown - just sleeping");
+            debug("Backend does not implement is_shutdown - just sleeping");
             sleep($timeout);
         }
         # -1 counts too
@@ -1426,9 +1426,9 @@ sub save_memory_dump {
     $args->{filename} ||= ref($autotest::current_test);
 
     bmwqemu::log_call();
-    OpenQA::Log::debug "If save_memory_dump is called multiple times with the same '\$filename', it will be rewritten."
+    debug "If save_memory_dump is called multiple times with the same '\$filename', it will be rewritten."
       unless ((caller(1))[3]) =~ /post_fail_hook/;
-    OpenQA::Log::debug("Trying to save machine state");
+    debug("Trying to save machine state");
 
     query_isotovideo('backend_save_memory_dump', $args);
 }
@@ -1451,7 +1451,7 @@ sub save_storage_drives {
     die "Method should be called within a post_fail_hook" unless ((caller(1))[3]) =~ /post_fail_hook/;
 
     bmwqemu::log_call();
-    OpenQA::Log::debug("Trying to save machine drives");
+    debug("Trying to save machine drives");
     bmwqemu::load_vars();
 
     # Right now, we're saving all the disks
@@ -1624,10 +1624,10 @@ sub wait_idle {
         threshold => get_var('IDLETHRESHOLD', 18)};
     my $rsp = query_isotovideo('backend_wait_idle', $args);
     if ($rsp && $rsp->{idle}) {
-        OpenQA::Log::debug("idle detected");
+        debug("idle detected");
     }
     else {
-        OpenQA::Log::debug("timed out after $timeout");
+        debug("timed out after $timeout");
     }
     return;
 }
@@ -1646,7 +1646,7 @@ Write a diagnostic message to the logfile. In color, if possible.
 
 sub diag {
     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
-    return OpenQA::Log::debug(@_);
+    return debug(@_);
 }
 
 =head2 autoinst_url

--- a/testapi.pm
+++ b/testapi.pm
@@ -361,7 +361,7 @@ sub assert_and_click {
     my $ry       = 1;                                                  # $origy / $img->yres();
     my $x        = int(($lastarea->{x} + $lastarea->{w} / 2) * $rx);
     my $y        = int(($lastarea->{y} + $lastarea->{h} / 2) * $ry);
-    bmwqemu::diag("clicking at $x/$y");
+    OpenQA::Log::debug("clicking at $x/$y");
     mouse_set($x, $y);
     if ($dclick) {
         mouse_dclick($button, $clicktime);
@@ -879,7 +879,7 @@ sub validate_script_output($&;$) {
     $_ = $output;
     if (!$code->()) {
         $res = 'fail';
-        bmwqemu::diag("output does not pass the code block:\n$output");
+        OpenQA::Log::debug("output does not pass the code block:\n$output");
     }
     # abusing the function
     $autotest::current_test->record_serialresult($output, $res, $output);
@@ -1377,7 +1377,7 @@ sub assert_shutdown {
     while ($timeout >= 0) {
         my $is_shutdown = query_isotovideo('backend_is_shutdown') || 0;
         if ($is_shutdown < 0) {
-            bmwqemu::diag("Backend does not implement is_shutdown - just sleeping");
+            OpenQA::Log::debug("Backend does not implement is_shutdown - just sleeping");
             sleep($timeout);
         }
         # -1 counts too
@@ -1425,8 +1425,9 @@ sub save_memory_dump {
     $args->{filename} ||= ref($autotest::current_test);
 
     bmwqemu::log_call();
-    bmwqemu::diag "If save_memory_dump is called multiple times with the same '\$filename', it will be rewritten." unless ((caller(1))[3]) =~ /post_fail_hook/;
-    bmwqemu::diag("Trying to save machine state");
+    OpenQA::Log::debug "If save_memory_dump is called multiple times with the same '\$filename', it will be rewritten."
+      unless ((caller(1))[3]) =~ /post_fail_hook/;
+    OpenQA::Log::debug("Trying to save machine state");
 
     query_isotovideo('backend_save_memory_dump', $args);
 }
@@ -1449,7 +1450,7 @@ sub save_storage_drives {
     die "Method should be called within a post_fail_hook" unless ((caller(1))[3]) =~ /post_fail_hook/;
 
     bmwqemu::log_call();
-    bmwqemu::diag("Trying to save machine drives");
+    OpenQA::Log::debug("Trying to save machine drives");
     bmwqemu::load_vars();
 
     # Right now, we're saving all the disks
@@ -1644,7 +1645,7 @@ Write a diagnostic message to the logfile. In color, if possible.
 
 sub diag {
     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
-    return bmwqemu::diag(@_);
+    return OpenQA::Log::debug(@_);
 }
 
 =head2 autoinst_url

--- a/testapi.pm
+++ b/testapi.pm
@@ -879,12 +879,12 @@ sub validate_script_output($&;$) {
     $_ = $output;
     if (!$code->()) {
         $res = 'fail';
-        OpenQA::Log::debug("output does not pass the code block:\n$output");
+        OpenQA::Log::warn("output does not pass the code block:\n$output");
     }
     # abusing the function
     $autotest::current_test->record_serialresult($output, $res, $output);
     if ($res eq 'fail') {
-        croak "output not validating";
+        OpenQA::Log::warn("output not validating");
     }
 }
 
@@ -1426,7 +1426,7 @@ sub save_memory_dump {
 
     bmwqemu::log_call();
     OpenQA::Log::debug "If save_memory_dump is called multiple times with the same '\$filename', it will be rewritten."
-      unless ((caller(1))[3]) =~ /post_fail_hook/;
+     unless ((caller(1))[3]) =~ /post_fail_hook/;
     OpenQA::Log::debug("Trying to save machine state");
 
     query_isotovideo('backend_save_memory_dump', $args);

--- a/testapi.pm
+++ b/testapi.pm
@@ -31,6 +31,7 @@ use OpenQA::Exceptions;
 use Digest::MD5 'md5_base64';
 use Carp qw(cluck croak);
 use MIME::Base64 'decode_base64';
+use OpenQA::Log;
 
 require bmwqemu;
 
@@ -193,8 +194,7 @@ sub _check_backend_response {
         my $img = tinycv::from_ppm(decode_base64($rsp->{image}));
         $autotest::current_test->record_screenmatch($img, $foundneedle, $tags, $rsp->{candidates});
         my $lastarea = $foundneedle->{area}->[-1];
-        debug(
-            sprintf("found %s, similarity %.2f @ %d/%d", $foundneedle->{needle}->{name}, $lastarea->{similarity}, $lastarea->{x}, $lastarea->{y}));
+        debug(sprintf("found %s, similarity %.2f @ %d/%d", $foundneedle->{needle}->{name}, $lastarea->{similarity}, $lastarea->{x}, $lastarea->{y}));
         $last_matched_needle = $foundneedle;
         return $foundneedle;
     }

--- a/testapi.pm
+++ b/testapi.pm
@@ -109,7 +109,8 @@ os-autoinst is used in the openQA project.
 
 =head2 init
 
-Used for internal initialization, do not call from tests.
+Sets the C<$serialdev> if the variable is set on the I<vars.json> file, otherwise
+it will try to set it using the C<get_var(BACKEND)> variable.
 
 =cut
 
@@ -147,7 +148,7 @@ sub set_distribution {
 
 =for stopwords SUT
 
-=head1 video output handling
+=head1 Video output handling
 
 =head2 save_screenshot
 
@@ -1642,6 +1643,7 @@ Write a diagnostic message to the logfile. In color, if possible.
 =cut
 
 sub diag {
+    local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
     return bmwqemu::diag(@_);
 }
 


### PR DESCRIPTION
The intent for this is to have improved logging facility that would allow for better searching and monitoring of log files (As everything is basically passed though bmwqemu).

A run with this changes can be seen here: http://deimos.suse.de/tests/1368

Ideally, we'll be able to have something similar like the attached image which requires some work on the webui:
![screenshot from 2017-01-11 10-10-09](https://cloud.githubusercontent.com/assets/229240/21842332/9300c21c-d7e6-11e6-96e2-ece85f6274ff.png) 

Oh! and also, we no longer need to use print "Line\n"; 

The log currently looks like this:
```
[84257] INFO 2017-01-10 17:06:10,319 os-autoinst testapi::send_key (894) - >>> /var/lib/openqa/share/tests/opensuse/tests/installation/bootloader.pm:32 called testapi::send_key
[84257] INFO 2017-01-10 17:06:10,319 os-autoinst bootloader::run (32) - ::: <<< testapi::send_key(key='ret')
[84459] INFO 2017-01-10 17:06:10,521 os-autoinst basetest::runtest (346) - ||| finished bootloader installation at 2017-01-10 16:06:10 (82 s)
[84460] INFO 2017-01-10 17:06:10,521 os-autoinst autotest::runalltests (233) - ||| starting welcome tests/installation/welcome.pm at 2017-01-10 16:06:10
[84460] INFO 2017-01-10 17:06:10,522 os-autoinst autotest::make_snapshot (102) - Creating a VM snapshot installation-welcome
[84554] INFO 2017-01-10 17:06:10,616 os-autoinst backend::qemu::save_snapshot (207) - SAVED installation-welcome savevm installation-welcome
[84554] INFO 2017-01-10 17:06:10,616 os-autoinst testapi::assert_screen (260) - >>> /var/lib/openqa/share/tests/opensuse/tests/installation/welcome.pm:31 called testapi::assert_screen
[84555] INFO 2017-01-10 17:06:10,616 os-autoinst welcome::run (31) - ::: <<< testapi::assert_screen(mustmatch=[
  'inst-welcome',
  'inst-welcome-confirm-self-update-server'
], timeout=500)
[84689] INFO 2017-01-10 17:06:10,751 os-autoinst tinycv::Image::search_ (122) - MATCH(inst-welcome-20150131:0.00)
[84819] INFO 2017-01-10 17:06:10,881 os-autoinst tinycv::Image::search_ (122) - MATCH(inst-welcome-20151113:0.00)
[84955] INFO 2017-01-10 17:06:11,016 os-autoinst tinycv::Image::search_ (122) - MATCH(inst-welcome-20160915:0.00)
[84955] WARN 2017-01-10 17:06:11,016 os-autoinst backend::baseclass::check_asserted_screen (883) - !!! no match 500
```

And as for backend calls:
```
[992] DEBUG 2017-01-10 17:04:47,053 os-autoinst consoles::vnc_base::try {...}  (65) - trying to login
[1041] INFO 2017-01-10 17:04:47,103 os-autoinst backend::qemu::start_qemu (747) - QEMU emulator version 2.6.1 (openSUSE Tumbleweed), Copyright (c) 2003-2008 Fabrice Bellard
[1041] WARN 2017-01-10 17:04:47,103 os-autoinst backend::qemu::start_qemu (748) - !!! starting: /usr/bin/qemu-kvm -serial file:serial0 -soundhw ac97 -vga cirrus -global isa-fdc.driveA= -vga cirrus -m 1024 -cpu qemu64 -netdev user,id=qanet0 -device virtio-net,netdev=qanet0,mac=52:54:00:12:34:56 -device virtio-scsi-pci,id=scsi0 -device virtio-blk,drive=hd1 -drive file=raid/l1,cache=unsafe,if=none,id=hd1,format=qcow2 -drive media=cdrom,if=none,id=cd0,format=raw,file=/var/lib/openqa/factory/iso/openSUSE-Tumbleweed-DVD-x86_64-Snapshot20161113-Media.iso -device scsi-cd,drive=cd0,bus=scsi0.0 -boot once=d,menu=on,splash-time=5000 -device usb-ehci -device usb-tablet -smp 1 -enable-kvm -no-shutdown -vnc :91,share=force-shared -qmp unix:qmp_socket,server,nowait -monitor unix:hmp_socket,server,nowait -S -monitor telnet:127.0.0.1:20012,server,nowait
[1993] DEBUG 2017-01-10 17:04:48,054 os-autoinst consoles::vnc_base::try {...}  (65) - trying to login
/home/foursixnine/Projects/suse.com/github.com/os-autoinst/os-autoinst/consoles/vnc_base.pm:68:done

[2045] DEBUG 2017-01-10 17:04:48,107 os-autoinst consoles::VNC::_receive_update (925) - pointer type 0 0 640 480 -257
[2046] ERROR 2017-01-10 17:04:48,107 os-autoinst consoles::VNC::_receive_update (932) - EEE led state 0 1 1 -261
[2059] DEBUG 2017-01-10 17:04:48,120 os-autoinst backend::qemu::start_qemu (801) - hmpsocket 20, qmpsocket 21
[2059] INFO 2017-01-10 17:04:48,121 os-autoinst backend::qemu::start_qemu (807) - ::: WELCOME QEMU 2.6.1 monitor - type 'help' for more information
Start CPU
[2061] DEBUG 2017-01-10 17:04:48,123 os-autoinst backend::qemu::handle_qmp_command (919) - EVENT {"timestamp":{"microseconds":123119,"seconds":1484064288},"event":"RESUME"}
GOT GO
```