### PR TITLE
Add support for older qemu versions on aarch64

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -395,7 +395,8 @@ sub start_qemu {
         $arch_supports_boot_order = 0;
     }
     if ($vars->{ARCH} eq 'aarch64' || $vars->{ARCH} eq 'arm') {
-        push @vgaoptions, '-device', 'virtio-gpu-pci';
+        my $video_device = ($vars->{QEMU_OVERRIDE_VIDEO_DEVICE_AARCH64}) ? 'VGA' : 'virtio-gpu-pci';
+        push @vgaoptions, '-device', $video_device;
         $arch_supports_boot_order = 0;
         $use_usb_kbd              = 1;
     }

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -54,6 +54,7 @@ NICTYPE_USER_OPTIONS;string;undef;Arbitrary options for NICTYPE
 NICVLAN;integer;undef;network (vlan) number to which the NIC should be connected, assigned by scheduler to jobs with NICTYPE != user
 NUMDISKS;integer;1;Number of disks to be created and attached to VM
 OFW;;;
+QEMU_OVERRIDE_VIDEO_DEVICE_AARCH64;boolean;undef;If set, for aarch64 systems use VGA as video adapter
 PATHCNT;integer;2;Number of paths in MULTIPATH scenario
 PXEBOOT;boolean;0;Boot VM from network
 QEMU;QEMU binary filename;undef;Filename of QEMU binary to use


### PR DESCRIPTION
Since the switch to virtio-gpu-pci (64476a5) some of our workers have
stop working properly. This is due to the worker only having support
For VGA. (This is the counterpart of bsc#1023101)