### PR TITLE
Add option to upload assets on demand even in failed jobs

### DIFF
--- a/isotovideo
+++ b/isotovideo
@@ -448,42 +448,56 @@ if (!$return_code) {
 # read calculated variables from backend and tests
 bmwqemu::load_vars();
 
-# mark hard disks for upload if test finished
-if (!$return_code && $command_handler->test_completed && $bmwqemu::vars{BACKEND} eq 'qemu') {
+sub store_asset {
+    my ($index, $name, $dir) = @_;
+    $name =~ /\.([[:alnum:]]+)$/;
+    my $format = $1;
+    return {hdd_num => $index, name => $name, dir => $dir, format => $format};
+}
+
+sub handle_generated_assets {
+    # mark hard disks for upload if test finished
+    return unless !$return_code && $command_handler->test_completed && ($bmwqemu::vars{BACKEND} eq 'qemu');
     my @toextract;
-    for my $i (1 .. $bmwqemu::vars{NUMDISKS}) {
-        my $dir  = 'assets_private';
-        my $name = $bmwqemu::vars{"STORE_HDD_$i"} || undef;
-        unless ($name) {
-            $name = $bmwqemu::vars{"PUBLISH_HDD_$i"} || undef;
-            $dir  = 'assets_public';
-        }
-        next unless $name;
-        $name =~ /\.([[:alnum:]]+)$/;
-        my $format = $1;
-        push @toextract, {hdd_num => $i, name => $name, dir => $dir, format => $format};
-    }
-    if ($bmwqemu::vars{UEFI} && $bmwqemu::vars{PUBLISH_PFLASH_VARS}) {
-        push(@toextract, {pflash_vars => 1,
-                name   => $bmwqemu::vars{PUBLISH_PFLASH_VARS},
-                dir    => 'assets_public',
-                format => 'qcow2'});
-    }
-    if (@toextract && !$clean_shutdown) {
-        diag "ERROR: Machine not shut down when uploading disks!\n";
-        $return_code = 1;
-    }
-    else {
-        for my $asset (@toextract) {
-            local $@;
-            eval { $bmwqemu::backend->extract_assets($asset); };
-            if ($@) {
-                diag "extract assets failed: $@";
-                $return_code = 1;
+    my $nd = $bmwqemu::vars{NUMDISKS};
+    if ($command_handler->test_completed) {
+        for my $i (1 .. $nd) {
+            my $dir  = 'assets_private';
+            my $name = $bmwqemu::vars{"STORE_HDD_$i"} || undef;
+            unless ($name) {
+                $name = $bmwqemu::vars{"PUBLISH_HDD_$i"} || undef;
+                $dir  = 'assets_public';
             }
+            next unless $name;
+            push @toextract, store_asset($i, $name, $dir);
+        }
+        if ($bmwqemu::vars{UEFI} && $bmwqemu::vars{PUBLISH_PFLASH_VARS}) {
+            push(@toextract, {pflash_vars => 1,
+                    name   => $bmwqemu::vars{PUBLISH_PFLASH_VARS},
+                    dir    => 'assets_public',
+                    format => 'qcow2'});
+        }
+        if (@toextract && !$clean_shutdown) {
+            diag "ERROR: Machine not shut down when uploading disks!\n";
+            $return_code = 1;
+            return;
+        }
+    }
+    for my $i (1 .. $nd) {
+        my $name = $bmwqemu::vars{"FORCE_PUBLISH_HDD_$i"} || next;
+        diag "Requested to force the publication of '$name'";
+        push @toextract, store_asset($i, $name, 'assets_public');
+    }
+    for my $asset (@toextract) {
+        local $@;
+        eval { $bmwqemu::backend->extract_assets($asset); };
+        if ($@) {
+            diag "extract assets failed: $@";
+            $return_code = 1;
         }
     }
 }
+handle_generated_assets;
 
 END {
     kill_backend;

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -14,9 +14,10 @@ my $pool_dir     = "$toplevel_dir/t/pool";
 
 sub isotovideo {
     my (%args) = @_;
-    $args{opts} //= '';
+    $args{opts}      //= '';
+    $args{exit_code} //= 1;
     system("perl $toplevel_dir/isotovideo -d $args{opts} 2>&1 | tee autoinst-log.txt");
-    is(system('grep -q "\d*: EXIT 1" autoinst-log.txt'), 0, $args{end_test_str} ? $args{end_test_str} : 'isotovideo run exited as expected');
+    is(system('grep -q "\d*: EXIT ' . $args{exit_code} . '" autoinst-log.txt'), 0, $args{end_test_str} ? $args{end_test_str} : 'isotovideo run exited as expected');
 }
 
 sub is_in_log {
@@ -72,6 +73,14 @@ subtest 'productdir variable relative/absolute' => sub {
     symlink("$data_dir/tests/main.pm", "$pool_dir/product/foo/main.pm") unless -e "$pool_dir/product/foo/main.pm";
     isotovideo(opts => "casedir=$data_dir/tests _exit_after_schedule=1 productdir=product/foo");
     is_in_log('\d* scheduling.*shutdown', 'schedule can still be found');
+};
+
+subtest 'upload assets on demand even in failed jobs' => sub {
+    chdir($pool_dir);
+    unlink('vars.json') if -e 'vars.json';
+    isotovideo(opts => "casedir=$data_dir/tests schedule=tests/failing_module force_publish_hdd_1=foo.qcow2 qemu_no_kvm=1 arch=i386 backend=qemu qemu=i386", exit_code => 0);
+    is_in_log('qemu-img.*foo.qcow2', 'requested image is published even though the job failed');
+    ok(-e $pool_dir . '/assets_public/foo.qcow2', 'published image exists');
 };
 
 done_testing();

--- a/t/data/tests/tests/failing_module.pm
+++ b/t/data/tests/tests/failing_module.pm
@@ -1,0 +1,28 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use 5.018;
+use strict;
+use warnings;
+
+use base 'basetest';
+
+use testapi;
+
+sub run {
+    die "fail";
+}
+
+1;


### PR DESCRIPTION
Example log output:

```
[Sat Dec 16 08:20:34 2017] [18363:debug] >>> testapi::_check_backend_response: match=bootloader timed out after 30
[Sat Dec 16 08:20:35 2017] [18363:debug] test boot failed
[Sat Dec 16 08:20:35 2017] [18357:debug] isotovideo done
[Sat Dec 16 08:20:35 2017] [18357:debug] BACKEND SHUTDOWN
[Sat Dec 16 08:20:36 2017] [18368:debug] sending magic and exit
[Sat Dec 16 08:20:36 2017] [18357:debug] received magic close
[Sat Dec 16 08:20:36 2017] [18357:debug] preparing hdd 1 for upload as opensuse-Tumbleweed-x86_64-20170505-textmode@64bit.qcow2 in qcow2
[Sat Dec 16 08:20:36 2017] [18357:debug] running nice ionice qemu-img convert -O qcow2 raid/l1 assets_public/opensuse-Tumbleweed-x86_64-20170505-textmode@64bit.qcow
```