### PR TITLE
Add possibility to share files on worker directly

### DIFF
--- a/commands.pm
+++ b/commands.pm
@@ -221,6 +221,14 @@ sub isotovideo_post {
     return isotovideo_command($c, [qw(interactive stop_waitforneedle continue_waitforneedle reload_needles)]);
 }
 
+sub get_temp_file {
+    my ($self)  = @_;
+    my $relpath = $self->param('relpath');
+    my $path    = testapi::hashed_string($relpath);
+    return _test_data_file($self, $path) if -f $path;
+    return $self->reply->not_found;
+}
+
 sub run_daemon {
     my ($port) = @_;
 
@@ -249,6 +257,9 @@ sub run_daemon {
 
     # to get the current bash script out of the test
     $token_auth->get('/current_script' => \&current_script);
+
+    # to get temporary files from the current worker
+    $token_auth->get('/files/*relpath' => \&get_temp_file);
 
     # get asset
     $token_auth->get('/assets/#assettype/#assetname'          => \&get_asset);

--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -63,6 +63,10 @@ is(system('grep -q "wait_still_screen: detected same image for 5 seconds" autoin
 is(system('grep -q "wait_still_screen: detected same image for 10 seconds" autoinst-log.txt'), 0, 'test type string and wait for 10 seconds');
 is(system('grep -q "wait_still_screen: detected same image for 20 seconds" autoinst-log.txt'), 0, 'test type string and wait for 20 seconds');
 
+
+is(system('grep -q "get_test_data returned expected file" autoinst-log.txt'), 0, 'get_test_data test');
+is(system('grep -q "save_tmp_file returned expected file" autoinst-log.txt'), 0, 'save_tmp_file test');
+
 my $ignore_results_re = qr/fail/;
 for my $result (grep { $_ !~ $ignore_results_re } glob("testresults/result*.json")) {
     my $json = from_json(Mojo::File->new($result)->slurp);

--- a/t/data/tests/data/autoinst.xml
+++ b/t/data/tests/data/autoinst.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+<users config:type="list">
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>PASSWORD</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/t/data/tests/main.pm
+++ b/t/data/tests/main.pm
@@ -40,6 +40,7 @@ unless (get_var('INTEGRATION_TESTS')) {
     autotest::loadtest "tests/assert_screen_fail_test.pm";
     autotest::loadtest "tests/typing.pm";
     autotest::loadtest "tests/reload_needles.pm";
+    autotest::loadtest "tests/modify_and_upload_file.pm";
 }
 autotest::loadtest "tests/shutdown.pm";
 

--- a/t/data/tests/tests/modify_and_upload_file.pm
+++ b/t/data/tests/tests/modify_and_upload_file.pm
@@ -1,0 +1,50 @@
+# Copyright (C) 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use strict;
+use base "basetest";
+use testapi;
+
+my $orig_file = <<'END';
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+<users config:type="list">
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>PASSWORD</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>
+END
+
+sub run {
+    # Get file from data directory
+    my $content = get_test_data('autoinst.xml');
+
+    if ($content eq $orig_file) {
+        type_string("echo get_test_data returned expected file\n");
+    }
+    my $url = autoinst_url . '/files/modified.xml';
+    $content =~ s/PASSWORD/nots3cr3t/g;
+    save_tmp_file('modified.xml', $content);
+    # Verify that correct file is downloaded
+    assert_script_run("wget -q $url");
+    script_run "echo '72d2c15cb10535f36862d7d2eecc8a79  modified.xml' > modified.md5";
+    assert_script_run("md5sum -c modified.md5");
+
+    type_string("echo save_tmp_file returned expected file\n");
+}

--- a/testapi.pm
+++ b/testapi.pm
@@ -21,7 +21,8 @@ use Carp;
 use Exporter;
 use 5.018;
 use warnings;
-use File::Basename 'basename';
+use File::Basename qw(basename dirname);
+use File::Path 'make_path';
 use Time::HiRes qw(sleep gettimeofday tv_interval);
 use autotest 'query_isotovideo';
 use Mojo::DOM;
@@ -62,6 +63,8 @@ our @EXPORT = qw($realname $username $password $serialdev %cmd %vars
   save_memory_dump save_storage_drives freeze_vm resume_vm
 
   diag hashed_string
+
+  save_tmp_file
 );
 our @EXPORT_OK = qw(is_serial_terminal);
 
@@ -959,6 +962,34 @@ sub script_output {
     $output =~ s/^\s+|\s+$//g;
 
     return $output;
+}
+
+
+=head2 save_tmp_file
+
+  save_tmp_file($relpath, $content)
+
+Saves content to the file in the worker pool directory using hash of the path,
+including file, so it can be fetched via http later on using
+ C< <autoinst_url>/files/#path_to_the_file> > url.
+Can be used to modify files for specific test needs, e.g. autoinst profiles.
+Dies if cannot open file for writing.
+
+Example:
+  save_tmp_file('autoyast/autoinst.xml', '<profile>Test</profile>')
+Then the file can be fetched using url:
+C< <autoinst_url>/files/autoyast/autoinst.xml> >
+
+=cut
+
+sub save_tmp_file {
+    my ($relpath, $content) = @_;
+    my $path = hashed_string($relpath);
+
+    bmwqemu::log_call(path => $relpath);
+    open my $fh, ">", $path;
+    print $fh $content;
+    close $fh;
 }
 
 =head2 validate_script_output

--- a/testapi.pm
+++ b/testapi.pm
@@ -64,7 +64,7 @@ our @EXPORT = qw($realname $username $password $serialdev %cmd %vars
 
   diag hashed_string
 
-  save_tmp_file
+  save_tmp_file get_test_data
 );
 our @EXPORT_OK = qw(is_serial_terminal);
 
@@ -990,6 +990,33 @@ sub save_tmp_file {
     open my $fh, ">", $path;
     print $fh $content;
     close $fh;
+}
+
+=head2 get_test_data
+
+  get_test_data($relpath)
+
+Returns content of the file located in data directory. This method can be used
+if one needs to modify files content before accessing it in SUT.
+
+Example:
+  get_test_data('autoyast/autoinst.xml')
+This will return content of the file located in data/autoyast/autoinst.xml
+
+=cut
+
+sub get_test_data {
+    my ($path) = @_;
+    $path = get_var('CASEDIR') . '/data/' . $path;
+    bmwqemu::log_call(path => $path);
+    unless (-e $path) {
+        bmwqemu::diag("File doesn't exist: $path");
+        return;
+    }
+    open my $fh, "<", $path;
+    my $content = do { local $/; <$fh> };
+    close $fh;
+    return $content;
 }
 
 =head2 validate_script_output


### PR DESCRIPTION
These changes are mainly caused by scenarios for autoyast installations.
For SLE15 we need to introduce information for registration, modules
into the profiles which differ for architectures. As an alternative we
could use chained test suites or support server. However, support server
does variables expansion using apache features, and would introduce
more load on multimachine capable workers. Chained jobs is better
solution than support server, and basic sharing modified autoyast profile
will work, whereas this approach won't work for class based autoyast
installations. These changes also will help in other scenarios allowing
avoidance of the extra resources usage.

Tested only manually so far using isotovideo.

See [poo#27076](https://progress.opensuse.org/issues/27076).