### PR TITLE
testapi: Ensure script_output only returns the actual ouput of the executed script

### DIFF
--- a/t/data/tests/tests/boot.pm
+++ b/t/data/tests/tests/boot.pm
@@ -50,6 +50,12 @@ END
     script_run "echo '924095f2cb4d622a8796de66a5e0a44a  text' > text.md5";
     assert_script_run 'md5sum -c text.md5';
 
+    # TinyCore busybox sh acts as bash but does not provide it so we do here
+    script_run 'alias bash=sh', 0;
+    my $out = script_output('mount');
+    die "mount does not show any mount points? output: $out" unless $out =~ /.*\/.*on/;
+    die "^rootfs not found. output: $out"                    unless $out =~ qr{^rootfs};
+    die "tmpfs on /dev/shm not found. output: $out"          unless $out =~ qr{tmpfs on /dev/shm};
 }
 
 sub test_flags {

--- a/testapi.pm
+++ b/testapi.pm
@@ -954,6 +954,7 @@ sub script_output {
     my $shell_cmd = is_serial_terminal() ? 'bash -oe pipefail' : 'bash -eox pipefail';
     my $run_script = "echo $marker; $shell_cmd $script_path ; echo SCRIPT_FINISHED$marker-\$?-";
     if (is_serial_terminal) {
+        wait_serial('# ', undef, 0, no_regex => 1);
         type_string("$run_script\n");
         wait_serial($run_script, undef, 0, no_regex => 1);
     }

--- a/testapi.pm
+++ b/testapi.pm
@@ -621,7 +621,7 @@ Set test variable C<$variable> to value C<$value>.
 
 Specify a true value for the C<reload_needles> flag to trigger a reloading
 of needles in the backend and call the cleanup handler with the new variables
-to make sure that possibly unselected needles are now taken into account
+to make sure that possibly deselected needles are now taken into account
 (useful if you change scenarios during the test run)
 
 =cut


### PR DESCRIPTION
This prevents additional data on the used serial device to confuse
script_output callers which do not expect script_output to implicitly consume
and return that additional "noise" data.

The test data mocking in the unit is certainly not perfect because it relies
on the actual definition of context markers used within the implementation of
script_output but I have not found a better way.

Related progress issue: https://progress.opensuse.org/issues/30613