### PR TITLE
[WIP] Use ESXi server instead of vSphere

### DIFF
--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -107,8 +107,6 @@ VIRSH_GUEST;string;Where to look for VNC server (SUT or VM);
 VIRSH_INSTANCE;integer;VM's instance number on VIRSH_HOSTNAME;
 VMWARE_USERNAME;string;Administrator's username ('@' is '%40');
 VMWARE_PASSWORD;string;Administrator's password;
-VMWARE_HOST;string;VCS server for autentication;
-VMWARE_DATACENTER;string;VMware datacenter;
 VMWARE_SERVER;string;ESX server to start VM on;
 VMWARE_DATASTORE;string;VMware datastore;
 VMWARE_SERIAL_PORT;string;TCP port where is VM's serial port stream to be expected on the ESX server;


### PR DESCRIPTION
In future we should probably use ESXi server directly not via vSpere cluster. Well but currently we don't have reasonable server wirh non-free license, and free one has API disabled:

error: Failed to define domain from /var/lib/libvirt/images/openQA-SUT-1.xml
error: internal error: HTTP response code 500 for call to 'RegisterVM_Task'. Fault: ServerFaultCode - Current license or ESXi version prohibits execution of the requested operation.