### PR TITLE
svirt: Add {start,stop}_serial_grab interface

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -528,6 +528,18 @@ sub attach_to_running {
     }
 }
 
+sub start_serial_grab {
+    my ($self, $args) = @_;
+
+    $self->backend->start_serial_grab($self->name);
+}
+
+sub stop_serial_grab {
+    my ($self, $args) = @_;
+
+    $self->backend->stop_serial_grab($self->name);
+}
+
 # Sends command to libvirt host, logs stdout and stderr of the command,
 # returns exit status.
 #


### PR DESCRIPTION
Provides interface for `start_serial_grab` and `stop_serial_grab` subs
which can se used from test code to start/stop serial console SSH grab
where needed.

Fixes poo#16418: "svirt: openQA won't perform another query_isotovideo
check when VM is down -> incompletes" (second part in
os-autoinst-distri-opensuse).

Validation run: http://assam.suse.cz/tests/95 (restarted 20 times in
revive_xen_domain test module).

```
[2017-12-20T14:34:04.0946 CET] [debug]
/var/lib/openqa/share/tests/sle/tests/jeos/revive_xen_domain.pm:24
called utils::power_action
[2017-12-20T14:34:04.0946 CET] [debug] <<<
backend::console_proxy::__ANON__(wrapped_call={
  'console' => 'svirt',
  'function' => 'stop_serial_grab',
  'args' => []
})

[2017-12-20T14:35:13.0170 CET] [debug] <<<
backend::console_proxy::__ANON__(wrapped_call={
  'args' => [],
  'function' => 'start_serial_grab',
  'console' => 'svirt'
})
[2017-12-20T14:35:13.0477 CET] [debug] Connection to
root@openqaw5-xen.qa.suse.de established
```

os-autoinst-distri-opensuse user: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4107