### PR TITLE
Only abort test on stall if assert_screen failed (not check)

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -852,15 +852,14 @@ sub check_asserted_screen {
         # make sure we recheck later
         $self->assert_screen_last_check(undef);
 
-        if ($self->stall_detected) {
-            backend::baseclass::write_crash_file();
-            bmwqemu::mydie "assert_screen fails, but we detected a timeout in the process, so we abort";
-        }
         my $failed_screens = $self->assert_screen_fails;
         # store the final mismatch
         push(@$failed_screens, [$img, $failed_candidates, 0, 1000]);
         my $hash = $self->_failed_screens_to_json;
         $hash->{image} = encode_base64($img->ppm_data);
+        # store stall status
+        $hash->{stall} = $self->stall_detected;
+
         return $hash;
     }
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -261,6 +261,16 @@ sub _check_backend_response {
                 );
             }
         }
+        # Handle case where a stall was detected: fail if this is an
+        # assert_screen, warn if it's a check_screen
+        if ($rsp->{stall}) {
+            if (!$check) {
+                record_info('Stall detected', 'Stall was detected during assert_screen fail', result => 'fail');
+            }
+            else {
+                bmwqemu::fctwarn("stall detected during check_screen failure!");
+            }
+        }
         if (!$check && !$rsp->{saveresult}) {
             OpenQA::Exception::FailedNeedle->throw(error => "needle(s) '$mustmatch' not found", tags => $mustmatch);
         }


### PR DESCRIPTION
As discussed in #713, this code which aborts the test if a stall
is detected during a needle check has a problem. It will abort
the test even in `check_screen`, not just `assert_screen` - so
it can cause tests to fail which otherwise would not have.

This makes `check_asserted_screen` only register whether a stall
was detected or not, and makes `_check_backend_response` abort
the test if a stall was detected *and* it's in 'assert mode'. If
it's in 'check mode', it just logs a warning about the stall,
but will continue the test.

I'm a bit unsure what to do about the backend.crashed file.