### PR TITLE
Set PRJDIR to default if not provided by vars.json

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -124,18 +124,16 @@ sub init {
     $| = 1;
     select($oldfh);
 
-    unless ($vars{CASEDIR}) {
-        die "DISTRI undefined\n" . pp(\%vars) . "\n" unless $vars{DISTRI};
-        my @dirs = ("$scriptdir/distri/$vars{DISTRI}");
-        unshift @dirs, $dirs[-1] . "-" . $vars{VERSION} if ($vars{VERSION});
-        for my $d (@dirs) {
-            if (-d $d) {
-                $vars{CASEDIR} = $d;
-                last;
-            }
+    die "CASEDIR variable not set in vars.json, unknown test case directory" if !$vars{CASEDIR};
+
+    unless ($vars{PRJDIR}) {
+        if (index($vars{CASEDIR}, '/var/lib/openqa/share') != 0) {
+            die "PRJDIR not specified and CASEDIR ($vars{CASEDIR}) does not appear to be a
+                subdir of default (/var/lib/openqa/share). Please specify PRJDIR in vars.json";
         }
-        die "can't determine test directory for $vars{DISTRI}\n" unless $vars{CASEDIR};
+        $vars{PRJDIR} = '/var/lib/openqa/share';
     }
+
 
     # defaults
     $vars{QEMUPORT} ||= 15222;

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -141,11 +141,6 @@ sub init {
     # openQA already sets a random string we can reuse
     $vars{JOBTOKEN} ||= random_string(10);
 
-    # FIXME: does not belong here
-    if (defined($vars{DISTRI}) && $vars{DISTRI} eq 'archlinux') {
-        $vars{HDDMODEL} = "ide";
-    }
-
     save_vars();
 
     ## env vars end

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -151,7 +151,7 @@ sub init {
     ## env vars end
 
     ## some var checks
-    if (!-x $gocrbin) {
+    if ($gocrbin && !-x $gocrbin) {
         $gocrbin = undef;
     }
     if ($vars{SUSEMIRROR} && $vars{SUSEMIRROR} =~ s{^(\w+)://}{}) {    # strip & check proto

--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -1,0 +1,102 @@
+#!/usr/bin/perl
+
+# Copyright (C) 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use 5.018;
+use warnings;
+use Test::More;
+use File::Temp 'tempdir';
+use File::Path 'make_path';
+use JSON;
+
+BEGIN {
+    unshift @INC, '..';
+}
+
+sub create_vars {
+    my $data = shift;
+    open(my $varsfh, '>', 'vars.json') || BAIL_OUT('can not create vars.json');
+    my $json = JSON->new->pretty->canonical;
+    print $varsfh $json->encode($data);
+    close($varsfh);
+}
+
+sub read_vars {
+    local $/;
+    open(my $varsfh, '<', 'vars.json') || BAIL_OUT('can not open vars.json for reading');
+    my $ret;
+    eval { $ret = JSON->new->relaxed->decode(<$varsfh>); };
+    die "parse error in vars.json:\n$@" if $@;
+    close($varsfh);
+    return $ret;
+}
+
+subtest 'CASEDIR is mandatory' => sub {
+    my $dir = '/var/lib/openqa';
+    create_vars({DISTRI => 'test', PRJDIR => $dir});
+
+    eval {
+        use bmwqemu ();
+        bmwqemu::init;
+    };
+    like($@, qr(CASEDIR variable not set in vars.json.*), 'bmwqemu refuses to init');
+
+
+    my %vars = %{read_vars()};
+    is($vars{DISTRI}, 'test', 'DISTRI unchanged by init call');
+    ok(!$vars{CASEDIR}, 'CASEDIR not set');
+    is($vars{PRJDIR}, $dir, 'PRJDIR unchanged');
+};
+
+subtest 'test PRJDIR default' => sub {
+    my $dir = '/var/lib/openqa/share/tests/test';
+    create_vars({CASEDIR => $dir});
+
+    eval {
+        use bmwqemu ();
+        bmwqemu::init;
+    };
+    ok(!$@, 'init successful');
+
+    my %vars = %{read_vars()};
+    ok(!$vars{DISTRI}, 'DISTRI not supplied and not set');
+    is($vars{CASEDIR}, $dir, 'CASEDIR unchanged');
+    is($vars{PRJDIR}, '/var/lib/openqa/share', 'PRJDIR set to default');
+};
+
+subtest 'test CASEDIR not under PRJDIR default' => sub {
+    my $dir = '/tmp/some/dir/tests/test';
+    create_vars({CASEDIR => $dir});
+
+    eval {
+        use bmwqemu ();
+        bmwqemu::init;
+    };
+    ok($@, 'bmwqemu init failed');
+
+    my %vars = %{read_vars()};
+    ok(!$vars{DISTRI}, 'DISTRI not supplied and not set');
+    is($vars{CASEDIR}, $dir, 'CASEDIR unchanged');
+    ok(!$vars{PRJDIR}, 'PRJDIR not supplied and not set');
+};
+
+done_testing;
+
+END {
+    unlink 'vars.json';
+}
+
+1;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,4 +1,4 @@
 AM_MAKEFLAGS = PERL5OPT="-MDevel::Cover=-db,$(abs_builddir)/cover_db"
-TESTS = 00-compile-check-all.t 01-test_needle.t 02-test_ocr.t 03-testapi.t 04-check_vars_docu.t 05-pod.t 06-pod-coverage.t 07-commands.t 08-autotest.t 09-lockapi.t 10-terminal.t 11-image-ppm.t 20-openqa-benchmark-stopwatch-utils.t 99-full-stack.t
+TESTS = 00-compile-check-all.t 01-test_needle.t 02-test_ocr.t 03-testapi.t 04-check_vars_docu.t 05-pod.t 06-pod-coverage.t 07-commands.t 08-autotest.t 09-lockapi.t 10-terminal.t 11-image-ppm.t 12-bmwqemu.t 20-openqa-benchmark-stopwatch-utils.t 99-full-stack.t
 
 EXTRA_DIST = $(TESTS)


### PR DESCRIPTION
if PRJDIR is not provided by vars.json try to set it to default
'/var/lib/openqa/share'. But do so only if CASEDIR is subdir of
this directory, otherwise report error and bail out

See https://progress.opensuse.org/issues/16362