### PR TITLE
Die when validate_script_output called without $code

### DIFF
--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -203,6 +203,19 @@ subtest 'record_info' => sub {
     like(exception { record_info('my title', 'output', result => 'not supported', resultname => 'foo') }, qr/unsupported/, 'invalid result');
 };
 
+subtest 'validate_script_output' => sub {
+    my $mock_testapi = new Test::MockModule('testapi');
+    $mock_testapi->mock(script_output => sub ($;$) { return 'output'; });
+    pass(validate_script_output('script', sub { m/output/ }));
+    pass(validate_script_output('script', sub { m/output/ }, 30));
+    like(
+        exception {
+            validate_script_output('script', sub { m/error/ });
+        },
+        qr/output not validating/
+    );
+};
+
 done_testing;
 
 # vim: set sw=4 et:

--- a/testapi.pm
+++ b/testapi.pm
@@ -912,7 +912,6 @@ sub validate_script_output($&;$) {
     $wait ||= 30;
 
     my $output = script_output($script, $wait);
-    return unless $code;
     my $res = 'ok';
 
     # set $_ so the callbacks can be simpler code


### PR DESCRIPTION
No sense of using validate_script_output without callback code
for validation so function will fail with
proper error message when it is happening