### PR TITLE
Change debug output join character of needle tags to more common ', '

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -752,7 +752,7 @@ sub set_tags_to_assert {
         my %h = map { $_ => 1 } @tags;
         @tags = sort keys %h;
     }
-    $mustmatch = join('_', @tags);
+    $mustmatch = join(',', @tags);
 
     if (!@$needles) {
         bmwqemu::diag("NO matching needles for $mustmatch");


### PR DESCRIPTION
It looks very weird if needle tags are merged together in debug output with an
underscore which is also used within tags, e.g. in
"No matching needles for firefox_firefox_clean".