### PR TITLE
Generalize x11_start_program with standard array argument

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -72,10 +72,6 @@ sub add_console {
 }
 
 sub x11_start_program {
-    my ($program, $timeout, $options) = @_;
-    $timeout ||= 6;
-    $options ||= {};
-
     die "TODO: implement x11_start_program for your distri " . testapi::get_var('DISTRI');
 }
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -747,7 +747,7 @@ sub wait_serial {
 
 =head2 x11_start_program
 
-    x11_start_program($program[, $timeout, $options]);
+    x11_start_program($program[, @args]);
 
 Start C<$program> in graphical desktop environment.
 
@@ -756,9 +756,9 @@ I<The implementation is distribution specific and not always available.>
 =cut
 
 sub x11_start_program {
-    my ($program, $timeout, $options) = @_;
-    bmwqemu::log_call(timeout => $timeout, options => $options);
-    return $distri->x11_start_program($program, $timeout, $options);
+    my ($program, @args) = @_;
+    bmwqemu::log_call(program => $program, @args);
+    return $distri->x11_start_program($program, @args);
 }
 
 sub _handle_script_run_ret {


### PR DESCRIPTION
This is a backward-compatible change. As the baseclass does not provide a real
implementation we should not try to parse any arguments. Having the last
argument as a generic array still allows for the old signature implicitly but
also other uses, for example a hash assignment for named parameters. This
change corrects the debug log output for os-autoinst-distri-opensuse after
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/3671

Use of old-style x11_start_program: http://lord.arch/tests/7652
New-style x11_start_program: http://lord.arch/tests/7653