### PR TITLE
Increase the limits for checking the VNC console. 

### DIFF
--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -12,6 +12,8 @@ NOVIDEO;boolean;0;Do not encode video if set
 VNC_TYPING_LIMIT;integer;50;Maximum number of keys per second
 NO_DEBUG_IO;boolean;0;Disable the I/O debug output in case of needle comparison times longer than expected
 SCREENSHOTINTERVAL;float;0.5;The interval in seconds at which screenshots are taken internally
+_CHKSEL_RATE_WAIT_TIME;integer;30;The ammount of time isotovideo is going to wait for the VNC console to become responsive
+_CHKSEL_RATE_HITS;integer;15000;The ammount of times, the select should return the same fileno during the _CHKSEL_RATE_WAIT_TIME seconds, to consider the VNC console unresponsive
 |====================
 
 .IPMI backend


### PR DESCRIPTION
The limits, although were big enough for most of the tests, were not big enough
for xen tests or when the machines were under heavy load.

Limits increased 3 times.

It's now possible to control this values by using the vars _CHKSEL_RATE_WAIT_TIME and _CHKSEL_RATE_HITS

The checking function was also changed to make sure that:

-  will wait the CHKSEL_RATE_WAIT_TIME. Before if it hit the _CHKSEL_RATE_HITS, it would consider dead

- All the FD in the bucket need to achieve the _CHKSEL_RATE_HITS, not just one. This in conjunction with the previous point will allow the system to recover if another FD suddenly starts responding.