### PR TITLE
[svirt] Copy cdrom images

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -325,9 +325,11 @@ sub add_disk {
     else {    # Copy image to VM host
         my $dir = "/var/lib/libvirt/images";
         die "No file given" unless $args->{file};
-        if ($args->{backingfile}) {
+        if ($args->{cdrom} or $args->{backingfile}) {
             die "File $args->{file} not readable" unless -r $args->{file};
             $self->run_cmd(sprintf("rsync -av '$args->{file}' '${dir}/%s'", basename($args->{file}))) && die 'rsync failed';
+        }
+        if ($args->{backingfile}) {
             if ($self->vmm_family ne 'vmware') {
                 $file = "/var/lib/libvirt/images/$file";
                 $self->run_cmd(sprintf("qemu-img create '${file}' -f qcow2 -b '$dir/%s'", basename($args->{file})))


### PR DESCRIPTION
Due to commit 38ae838 cdrom images,
which are not 'created' nor used as 'backing' files, we not synced from
NFS. They are synced now. zKVM should not be affected.

Failing test with old os-autoinst: http://assam.suse.cz/tests/5625.

Verification that cdrom images are found, synced, and used correctly:
* SLES: http://assam.suse.cz/tests/5626
* SLES+WE: http://assam.suse.cz/tests/5632
* JeOS: http://assam.suse.cz/tests/5628
* CaaSP: http://assam.suse.cz/tests/5630

@Soulofdestiny FYI.