### PR TITLE
Reduce noise in stopwatch output and reformat needle dimensions/position

### DIFF
--- a/ppmclibs/tinycv.pm
+++ b/ppmclibs/tinycv.pm
@@ -120,7 +120,6 @@ sub search_ {
 
     $ret->{error} = mean_square_error($ret->{area});
     bmwqemu::diag(sprintf("MATCH(%s:%.2f)", $needle->{name}, 1 - sqrt($ret->{error})));
-    $stopwatch->lap("**++ mean_square_error") if $stopwatch;
     if ($ret->{ok}) {
         for my $a (@ocr) {
             $ret->{ocr} ||= [];

--- a/ppmclibs/tinycv.pm
+++ b/ppmclibs/tinycv.pm
@@ -87,15 +87,15 @@ sub search_ {
             $img->replacerect($a->{xpos}, $a->{ypos}, $a->{width}, $a->{height});
             $stopwatch->lap("**++-- search__: rectangle replacement") if $stopwatch;
         }
+        $stopwatch->lap("**++ search__: areas exclusion") if $stopwatch;
     }
-    $stopwatch->lap("**++ search__: areas exclusion") if $stopwatch;
     my $ret = {ok => 1, needle => $needle, area => []};
     for my $area (@match) {
         my $margin = int($area->{margin} + $search_ratio * (1024 - $area->{margin}));
 
         ($sim, $xmatch, $ymatch) = $img->search_needle($needle_image, $area->{xpos}, $area->{ypos}, $area->{width}, $area->{height}, $margin);
 
-        $stopwatch->lap("**++ tinycv::search_needle $area->{xpos}x$area->{ypos}x$area->{width}") if $stopwatch;
+        $stopwatch->lap("**++ tinycv::search_needle $area->{width}x$area->{height} + $margin @ $area->{xpos}x$area->{ypos}") if $stopwatch;
         my $ma = {
             similarity => $sim,
             x          => $xmatch,


### PR DESCRIPTION
Currently the output looks like:
```
 Searching for needles                                  0.000       0.000           0.001%
 **++ search__: get image                               0.000       0.000           0.001%
 **++ search__: areas exclusion                         0.000       0.000           0.001%
 **++ tinycv::search_needle 534x12x51                   0.081       0.081           3.842%
 **++ tinycv::search_needle 2x9x83                      0.056       0.138           2.672%
 **++ mean_square_error                                 0.000       0.138           0.005%
 ** search_: tty2-selected-20151130                     0.000       0.138           0.000%
 **++ search__: get image                               0.000       0.138           0.001%
 **++ search__: areas exclusion                         0.000       0.138           0.000%
 **++ tinycv::search_needle 534x12x51                   0.058       0.196           2.756%
 **++ tinycv::search_needle 2x17x80                     0.055       0.251           2.597%
 **++ mean_square_error                                 0.000       0.251           0.006%
 ** search_: tty2-selected-20170426                     0.000       0.251           0.000%
 **++ search__: get image                               0.000       0.251           0.001%
 **++ search__: areas exclusion                         0.000       0.251           0.000%
...
 _stop_                                                 0.000       2.115           0.006%
```

The new output looks like:
```
 Searching for needles                                  0.000       0.000           0.001%
 **++ search__: get image                               0.000       0.000           0.001%
 **++ tinycv::search_needle 51x40 + 50 @ 534x12         0.081       0.081           3.842%
 **++ tinycv::search_needle 83x20 + 50 @ 2x9            0.056       0.138           2.672%
 ** search_: tty2-selected-20151130                     0.000       0.138           0.000%
 **++ search__: get image                               0.000       0.138           0.001%
 **++ tinycv::search_needle 51x40 + 50 @ 534x12         0.058       0.196           2.756%
 **++ tinycv::search_needle 80x20 + 50 @ 2x17           0.055       0.251           2.597%
 ** search_: tty2-selected-20170426                     0.000       0.251           0.000%
 **++ search__: get image                               0.000       0.251           0.001%
...
 _stop_                                                 0.000       2.115           0.006%
```