### PR TITLE
Re-scale screen on Xen PV to fix assert_and_click

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -345,10 +345,14 @@ sub assert_and_click {
 
     # last_matched_needle has to be set, or the assert is buggy :)
     my $lastarea = $last_matched_needle->{area}->[-1];
-    my $rx       = 1;                                                  # $origx / $img->xres();
-    my $ry       = 1;                                                  # $origy / $img->yres();
-    my $x        = int(($lastarea->{x} + $lastarea->{w} / 2) * $rx);
-    my $y        = int(($lastarea->{y} + $lastarea->{h} / 2) * $ry);
+    my $rx       = 1;                                    # $origx / $img->xres();
+    my $ry       = 1;                                    # $origy / $img->yres();
+    if (check_var('VIRSH_VMM_FAMILY', 'xen') and check_var('VIRSH_VMM_TYPE', 'linux')) {
+        # POO#13536 - openQA on Xen PV seems to believe it's on 800x600 resolution
+        $rx = $ry = 1 / (1024 / 800);
+    }
+    my $x = int(($lastarea->{x} + $lastarea->{w} / 2) * $rx);
+    my $y = int(($lastarea->{y} + $lastarea->{h} / 2) * $ry);
     bmwqemu::diag("clicking at $x/$y");
     mouse_set($x, $y);
     if ($dclick) {


### PR DESCRIPTION
When testing Xen PV SUT under svirt backend openQA believes that SUT has
800x600 px resolution, but it's actually 1024x768. Be it a bug in Xen's
Qemu VNC (e.g. not sending re-scale desktop information) or openQA's VNC
client, scaling it by a factor of 1/(1024/800) makes assert_and_click()
work on Xen PV.

E.g.: `assert_screen` matches needle, computes it's geometrical centre
and clicks to that point. If the computed point is 215x156, openQA
actually clicks to 273x198 (approximately). With this workaround, openQA
places pointer to the correct area (though not exactly 100 %).

Verification run: http://assam.suse.cz/tests/4714