### PR TITLE
Change 'important' flag to 'unimportant'

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -88,11 +88,9 @@ sub is_applicable {
 Return a hash of flags that are either there or not
 
   without anything - rollback to 'lastgood' snapshot if failed
-  'fatal' - whole test suite is in danger if this fails
-  'milestone' - after this test succeeds, update 'lastgood'
-  'important' - if this fails, set the overall state to 'fail'
-
-default is obviously no flags, installation tests are 'fatal' by default
+  'fatal'          - abort whole test suite if this fails (and set overall state 'failed')
+  'ignore_failure' - if this module fails, it will not affect the overall result at all
+  'milestone'      - after this test succeeds, update 'lastgood'
 
 =cut
 

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -95,12 +95,12 @@ is($died,      0, 'non-fatal test failure should not die');
 is($completed, 1, 'non-fatal test failure should complete');
 @sent = [];
 
-# now let's add an important test
-loadtest 'important';
+# now let's add an ignore_failure test
+loadtest 'ignore_failure';
 autotest::run_all;
 ($died, $completed) = get_tests_done;
-is($died,      0, 'important test failure should not die');
-is($completed, 1, 'important test failure should complete');
+is($died,      0, 'unimportant test failure should not die');
+is($completed, 1, 'unimportant test failure should complete');
 @sent = [];
 
 # now let's add a fatal test

--- a/t/data/tests/tests/boot.pm
+++ b/t/data/tests/tests/boot.pm
@@ -53,7 +53,7 @@ END
 }
 
 sub test_flags {
-    return {important => 1};
+    return {};
 }
 
 1;

--- a/t/fake/tests/ignore_failure.pm
+++ b/t/fake/tests/ignore_failure.pm
@@ -5,7 +5,7 @@ use base 'basetest';
 sub run { }
 
 sub test_flags {
-    return {important => 1};
+    return {ignore_failure => 1};
 }
 
 1;

--- a/testapi.pm
+++ b/testapi.pm
@@ -1586,7 +1586,7 @@ sub parse_junit_log {
 
         push @tests,
           {
-            flags    => {important => 1},
+            flags    => {},
             category => $ts_category,
             name     => $ts_name,
             script   => $autotest::current_test->{script},


### PR DESCRIPTION
This goes with https://github.com/os-autoinst/openQA/pull/1297 .
It updates os-autoinst's docs, comments and sample / test
modules to document and use the 'unimportant' flag rather than
'important'. os-autoinst itself doesn't actually take the
'important' flag into account at any point, so this commit alone
should have no real practical impact at all. See the openQA PR
for more info on the 'why' of this.