### PR TITLE
Fix become_root for Fedora

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -99,7 +99,7 @@ sub become_root {
     my ($self) = @_;
 
     testapi::script_sudo("bash", 0);    # become root
-    testapi::script_run("test $(id -u) -eq 0 && echo 'imroot' > /dev/$testapi::serialdev", 0);
+    testapi::script_run('test $(id -u) -eq 0 && echo "imroot" > /dev/' . $testapi::serialdev, 0);
     testapi::wait_serial("imroot", 5) || die "Root prompt not there";
     testapi::script_run("cd /tmp");
 }


### PR DESCRIPTION
'$(id -u)' is misinterpreted on Fedora.
openSUSE is fine since become_root function is overloaded.