### PR TITLE
Remove all disabled debug statements

### DIFF
--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -924,8 +924,6 @@ sub _receive_update {
     my $hlen                 = $socket->read(my $header, 3) || die 'unexpected end of data';
     my $number_of_rectangles = unpack('xn', $header);
 
-    #bmwqemu::diag "NOR $number_of_rectangles";
-
     my $depth = $self->depth;
 
     my $do_endian_conversion = $self->_do_endian_conversion;
@@ -936,8 +934,6 @@ sub _receive_update {
 
         # unsigned -> signed conversion
         $encoding_type = unpack 'l', pack 'L', $encoding_type;
-
-        #bmwqemu::diag "UP $x,$y $w x $h $encoding_type";
 
         # work around buggy addrlink VNC
         next if ($w * $h == 0);
@@ -1052,14 +1048,12 @@ sub _receive_ikvm_encoding {
     # ikvm specific
     $socket->read(my $aten_data, 8);
     my ($data_prefix, $data_len) = unpack('NN', $aten_data);
-    #printf "P $encoding_type $data_prefix $data_len $x+$y $w x $h (%dx%d)\n", $self->width, $self->height;
 
     $self->screen_on($w < 33000);    # screen is off is signaled by negative numbers
 
     # ikvm doesn't bother sending screen size changes
     if ($w != $self->width || $h != $self->height) {
         if ($self->screen_on) {
-            # printf "resizing to $w $h from %dx%d\n", $self->width, $self->height;
             my $newimg = tinycv::new($w, $h);
             if ($image) {
                 $image = $image->copyrect(0, 0, min($image->xres(), $w), min($image->yres(), $h));


### PR DESCRIPTION
"print-debugging" effects should not be visible in code.
If necessary, proper logging calls should be used.
Disabled code (with no good explanation) should not be
present in production code. That is what a VCS is for,
e.g. store in private development branches.