### PR TITLE
Remove String::Random dependency

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -57,7 +57,6 @@ on 'test' => sub {
   requires 'Test::MockModule';
   requires 'Pod::Coverage';
   requires 'Devel::Cover';
-  requires 'String::Random';
 };
 
 feature 'coverage', 'coverage for travis' => sub {

--- a/t/10-test-image-conversion-benchmark.t
+++ b/t/10-test-image-conversion-benchmark.t
@@ -9,7 +9,7 @@ use Test::Warnings;
 use Try::Tiny;
 use File::Basename;
 use File::Path qw(make_path remove_tree);
-use String::Random;
+use File::Temp 'tempfile';
 use Cwd;
 
 
@@ -23,7 +23,6 @@ use OpenQA::Benchmark::Stopwatch;
 # optional but very useful
 eval 'use Test::More::Color';                 ## no critic
 eval 'use Test::More::Color "foreground"';    ## no critic
-my $string = new String::Random;
 
 use needle;
 use cv;
@@ -47,8 +46,7 @@ my $watch = OpenQA::Benchmark::Stopwatch->new();
 $watch->start();
 
 foreach my $img_src (@all_images) {
-
-    my $filename = "$result_dir/test-" . $string->randregex('\d\d\d\d\d') . "$img_src";
+    my (undef, $filename) = tempfile('test-XXXXX', DIR => $result_dir, SUFFIX => $img_src, OPEN => 0);
     $image = tinycv::read($data_dir . '/' . $img_src);
     if ($image) {
         $image->write($filename);


### PR DESCRIPTION
String::Random is not packaged in Tumbleweed and instead adding new
dependency redo filename generation by using File::Temp