### PR TITLE
Only abort on system stalls detected when explicitly asked for

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -1,5 +1,5 @@
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -852,7 +852,7 @@ sub check_asserted_screen {
         # make sure we recheck later
         $self->assert_screen_last_check(undef);
 
-        if ($self->stall_detected) {
+        if (($args->{abort_on_stall} || $bmwqemu::vars{ABORT_ON_STALL}) && $self->stall_detected) {
             backend::baseclass::write_crash_file();
             bmwqemu::mydie "assert_screen fails, but we detected a timeout in the process, so we abort";
         }

--- a/isotovideo
+++ b/isotovideo
@@ -304,6 +304,9 @@ my $timeout = undef;
 # do not wait for timeout if set
 my $no_wait = undef;
 
+# detect stalls of the system where we are blind during the screen checks
+my $abort_on_stall = undef;
+
 # marks a running check_screen
 our $tags = undef;
 
@@ -329,7 +332,7 @@ sub _calc_check_delta {
 }
 
 sub check_asserted_screen {
-    my ($force_timeout, $no_wait) = @_;
+    my ($force_timeout, $no_wait, $abort_on_stall) = @_;
 
     if ($no_wait) {
         # prevent CPU overload by waiting at least a little bit
@@ -341,7 +344,7 @@ sub check_asserted_screen {
         return if $timeout > 0.05;
     }
     ($last_check_seconds, $last_check_microseconds) = gettimeofday;
-    my $rsp = $bmwqemu::backend->_send_json({cmd => 'check_asserted_screen'}) || {};
+    my $rsp = $bmwqemu::backend->_send_json({cmd => 'check_asserted_screen', arguments => {abort_on_stall => $abort_on_stall}}) || {};
     # the test needs that information
     $rsp->{tags} = $tags;
     if ($rsp->{found}) {
@@ -410,7 +413,8 @@ while ($loop) {
         if ($rsp->{cmd} eq 'check_screen') {
             my $mustmatch     = $rsp->{mustmatch};
             my $check_timeout = $rsp->{timeout};
-            $no_wait = $rsp->{no_wait} // 0;
+            $no_wait        = $rsp->{no_wait}        // 0;
+            $abort_on_stall = $rsp->{abort_on_stall} // 0;
 
             $tags = $bmwqemu::backend->_send_json(
                 {
@@ -445,7 +449,7 @@ while ($loop) {
                 $bmwqemu::backend->_send_json({cmd => 'retry_assert_screen'});
                 $needinput = 0;
                 $timeout   = .1;
-                check_asserted_screen(1, $no_wait);
+                check_asserted_screen(1, $no_wait, $abort_on_stall);
             }
             myjsonrpc::send_json($r, {interactive => $interactive});
             next;
@@ -464,14 +468,14 @@ while ($loop) {
             $bmwqemu::backend->_send_json({cmd => 'retry_assert_screen', arguments => {reload_needles => $reload}});
             # that's enough for the webui to know
             myjsonrpc::send_json($r, {ret => 0});
-            check_asserted_screen(1, $no_wait);
+            check_asserted_screen(1, $no_wait, $abort_on_stall);
             next;
         }
         die "Unknown command $rsp->{cmd}";
     }
 
     if (defined $tags && !$needinput) {
-        check_asserted_screen(0, $no_wait);
+        check_asserted_screen(0, $no_wait, $abort_on_stall);
     }
 }
 

--- a/t/data/tests/tests/boot.pm
+++ b/t/data/tests/tests/boot.pm
@@ -23,7 +23,7 @@ sub run {
     assert_screen 'core', 15, no_wait => 1;
     # different variants of parameter selection
     assert_screen 'core', timeout => 60;
-    assert_screen 'core', no_wait => 1;
+    assert_screen 'core', no_wait => 1, abort_on_stall => 1;
     send_key 'ret';
 
     assert_screen 'on_prompt';

--- a/testapi.pm
+++ b/testapi.pm
@@ -251,14 +251,16 @@ sub _check_or_assert {
 
     die "current_test undefined" unless $autotest::current_test;
 
-    my $rsp = query_isotovideo('check_screen', {mustmatch => $mustmatch, check => $check, timeout => $args{timeout}, no_wait => $args{no_wait}});
+    $args{mustmatch} //= $mustmatch;
+    $args{check}     //= $check;
+    my $rsp = query_isotovideo('check_screen', \%args);
     # separate function because it needs to call itself
-    return _check_backend_response($rsp, $check, $args{timeout}, $mustmatch, $args{no_wait});
+    return _check_backend_response($rsp, $check, $args{timeout}, $mustmatch, $args{no_wait}, $args{abort_on_stall});
 }
 
 =head2 assert_screen
 
-  assert_screen($mustmatch [, [$timeout] | [timeout => $timeout]] [, no_wait => $no_wait]);
+  assert_screen($mustmatch [, [$timeout] | [timeout => $timeout]] [, no_wait => $no_wait] [, abort_on_stall => $abort_on_stall]);
 
 Wait for needle with tag C<$mustmatch> to appear on SUT screen. C<$mustmatch>
 can be string or C<ARRAYREF> of string (C<['tag1', 'tag2']>). The maximum
@@ -272,6 +274,13 @@ Specify C<$no_wait> to run the screen check as fast as possible that is
 possibly more than once per second which is default. Select this to check a
 screen which can change in a range faster than 1-2 seconds not to miss the
 screen to check for.
+
+Specify C<$abort_on_stall> to look for system stalls while checking for screens.
+Sometimes systems running tests can stall during which C<isotovideo> is
+basically blind. When it is mandatory for testing to not miss a screen, set
+this option. As C<$no_wait> is meant for checking time critical screen changes
+consider setting both C<$no_wait> and C<$abort_on_stall> together for example
+when checking dialogues which timeout.
 
 Returns matched needle or throws C<NeedleFailed> exception if $timeout timeout
 is hit. Default timeout is 30s.
@@ -289,7 +298,7 @@ sub assert_screen {
 
 =head2 check_screen
 
-  check_screen($mustmatch [, [$timeout] | [timeout => $timeout]] [, no_wait => $no_wait]);
+  check_screen($mustmatch [, [$timeout] | [timeout => $timeout]] [, no_wait => $no_wait] [, abort_on_stall => $abort_on_stall]);
 
 Similar to C<assert_screen> but does not throw exceptions. Use this for optional matches.
 Check C<assert_screen> for parameters.


### PR DESCRIPTION
This changes the previous behaviour of always aborting the test in case of a
system stall to only abort when explicitly selected.

A system stall is bad but we can not fix it in the scope of os-autoinst
because it is an infrastructure issue. Also, not every check_screen or
assert_screen with a stall within is necessary for us to die on. Same as a
manual tester that goes for a cup of coffee. If he misses a dialog on the
screen with a timeout, this would be bad, but in most cases when he returns to
check the screen either the SUT is still busy doing something or already
waiting at the state where the user would need to give new inputs and the
tester actually checks the screen against his reference.

Explicit checking for stalls can be selected on the calls of
`check|assert_screen` as well as for the whole test execution with the
`vars.json` variable `DETECT_STALL`.

Manually verified with the help of `t/99-full-stack.t` checking for correct
settings of the flag based on the testapi calls.