### PR TITLE
Convert the needle tags to string when they aren't found

### DIFF
--- a/t/data/tests/tests/assert_screen_fail_test.pm
+++ b/t/data/tests/tests/assert_screen_fail_test.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2017 SUSE LLC
+# Copyright (C) 2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,14 +13,19 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
+use 5.018;
+use base 'basetest';
 use testapi;
 
-autotest::loadtest "tests/boot.pm";
-autotest::loadtest "tests/assert_screen_fail_test.pm";
-autotest::loadtest "tests/shutdown.pm";
+sub run {
+    # Test done this way, because:
+    eval { assert_screen ['no_tag', 'no_tag2'], timeout => 1, no_wait => 1; };
+    bmwqemu::diag($@) if ($@);
 
+    eval { assert_screen 'no_tag3', timeout => 1, no_wait => 1; };
+    bmwqemu::diag($@) if ($@);
+
+
+}
 
 1;
-
-# vim: set sw=4 et:

--- a/testapi.pm
+++ b/testapi.pm
@@ -275,7 +275,15 @@ sub _check_backend_response {
             }
         }
         if (!$check && !$rsp->{saveresult}) {
-            OpenQA::Exception::FailedNeedle->throw(error => "no candidate needle with tag(s) '$mustmatch' matched", tags => $mustmatch);
+            # Must match can be only scalar or array ref.
+            my $needletags = $mustmatch;
+            if (ref($mustmatch) eq 'ARRAY') {
+                $needletags = join(', ', @$mustmatch);
+            }
+            OpenQA::Exception::FailedNeedle->throw(
+                error => "no candidate needle with tag(s) '$needletags' matched",
+                tags  => $mustmatch
+            );
         }
         if ($rsp->{saveresult}) {
             $autotest::current_test->save_test_result();


### PR DESCRIPTION

The input parameter mustmatch can be a scalar or an array ref.
In case of failure to find the need the needles must be converted
to string.

Before:

> 16:08:44.9082 1527 post_fail_hook failed: no candidate needle with tag(s) 'ARRAY(0x37d3128)' matched

at [tragicbox job 528](http://tragicbox.suse.cz/tests/528/file/autoinst-log.txt)


After:

> 17:30:29.1704 5146 post_fail_hook failed: no candidate needle with tag(s) '3' matched

at [tragicbox job 536](http://tragicbox.suse.cz/tests/536/file/autoinst-log.txt)

