### PR TITLE
Support IPMI_HW=dell

### DIFF
--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -45,7 +45,7 @@ use Time::HiRes qw(gettimeofday);
 sub ipmi_cmdline {
     my ($self) = @_;
 
-    return ('ipmitool', '-H', $bmwqemu::vars{IPMI_HOSTNAME}, '-U', $bmwqemu::vars{IPMI_USER}, '-P', $bmwqemu::vars{IPMI_PASSWORD});
+    return ('ipmitool', '-I', 'lanplus', '-H', $bmwqemu::vars{IPMI_HOSTNAME}, '-U', $bmwqemu::vars{IPMI_USER}, '-P', $bmwqemu::vars{IPMI_PASSWORD});
 }
 
 sub ipmitool {
@@ -59,9 +59,17 @@ sub ipmitool {
     chomp $stdout;
     chomp $stderr;
 
+    $self->dell_sleep;
+
     die join(' ', @cmd) . ": $stderr" unless ($ret);
     bmwqemu::diag("IPMI: $stdout");
     return $stdout;
+}
+
+# DELL BMCs are touchy
+sub dell_sleep {
+    my ($self) = @_;
+    return unless ($bmwqemu::vars{IPMI_HW} || '') eq 'dell', sleep 3;
 }
 
 sub restart_host {
@@ -92,16 +100,19 @@ sub relogin_vnc {
         sleep(1);
     }
 
-    my $vnc = $testapi::distri->add_console(
-        'sut',
-        'vnc-base',
-        {
-            hostname => $bmwqemu::vars{IPMI_HOSTNAME},
-            port     => 5900,
-            username => $bmwqemu::vars{IPMI_USER},
-            password => $bmwqemu::vars{IPMI_PASSWORD},
-            ikvm     => 1
-        });
+    my $vncopts = {
+        hostname => $bmwqemu::vars{IPMI_HOSTNAME},
+        port     => 5900,
+        username => $bmwqemu::vars{IPMI_USER},
+        password => $bmwqemu::vars{IPMI_PASSWORD},
+    };
+    my $hwclass = $bmwqemu::vars{IPMI_HW} || 'supermicro';
+    $vncopts->{ikvm} = 1 if $hwclass eq 'supermicro';
+    if ($hwclass eq 'dell') {
+        $vncopts->{dell} = 1;
+        $vncopts->{port} = 5901;
+    }
+    my $vnc = $testapi::distri->add_console('sut', 'vnc-base', $vncopts);
     $vnc->backend($self);
     $self->select_console({testapi_console => 'sut'});
 

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -52,7 +52,7 @@ my %supported_depths = (
         green_shift => 8,
         blue_shift  => 0,
     },
-    16 => {
+    16 => {    # same as 15
         bpp         => 16,
         true_colour => 1,
         red_max     => 31,
@@ -61,6 +61,16 @@ my %supported_depths = (
         red_shift   => 10,
         green_shift => 5,
         blue_shift  => 0,
+    },
+    15 => {
+        bpp         => 16,
+        true_colour => 1,
+        red_max     => 31,
+        green_max   => 31,
+        blue_max    => 31,
+        red_shift   => 10,
+        green_shift => 5,
+        blue_shift  => 0
     },
     8 => {
         bpp         => 8,
@@ -188,10 +198,12 @@ sub _handshake_security {
     # Retrieve list of security options
     my $security_type;
     if ($self->_rfb_version ge '003.007') {
-        $socket->read(my $number_of_security_types, 1)
-          || die 'unexpected end of data';
-        $number_of_security_types = unpack('C', $number_of_security_types);
-
+        my $number_of_security_types = 0;
+        my $number_of_security_types;
+        my $r = $socket->read($number_of_security_types, 1);
+        if ($r) {
+            $number_of_security_types = unpack('C', $number_of_security_types);
+        }
         if ($number_of_security_types == 0) {
             die 'Error authenticating';
         }


### PR DESCRIPTION
This is not yet used for anything, because iDrac8 talks standard VNC (if configured),
but to differ it in the ipmi backend, I explicitly set it also in the VNC console

Validation: http://147.2.212.248/tests/664#step/login_console/14