### PR TITLE
serial terminal: Use newline to clear buffer instead of EOT

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -809,8 +809,8 @@ sub script_output($;$) {
         my $cat = "cat - > /tmp/script$suffix.sh; echo $suffix-\$?-";
         type_string($cat . "\n");
         wait_serial("$cat", undef, 0, no_regex => 1);
-        type_string($current_test_script, terminate_with => 'EOT');
-        type_string('',                   terminate_with => 'EOT');
+        type_string($current_test_script);
+        type_string("\n", terminate_with => 'EOT');
         wait_serial("$suffix-0-");
     }
     else {


### PR DESCRIPTION
Send a newline character which causes the terminal to flush its input buffer
and cat to read the incoming data. Once the terminal's input buffer is empty,
we send EOT (End Of Transmission) which causes the EOF condition in
cat (i.e. read() returns zero).

Previously EOT was used twice, once to flush the buffer and then a second time
to exit. If the buffer was already empty this would result in cat exiting
after the first EOT then the second would cause the shell to log out. Unlike
EOT newline can not cause the EOF condition because it is written to the buffer.

https://en.wikipedia.org/wiki/End-of-Transmission_character