### PR TITLE
Makefile.am: Fix install directory for RunArgs.pm

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -50,7 +50,7 @@ openqaexecbenchdir = $(pkglibexecdir)/OpenQA/Benchmark
 openqaexecbench_DATA = \
 	OpenQA/Benchmark/Stopwatch.pm
 
-openqaexecrunargsdir = $(pkglibexecdir)/OpenQA/Tests
+openqaexecrunargsdir = $(pkglibexecdir)/OpenQA/Test
 openqaexecrunargs_DATA = \
     OpenQA/Test/RunArgs.pm
 


### PR DESCRIPTION
commit db9fe8bc ("Add RunArgs to the Makefile") added wrong directory
for RunArgs.pm. Package expects to be in OpenQA/Test directory, but was
installed into OpenQA/Tests directory.