### PR TITLE
testapi: Add generic 'record_info' function similar to 'record_soft_failure'

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -396,6 +396,7 @@ sub record_serialresult {
 
 sub record_soft_failure_result {
     my ($self, $reason) = @_;
+    $reason //= '(no reason specified)';
 
     my $result = $self->record_testresult('unk');
     $self->_result_add_screenshot($result);

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -193,6 +193,12 @@ subtest 'assert_and_click' => sub {
     is_deeply($cmds->[-1], {cmd => 'backend_mouse_hide', offset => 0}, 'assert_and_click succeeds and hides mouse again -> undef return');
 };
 
+subtest 'record_info' => sub {
+    ok(record_info('my title', "my output\nnext line"), 'simple call');
+    ok(record_info('my title', 'output', result => 'ok', resultname => 'foo'), 'all arguments');
+    like(exception { record_info('my title', 'output', result => 'not supported', resultname => 'foo') }, qr/unsupported/, 'invalid result');
+};
+
 done_testing;
 
 # vim: set sw=4 et:


### PR DESCRIPTION
This generic 'record_info' function can be used to record a step result
without influencing the actual result and having more flexibility
regarding the content and what should be displayed.