### PR TITLE
Jplesnikova: add . to INC for coverage test (perl 5.26 doesn't)

### DIFF
--- a/t/06-pod-coverage.t
+++ b/t/06-pod-coverage.t
@@ -3,6 +3,10 @@
 use strict;
 use warnings;
 
+BEGIN {
+    push @INC, '.';
+}
+
 use Test::More;
 use Test::Warnings;
 use Pod::Coverage;


### PR DESCRIPTION
This patch is from Jitka Plesnikova at Red Hat. The os-autoinst
test suite fails on Perl 5.26.0 because . is no longer in INC
by default, so this test must add it explicitly.