### PR TITLE
Delete reference to unexisting test file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ script:
   # 'coverage' executes all tests and checks code coverage against threshold
   # in Makefile.am
   - make && make check coverage-coveralls VERBOSE=1
+sudo: required

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,4 +1,4 @@
 AM_MAKEFLAGS = PERL5OPT="-MDevel::Cover=-db,$(abs_builddir)/cover_db"
 TESTS = 00-compile-check-all.t 01-test_needle.t 02-test_ocr.t 03-testapi.t 04-check_vars_docu.t 05-pod.t 06-pod-coverage.t 07-commands.t 08-autotest.t 09-lockapi.t 10-terminal.t 11-image-ppm.t 20-openqa-benchmark-stopwatch-utils.t 99-full-stack.t
 
-EXTRA_DIST = $(TESTS) t/test_driver.pm
+EXTRA_DIST = $(TESTS)


### PR DESCRIPTION
File `t/test_driver.pm` was deleted [here](https://github.com/os-autoinst/os-autoinst/commit/57f22b1136fa7a757437238b7a29f22fdcd8de3a#diff-4151111f7b551df1803a0edba07db67c), so there is no need to have it into the tests.