### PR TITLE
Fix passing hash/arguments in testapi::wait_idle

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -1700,7 +1700,7 @@ sub wait_idle {
 
     bmwqemu::log_call(timeout => $timeout);
 
-    my $rsp = query_isotovideo('backend_wait_idle', timeout => $timeout);
+    my $rsp = query_isotovideo('backend_wait_idle', {timeout => $timeout});
     bmwqemu::fctres("slept $timeout seconds");
     return;
 }


### PR DESCRIPTION
Otherwise tests die with an error, eg.
```
Test died: Can't use string ("timeout") as a HASH ref while "strict refs" in use at /home/martchus/repos/os-autoinst/autotest.pm line 199.
```

Not sure how to add auto tests for this, but I tested locally under Tumbleweed.