### PR TITLE
Remove duplication in script_run and assert_script_run

### DIFF
--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -126,20 +126,20 @@ subtest 'script_run' => sub {
 
     is(assert_script_run('true'), undef, 'nothing happens on success');
     $fake_exit = 1;
-    like(exception { assert_script_run 'false', 42; }, qr/command.*false.*failed at/, 'with timeout option (deprecated mode)');
+    like(exception { assert_script_run 'false', 42; }, qr/command.*false.*failed or timed out at/, 'with timeout option (deprecated mode)');
     like(
         exception { assert_script_run 'false', 0, 'my custom fail message'; },
-        qr/command.*false.*failed: my custom fail message at/,
+        qr/command.*false.*failed or timed out: my custom fail message at/,
         'custom message on die (deprecated mode)'
     );
     like(
         exception { assert_script_run('false', fail_message => 'my custom fail message'); },
-        qr/command.*false.*failed: my custom fail message at/,
+        qr/command.*false.*failed or timed out: my custom fail message at/,
         'using named arguments'
     );
     like(
         exception { assert_script_run('false', timeout => 0, fail_message => 'my custom fail message'); },
-        qr/command.*false.*failed: my custom fail message at/,
+        qr/command.*false.*failed or timed out: my custom fail message at/,
         'using two named arguments'
     );
     $fake_exit = 0;


### PR DESCRIPTION
`assert_script_run` and `script_run` currently duplicate the
work to echo the exit code of the command to the serial port
and act on it. Instead, let's have `assert_script_run` just
take the exit code from `script_run` and die unless it's 0.

Note that this leaves `script_sudo` and `assert_script_sudo`
alone. Ideally I'd like to harmonize those too, but that's more
complex and debatable. I did add a note that `assert_script_sudo`
is unlikely to actually work with the default `script_sudo`.

I cleaned up the docs a bit, and renamed `script_runs` args
to match `assert_script_run`'s. And I made the fail message for
the assert functions a bit more accurate (it can die because the
command timed out as well as because it failed).