### PR TITLE
Remove typing tests from integration tests

### DIFF
--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -1,4 +1,19 @@
 #!/usr/bin/perl
+# Copyright (C) 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
 
 use strict;
 use warnings;
@@ -40,8 +55,13 @@ close($var);
 open($var, '>', 'live_log');
 close($var);
 system("perl $toplevel_dir/isotovideo -d 2>&1 | tee autoinst-log.txt");
-is(system('grep -q "\d*: EXIT 0" autoinst-log.txt'),                 0, 'test executed fine');
-is(system('grep -q "\d* Snapshots are supported" autoinst-log.txt'), 0, 'Snapshots are enabled');
+is(system('grep -q "\d*: EXIT 0" autoinst-log.txt'),                                           0, 'test executed fine');
+is(system('grep -q "\d* Snapshots are supported" autoinst-log.txt'),                           0, 'Snapshots are enabled');
+is(system('grep -q "\d* wait_idle sleeping for 1 seconds" autoinst-log.txt'),                  0, 'Wait idle waits for a second.');
+is(system('grep -q "do not wait_still_screen" autoinst-log.txt'),                              0, 'test type string and do not wait');
+is(system('grep -q "wait_still_screen: detected same image for 5 seconds" autoinst-log.txt'),  0, 'test type string and wait for 5 seconds');
+is(system('grep -q "wait_still_screen: detected same image for 10 seconds" autoinst-log.txt'), 0, 'test type string and wait for 10 seconds');
+is(system('grep -q "wait_still_screen: detected same image for 20 seconds" autoinst-log.txt'), 0, 'test type string and wait for 20 seconds');
 
 my $ignore_results_re = qr/fail/;
 for my $result (grep { $_ !~ $ignore_results_re } glob("testresults/result*.json")) {
@@ -89,13 +109,8 @@ EOV
 
 system("perl $toplevel_dir/isotovideo -d 2>&1 | tee autoinst-log.txt");
 isnt(system('grep -q "assert_screen_fail_test" autoinst-log.txt'), 0, 'assert screen test not scheduled');
-is(system('grep -q "\d* wait_idle sleeping for 1 seconds" autoinst-log.txt'),                  0, 'Wait idle waits for a second.');
-is(system('grep -q "do not wait_still_screen" autoinst-log.txt'),                              0, 'test type string and do not wait');
-is(system('grep -q "wait_still_screen: detected same image for 5 seconds" autoinst-log.txt'),  0, 'test type string and wait for 5 seconds');
-is(system('grep -q "wait_still_screen: detected same image for 10 seconds" autoinst-log.txt'), 0, 'test type string and wait for 10 seconds');
-is(system('grep -q "wait_still_screen: detected same image for 20 seconds" autoinst-log.txt'), 0, 'test type string and wait for 20 seconds');
-is(system('grep -q "\d* Snapshots are not supported" autoinst-log.txt'),                       0, 'Snapshots are not supported');
-is(system('grep -q "isotovideo done" autoinst-log.txt'),                                       0, 'isotovideo is done');
-is(system('grep -q "EXIT 0" autoinst-log.txt'),                                                0, 'Test finished as expected');
+is(system('grep -q "\d* Snapshots are not supported" autoinst-log.txt'), 0, 'Snapshots are not supported');
+is(system('grep -q "isotovideo done" autoinst-log.txt'),                 0, 'isotovideo is done');
+is(system('grep -q "EXIT 0" autoinst-log.txt'),                          0, 'Test finished as expected');
 
 done_testing();

--- a/t/data/tests/main.pm
+++ b/t/data/tests/main.pm
@@ -20,6 +20,7 @@ autotest::loadtest "tests/boot.pm";
 
 unless (get_var('INTEGRATION_TESTS')) {
     autotest::loadtest "tests/assert_screen_fail_test.pm";
+    autotest::loadtest "tests/typing.pm";
 }
 
 autotest::loadtest "tests/shutdown.pm";

--- a/t/data/tests/tests/boot.pm
+++ b/t/data/tests/tests/boot.pm
@@ -49,11 +49,7 @@ END
     type_string "\nEOF\n";
     script_run "echo '924095f2cb4d622a8796de66a5e0a44a  text' > text.md5";
     assert_script_run 'md5sum -c text.md5';
-    type_string("echo do not wait_still_screen\n", max_interval => 50, wait_still_screen => 0);
-    type_string("echo type string and wait for 5 seconds\n",               wait_still_screen => 5);
-    type_string("echo test\necho wait\necho 10se\n",                       max_interval      => 100, wait_screen_changes => 11, wait_still_screen => 10);
-    type_string("echo test if wait_screen_change functions as expected\n", max_interval      => 150, wait_screen_changes => 11, wait_still_screen => 10);
-    type_string("echo wait_still_screen for 20 seconds\n", max_interval => 200, wait_still_screen => 20);
+
 }
 
 sub test_flags {

--- a/t/data/tests/tests/typing.pm
+++ b/t/data/tests/tests/typing.pm
@@ -1,0 +1,37 @@
+# Copyright (C) 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use base "basetest";
+use strict;
+use testapi;
+
+sub run {
+
+    type_string("echo do not wait_still_screen\n", max_interval => 50, wait_still_screen => 0);
+    type_string("echo type string and wait for 5 seconds\n",               wait_still_screen => 5);
+    type_string("echo test\necho wait\necho 10se\n",                       max_interval      => 100, wait_screen_changes => 11, wait_still_screen => 10);
+    type_string("echo test if wait_screen_change functions as expected\n", max_interval      => 150, wait_screen_changes => 11, wait_still_screen => 10);
+    type_string("echo wait_still_screen for 20 seconds\n", max_interval => 200, wait_still_screen => 20);
+
+}
+
+sub test_flags {
+    return {};
+}
+
+1;
+
+# vim: set sw=4 et:
+


### PR DESCRIPTION
With changes from 517e20c5, we broke fullstack on openQA, this fixes the
problem.