### PR TITLE
testapi: Add 'no_wait' option to wait_still_screen

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -58,6 +58,7 @@ on 'test' => sub {
   requires 'Test::Warnings';
   requires 'Test::Pod';
   requires 'Test::MockModule';
+  requires 'Test::Mock::Time';
   requires 'Pod::Coverage';
   requires 'Devel::Cover';
 };

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -207,8 +207,8 @@ subtest 'record_info' => sub {
 subtest 'validate_script_output' => sub {
     my $mock_testapi = new Test::MockModule('testapi');
     $mock_testapi->mock(script_output => sub ($;$) { return 'output'; });
-    pass(validate_script_output('script', sub { m/output/ }));
-    pass(validate_script_output('script', sub { m/output/ }, 30));
+    ok(!validate_script_output('script', sub { m/output/ }), 'validating output with default timeout');
+    ok(!validate_script_output('script', sub { m/output/ }, 30), 'specifying timeout');
     like(
         exception {
             validate_script_output('script', sub { m/error/ });

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -5,6 +5,7 @@ use warnings;
 use Test::More;
 use Test::Output;
 use Test::Fatal;
+use Test::Mock::Time;
 use Test::Warnings;
 use File::Temp;
 
@@ -215,6 +216,16 @@ subtest 'validate_script_output' => sub {
         },
         qr/output not validating/
     );
+};
+
+subtest 'wait_still_screen' => sub {
+    $mod->mock(
+        read_json => sub {
+            return {ret => {sim => 999}};
+        });
+    ok(wait_still_screen,    'default arguments');
+    ok(wait_still_screen(3), 'still time specified');
+    ok(wait_still_screen(2, 4), 'still time and timeout');
 };
 
 done_testing;

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -226,6 +226,9 @@ subtest 'wait_still_screen' => sub {
     ok(wait_still_screen,    'default arguments');
     ok(wait_still_screen(3), 'still time specified');
     ok(wait_still_screen(2, 4), 'still time and timeout');
+    ok(wait_still_screen(stilltime => 2, no_wait => 1), 'no_wait option can be specified');
+    ok(!wait_still_screen(timeout => 4, no_wait => 1), 'two named args, with timeout below stilltime - which will always return false');
+    ok(wait_still_screen(1, 2, timeout => 3), 'named over positional');
 };
 
 done_testing;


### PR DESCRIPTION
As we already have the option 'no_wait' for check_screen/assert_screen this
patch adds the same functionality to `wait_still_screen`. With the option
'no_wait' the internal sleep period is reduced so that there is merely no
waiting time between two consecutive internal screenshot checks for "still
screen" detection.

This was a recommendation by @coolo based on IRC discussion.

Related progress issue: https://progress.opensuse.org/issues/19092