### PR TITLE
Set SCSI bus only for matching CD models

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -620,7 +620,7 @@ sub start_qemu {
             }
         }
 
-        my $cdbus = $vars->{CDMODEL} ne 'ide-cd' ? ',bus=scsi0.0' : '';
+        my $cdbus = $vars->{CDMODEL} eq 'scsi-cd' ? ',bus=scsi0.0' : '';
         if ($iso) {
             if ($vars->{USBBOOT}) {
                 push(@params, "-drive",  "if=none,id=usbstick,file=$iso,snapshot=on");


### PR DESCRIPTION
bus=scsi0.0 is only valid if CDMODEL is scsi-cd, and breaks qemu for e.g.
CDMODEL=virtio-blk-device. Fixes https://progress.opensuse.org/issues/18570

Signed-off-by: Stefan Brüns <stefan.bruens@rwth-aachen.de>