### PR TITLE
Avoid letting the kids get loose.

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -173,8 +173,10 @@ sub run_all {
         warn $@;
         $died = 1;    # test execution died
     }
-    bmwqemu::save_vars();
-    myjsonrpc::send_json($isotovideo, {cmd => 'tests_done', died => $died, completed => $completed});
+    eval {
+        bmwqemu::save_vars();
+        myjsonrpc::send_json($isotovideo, {cmd => 'tests_done', died => $died, completed => $completed});
+    };
     close $isotovideo;
     Devel::Cover::report() if Devel::Cover->can('report');
     _exit(0);


### PR DESCRIPTION
When there's no disk space available, it's unable to write to disk
and it will throw an exception.

These changes avoid the exception to propagate and so it won't let the child
to skip death.