### PR TITLE
svirt: Do not use is_shutdown()

### DIFF
--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -103,13 +103,6 @@ sub can_handle {
     return;
 }
 
-sub is_shutdown {
-    my ($self) = @_;
-    my $vmname = $self->console('svirt')->name;
-    my $rsp    = $self->run_cmd("! virsh dominfo $vmname | grep -w 'shut off'");
-    return $rsp;
-}
-
 sub save_snapshot {
     my ($self, $args) = @_;
     my $snapname = $args->{name};


### PR DESCRIPTION
If we gather information about VM's state under svirt via
`query_isotovideo`, it keeps executing `read_json` and no further
command is executed.

The root cause may be that something touches closed VNC connection
(which is closed on gues OS poweroff on libvirt), which ends up in
stall.

Fails on: https://openqa.suse.de/tests/754073
Verification run: http://assam.suse.cz/tests/5014