### PR TITLE
Poweroff the VM after tests

### DIFF
--- a/t/data/tests/tests/shutdown.pm
+++ b/t/data/tests/tests/shutdown.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2017 SUSE LLC
+# Copyright (C) 2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,16 +11,19 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
+use 5.018;
+use base 'basetest';
 use testapi;
 
-autotest::loadtest "tests/boot.pm";
-autotest::loadtest "tests/shutdown.pm";
+sub run {
+    type_string "poweroff\n";
+    assert_shutdown;
+}
 
+sub test_flags {
+    return {fatal => 1};
+}
 
 1;
-
-# vim: set sw=4 et:


### PR DESCRIPTION
- apart from covering assert_shutdown, this is needed for image upload tests within openQA