### PR TITLE
sshVirtsh: Hide confusing errors about undefined machines

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -462,6 +462,8 @@ sub get_ssh_output {
         return ($stdout, $errout);
     }
     else {
+        chomp($stdout);
+        chomp($errout);
         bmwqemu::diag "Command's stdout:\n$stdout" if length($stdout);
         bmwqemu::diag "Command's stderr:\n$errout" if length($errout);
     }
@@ -517,8 +519,9 @@ __END"
 
     # shut down possibly running previous test (just to be sure) - ignore errors
     # just making sure we continue after the command finished
-    $self->run_cmd("virsh $remote_vmm destroy " . $self->name);
-    $self->run_cmd("virsh $remote_vmm undefine --snapshots-metadata " . $self->name);
+    my $ignore = ' |& grep -v "\(failed to get domain\|Domain not found\)"';
+    $self->run_cmd("virsh $remote_vmm destroy " . $self->name . $ignore);
+    $self->run_cmd("virsh $remote_vmm undefine --snapshots-metadata " . $self->name . $ignore);
 
     # define the new domain
     $self->run_cmd("virsh $remote_vmm define $xmlfilename")  && die "virsh define failed";


### PR DESCRIPTION
Before:
```
20:21:54.4386 22178 Command executed: virsh  destroy openQA-SUT-12
20:21:54.4593 22178 Command's stdout:

20:21:54.4594 22178 Command's stderr:
error: failed to get domain 'openQA-SUT-12'
error: Domain not found: no domain with matching name 'openQA-SUT-12'

20:21:54.4990 22178 Command executed: virsh  undefine --snapshots-metadata openQA-SUT-12
20:21:54.5195 22178 Command's stdout:

20:21:54.5196 22178 Command's stderr:
error: failed to get domain 'openQA-SUT-12'
error: Domain not found: no domain with matching name 'openQA-SUT-12'
```

After:
```
20:44:00.1185 24093 Command executed: virsh  destroy openQA-SUT-12 >/dev/null 2>&1
20:44:00.4177 24093 Command executed: virsh  undefine --snapshots-metadata openQA-SUT-12 >/dev/null 2>&1
```