### PR TITLE
svirt: Extend time before providing password

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -76,7 +76,7 @@ sub activate {
         die "cant' start xterm on $display (err: $! retval: $?)";
     }
     # FIXME: assert_screen('xterm_password');
-    sleep 3;
+    sleep 10;
     $self->type_string({text => $password . "\n"});
     $self->_init_xml();
 }


### PR DESCRIPTION
In 50 % of cases it takes more that 3 seconds to connect to Hyper-V, and
system gets stuck - not being able to connect.