### PR TITLE
VNC: Handle temporarily unavailable socket during reconnect gracefully

### DIFF
--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -808,6 +808,10 @@ use POSIX ':errno_h';
 sub _send_frame_buffer {
     my ($self, $args) = @_;
 
+    if (!$self->socket) {
+        bmwqemu::diag 'undefined socket, ignoring request for _send_frame_buffer';
+        return;
+    }
     return $self->socket->print(
         pack(
             'CCnnnn',
@@ -878,7 +882,10 @@ sub _receive_message {
     my $self = shift;
 
     my $socket = $self->socket;
-    $socket or die 'socket does not exist. Probably your backend instance could not start or died.';
+    if (!$socket) {
+        bmwqemu::diag 'undefined socket, ignoring read request';
+        return;
+    }
     $socket->blocking(0);
     my $ret = $socket->read(my $message_type, 1);
     $socket->blocking(1);


### PR DESCRIPTION
Verification run: http://lord.arch/tests/6557#step/reconnect_s390/4

Related progress issue: https://progress.opensuse.org/issues/19262