### PR TITLE
Always restart the SOL - dumpconsole exits with 0 :(

### DIFF
--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -165,7 +165,8 @@ sub start_serial_grab {
     no autodie 'system';
 
     # Start serial grab
-    while (system(@cmd)) {
+    while (1) {
+        system(@cmd);
         print STDERR "SOL failed, reconnecting [$?]\n";
         sleep 1;
     }


### PR DESCRIPTION
```
[    9.822509] ata2.00: AT[SOL established]

[error received]: excess errors received

[closing the connection]
SOL failed, reconnecting [0]
```