### PR TITLE
[WIP] qemu: Increase memory dump performance

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -44,6 +44,7 @@ requires 'base';
 requires 'constant';
 requires 'strict';
 requires 'warnings';
+requires 'Socket::MsgHdr';
 
 on 'test' => sub {
   requires 'Devel::Cover';


### PR DESCRIPTION
This is mainly to help determine if migration can be made reliable for the benefit of snapshots. I will probably follow this up with another commit which enables performance counters during snapshots and memory dumps. Currently this requires a new package which I will try avoiding, but it is a pain.


Makes three changes to the memory dump:

1) Uses the file descriptor URI with the migrate command instead of exec. This
means that QEMU is writing the data directly to a file instead of writing it
to a pipe to /bin/sh which then relays it to gzip which tries to re-compress it
and write it back to a pipe to sh which then writes it to a file.

Note that QEMU compresses the image internally by default using zlib. The
compression level can be increased, but it did not result in a smaller file
size during my testing.

2) Set max bandwidth to 2^31 to make sure that the transfer speed is not being
limited by QEMU. It seems unlikely that this is a problem for us, but I am not
sure if QEMU can set this value automatically.

3) Make sure the VM is frozen before beginning the migration. QEMU will try to
copy most of the RAM while the VM is still running which requires it to track
dirtied RAM and resend it. Eventually it freezes the machine to finish the
copy. However if the guest is busy then this could increase the size of the
dump and cause it to take longer. It also means QEMU has to maintain a bitmap
of the guest RAM to track modified regions.

