### PR TITLE
WIP: Make sure that we don't leave running processes

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -173,9 +173,13 @@ sub run_all {
         warn $@;
         $died = 1;    # test execution died
     }
-    bmwqemu::save_vars();
-    myjsonrpc::send_json($isotovideo, {cmd => 'tests_done', died => $died, completed => $completed});
-    close $isotovideo;
+    eval {
+        # When the disk runs out of space there's nothing else we can do. We just can't allow to jump the exit
+        bmwqemu::save_vars();
+        myjsonrpc::send_json($isotovideo, {cmd => 'tests_done', died => $died, completed => $completed});
+        close $isotovideo;
+    };
+    warn "Exception while processing the send_json call: $@" if $@;
     Devel::Cover::report() if Devel::Cover->can('report');
     _exit(0);
 }

--- a/isotovideo
+++ b/isotovideo
@@ -146,6 +146,8 @@ sub kill_autotest {
 
 sub kill_backend {
     if (defined $bmwqemu::backend && $bmwqemu::backend->{backend_pid}) {
+        # Make sure that the backend child processes (eg. qemu) dies
+        _kill_all_descendants($bmwqemu::backend->{backend_pid});
         # save the pid in a scalar - signal handlers will reset it
         my $bpid = $bmwqemu::backend->{backend_pid};
         diag "killing backend process $bpid";
@@ -181,6 +183,7 @@ sub signalhandler_chld {
         }
         if ($bmwqemu::backend->{backend_pid} && $child == $bmwqemu::backend->{backend_pid}) {
             diag("backend $child died");
+            _kill_all_descendants($bmwqemu::backend->{backend_pid});
             $bmwqemu::backend->{backend_pid} = 0;
             $loop = 0;
             next;
@@ -323,6 +326,30 @@ our $tags = undef;
 my $backend_requester = undef;
 
 my ($last_check_seconds, $last_check_microseconds) = gettimeofday;
+
+# Kill all the descendantes of a PID - A grandchild process is not considered a child
+# We loop through the proc instead of checking the task/tid/children, so we can invoke this when processing SIGCHLD.
+# Since the orphans are adopted by init (pid 1), we need to check if the process group is the same as the actual group (since forks have the same group)
+# To know more about procfs, please check man(5) proc
+sub _kill_all_descendants {
+    no autodie;
+    my ($ppid) = @_;
+    my $group = getpgrp(0);
+    for my $proc_folder (glob("/proc/*")) {
+        next if (!-d $proc_folder || !-f "$proc_folder/stat" || $proc_folder eq "/proc/$$");
+        open my $ifh, '<', "$proc_folder/stat" or next;
+        my ($pid, $executable, $state, $parent, $pgroup) = split(' ', <$ifh>);
+        close $ifh;
+        if ($executable !~ /videoenc/ && (($parent == $ppid) || ($parent == 1 && $pgroup == $group)) && $state =~ /R|S/) {
+            if (kill 'TERM', $pid) {
+                diag "awaiting death of descendant $executable $pid";
+                my $ret = waitpid($pid, 0);
+                diag "descendant process $executable exited: $ret";
+            }
+        }
+    }
+}
+
 sub _calc_check_delta {
     # an estimate of eternity
     my $delta = 100;


### PR DESCRIPTION
poo#30388

We need to make sure that the qemu dies.

For example if isotovideo backend dies, then his kid qemu would survive.
This ensures that all the descendants will be dead.

Related changes:
https://github.com/os-autoinst/openQA/commit/5aa41337736490fe2bdc880de2aaf75b1579612c

Verification run: http://tragicbox.suse.cz/tests/473/file/autoinst-log.txt