### PR TITLE
Check if mouse pos var is defined before use

### DIFF
--- a/consoles/vnc_base.pm
+++ b/consoles/vnc_base.pm
@@ -52,7 +52,7 @@ sub get_last_mouse_set {
 sub connect_vnc {
     my ($self, $args) = @_;
 
-    $self->{mouse} = {x => undef, y => undef};
+    $self->{mouse} = {x => -1, y => -1};
 
     CORE::say __FILE__. ":" . __LINE__ . ":" . bmwqemu::pp($args);
     $self->{vnc} = consoles::VNC->new($args);


### PR DESCRIPTION
Fixes https://progress.opensuse.org/issues/17058