### PR TITLE
Do not split not initialized values

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -637,7 +637,7 @@ Return the given variable as array reference (split variable value by , | or ; )
 
 sub get_var_array {
     my ($var, $default) = @_;
-    my @vars = split(',|;', ($bmwqemu::vars{$var}));
+    my @vars = split(/,|;/, $bmwqemu::vars{$var} || '');
     return $default if !@vars;
     return \@vars;
 }


### PR DESCRIPTION
In check_var_array we call method get_var_array, which may have not
value defined, but we still try to split values. This may cause to
"Use of uninitialized value" error. This change resolves an issue by
returning default in case of value is not defined.

As verification run, one can compare autoinst logs:
before: https://openqa.suse.de/tests/1019626/file/autoinst-log.txt
after: http://10.160.66.147/tests/330/file/autoinst-log.txt