### PR TITLE
qemu: disable CoW for the HDD image directory

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -505,6 +505,7 @@ sub start_qemu {
     bmwqemu::save_vars();                     # update variables
 
     mkpath($basedir);
+    runcmd('/usr/bin/chattr', '-f', '+C', $basedir);
 
     my $keephdds = $vars->{KEEPHDDS} || $vars->{SKIPTO};
 


### PR DESCRIPTION
CoW lowers performance for VM disk images, thus disable it for the
HDD image directory.

Signed-off-by: Stefan Brüns <stefan.bruens@rwth-aachen.de>