### PR TITLE
Fix bug reference in docs/backend_vars.asciidoc

### DIFF
--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -56,7 +56,7 @@ NICVLAN;integer;undef;network (vlan) number to which the NIC should be connected
 NUMDISKS;integer;1;Number of disks to be created and attached to VM
 OFW;;;
 QEMU_OVERRIDE_VIDEO_DEVICE_AARCH64;boolean;undef;If set, for aarch64 systems use VGA as video adapter
-QEMU_DISABLE_SNAPSHOTS;boolean;undef;If set, disable snapshots in case the worker has slow disks to avoid save_vm calls failing due to timeouts (See [bsc#1035453](https://bugzilla.suse.com/show_bug.cgi?id=1035453))
+QEMU_DISABLE_SNAPSHOTS;boolean;undef;If set, disable snapshots in case the worker has slow disks to avoid save_vm calls failing due to timeouts (See https://bugzilla.suse.com/show_bug.cgi?id=1035453[bsc#1035453])
 PATHCNT;integer;2;Number of paths in MULTIPATH scenario
 PXEBOOT;boolean;0;Boot VM from network
 QEMU;QEMU binary filename;undef;Filename of QEMU binary to use


### PR DESCRIPTION
Due to the qemu hmp interface not being able to report status and the
combination with slow disks, we might end up having problems when a
system has been trying to save a snapshot but it takes way too long,
having the possibility to disable snapshots on slow workers comes in
handy for such situations.