### PR TITLE
Add context to loadtest

### DIFF
--- a/OpenQA/Test/RunArgs.pm
+++ b/OpenQA/Test/RunArgs.pm
@@ -1,0 +1,26 @@
+# Copyright © 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+=head2 OpenQA::Test::RunArgs
+
+Object passed to loadtest as an optional parameter. Tests wishing to use
+context with loadtest should create a subclass of this object.
+
+=cut
+
+package OpenQA::Test::RunArgs;
+use Mojo::Base -base;
+
+1;

--- a/basetest.pm
+++ b/basetest.pm
@@ -318,7 +318,12 @@ sub runtest {
     my $name = $self->{name};
     eval {
         $self->pre_run_hook();
-        $self->run();
+        if (defined $self->{run_args}) {
+            $self->run($self->{run_args});
+        }
+        else {
+            $self->run();
+        }
         $self->post_run_hook();
     };
     if ($@) {

--- a/t/fake/tests/run_args.pm
+++ b/t/fake/tests/run_args.pm
@@ -1,0 +1,11 @@
+use 5.018;
+use base 'basetest';
+
+sub run {
+    my ($self, $rargs) = @_;
+
+    unless (defined $rargs) {
+        die 'run_args not passed through';
+    }
+}
+1;


### PR DESCRIPTION
Allow arbitrary parameters to be sent to the test from main.pm

https://progress.opensuse.org/issues/27124