### PR TITLE
consoles: s3270: Make debug output of queue content less noisy

### DIFF
--- a/consoles/s3270.pm
+++ b/consoles/s3270.pm
@@ -207,7 +207,7 @@ sub expect_3270 {
                 $we_had_new_output = 1;
             }
 
-            say Dumper $self->{raw_expect_queue};
+            say "expect_3270 qeue content:\n\t" . join("\n\t", @{$self->{raw_expect_queue}->{queue}});
 
             # if there is MORE..., go and grab it.
             if ($status_line =~ /$arg{buffer_full}/) {
@@ -287,7 +287,7 @@ sub expect_3270 {
     }
 
     # tracing output
-    say Dumper $result;
+    say 'expect_3270 result: ' . Dumper(\$result);
     return $result;
 }
 


### PR DESCRIPTION
New behaviour:

```
expect_3270 qeue content:
        LOGON LINUX157
        NIC 0800 is created; devices 0800-0802 defined
        NIC 0700 is created; devices 0700-0702 defined
        z/VM Version 5 Release 4.0, Service Level 1501 (64-bit),
```

Old behaviour:

```
$VAR1 = bless( {
                 'queue' => [
                              'LOGON LINUX157                                                                  ',
                              'z/VM Version 5 Release 4.0, Service Level 1501 (64-bit),                        ',
                              'built on IBM Virtualization Technology                                          ',
                              'There is no logmsg data                                                         ',
                              'FILES: 0050 RDR, 0001 PRT,   NO PUN                                             ',
                              'RECONNECTED AT 18:32:37 EST TUESDAY 09/19/17                                    '
                            ]
               }, 'Thread::Queue' );
```