### PR TITLE
Add debug output on save|load_snapshot error

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -206,7 +206,7 @@ sub save_snapshot {
     my $vmname = $args->{name};
     my $rsp    = $self->_send_hmp("savevm $vmname");
     diag "SAVED $vmname $rsp";
-    die "Could not save snapshot \'$vmname\'" unless ($rsp eq "savevm $vmname");
+    die "Could not save snapshot \'$vmname\': $rsp" unless ($rsp eq "savevm $vmname");
     return;
 }
 
@@ -214,7 +214,7 @@ sub load_snapshot {
     my ($self, $args) = @_;
     my $vmname = $args->{name};
     my $rsp    = $self->_send_hmp("loadvm $vmname");
-    die "Could not load snapshot \'$vmname\'" unless ($rsp eq "loadvm $vmname");
+    die "Could not load snapshot \'$vmname\': $rsp" unless ($rsp eq "loadvm $vmname");
     $rsp = $self->handle_qmp_command({execute => 'stop'});
     $rsp = $self->handle_qmp_command({execute => 'cont'});
     sleep(10);


### PR DESCRIPTION
The response from the hmp command has useful information included. Example
output

```
DIE Could not load snapshot 'console-xorg_vt': loadvm console-xorg_vt
Device 'usbstick' does not have the requested snapshot 'console-xorg_vt' at
/local/os-autoinst/backend/qemu.pm line 217.

 at /local/os-autoinst/backend/baseclass.pm line 73.
```