### PR TITLE
Let Xen HVM guest use "xen" bus

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -387,11 +387,12 @@ sub add_disk {
         if ($self->vmm_type eq 'hvm') {
             if ($args->{cdrom}) {
                 $dev_type = "hd$dev_id";
+                $bus_type = 'ide';
             }
             else {
                 $dev_type = "hd$dev_id";
+                $bus_type = 'xen';
             }
-            $bus_type = 'ide';
         }
         elsif ($self->vmm_type eq 'linux') {
             if ($args->{cdrom}) {


### PR DESCRIPTION
'xen' bus is the default for Xen PV and should be for Xen HVM as well.

Validation runs (it's enought it boots from the disk):
* JeOS: http://assam.suse.cz/tests/147
* CaaSP: http://assam.suse.cz/tests/145
* SLES: http://assam.suse.cz/tests/151