### PR TITLE
os-autoinst-openvswitch: Check for valid $vlan parameter

### DIFF
--- a/os-autoinst-openvswitch
+++ b/os-autoinst-openvswitch
@@ -90,6 +90,10 @@ sub set_vlan {
         print STDERR "'$tap' does not fit the naming scheme\n";
         return;
     }
+    if ($vlan !~ /^[0-9]+$/) {
+        print STDERR "'$vlan' does not fit the naming scheme (only numbers)\n";
+        return;
+    }
 
     my $check_bridge = `ovs-vsctl port-to-br $tap`;
     chomp $check_bridge;


### PR DESCRIPTION
Adding an additional check as requested in
https://bugzilla.suse.com/show_bug.cgi?id=1032649
to pass security audit.