### PR TITLE
Fix scale_timeout call in wait_serial function

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -724,7 +724,7 @@ sub wait_serial {
     my %nargs = (@_, (regexp => $regexp, timeout => $timeout));
 
     bmwqemu::log_call(%nargs);
-    $timeout = bmwqemu::scale_timeout($timeout);
+    $nargs{timeout} = bmwqemu::scale_timeout($nargs{timeout});
 
     my $ret = query_isotovideo('backend_wait_serial', \%nargs);
     my $matched = $ret->{matched};


### PR DESCRIPTION
Some VMs can take time to run, and setting TIMEOUT_SCALE can be needed.
This patch adds support for TIMEOUT_SCALE in assert_script_run function, as it not supported yet.