### PR TITLE
Add optional 'no_wait' parameter for check/assert_screen

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -22,7 +22,7 @@ use Carp qw(cluck carp confess);
 use JSON 'to_json';
 use File::Copy 'cp';
 use File::Basename;
-use Time::HiRes qw(gettimeofday tv_interval);
+use Time::HiRes qw(gettimeofday time tv_interval);
 use POSIX '_exit';
 use bmwqemu;
 use IO::Select;
@@ -795,6 +795,10 @@ sub _failed_screens_to_json {
     return {timeout => 1, failed_screens => \@json_fails};
 }
 
+sub time_remaining_str {
+    return sprintf("%.1fs", shift);
+}
+
 sub check_asserted_screen {
     my ($self, $args) = @_;
 
@@ -817,7 +821,7 @@ sub check_asserted_screen {
     }
     else {
         if ($oldimg && $oldimg eq $img && $old_search_ratio >= $search_ratio) {
-            bmwqemu::diag("no change $n");
+            bmwqemu::diag('no change: ' . time_remaining_str($n));
             return;
         }
     }
@@ -881,7 +885,7 @@ sub check_asserted_screen {
             _reduce_to_biggest_changes($failed_screens, 20);
         }
     }
-    bmwqemu::diag("no match $n");
+    bmwqemu::diag('no match: ' . time_remaining_str($n));
     $self->assert_screen_last_check([$img, $search_ratio]);
     return;
 }

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -352,6 +352,8 @@ sub hashed_string {
 
 sub wait_for_one_more_screenshot {
     # sleeping for one second should ensure that one more screenshot is taken
+    # uncoverable subroutine
+    # uncoverable statement
     sleep 1;
 }
 

--- a/isotovideo
+++ b/isotovideo
@@ -301,6 +301,9 @@ my $current_test_name;
 # timeout for the select (only set for check_screens)
 my $timeout = undef;
 
+# do not wait for timeout if set
+my $no_wait = undef;
+
 # marks a running check_screen
 our $tags = undef;
 
@@ -326,11 +329,17 @@ sub _calc_check_delta {
 }
 
 sub check_asserted_screen {
-    my ($force_timeout) = @_;
+    my ($force_timeout, $no_wait) = @_;
 
-    my $delta = _calc_check_delta;
-    # come back later, avoid too often called function
-    return if $timeout > 0.05;
+    if ($no_wait) {
+        # prevent CPU overload by waiting at least a little bit
+        $timeout = 0.1;
+    }
+    else {
+        _calc_check_delta;
+        # come back later, avoid too often called function
+        return if $timeout > 0.05;
+    }
     ($last_check_seconds, $last_check_microseconds) = gettimeofday;
     my $rsp = $bmwqemu::backend->_send_json({cmd => 'check_asserted_screen'}) || {};
     # the test needs that information
@@ -354,7 +363,7 @@ sub check_asserted_screen {
         $timeout = undef;
     }
     else {
-        _calc_check_delta;
+        _calc_check_delta unless $no_wait;
     }
 }
 
@@ -399,16 +408,16 @@ while ($loop) {
             next;
         }
         if ($rsp->{cmd} eq 'check_screen') {
-            my $mustmatch = $rsp->{mustmatch};
-            my $timeout   = $rsp->{timeout};
-            my $check     = $rsp->{check};
+            my $mustmatch     = $rsp->{mustmatch};
+            my $check_timeout = $rsp->{timeout};
+            $no_wait = $rsp->{no_wait} // 0;
 
             $tags = $bmwqemu::backend->_send_json(
                 {
                     cmd       => 'set_tags_to_assert',
                     arguments => {
                         mustmatch => $mustmatch,
-                        timeout   => $timeout
+                        timeout   => $check_timeout
                     }})->{tags};
             next;
         }
@@ -436,7 +445,7 @@ while ($loop) {
                 $bmwqemu::backend->_send_json({cmd => 'retry_assert_screen'});
                 $needinput = 0;
                 $timeout   = .1;
-                check_asserted_screen(1);
+                check_asserted_screen(1, $no_wait);
             }
             myjsonrpc::send_json($r, {interactive => $interactive});
             next;
@@ -455,14 +464,14 @@ while ($loop) {
             $bmwqemu::backend->_send_json({cmd => 'retry_assert_screen', arguments => {reload_needles => $reload}});
             # that's enough for the webui to know
             myjsonrpc::send_json($r, {ret => 0});
-            check_asserted_screen(1);
+            check_asserted_screen(1, $no_wait);
             next;
         }
         die "Unknown command $rsp->{cmd}";
     }
 
     if (defined $tags && !$needinput) {
-        check_asserted_screen;
+        check_asserted_screen(0, $no_wait);
     }
 }
 

--- a/t/20-openqa-benchmark-stopwatch-utils.t
+++ b/t/20-openqa-benchmark-stopwatch-utils.t
@@ -4,6 +4,7 @@
 use strict;
 use warnings;
 use Test::More;
+use Time::HiRes 'sleep';
 
 
 BEGIN {
@@ -15,15 +16,15 @@ use OpenQA::Benchmark::Stopwatch;
 my $watch = OpenQA::Benchmark::Stopwatch->new();
 $watch->start();
 
-sleep 1;
-$watch->lap("Lap 1 sec");
-sleep 2;
-$watch->lap("Lap 2 sec");
+sleep 0.001;
+$watch->lap("Lap 0.001s");
+sleep 0.002;
+$watch->lap("Lap 0.002s");
 $watch->stop();
 
-ok($watch->as_data()->{total_time} gt 2,    "Pass summary as data");
-ok($watch->as_data()->{laps}[0]{time} gt 1, "Pass 1sec lap");
-ok($watch->as_data()->{laps}[1]{time} gt 2 && $watch->as_data()->{laps}[1]{time} lt 3, "Pass 2sec lap");
+ok($watch->as_data()->{total_time} gt 0.002,    "Pass summary as data");
+ok($watch->as_data()->{laps}[0]{time} gt 0.001, "Pass first lap");
+ok($watch->as_data()->{laps}[1]{time} gt 0.002 && $watch->as_data()->{laps}[1]{time} lt 3, "Pass second lap");
 print $watch->summary();
 
 done_testing();

--- a/t/data/tests/tests/boot.pm
+++ b/t/data/tests/tests/boot.pm
@@ -19,7 +19,8 @@ use strict;
 use testapi;
 
 sub run {
-    assert_screen 'core';
+    # just assume the first screen has a timeout so we should make sure not to miss it
+    assert_screen 'core', 15, no_wait => 1;
     send_key 'ret';
 
     assert_screen 'on_prompt';

--- a/t/data/tests/tests/boot.pm
+++ b/t/data/tests/tests/boot.pm
@@ -21,6 +21,9 @@ use testapi;
 sub run {
     # just assume the first screen has a timeout so we should make sure not to miss it
     assert_screen 'core', 15, no_wait => 1;
+    # different variants of parameter selection
+    assert_screen 'core', timeout => 60;
+    assert_screen 'core', no_wait => 1;
     send_key 'ret';
 
     assert_screen 'on_prompt';

--- a/testapi.pm
+++ b/testapi.pm
@@ -246,19 +246,19 @@ sub _check_backend_response {
 }
 
 sub _check_or_assert {
-    my ($mustmatch, $timeout, $check) = @_;
+    my ($mustmatch, $timeout, $check, %args) = @_;
     $timeout = bmwqemu::scale_timeout($timeout);
 
     die "current_test undefined" unless $autotest::current_test;
 
-    my $rsp = query_isotovideo('check_screen', {mustmatch => $mustmatch, timeout => $timeout, check => $check});
+    my $rsp = query_isotovideo('check_screen', {mustmatch => $mustmatch, timeout => $timeout, check => $check, no_wait => $args{no_wait}});
     # seperate function because it needs to call itself
-    return _check_backend_response($rsp, $check, $timeout, $mustmatch);
+    return _check_backend_response($rsp, $check, $timeout, $mustmatch, $args{no_wait});
 }
 
 =head2 assert_screen
 
-  assert_screen($mustmatch [,$timeout]);
+  assert_screen($mustmatch [,$timeout] [, no_wait => $no_wait]);
 
 Wait for needle with tag C<$mustmatch> to appear on SUT screen. C<$mustmatch>
 can be string or C<ARRAYREF> of string (C<['tag1', 'tag2']>). The maximum
@@ -268,21 +268,26 @@ very suitable for checking performance expectations. Under the normal
 circumstance of the screen being shown this does not imply a longer waiting
 time as the method returns as soon as a successful needle match occurred.
 
+Specify C<$no_wait> to run the screen check as fast as possible that is
+possibly more than once per second which is default. Select this to check a
+screen which can change in a range faster than 1-2 seconds not to miss the
+screen to check for.
+
 Returns matched needle or throws C<NeedleFailed> exception if $timeout timeout
 is hit. Default timeout is 30s.
 
 =cut
 
 sub assert_screen {
-    my ($mustmatch, $timeout) = @_;
+    my ($mustmatch, $timeout, %args) = @_;
     $timeout //= $bmwqemu::default_timeout;
-    bmwqemu::log_call(mustmatch => $mustmatch, timeout => $timeout);
-    return _check_or_assert($mustmatch, $timeout, 0);
+    bmwqemu::log_call(mustmatch => $mustmatch, timeout => $timeout, %args);
+    return _check_or_assert($mustmatch, $timeout, 0, %args);
 }
 
 =head2 check_screen
 
-  check_screen($mustmatch [,$timeout]);
+  check_screen($mustmatch [,$timeout] [, no_wait => $no_wait]);
 
 Similar to C<assert_screen> but does not throw exceptions. Use this for optional matches.
 Check C<assert_screen> for parameters.
@@ -300,10 +305,10 @@ Returns matched needle or C<undef> if timeout is hit. Default timeout is 30s.
 =cut
 
 sub check_screen {
-    my ($mustmatch, $timeout) = @_;
+    my ($mustmatch, $timeout, %args) = @_;
     $timeout //= $bmwqemu::default_timeout;
-    bmwqemu::log_call(mustmatch => $mustmatch, timeout => $timeout);
-    return _check_or_assert($mustmatch, $timeout, 1);
+    bmwqemu::log_call(mustmatch => $mustmatch, timeout => $timeout, %args);
+    return _check_or_assert($mustmatch, $timeout, 1, %args);
 }
 
 =head2 match_has_tag

--- a/testapi.pm
+++ b/testapi.pm
@@ -88,6 +88,8 @@ sub type_password;
 
 =head1 introduction
 
+=for stopwords os autoinst isotovideo openQA
+
 This test API module provides methods exposed by the os-autoinst backend to be
 used within tests.
 
@@ -264,7 +266,7 @@ waiting time is defined by C<$timeout>. It is recommended to use a value lower
 than the default timeout only when explicitly needed. C<assert_screen> is not
 very suitable for checking performance expectations. Under the normal
 circumstance of the screen being shown this does not imply a longer waiting
-time as the method returns as soon as a successful needle match occured.
+time as the method returns as soon as a successful needle match occurred.
 
 Returns matched needle or throws C<NeedleFailed> exception if $timeout timeout
 is hit. Default timeout is 30s.
@@ -579,6 +581,7 @@ sub check_var_array {
 
 =head1 script execution helpers
 
+=for stopwords os-autoinst autoinst isotovideo VNC
 
 =head2 is_serial_terminal
 
@@ -587,7 +590,7 @@ sub check_var_array {
 Determines if communication with the guest is being performed purely over a
 serial port. When true, the guest should have a tty attached to a serial port
 and os-autoinst sends commands to it as text. This differs from when a text
-console is selected in the guest, but VNC is being used to simulate keypresses.
+console is selected in the guest, but VNC is being used to simulate key presses.
 
 When a serial terminal is selected you will not be able to use functions which
 rely on needles. This sub is not exported by default as most tests I<will not
@@ -1286,6 +1289,8 @@ sub reset_consoles {
 
 =head1 audio support
 
+=for stopwords qemu
+
 =head2 start_audiocapture
 
   start_audiocapture;
@@ -1450,9 +1455,10 @@ sub save_storage_drives {
 
   freeze_vm;
 
-If the backend supports it, freeze the vm. This will allow the vm to be
-paused/frozen within the test, but only from the post_fail_hook. So that memory
-and disk dumps can be extracted without any risk of data changing.
+If the backend supports it, freeze the virtual machine. This will allow the
+virtual machine to be paused/frozen within the test, but only from the
+post_fail_hook. So that memory and disk dumps can be extracted without any
+risk of data changing.
 
 Call this method to ensure memory and disk dump refer to the same machine state.
 
@@ -1472,8 +1478,8 @@ sub freeze_vm {
 
   resume_vm;
 
-If the backend supports it, resume the vm.
-Call this method to start vm CPU explicitly if DELAYED_START is set.
+If the backend supports it, resume the virtual machine. Call this method to
+start virtual machine CPU explicitly if DELAYED_START is set.
 
 I<Currently only qemu backend is supported.>
 
@@ -1727,6 +1733,8 @@ sub upload_logs {
 
 =head2 upload_asset
 
+=for stopwords svirt
+
   upload_asset $file [,$public[,$nocheck]];
 
 Uploads C<$file> as asset to OpenQA WebUI
@@ -1743,7 +1751,7 @@ replacing previous assets - useful for external users:
 If you just want to upload a file and verify that it was uploaded
 correctly on your own (e.g. in svirt console we don't have a serial
 line and can't rely on assert_script_run check), add an optional
-'nocheck' parameter:
+C<$nocheck> parameter:
 
     upload_asset '/tmp/suse.ps', 1, 1;
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -1,5 +1,5 @@
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -460,7 +460,7 @@ sub assert_screen_change(&@) {
 
 =for stopwords stilltime
 
-  wait_still_screen([$stilltime_sec [, $timeout_sec [, $similarity_level]]]);
+  wait_still_screen([$stilltime_sec [, $timeout [, $similarity_level]]]);
 
 Wait until the screen stops changing.
 
@@ -786,7 +786,7 @@ sub assert_script_sudo {
   script_sudo($program [, $wait]);
 
 Run C<$program> using sudo. Handle the sudo timeout and send password when appropriate.
-C<$wait_seconds> defaults to 2 seconds.
+C<$wait> defaults to 2 seconds.
 
 I<The implementation is distribution specific and not always available.>
 


### PR DESCRIPTION
The default interval of checking screens every 1 second is an unsuitable
choices in multiple occasions. When screens change without external
interaction within a certain time, for example a boot menue, it is safer to
check more than once per second. In other occasions the screen repeatedly
alternates in an even interval and the screen check is conducted at the same
interval but shifted in time so that always the "wrong" screen is catched. In
this case a lower timeout which can also be an odd value should be selected.

In the cases of os-autoinst-distri-opensuse the openSUSE Krypton live CD is
built with SUSE kiwi v>=8 which yields a boot screen timeout of 1-2 seconds
Checking only once per second is just not often enough to be able to check the
screen and conduct actions immediately afterwards, e.g. press a key to abort
the timeout.

The second example is checking a text entry field in oomath where the needle
covers the blinking text cursor to be sure the focus is on that field. The
test fails here repeatedly but obviously not every time because the needle
checking interval matches the blinking cursor interval but is of by a fraction
of a second so that only the instances of the cursor not being shown is
matched.

Related progress issue: https://progress.opensuse.org/issues/16038