### PR TITLE
Distinguish modules name in a test run if it's a duplicate

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -67,6 +67,7 @@ sub loadtest {
         # to all perl hardcore hackers: fuck off!
         $nr = $nr eq '' ? 1 : $nr + 1;
         bmwqemu::diag($fullname . ' already scheduled');
+        $test->{name} = join("#", $name, $nr);
     }
     $tests{$fullname . $nr} = $test;
 
@@ -80,7 +81,7 @@ our $last_milestone;
 
 sub set_current_test {
     ($current_test) = @_;
-    query_isotovideo('set_current_test', {name => ref($current_test)});
+    query_isotovideo('set_current_test', {name => $current_test->{name}});
 }
 
 sub write_test_order {
@@ -90,7 +91,7 @@ sub write_test_order {
         push(
             @result,
             {
-                name     => ref($t),
+                name     => $t->{name},
                 category => $t->{category},
                 flags    => $t->test_flags(),
                 script   => $t->{script}});
@@ -232,7 +233,7 @@ sub runalltests {
             $vmloaded = 1;
         }
         if ($vmloaded) {
-            my $name = ref($t);
+            my $name = $t->{name};
             bmwqemu::modstart "starting $name $t->{script}";
             $t->start();
 

--- a/basetest.pm
+++ b/basetest.pm
@@ -49,7 +49,7 @@ sub new {
     $self->{post_fail_hook_running} = 0;
     $self->{timeoutcounter}         = 0;
     $self->{activated_consoles}     = [];
-
+    $self->{name}                   = $class;
     return bless $self, $class;
 }
 
@@ -173,7 +173,7 @@ serialize a match result from needle::search
 sub _serialize_match {
     my ($self, $cand) = @_;
 
-    my $testname = ref($self);
+    my $testname = $self->{name};
     my $count    = $self->{test_count};
 
     my $candidates;
@@ -315,7 +315,7 @@ sub runtest {
     my $starttime = time;
 
     my $ret;
-    my $name = ref($self);
+    my $name = $self->{name};
     eval {
         $self->pre_run_hook();
         $self->run();
@@ -366,14 +366,14 @@ sub save_test_result {
     $result->{extra_test_results} = $self->{extra_test_results} if $self->{extra_test_results};
 
     # be aware that $name has to be unique within one job (also assumed in several other places)
-    my $fn = bmwqemu::result_dir() . sprintf("/result-%s.json", ref $self);
+    my $fn = bmwqemu::result_dir() . sprintf("/result-%s.json", $self->{name});
     bmwqemu::save_json_file($result, $fn);
     return $result;
 }
 
 sub next_resultname {
     my ($self, $type, $name) = @_;
-    my $testname = ref($self);
+    my $testname = $self->{name};
     my $count    = ++$self->{test_count};
     if ($name) {
         return "$testname-$count.$name.$type";
@@ -511,7 +511,7 @@ sub take_screenshot {
 
 sub capture_filename {
     my ($self) = @_;
-    my $fn = ref($self) . "-captured.wav";
+    my $fn = $self->{name} . "-captured.wav";
     die "audio capture already in progress. Stop it first!\n" if ($self->{wav_fn});
     $self->{wav_fn} = $fn;
     return $fn;

--- a/testapi.pm
+++ b/testapi.pm
@@ -1567,7 +1567,7 @@ I<Currently only qemu backend is supported.>
 
 sub save_memory_dump {
     my %nargs = @_;
-    $nargs{filename} ||= ref($autotest::current_test);
+    $nargs{filename} ||= $autotest::current_test->{name};
 
     bmwqemu::log_call(%nargs);
     bmwqemu::diag "If save_memory_dump is called multiple times with the same '\$filename', it will be rewritten." unless ((caller(1))[3]) =~ /post_fail_hook/;
@@ -1590,7 +1590,7 @@ I<Currently only qemu backend is supported.>
 =cut
 
 sub save_storage_drives {
-    my $filename ||= ref($autotest::current_test);
+    my $filename ||= $autotest::current_test->{name};
     die "Method should be called within a post_fail_hook" unless ((caller(1))[3]) =~ /post_fail_hook/;
 
     bmwqemu::log_call();
@@ -1870,7 +1870,7 @@ sub upload_logs {
 
     bmwqemu::log_call(file => $file, %args);
     my $basename = basename($file);
-    my $upname   = ($args{log_name} || ref($autotest::current_test)) . '-' . $basename;
+    my $upname   = ($args{log_name} || $autotest::current_test->{name}) . '-' . $basename;
     my $cmd      = "curl --form upload=\@$file --form upname=$upname ";
     $cmd .= autoinst_url("/uploadlog/$basename");
     if ($failok) {


### PR DESCRIPTION
~~WIP because needs testing (currently changes are applied in staging instance) and i'd like to add unit tests.~~

[Success run](http://e122.suse.de/tests/2871) - [hostname](http://e122.suse.de/tests/2871#step/hostname%232/11) and [enable_usb_repo](http://e122.suse.de/tests/2871#step/enable_usb_repo%231/2) test
[Failed run](http://e122.suse.de/tests/2598#downloads) - logs/assets uploaded are unique
[Tests not using duplicate modules](http://e122.suse.de/tests/overview?distri=sle&version=12-SP3&build=0473&groupid=28) are unaffected by the change.

See related Progress issue: https://progress.opensuse.org/issues/10514