### PR TITLE
Also compute and store needles git hash

### DIFF
--- a/isotovideo
+++ b/isotovideo
@@ -196,27 +196,32 @@ sub signalhandler_chld {
     }
 }
 
+our $test_git_hash;
+our $needles_git_hash;
+
 sub init_backend {
     my ($name) = @_;
     $bmwqemu::vars{BACKEND} ||= "qemu";
 
     # make sure the needles are initialized
-    needle::init($bmwqemu::vars{PRODUCTDIR} . "/needles");
+    my $needles_dir = $bmwqemu::vars{PRODUCTDIR} . '/needles';
+    needle::init($needles_dir);
+    $needles_git_hash = calculate_git_hash($needles_dir);
+    $bmwqemu::vars{NEEDLES_GIT_HASH} = $needles_git_hash;
 
     $bmwqemu::backend = backend::driver->new($bmwqemu::vars{BACKEND});
     return $bmwqemu::backend;
 }
 
-our $test_git_hash;
-
 sub calculate_git_hash {
+    my ($git_repo_dir) = @_;
     my $dir = getcwd;
-    chdir($bmwqemu::vars{CASEDIR});
-    chomp($test_git_hash = qx{git rev-parse HEAD});
-    $test_git_hash ||= "UNKNOWN";
+    chdir($git_repo_dir);
+    chomp(my $git_hash = qx{git rev-parse HEAD});
+    $git_hash ||= "UNKNOWN";
     chdir($dir);
-    diag "git hash of test distribution: $test_git_hash";
-    return $test_git_hash;
+    diag "git hash in $git_repo_dir: $git_hash";
+    return $git_hash;
 }
 
 $SIG{TERM} = \&signalhandler;
@@ -241,7 +246,7 @@ $bmwqemu::vars{PRODUCTDIR} ||= $bmwqemu::vars{CASEDIR};
 # as we are about to load the test modules store the git hash that has been
 # used. If it is not a git repo fail silently, i.e. store an empty variable
 
-calculate_git_hash;
+$test_git_hash = calculate_git_hash($bmwqemu::vars{CASEDIR});
 # TODO find a better place to store hash in than vars.json, see
 # https://github.com/os-autoinst/os-autoinst/pull/393#discussion_r50143013
 $bmwqemu::vars{TEST_GIT_HASH} = $test_git_hash;
@@ -433,7 +438,7 @@ while ($loop) {
         }
 
         if ($rsp->{cmd} eq 'version') {
-            my $result = {test_git_hash => $test_git_hash, version => $INTERFACE};
+            my $result = {test_git_hash => $test_git_hash, needles_git_hash => $needles_git_hash, version => $INTERFACE};
             myjsonrpc::send_json($r, $result);
             next;
         }


### PR DESCRIPTION
This allows easier investigation when the needles repository is its own and
one want so review what changes have been introduced between two test runs.

Example output:

```
17:21:32.5690 5175 git hash in /var/lib/openqa/share/tests/opensuse: 9302c275cdd6e8a55cbf0a34a9bf8bc5f8c176a3
[…]
17:21:33.4503 5175 git hash in /var/lib/openqa/share/tests/opensuse/products/opensuse/needles: 517190eb2793b3903b7eccd34650dae1c0e42e17
```

Obviously, if the needles directory is part of the same git repository it will
output the same git hash for both directories.