### PR TITLE
testapi: Simplify save_memory_dump call

### DIFF
--- a/doc/memorydumps.asciidoc
+++ b/doc/memorydumps.asciidoc
@@ -48,7 +48,7 @@ A very simple way to use this helpful feature is the following:
 sub post_fail_hook {
 	my $self = shift;
 	freeze_vm;
-	save_memory_dump("my-memory-dump");
+	save_memory_dump(filename => "my-memory-dump");
 	save_storage_drives("my-disk");
 }
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -1406,7 +1406,7 @@ sub eject_cd {
 
 =head2 save_memory_dump
 
-  save_memory_dump([{ filename => undef, migration_speed => "4096m" }]);
+  save_memory_dump(filename => undef, migration_speed => "4096m");
 
 Saves the SUT memory state using C<$filename> as base for the memory dump
 filename,  the default will be the current test's name.
@@ -1420,14 +1420,14 @@ I<Currently only qemu backend is supported.>
 =cut
 
 sub save_memory_dump {
-    my ($args) = @_;
-    $args->{filename} ||= ref($autotest::current_test);
+    my %nargs = @_;
+    $nargs{filename} ||= ref($autotest::current_test);
 
-    bmwqemu::log_call();
+    bmwqemu::log_call(%nargs);
     bmwqemu::diag "If save_memory_dump is called multiple times with the same '\$filename', it will be rewritten." unless ((caller(1))[3]) =~ /post_fail_hook/;
     bmwqemu::diag("Trying to save machine state");
 
-    query_isotovideo('backend_save_memory_dump', $args);
+    query_isotovideo('backend_save_memory_dump', \%nargs);
 }
 
 =head2 save_storage_drives


### PR DESCRIPTION
Use idiomatic Perl named arguments. That is, interpret the argument list as a
map, so that named arguments can be passed without brackets. Also record the
arguments in the log and correct the documentation.

AFAIK the only user of this function with named arguments is the LTP runner.