### PR TITLE
Add option to exit early for test schedule evaluation

### DIFF
--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -7,6 +7,7 @@ Supported variables per backend
 |====================
 Variable;Values allowed;Default value;Explanation
 EXCLUDE_MODULES;string;;comma separated names or fullnames of excluded test modules
+_EXIT_AFTER_SCHEDULE;boolean;0;Exit test execution immediately after evaluation of the test schedule, e.g. to check only which test modules would be executed
 NOVIDEO;boolean;0;Do not encode video if set
 VNC_TYPING_LIMIT;integer;50;Maximum number of keys per second
 NO_DEBUG_IO;boolean;0;Disable the I/O debug output in case of needle comparison times longer than expected

--- a/isotovideo
+++ b/isotovideo
@@ -262,6 +262,9 @@ unshift @INC, $bmwqemu::vars{CASEDIR} . '/lib';
 require $bmwqemu::vars{PRODUCTDIR} . "/main.pm";
 @INC = @oldINC;
 
+diag 'Early exit has been requested with _EXIT_AFTER_SCHEDULE. Only evaluating test schedule.';
+exit 0 if $bmwqemu::vars{_EXIT_AFTER_SCHEDULE};
+
 # set a default distribution if the tests don't have one
 $testapi::distri ||= distribution->new;
 

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -1,0 +1,27 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More;
+use File::Basename;
+use Cwd 'abs_path';
+
+my $toplevel_dir = abs_path(dirname(__FILE__) . '/..');
+my $data_dir     = "$toplevel_dir/t/data/";
+my $pool_dir     = "$toplevel_dir/t/pool/";
+
+chdir($pool_dir);
+open(my $var, '>', 'vars.json');
+print $var <<EOV;
+{
+   "CASEDIR" : "$data_dir/tests",
+   "PRJDIR"  : "$data_dir",
+   "_EXIT_AFTER_SCHEDULE" : 1,
+}
+EOV
+close($var);
+system("perl $toplevel_dir/isotovideo -d 2>&1 | tee autoinst-log.txt");
+is(system('grep -q "\d*: EXIT 1" autoinst-log.txt'),              0, 'test exited early as requested');
+is(system('grep -q "\d* scheduling.*shutdown" autoinst-log.txt'), 0, 'schedule has been evaluated');
+
+done_testing();

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,4 +1,4 @@
 AM_MAKEFLAGS = PERL5OPT="-MDevel::Cover=-db,$(abs_builddir)/cover_db"
-TESTS = 00-compile-check-all.t 01-test_needle.t 02-test_ocr.t 03-testapi.t 04-check_vars_docu.t 05-pod.t 06-pod-coverage.t 07-commands.t 08-autotest.t 09-lockapi.t 10-terminal.t 11-image-ppm.t 12-bmwqemu.t 13-osutils.t 20-openqa-benchmark-stopwatch-utils.t 99-full-stack.t
+TESTS = 00-compile-check-all.t 01-test_needle.t 02-test_ocr.t 03-testapi.t 04-check_vars_docu.t 05-pod.t 06-pod-coverage.t 07-commands.t 08-autotest.t 09-lockapi.t 10-terminal.t 11-image-ppm.t 12-bmwqemu.t 13-osutils.t 14-isotovideo.t 20-openqa-benchmark-stopwatch-utils.t 99-full-stack.t
 
 EXTRA_DIST = $(TESTS)


### PR DESCRIPTION
By setting the newly introduced test variable _EXIT_AFTER_SCHEDULE to a true
value the execution of actual tests is never started so that only the
evaluated schedule can be checked with fast feedback.