### PR TITLE
[WIP] Improve User-feedback for VNC sockets is not existing

### DIFF
--- a/OpenQA/Exceptions.pm
+++ b/OpenQA/Exceptions.pm
@@ -32,6 +32,10 @@ use Exception::Class (
     'OpenQA::Exception::VNCProtocolError' => {
         description => 'VNC Server interrupted connection'
     },
+
+    'OpenQA::Exception::VNCSocketError' => {
+        description => 'VNC Socket does not exist',
+    },
 );
 
 1;

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -9,6 +9,8 @@ use Time::HiRes qw( usleep gettimeofday time );
 use Carp;
 use List::Util 'min';
 
+use testapi 'record_info';
+
 use Crypt::DES;
 use Compress::Raw::Zlib;
 
@@ -816,7 +818,7 @@ sub _send_frame_buffer {
             $args->{x},
             $args->{y},
             $args->{width},
-            $args->{height}));
+            $args->{height})) if $self->socket;
 }
 
 # frame buffer update request
@@ -878,7 +880,11 @@ sub _receive_message {
     my $self = shift;
 
     my $socket = $self->socket;
-    $socket or die 'socket does not exist. Probably your backend instance could not start or died.';
+    #$socket or die 'socket does not exist. Probably your backend instance could not start or died.';
+    if (!$socket) {
+        record_info('VNC Error', 'Socket does not exist', result => 'fail');
+        OpenQA::Exception::VNCSocketError->throw(error => 'There is no socket we can connect to.');
+    }
     $socket->blocking(0);
     my $ret = $socket->read(my $message_type, 1);
     $socket->blocking(1);

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -880,7 +880,6 @@ sub _receive_message {
     my $self = shift;
 
     my $socket = $self->socket;
-    #$socket or die 'socket does not exist. Probably your backend instance could not start or died.';
     if (!$socket) {
         record_info('VNC Error', 'Socket does not exist', result => 'fail');
         OpenQA::Exception::VNCSocketError->throw(error => 'There is no socket we can connect to.');


### PR DESCRIPTION
Based on https://github.com/os-autoinst/os-autoinst/pull/862, simple fix of review comment:

On ipmi and s390x sometimes jobs gets incomplete or fail without a module
This PR is meant to improve user feedback by showing a record_info box with a proper
error message

see related tickets:
https://progress.opensuse.org/issues/20022
https://progress.opensuse.org/issues/23650