### PR TITLE
Die early when usb-kbd: key event full is found

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -932,6 +932,7 @@ sub read_qemupipe {
     chomp $buffer;
     for my $line (split(/\n/, $buffer)) {
         bmwqemu::diag "QEMU: $line";
+        die "QEMU: Shutting down the job" if $line =~ m/key event queue full/;
     }
     return $bytes;
 }


### PR DESCRIPTION
To try to mitigate the time wasted of failing jobs due to this problem