### PR TITLE
Make output of remaining time consistent with search_ratio calculation

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -800,7 +800,9 @@ sub _failed_screens_to_json {
 }
 
 sub time_remaining_str {
-    return sprintf("%.1fs", shift);
+    my $time = shift;
+    # compensate rounding to be consistent with truncation in $search_ratio calculation
+    return sprintf("%.1fs", $time - 0.05);
 }
 
 sub check_asserted_screen {


### PR DESCRIPTION
For e.g 4.95 seconds of remaining time, the search ratio will be kept
at the normal value (4.95 % 5 == 4), but the remaining time will
be reported as 5.0 seconds, as printf does proper rounding.

Signed-off-by: Stefan Brüns <stefan.bruens@rwth-aachen.de>