### PR TITLE
Define $args{username} sooner

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -1000,6 +1000,7 @@ sub retry_assert_screen {
 # shared between svirt and s390 backend
 sub new_ssh_connection {
     my ($self, %args) = @_;
+    $args{username} ||= 'root';
 
     my $ssh = Net::SSH2->new;
 
@@ -1007,7 +1008,6 @@ sub new_ssh_connection {
     my $counter = 5;
     while ($counter > 0) {
         if ($ssh->connect($args{hostname})) {
-            $args{username} ||= 'root';
 
             if ($args{password}) {
                 $ssh->auth(username => $args{username}, password => $args{password});


### PR DESCRIPTION
https://openqa.suse.de/tests/1192638/file/autoinst-log.txt
```
Use of uninitialized value $args{"username"} in concatenation (.) or
string at /usr/lib/os-autoinst/backend/baseclass.pm line 1023.
06:30:06.2693 26372 Could not connect to @flexo.qa.suse.cz, Retry
Use of uninitialized value $args{"username"} in concatenation (.) or
string at /usr/lib/os-autoinst/backend/baseclass.pm line 1029.
DIE Failed to login to @flexo.qa.suse.cz at
/usr/lib/os-autoinst/backend/baseclass.pm line 1029.
```