### PR TITLE
serial_terminal: Wait for prompt

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -25,6 +25,19 @@ sub new() {
 
     my $self = bless {}, $class;
     $self->{consoles} = {};
+
+=head2 serial_term_prompt
+
+   wait_serial($serial_term_prompt);
+
+A simple undecorated prompt for serial terminals. ANSI escape characters only
+serve to create log noise in most tests which use the serial terminal, so
+don't use them here. Also avoid using characters which have special meaning in
+a regex. Note that our common prompt character '#' denotes a comment in a
+regex with '/z' on the end, but if you are using /z you will need to wrap the
+prompt in \Q and \E anyway otherwise the whitespace will be ignored.
+=cut
+    $self->{serial_term_prompt} = '# ';
     return $self;
 }
 
@@ -108,6 +121,9 @@ sub script_run {
     my ($self, $cmd, $wait) = @_;
     $wait //= $bmwqemu::default_timeout;
 
+    if (testapi::is_serial_terminal) {
+        testapi::wait_serial($self->{serial_term_prompt}, undef, 0, no_regex => 1);
+    }
     testapi::type_string "$cmd";
     if ($wait > 0) {
         my $str = testapi::hashed_string("SR$cmd$wait");


### PR DESCRIPTION
It appears that os-autoinst is sometimes too fast for the SUT and starts
sending characters before the shell (e.g. Bash) is ready to receive
them. Possibly the input is sent to the previous command's STDIN before it has
chance to close the file descriptors or at least before Bash resumes
interpreting TTY input.

I have only seen this happen on the virtio_console, but it may also happen on
VNC if the SUT stalls at just the right time.

The solution is to wait for the terminal prompt to be printed. Possibly there
is still a race condition where the shell doesn't start accepting input for a
period after printing the prompt. However I have not seen any evidence of this
yet.

https://progress.opensuse.org/issues/16320

This PR should be merged just before a related change in the tests. I have tested this with the LTP test runner and qa_run which are the only two users of virtio_console AFAIK.