### PR TITLE
Add a new control variable to full stack tests

### DIFF
--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -45,12 +45,12 @@ is(system('grep -q "\d*: EXIT 0" autoinst-log.txt'), 0, 'test executed fine');
 my $ignore_results_re = qr/fail/;
 for my $result (grep { $_ !~ $ignore_results_re } glob("testresults/result*.json")) {
     my $json = from_json(Mojo::File->new($result)->slurp);
-    is($json->{result}, 'ok', "Result in $result is ok");
+    is($json->{result}, 'ok', "Result in $result is ok") or BAIL_OUT("$result failed");
 }
 
 for my $result (glob("testresults/result*fail*.json")) {
     my $json = from_json(Mojo::File->new($result)->slurp);
-    is($json->{result}, 'fail', "Result in $result is fail");
+    is($json->{result}, 'fail', "Result in $result is fail") or BAIL_OUT("$result failed");
 }
 
 subtest 'Assert screen failure' => sub {

--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -66,4 +66,28 @@ subtest 'Assert screen failure' => sub {
     is($count, 2, 'Assert screen failures');
 };
 
+open($var, '>', 'vars.json');
+print $var <<EOV;
+{
+   "ARCH" : "i386",
+   "BACKEND" : "qemu",
+   "QEMU" : "i386",
+   "QEMU_NO_KVM" : "1",
+   "QEMU_NO_TABLET" : "1",
+   "QEMU_NO_FDC_SET" : "1",
+   "CASEDIR" : "$data_dir/tests",
+   "PRJDIR"  : "$data_dir",
+   "ISO" : "$data_dir/Core-7.2.iso",
+   "CDMODEL" : "ide-cd",
+   "HDDMODEL" : "ide-drive",
+   "INTEGRATION_TESTS" : "1",
+   "VERSION" : "1",
+}
+EOV
+
+system("perl $toplevel_dir/isotovideo -d 2>&1 | tee autoinst-log.txt");
+isnt(system('grep -q "assert_screen_fail_test" autoinst-log.txt'), 0, 'assert screen test not scheduled');
+is(system('grep -q "isotovideo done" autoinst-log.txt'), 0, 'isotovideo is done');
+is(system('grep -q "EXIT 0" autoinst-log.txt'),          0, 'Test finished as expected');
+
 done_testing();

--- a/t/data/tests/main.pm
+++ b/t/data/tests/main.pm
@@ -17,9 +17,12 @@ use strict;
 use testapi;
 
 autotest::loadtest "tests/boot.pm";
-autotest::loadtest "tests/assert_screen_fail_test.pm";
-autotest::loadtest "tests/shutdown.pm";
 
+unless (get_var('INTEGRATION_TESTS')) {
+    autotest::loadtest "tests/assert_screen_fail_test.pm";
+}
+
+autotest::loadtest "tests/shutdown.pm";
 
 1;
 

--- a/t/data/tests/tests/assert_screen_fail_test.pm
+++ b/t/data/tests/tests/assert_screen_fail_test.pm
@@ -25,7 +25,6 @@ sub run {
     eval { assert_screen 'no_tag3', timeout => 1, no_wait => 1; };
     bmwqemu::diag($@) if ($@);
 
-
 }
 
 1;


### PR DESCRIPTION
Use INTEGRATION_TESTS to toggle the assert_screen_failt_test so that
when used by the full stack test of openQA, it can be enabled on demand.

This addresses the problems introduced by 126bf5ac on the openQA side.