### PR TITLE
Handle expects expects number, gets string

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -824,6 +824,7 @@ sub assert_script_sudo {
     my $str = hashed_string("ASS$cmd");
     script_sudo("$cmd; echo $str-\$?- > /dev/$serialdev", 0);
     my $ret = wait_serial("$str-\\d+-", $wait);
+    $ret = ($ret =~ /$str-(\d+)-/)[0] if $ret;
     _handle_script_run_ret($ret, $cmd);
     return;
 }


### PR DESCRIPTION
`wait_serial` returns matched string or undef. However
`_handle_script_run_ret` expects in $1 to have return number. This
change feeds `_handle_script_run_ret` with zero on match, or undef
otherwise.