### PR TITLE
Add wait_screen_change option on send_key

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -1020,7 +1020,7 @@ sub new_ssh_connection {
             last;
         }
         else {
-            bmwqemu::diag "Could not connect to $args{username}\@$args{hostname}, Retry";
+            bmwqemu::diag "Could not connect to $args{username}\@$args{hostname}, Retrying after some seconds...";
             sleep(10);
             $counter--;
             next;

--- a/testapi.pm
+++ b/testapi.pm
@@ -1184,7 +1184,6 @@ sub mouse_click {
     my $time   = shift || 0.15;
     bmwqemu::log_call(button => $button, cursor_down => $time);
     query_isotovideo('backend_mouse_button', {button => $button, bstate => 1});
-    # FIXME sleep resolution = 1s, use usleep
     sleep $time;
     query_isotovideo('backend_mouse_button', {button => $button, bstate => 0});
 }
@@ -1202,7 +1201,6 @@ sub mouse_dclick(;$$) {
     my $time   = shift || 0.10;
     bmwqemu::log_call(button => $button, cursor_down => $time);
     query_isotovideo('backend_mouse_button', {button => $button, bstate => 1});
-    # FIXME sleep resolution = 1s, use usleep
     sleep $time;
     query_isotovideo('backend_mouse_button', {button => $button, bstate => 0});
     sleep $time;


### PR DESCRIPTION
While doing this, deprecating do_wait which is calling wait_idle which we want
to avoid as it is too much relying on a backend specific implementation which
can not be made available on enough backends.