### PR TITLE
Do not reset NUMDISKS if RAIDLEVEL is not present

### DIFF
--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -37,7 +37,8 @@ sub do_start_vm {
     my ($self) = @_;
 
     my $vars = \%bmwqemu::vars;
-    $vars->{NUMDISKS} ||= defined($vars->{RAIDLEVEL}) ? 4 : 1;
+    my $n = $vars->{NUMDISKS} || 1;
+    $vars->{NUMDISKS} ||= defined($vars->{RAIDLEVEL}) ? 4 : $n;
 
     # truncate the serial file
     open(my $sf, '>', $self->{serialfile});


### PR DESCRIPTION
Currently if `RAIDLEVEL` is not set but `NUMDISKS` is , `NUMDISKS` is
reset to `1`. Thus preventing runs with e.g. `NUMDISKS=2`.