### PR TITLE
svirt: Catch errors in passing wrong arguments

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -324,11 +324,14 @@ sub add_disk {
     }
     else {    # Copy image to VM host
         my $dir = "/var/lib/libvirt/images";
-        $self->run_cmd("rsync -av $args->{file} ${dir}/" . basename($args->{file})) && die 'rsync failed';
+        die "No file given" unless $args->{file};
+        die "File $args->{file} not readable" unless -r $args->{file};
+        $self->run_cmd(sprintf("rsync -av '$args->{file}' '${dir}/%s'", basename($args->{file}))) && die 'rsync failed';
         if ($args->{backingfile}) {
             if ($self->vmm_family ne 'vmware') {
                 $file = "/var/lib/libvirt/images/$file";
-                $self->run_cmd("qemu-img create ${file} -f qcow2 -b " . $dir . '/' . basename($args->{file})) && die "qemu-img create with backing file failed";
+                $self->run_cmd(sprintf("qemu-img create '${file}' -f qcow2 -b '$dir/%s'", basename($args->{file})))
+                  && die "qemu-img create with backing file failed";
             }
         }
         else {    # cdrom


### PR DESCRIPTION
Do not create rsync command lines without checking