### PR TITLE
Add option to disable qemu snapshots

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -186,6 +186,8 @@ sub can_handle {
         # See also https://github.com/os-autoinst/os-autoinst/pull/781
         return if $vars->{HDDMODEL} eq 'nvme';
 
+        return if $vars->{QEMU_DISABLE_SNAPSHOTS};
+
         return {ret => 1};
     }
     return;

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -56,6 +56,7 @@ NICVLAN;integer;undef;network (vlan) number to which the NIC should be connected
 NUMDISKS;integer;1;Number of disks to be created and attached to VM
 OFW;;;
 QEMU_OVERRIDE_VIDEO_DEVICE_AARCH64;boolean;undef;If set, for aarch64 systems use VGA as video adapter
+QEMU_DISABLE_SNAPSHOTS;boolean;undef;If set, disable snapshots in case the worker has slow disks to avoid save_vm calls failing due to timeouts (See [bsc#1035453](https://bugzilla.suse.com/show_bug.cgi?id=1035453))
 PATHCNT;integer;2;Number of paths in MULTIPATH scenario
 PXEBOOT;boolean;0;Boot VM from network
 QEMU;QEMU binary filename;undef;Filename of QEMU binary to use

--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -40,7 +40,8 @@ close($var);
 open($var, '>', 'live_log');
 close($var);
 system("perl $toplevel_dir/isotovideo -d 2>&1 | tee autoinst-log.txt");
-is(system('grep -q "\d*: EXIT 0" autoinst-log.txt'), 0, 'test executed fine');
+is(system('grep -q "\d*: EXIT 0" autoinst-log.txt'),                 0, 'test executed fine');
+is(system('grep -q "\d* Snapshots are supported" autoinst-log.txt'), 0, 'Snapshots are enabled');
 
 my $ignore_results_re = qr/fail/;
 for my $result (grep { $_ !~ $ignore_results_re } glob("testresults/result*.json")) {
@@ -82,12 +83,14 @@ print $var <<EOV;
    "HDDMODEL" : "ide-drive",
    "INTEGRATION_TESTS" : "1",
    "VERSION" : "1",
+   "QEMU_DISABLE_SNAPSHOTS" : "1"
 }
 EOV
 
 system("perl $toplevel_dir/isotovideo -d 2>&1 | tee autoinst-log.txt");
 isnt(system('grep -q "assert_screen_fail_test" autoinst-log.txt'), 0, 'assert screen test not scheduled');
-is(system('grep -q "isotovideo done" autoinst-log.txt'), 0, 'isotovideo is done');
-is(system('grep -q "EXIT 0" autoinst-log.txt'),          0, 'Test finished as expected');
+is(system('grep -q "\d* Snapshots are not supported" autoinst-log.txt'), 0, 'Snapshots are not supported');
+is(system('grep -q "isotovideo done" autoinst-log.txt'),                 0, 'isotovideo is done');
+is(system('grep -q "EXIT 0" autoinst-log.txt'),                          0, 'Test finished as expected');
 
 done_testing();


### PR DESCRIPTION
Due to the qemu hmp interface not being able to report status and the
combination with slow disks, we might end up having problems when a
system has been trying to save a snapshot but it takes way too long,
having the possibility to disable snapshots on slow workers comes in
handy for such situations