### PR TITLE
Skip save_tmp_file full stack test if no network

### DIFF
--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -64,8 +64,8 @@ is(system('grep -q "wait_still_screen: detected same image for 10 seconds" autoi
 is(system('grep -q "wait_still_screen: detected same image for 20 seconds" autoinst-log.txt'), 0, 'test type string and wait for 20 seconds');
 
 
-is(system('grep -q "get_test_data returned expected file" autoinst-log.txt'), 0, 'get_test_data test');
-is(system('grep -q "save_tmp_file returned expected file" autoinst-log.txt'), 0, 'save_tmp_file test');
+is(system('grep -q "get_test_data returned expected file" autoinst-log.txt'),                                         0, 'get_test_data test');
+is(system('grep -qE "save_tmp_file returned expected file|no network: save_tmp_file test skipped" autoinst-log.txt'), 0, 'save_tmp_file test');
 
 my $ignore_results_re = qr/fail/;
 for my $result (grep { $_ !~ $ignore_results_re } glob("testresults/result*.json")) {

--- a/t/data/tests/tests/modify_and_upload_file.pm
+++ b/t/data/tests/tests/modify_and_upload_file.pm
@@ -41,10 +41,15 @@ sub run {
     my $url = autoinst_url . '/files/modified.xml';
     $content =~ s/PASSWORD/nots3cr3t/g;
     save_tmp_file('modified.xml', $content);
-    # Verify that correct file is downloaded
-    assert_script_run("wget -q $url");
-    script_run "echo '72d2c15cb10535f36862d7d2eecc8a79  modified.xml' > modified.md5";
-    assert_script_run("md5sum -c modified.md5");
-
-    type_string("echo save_tmp_file returned expected file\n");
+    # Ping default gateway to see if network is available and skip test otherwise
+    if (script_run("ping -q -w 1 -c 1 `ip r | grep default | cut -d ' ' -f 3`")) {
+        # Verify that correct file is downloaded
+        assert_script_run("wget -q $url");
+        script_run "echo '72d2c15cb10535f36862d7d2eecc8a79  modified.xml' > modified.md5";
+        assert_script_run("md5sum -c modified.md5");
+        type_string("echo save_tmp_file returned expected file\n");
+    }
+    else {
+        type_string("echo no network: save_tmp_file test skipped\n");
+    }
 }


### PR DESCRIPTION
Changes introduced in
[PR#877](https://github.com/os-autoinst/os-autoinst/pull/877#) break
build for fedora, as no network is there. Skip test which relies on
network connection if cannot ping default gateway.