### PR TITLE
Rename 'zlre' strings to 'zrle'

### DIFF
--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -491,7 +491,7 @@ sub _server_initialization {
     @encs = reverse sort { $a->{num} <=> $b->{num} } @encs;
 
     if ($self->dell) {
-        # idrac's zlre implementation even kills tigervnc, they duplicate
+        # idrac's ZRLE implementation even kills tigervnc, they duplicate
         # frames under certain conditions. Raw works ok
         @encs = grep { $_->{name} ne 'ZRLE' } @encs;
     }
@@ -957,7 +957,7 @@ sub _receive_update {
             $image->map_raw_data($data, $x, $y, $w, $h, $self->vncinfo);
         }
         elsif ($encoding_type == 16) {
-            $self->_receive_zlre_encoding($x, $y, $w, $h);
+            $self->_receive_zrle_encoding($x, $y, $w, $h);
         }
         elsif ($encoding_type == -223) {
             $self->width($w);
@@ -1007,7 +1007,7 @@ sub _discard_ikvm_message {
     #     bytes "get-viewer-lang", 8
 }
 
-sub _receive_zlre_encoding {
+sub _receive_zrle_encoding {
     my ($self, $x, $y, $w, $h) = @_;
 
     my $socket = $self->socket;
@@ -1023,7 +1023,7 @@ sub _receive_zlre_encoding {
     while ($read_len < $data_len) {
         my $len = read($socket, $data, $data_len - $read_len, $read_len);
         if (!$len) {
-            OpenQA::Exception::VNCProtocolError->throw(error => "short read for zlre data $read_len - $data_len");
+            OpenQA::Exception::VNCProtocolError->throw(error => "short read for zrle data $read_len - $data_len");
         }
         $read_len += $len;
     }

--- a/ppmclibs/tinycv.h
+++ b/ppmclibs/tinycv.h
@@ -63,8 +63,8 @@ void image_map_raw_data_rgb555(Image *a, const unsigned char *data);
 // this is for IPMI Supermicro X10 support - ast2100 (don't ask)
 void image_map_raw_data_ast2100(Image *a, const unsigned char *data, size_t len);
 
-// ZLRE encoding for VNC
-long image_map_raw_data_zlre(Image* a, long x, long y, long w, long h,
+// ZRLE encoding for VNC
+long image_map_raw_data_zrle(Image* a, long x, long y, long w, long h,
 			     VNCInfo *info,
 			     unsigned char *data,
 			     size_t len);

--- a/ppmclibs/tinycv.xs
+++ b/ppmclibs/tinycv.xs
@@ -116,7 +116,7 @@ void map_raw_data_ast2100(tinycv::Image self, unsigned char *data, size_t len)
 
 long map_raw_data_zrle(tinycv::Image self, long x, long y, long w, long h, tinycv::VNCInfo info, unsigned char *data, size_t len)
   CODE:
-   RETVAL = image_map_raw_data_zlre(self, x, y, w, h, info, data, len);
+   RETVAL = image_map_raw_data_zrle(self, x, y, w, h, info, data, len);
 
   OUTPUT:
    RETVAL

--- a/ppmclibs/tinycv_impl.cc
+++ b/ppmclibs/tinycv_impl.cc
@@ -661,10 +661,10 @@ cv::Vec3b VNCInfo::read_cpixel(const unsigned char* data, size_t& offset)
     return cv::Vec3b(blue, green, red);
 }
 
-long image_map_raw_data_zlre(Image* a, long x, long y, long w, long h,
+long image_map_raw_data_zrle(Image* a, long x, long y, long w, long h,
     VNCInfo* info, unsigned char* data, size_t bytes)
 {
-    /* ZLRE implementation is described pretty straight forward in the RFB 3.8
+    /* ZRLE implementation is described pretty straight forward in the RFB 3.8
    * protocol */
 
     size_t offset = 0;
@@ -675,7 +675,7 @@ long image_map_raw_data_zlre(Image* a, long x, long y, long w, long h,
         x = orig_x;
         while (w > 0) {
             if (offset >= bytes) {
-                fprintf(stderr, "not enough bytes for zlre\n");
+                fprintf(stderr, "not enough bytes for zrle\n");
                 abort();
             }
             unsigned char sub_encoding = data[offset++];


### PR DESCRIPTION
Some refrences to RFB's run-length encoding protocol has the string
'zlre' instead of 'zrle'. Now it's unified to 'zrle'.

Those using os-autoinst from git may need to run `make clean && make`
twice (at least I had to).

Tested: http://assam.suse.cz/tests/27.