### PR TITLE
Fix snd2png check on TW: don't use PNM but PNG

### DIFF
--- a/snd2png/Makefile.am
+++ b/snd2png/Makefile.am
@@ -7,7 +7,7 @@ AM_CPPFLAGS = $(OPENCV_CFLAGS) $(FFTW_CFLAGS) $(SNDFILE_CFLAGS)
 snd2png_LDFLAGS = $(OPENCV_LIBS) $(FFTW_LIBS) $(SNDFILE_LIBS) -lm
 
 check-local:
-	-rm -f test.pnm
-	./snd2png $(srcdir)/aplay-captured.wav test.pnm
-	md5sum test.pnm > test.pnm.md5
-	diff -u test.pnm.md5 $(srcdir)/test.pnm.md5.original
+	-rm -f test.png
+	./snd2png $(srcdir)/aplay-captured.wav test.png
+	md5sum test.png > test.png.md5
+	diff -u test.png.md5 $(srcdir)/test.png.md5.original

--- a/snd2png/test.png.md5.original
+++ b/snd2png/test.png.md5.original
@@ -1,0 +1,1 @@
+095090d5fe045a3c09dae216ccd23a26  test.png

--- a/snd2png/test.pnm.md5.original
+++ b/snd2png/test.pnm.md5.original
@@ -1,1 +1,0 @@
-b52bc7078f88da4684c12956af7be618  test.pnm


### PR DESCRIPTION
(the program's name doesn't imply it can do PNM anyway :), PNM contains
now a comment about the opencv version - png does not (for now)