### PR TITLE
Fix assert_and_click mouse hiding

### DIFF
--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -45,6 +45,9 @@ sub fake_read_json {
     elsif ($cmd eq 'backend_mouse_hide') {
         return {ret => 1};
     }
+    elsif ($cmd eq 'backend_get_last_mouse_set') {
+        return {ret => {x => -1, y => -1}};
+    }
     else {
         print "not implemented \$cmd: $cmd\n";
     }

--- a/testapi.pm
+++ b/testapi.pm
@@ -418,7 +418,7 @@ sub assert_and_click {
     sleep 1;
     # move mouse back to where it was before we clicked, or to the 'hidden'
     # position if it had never been positioned
-    if (defined $old_mouse_coords->{x} && defined $old_mouse_coords->{y}) {
+    if ($old_mouse_coords->{x} > -1 && $old_mouse_coords->{y} > -1) {
         return mouse_set($old_mouse_coords->{x}, $old_mouse_coords->{y});
     }
     else {


### PR DESCRIPTION
See https://progress.opensuse.org/issues/17058#note-7 - #728
caused a problem with the cursor reposition that occurs at the
end of `assert_and_click`, in the case that the cursor had not
been explicitly positioned before the `assert_and_click`. In
this case, `assert_and_click` is meant to call `mouse_hide`.
However, #728 made `get_last_mouse_set` *always* return defined
values, while `assert_and_click` expected it to return undefined
values when the cursor had never been positioned, so it wound
up trying to position the cursor to -1, -1 instead of calling
`mouse_hide`.

The fix is pretty simple: just adapt the condition to the new
behaviour of `get_last_mouse_set`.