### PR TITLE
Forward custom arguments to console_selected callback

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -1249,7 +1249,11 @@ our %testapi_console_proxies;
 
 =head2 select_console
 
-  select_console("root-console")
+    select_console($console [, @args]);
+
+Example:
+
+  select_console("root-console");
 
 Select the named console for further C<testapi> interaction (send_text,
 send_key, wait_screen_change, ...)
@@ -1261,10 +1265,13 @@ object (in this example) - so it will ensure the console is active,
 but to setup the root shell on this console, the distribution needs
 to run test code.
 
+After the console selection the distribution callback
+C<$distri->console_selected> is called with C<@args>.
+
 =cut
 
 sub select_console {
-    my ($testapi_console) = @_;
+    my ($testapi_console, @args) = @_;
     bmwqemu::log_call(testapi_console => $testapi_console);
     if (!exists $testapi_console_proxies{$testapi_console}) {
         $testapi_console_proxies{$testapi_console} = backend::console_proxy->new($testapi_console);
@@ -1279,7 +1286,7 @@ sub select_console {
         }
         $testapi::distri->activate_console($testapi_console);
     }
-    $testapi::distri->console_selected($testapi_console);
+    $testapi::distri->console_selected($testapi_console, @args);
 
     return $testapi_console_proxies{$testapi_console};
 }


### PR DESCRIPTION
Follow-up to https://github.com/os-autoinst/os-autoinst/pull/738

For the cases where a 'console_selected' callback is not desired but a test
distri specific one has been specified the callback can be configured to be
not called at all. For example when the callback is a check for the console to
be shown but the check should be done explicitly in the test and it is not
desired to overwrite the distribution callback.

Related progress issue: https://progress.opensuse.org/issues/14826