### PR TITLE
Swtich to virtio-gpu on aarch64

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -394,7 +394,7 @@ sub start_qemu {
         $arch_supports_boot_order = 0;
     }
     if ($vars->{ARCH} eq 'aarch64' || $vars->{ARCH} eq 'arm') {
-        push @vgaoptions, '-device', 'VGA';
+        push @vgaoptions, '-device', 'virtio-gpu-pci';
         $arch_supports_boot_order = 0;
         $use_usb_kbd              = 1;
     }


### PR DESCRIPTION
To avoid unreliable test results in our arm workers, this switch to
virtio-gpu which requires qemu version 2.8 will allow to use proper
video emulation.

This video shows the switch from terminal console to X back and forth (http://xgene2.arch/tests/158/file/video.ogv) in the autoinst-log.txt file the `-device virtio-gpu-pci` option can be seen also. 

This also requires two PR from gitlab defined in poo#17740