### PR TITLE
Do not use absolute path in needle JSON

### DIFF
--- a/isotovideo
+++ b/isotovideo
@@ -35,7 +35,7 @@ BEGIN {
 
 # this shall be an integer increased by every change of the API
 # either to the worker or the tests
-our $INTERFACE = 6;
+our $INTERFACE = 7;
 
 use bmwqemu;
 use needle;

--- a/needle.pm
+++ b/needle.pm
@@ -51,7 +51,13 @@ sub new {
             return;
         }
     }
-    my $self = {tags => ($json->{tags} || [])};
+    my $self = {};
+
+    die "Needle $jsonfile is not under project directory $bmwqemu::vars{PRJDIR}" if (index($jsonfile, $bmwqemu::vars{PRJDIR}));
+    # store json file path relative to $prjdir
+    $self->{file} = substr($jsonfile, length($bmwqemu::vars{PRJDIR}) + 1);
+
+    $self->{tags}       = $json->{tags}       || [];
     $self->{properties} = $json->{properties} || [];
 
     my $gotmatch;
@@ -79,7 +85,6 @@ sub new {
         return;
     }
 
-    $self->{file} = $jsonfile;
     $self->{name} = basename($jsonfile, '.json');
     my $png = $self->{png} || $self->{name} . ".png";
 
@@ -209,7 +214,7 @@ sub init {
     ($needledir, $shared_cache) = @_;
 
     $needledir //= "$bmwqemu::vars{PRODUCTDIR}/needles/";
-    $needledir = abs_path($needledir) // die "needledir not found: $needledir (check vars.json?)";
+    -d $needledir || die "needledir not found: $needledir (check vars.json?)";
 
     %needles = ();
     %tags    = ();


### PR DESCRIPTION
- different project directories can be used on worker and webui
leading to errors during upload. Instead of absolute path (with
symlinks expanded) use path relative to project directory and keep
the links unexpanded