### PR TITLE
Introduce check_recorded_sound method

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -534,7 +534,7 @@ sub stop_audiocapture {
 }
 
 sub verify_sound_image {
-    my ($self, $imgpath, $mustmatch) = @_;
+    my ($self, $imgpath, $mustmatch, $check) = @_;
 
     my $rsp = autotest::query_isotovideo('backend_verify_image', {imgpath => $imgpath, mustmatch => $mustmatch});
 
@@ -547,14 +547,13 @@ sub verify_sound_image {
         return $foundneedle;
     }
     bmwqemu::fctres(sprintf("failed to find %s", $mustmatch));
-
-    $self->record_screenfail(
-        img     => $img,
-        needles => $rsp->{candidates},
-        tags    => [$mustmatch],
-        result  => 'fail',
-        overall => 'fail'
-    );
+    my @needles_params = (img => $img, needles => $rsp->{candidates}, tags => [$mustmatch]);
+    if ($check) {
+        $self->record_screenfail(@needles_params, result => 'unk');
+    }
+    else {
+        $self->record_screenfail(@needles_params, result => 'fail', overall => 'fail');
+    }
     return;
 }
 


### PR DESCRIPTION
We have unstable aplay test, which fails due to the [bsc#1048271](https://bugzilla.opensuse.org/show_bug.cgi?id=1048271) once in
a while. We cannot work it around with needles, as pattern is different
event if match level is 60%. In order to soft-fail this test module, we
introduce check_recorded_sound method, which doesn't fail the test, but
returns match result.

Verification was done using isotovideo run for 2 scenarios, when needle is available and when it's not.
Here is part of autoinst log for scenario when needle doesn't match:
13:41:44.2286 32131 <<< basetest::stop_audiocapture()
13:41:44.4666 32131 >>> basetest::verify_sound_image: failed to find DTMF-159D
13:41:44.4769 32131 <<< testapi::record_soft_failure(reason='bsc#1048271')
32103: EXIT 0

Here is part of autoinst log for scenario when needle matches:
13:56:00.7150 10807 <<< basetest::stop_audiocapture()
13:56:00.9133 10999 MATCH(DTMF-159D-20160519:1.00)
13:56:00.9546 10999 MATCH(DTMF-159D-20171011:0.00)
13:56:00.9693 10807 >>> basetest::verify_sound_image: found DTMF-159D-20160519, similarity 1.00 @ 0/0
10711: EXIT 0