### PR TITLE
Enable keepalive for IPMI SOL

### DIFF
--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -155,7 +155,10 @@ sub start_serial_grab {
         open(my $serial, '>',  $self->{serialfile});
         open(STDOUT,     ">&", $serial);
         open(STDERR,     ">&", $serial);
-        my @cmd = ('/usr/sbin/ipmiconsole', '-h', $bmwqemu::vars{IPMI_HOSTNAME}, '-u', $bmwqemu::vars{IPMI_USER}, '-p', $bmwqemu::vars{IPMI_PASSWORD});
+        my @cmd = (
+            '/usr/sbin/ipmiconsole', '--serial-keepalive', '-h', $bmwqemu::vars{IPMI_HOSTNAME},
+            '-u', $bmwqemu::vars{IPMI_USER},
+            '-p', $bmwqemu::vars{IPMI_PASSWORD});
 
         # zypper in dumponlyconsole, check devel:openQA for a patched freeipmi version that doesn't grab the terminal
         push(@cmd, '--dumponly');


### PR DESCRIPTION
The Serial over LAN for ipmiconsole is vulnerable to disconnects if it is not being used interactively. This will force the ipmiconsole to send regular NUL characters to keep the connection alive, which should make it a lot more robust.

This function was precisely intended for situations where an IPMI console might not be having user interactivity but is needed for long term logging, much like we need in some openQA scenarios.