### PR TITLE
Clarify error message for undiscoverable needle

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -272,7 +272,7 @@ sub _check_backend_response {
             }
         }
         if (!$check && !$rsp->{saveresult}) {
-            OpenQA::Exception::FailedNeedle->throw(error => "needle(s) '$mustmatch' not found", tags => $mustmatch);
+            OpenQA::Exception::FailedNeedle->throw(error => "no candidate needle with tag(s) '$mustmatch' matched", tags => $mustmatch);
         }
         if ($rsp->{saveresult}) {
             $autotest::current_test->save_test_result();


### PR DESCRIPTION
This clarifies error messages like this:
`10:06:41.8585 17198 post_fail_hook failed: needle(s) 'password-prompt' not found`
(like seen in https://openqa.suse.de/tests/918407/file/autoinst-log.txt)

Proof run is in progress and will be added later. If not needed, feel free to merge and close.