### PR TITLE
Add variables to change ipmi behavior in test

### DIFF
--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -111,7 +111,9 @@ sub do_start_vm {
 sub do_stop_vm {
     my ($self) = @_;
 
-    $self->ipmitool("chassis power off");
+    if (!$bmwqemu::vars{IPMI_DO_NOT_POWER_OFF}) {
+        $self->ipmitool("chassis power off");
+    }
     $self->deactivate_console({testapi_console => 'sol'});
     return {};
 }

--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -76,18 +76,18 @@ sub restart_host {
 
     $self->ipmitool("chassis power off");
     while (1) {
+        sleep(3);
         my $stdout = $self->ipmitool('chassis power status');
         last if $stdout =~ m/is off/;
         $self->ipmitool('chassis power off');
-        sleep(2);
     }
 
     $self->ipmitool("chassis power on");
     while (1) {
+        sleep(3);
         my $ret = $self->ipmitool('chassis power status');
         last if $ret =~ m/is on/;
         $self->ipmitool('chassis power on');
-        sleep(2);
     }
 }
 

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -24,6 +24,7 @@ Variable;Values allowed;Default value;Explanation
 IPMI_HOSTNAME;string;Hostname/IP for IPMI interface;
 IPMI_PASSWORD;string;Password for the IPMI interface;
 IPMI_USER;string;Username for the IPMI interface;
+IPMI_DO_NOT_POWER_OFF;boolean;undef;Don't power off the machine after test
 |====================
 
 .QEMU backend

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -9,9 +9,10 @@ Variable;Values allowed;Default value;Explanation
 EXCLUDE_MODULES;string;;comma separated names or fullnames of excluded test modules
 _EXIT_AFTER_SCHEDULE;boolean;0;Exit test execution immediately after evaluation of the test schedule, e.g. to check only which test modules would be executed
 NOVIDEO;boolean;0;Do not encode video if set
-VNC_TYPING_LIMIT;integer;50;Maximum number of keys per second
 NO_DEBUG_IO;boolean;0;Disable the I/O debug output in case of needle comparison times longer than expected
 SCREENSHOTINTERVAL;float;0.5;The interval in seconds at which screenshots are taken internally
+VNC_STALL_TRESHOLD;integer;4;Time after which is VNC considered stalled
+VNC_TYPING_LIMIT;integer;50;Maximum number of keys per second
 _CHKSEL_RATE_WAIT_TIME;integer;30;The ammount of time isotovideo is going to wait for the VNC console to become responsive
 _CHKSEL_RATE_HITS;integer;15000;The ammount of times, the select should return the same fileno during the _CHKSEL_RATE_WAIT_TIME seconds, to consider the VNC console unresponsive
 |====================


### PR DESCRIPTION
Servers in Prague assigned for SES testing have configuration that needs this modifications.
e.g.
* hornet is master server and has 2 network cards and pretty fast boot and tent to fail with existing sleep 2 after status check http://10.100.12.155/tests/493/file/autoinst-log.txt
* 4 nodes have 7 network cards, boot takes much longer and there are windows without change, much longer than 4 seconds stall time. Configurable stall time is useful anyway
http://10.100.12.155/tests/523
* Shutting down the machines after installation is not needed, after installation continues manual testing or openQA testing in future. Configurable shutdown of ipmi machine after the test is done is also useful. Right ? :smile: 

Added variables leave default values if unset.
Tests: http://10.100.12.155/tests