### PR TITLE
Fix svirt add_disk for remote files

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -325,16 +325,16 @@ sub add_disk {
     else {    # Copy image to VM host
         my $dir = "/var/lib/libvirt/images";
         die "No file given" unless $args->{file};
-        die "File $args->{file} not readable" unless -r $args->{file};
-        $self->run_cmd(sprintf("rsync -av '$args->{file}' '${dir}/%s'", basename($args->{file}))) && die 'rsync failed';
         if ($args->{backingfile}) {
+            die "File $args->{file} not readable" unless -r $args->{file};
+            $self->run_cmd(sprintf("rsync -av '$args->{file}' '${dir}/%s'", basename($args->{file}))) && die 'rsync failed';
             if ($self->vmm_family ne 'vmware') {
                 $file = "/var/lib/libvirt/images/$file";
                 $self->run_cmd(sprintf("qemu-img create '${file}' -f qcow2 -b '$dir/%s'", basename($args->{file})))
                   && die "qemu-img create with backing file failed";
             }
         }
-        else {    # cdrom
+        else {    # e.g. cdrom
             $file = "/var/lib/libvirt/images/" . basename($args->{file});
         }
     }


### PR DESCRIPTION
In case of patched systems, add_disk files are not readable on the
openqa worker but only on the remote system - and as such there is no
point in either checking nor calling rsync

See https://openqa.suse.de/tests/887899#step/bootloader_zkvm_sym/16