### PR TITLE
Do not output a warning for only OCR areas

### DIFF
--- a/needle.pm
+++ b/needle.pm
@@ -83,7 +83,7 @@ sub new {
         $a->{type}   = $area->{type}   || 'match';
         $a->{margin} = $area->{margin} || 50;
 
-        $gotmatch = 1 if $a->{type} eq 'match';
+        $gotmatch = 1 if $a->{type} =~ /match|ocr/;
 
         $self->{area} ||= [];
         push @{$self->{area}}, $a;


### PR DESCRIPTION
This prevents warnings like

```
/var/lib/openqa/share/tests/opensuse/products/opensuse/needles/XFCE-desktop-20170522.json missing match area
/var/lib/openqa/share/tests/opensuse/products/opensuse/needles/yast2_tftp-server_configuration_newdir_typed-20170706.json missing match area
```

for two needles that only include OCR or exclude areas which should be
considered as valid.