### PR TITLE
Do not stop the debug viewer but keep running with old/black image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: perl
 perl:
   - "5.18-extras"

--- a/debugviewer/debugviewer.cpp
+++ b/debugviewer/debugviewer.cpp
@@ -16,15 +16,11 @@ int main(int argc, char** argv)
         return -1;
     }
 
-    Mat image;
+    Mat image(768, 1024, CV_8UC3, Scalar(0, 0, 0));
     while (1) {
-        image = imread(argv[1], CV_LOAD_IMAGE_COLOR); // Read the file
-
-        if (!image.data) // Check for invalid input
-        {
-            cout << "Could not open or find the image" << std::endl;
-            return -1;
-        }
+        Mat last = imread(argv[1], CV_LOAD_IMAGE_COLOR); // Read the file
+        if (last.data)
+            image = last;
 
         namedWindow("Display window",
             WINDOW_AUTOSIZE); // Create a window for display.


### PR DESCRIPTION
It's quite annoying if the debug viewer closes on temporary glitches or
if the test did not yet create a last.png. Just keep it running - it's
for debugging after all