### PR TITLE
[WIP] Initial support for NVRAM uefi variable storage using QEMU_PFLASH variable

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -668,8 +668,17 @@ sub start_qemu {
 
         if ($vars->{UEFI_PFLASH}) {
             # Convert the firmware file into qcow2 format or savevm would fail
-            runcmd('qemu-img', 'convert', '-O', 'qcow2', $vars->{BIOS}, 'ovmf.bin');
-            push(@params, "-drive", "if=pflash,format=qcow2,file=ovmf.bin");
+            # Prepare clean 64M nvram image for uefi vars in raw format
+            runcmd("dd", "if=/dev/zero", "of=uefi-vars.bin", "iflag=fullblock", "bs=1M", "count=64");
+            # Convert uefi raw fw from BIOS var into 64M image for uefi code in raw format
+            runcmd("dd", "if=$vars->{BIOS}", "iflag=fullblock", "bs=1M", "of=uefi-code.bin");
+            runcmd("truncate", "-s", "64M", "uefi-code.bin");
+            # Convert both raw images into qcow2 format
+            foreach my $i (qw(uefi-vars uefi-code)) {
+                runcmd("qemu-img", "convert", "-O", "qcow2", "$i.bin", "$i.qcow2");
+            }
+            push(@params, "-drive", "if=pflash,format=qcow2,file=uefi-code.qcow2,unit=0,readonly=on");
+            push(@params, "-drive", "if=pflash,format=qcow2,file=uefi-vars.qcow2,unit=1");
         }
         elsif ($vars->{BIOS}) {
             push(@params, "-bios", $vars->{BIOS});


### PR DESCRIPTION
Refactoring of QEMU_PFLASH variable for future use.

Problem description: until now we miss a persistent storage for uefi vars which contains for eg. boot-order values for efi firmware. It means that if we want to use image generated on uefi machine in different job the machine will not boot from provided image but from mounted iso/DVD instead. If we transfer also uefi-vars.qcow2 together with hdd image we will be able to boot directly from the image.

https://wiki.linaro.org/LEG/UEFIforQEMU

TODO:
1) add support for publishing hdd image together with uefi-vars.qcow2  over PUBLISH_HDD variable
2) do not override uefi-vars.qcow2 for children jobs using QEMU_PFLASH and same BIOS value as parent job
3) make it compatible with x86_64 (current code compatible only with aarch64)