### PR TITLE
Pass required C++ version to Makefile.PL

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -106,7 +106,7 @@ OPENVSWITCH_SERVICE = systemd/os-autoinst-openvswitch.service
 
 ppmclibs/Makefile: ppmclibs/Makefile.PL
 	cd ppmclibs && \
-	perl Makefile.PL OPTIMIZE="$(CXXFLAGS)"
+	perl Makefile.PL OPTIMIZE="$(CXXFLAGS)" CC="$(CXX)"
 
 $(PERL_MODULE): ppmclibs/Makefile
 	$(MAKE) -C ppmclibs


### PR DESCRIPTION
The autoconf macro adds the option to the CXX variable (e.g.
CXX=g++ -std=gnu++11), so pass this on to MakeMaker.
This completes/fixes PR #788.

Signed-off-by: Stefan Brüns <stefan.bruens@rwth-aachen.de>