### PR TITLE
Remove duplicated @vgaoptions

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -530,7 +530,7 @@ sub start_qemu {
     die "fork failed" unless defined($pid);
     if ($pid == 0) {
         $SIG{__DIE__} = undef;    # overwrite the default - just exit
-        my @params = ("-serial", "file:serial0", "-soundhw", "ac97", @vgaoptions);
+        my @params = ("-serial", "file:serial0", "-soundhw", "ac97");
 
         push(@params, "-global", "isa-fdc.driveA=") unless ($vars->{QEMU_NO_FDC_SET});
         push(@params, @vgaoptions);


### PR DESCRIPTION
This was causing the following message from the qemu backend on xgene2.arch:

RAMBlock "vga.vram" already registered, abort!