### PR TITLE
Fix error checking on load_snapshot and remove sleep

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -265,12 +265,9 @@ sub load_snapshot {
     my ($self, $args) = @_;
     my $vmname = $args->{name};
     my $rsp    = $self->handle_qmp_command(_wrap_hmc("loadvm $vmname"));
-    if ($rsp || $rsp->{return} ne '') {
+    if (!$rsp || $rsp->{return} ne '') {
         die "Could not load snapshot \'$vmname\': " . Dumper($rsp);
     }
-    $rsp = $self->handle_qmp_command({execute => 'stop'});
-    $rsp = $self->handle_qmp_command({execute => 'cont'});
-    sleep(10);
     return $rsp;
 }
 


### PR DESCRIPTION
Fail if $rsp is a falsy value. Also drop the stop, cont and sleep because
there does not appear to be any reason for them. They just cause a 1 second
load to take 10 seconds instead.

@coolo 