### PR TITLE
Unconditionally set serial id on qemu drives (bsc#1041692)

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -565,7 +565,7 @@ sub start_qemu {
             else {
                 # when booting from disk on UEFI, first connected disk gets ",bootindex=0"
                 my $bootindex = ($i == 1 && $vars->{UEFI} && $bootfrom eq "disk") ? "bootindex=0" : "";
-                my $serial = ($vars->{HDDMODEL} eq "nvme") ? "serial=$i" : "";    # serial for nvme is mandatory
+                my $serial = "serial=$i";
                 gen_params @params, 'device', [qv "$vars->{HDDMODEL} drive=hd$i $bootindex $serial"];
                 gen_params @params, 'drive',  [qv "file=$basedir/l$i cache=unsafe if=none id=hd$i format=$vars->{HDDFORMAT}"];
             }


### PR DESCRIPTION
Normally one would expect a serial ID on each HDD drive. Previously we set
this only for NVME devices and not at all for other devices. To fix
bsc#1041692 we need to explicitly set it and it is making the case easier if
we just apply this in all cases. Probably we will not have a problem with that
in all currently used qemu versions.

Verification run: https://openqa.suse.de/tests/1044039