### PR TITLE
More fixes for the DELL VNC implementation on idrac

### DIFF
--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -67,7 +67,8 @@ sub ipmitool {
 # DELL BMCs are touchy
 sub dell_sleep {
     my ($self) = @_;
-    return unless ($bmwqemu::vars{IPMI_HW} || '') eq 'dell', sleep 3;
+    return unless ($bmwqemu::vars{IPMI_HW} || '') eq 'dell';
+    sleep 4;
 }
 
 sub restart_host {


### PR DESCRIPTION
- sleep 4 instead 3 seconds between ipmi commands
- throw out ZLRE encoding as it is not RFB compliant (I also
  threw it out in general due to problems with some qemu implementations,
  reenable it with save_bandwith = 1 in the vnc console setup)
- do not catch generic dies in the vnc code, only wait for the connection.
  Every crash afterwards is a real one. Should make it easier to debug
  also the zkvm update case