### PR TITLE
tinycv: Reenable cache for prepped images for needle search

### DIFF
--- a/ppmclibs/tinycv_impl.cc
+++ b/ppmclibs/tinycv_impl.cc
@@ -45,7 +45,7 @@ struct Image {
 
     cv::Mat prep() const
     {
-        if (!_preped.empty() && false)
+        if (!_preped.empty())
             return _preped;
 
         _preped = img.clone();


### PR DESCRIPTION
Commit b4f690c3b6 "Support ZLRE and RRE encoding in VNC implementation"
disabled the cache for the prepped, i.e. blurred and grayscale converted,
scene and needle image data. This change was not intended, reenable the
cache.

Signed-off-by: Stefan Brüns <stefan.bruens@rwth-aachen.de>