### PR TITLE
Provide `stop_vm` argument for attach_to_running()

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -517,14 +517,17 @@ __END"
 }
 
 sub attach_to_running {
-    my ($self, $name) = @_;
+    my ($self, $args) = @_;
 
+    my $name = ref($args) ? $args->{name} : $args;
     $self->name($name) if $name;
     $self->backend->start_serial_grab($self->name);
 
     # Setting SVIRT_KEEP_VM_RUNNING variable prevents destruction of a perhaps valuable VM
-    # outside of openQA. Un-set it on your own in test should the VM be destroyed.
-    set_var('SVIRT_KEEP_VM_RUNNING', 1);
+    # outside of openQA. Set 'stop_vm' argument should the VM be destroyed at the end.
+    unless ($args->{stop_vm}) {
+        set_var('SVIRT_KEEP_VM_RUNNING', 1);
+    }
 }
 
 # Sends command to libvirt host, logs stdout and stderr of the command,


### PR DESCRIPTION
Set 'stop_vm' argument should the VM be destroyed at the end of testing.

Verification: http://assam.suse.cz/tests/4689