### PR TITLE
Use hash ref in query_isotovideo

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -1700,7 +1700,7 @@ sub wait_idle {
 
     bmwqemu::log_call(timeout => $timeout);
 
-    my $rsp = query_isotovideo('backend_wait_idle', timeout => $timeout);
+    my $rsp = query_isotovideo('backend_wait_idle', {timeout => $timeout});
     bmwqemu::fctres("slept $timeout seconds");
     return;
 }


### PR DESCRIPTION
With Perl 5.18.2 I get:

```
18:50:30.2820 480 <<< testapi::wait_idle(timeout=19)
18:50:30.3698 480 # Test died: Can't use string ("timeout") as a HASH
ref while "strict refs" in use
```

Regressed in b9045f43a3c8186db352c7a5de8eea501d861a84.