### PR TITLE
Collect ipmi management controller info before restarting host

### DIFF
--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -123,6 +123,7 @@ sub do_start_vm() {
 
     # remove backend.crashed
     $self->unlink_crash_file;
+    $self->get_mc_status;
     $self->restart_host;
     $self->relogin_vnc;
     $self->start_serial_grab;
@@ -176,6 +177,18 @@ sub stop_serial_grab {
 }
 
 # serial grab end
+
+# management controller status
+
+sub get_mc_status {
+    my ($self) = @_;
+
+    $self->ipmitool("mc guid");
+    $self->ipmitool("mc info");
+    $self->ipmitool("mc selftest");
+}
+
+# management controller status end
 
 1;
 


### PR DESCRIPTION
As part of the investigations for https://progress.opensuse.org/issues/18144 we need to be more aware of the status of the IPMI management controller (mc) at the start of every test run.

This PR will get the guid, info, and selftest results of the ipmi mc as part of every test run.

This information is useful to have even if we weren't diagnosing the issues in poo#18144, hence not a hotfix.