### PR TITLE
[RFC] Do sanity check for validate code

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -1037,6 +1037,15 @@ sub validate_script_output($&;$) {
     my $output = script_output($script, $wait);
     my $res = 'ok';
 
+    if ($ENV{SANITYCHECK}) {
+        # quick sanity check for check functions:
+        $_ = '';
+        my $ret1 = $code->();
+        $_ = 'foobar';
+        if ($ret1 && $code->()) {
+            confess("sanity check failed for $script validator code - always returns true");
+        }
+    }
     # set $_ so the callbacks can be simpler code
     $_ = $output;
     if (!$code->()) {


### PR DESCRIPTION
to avoid cases like zypper_moo returning a constant string
instead of doing a pattern match
This created confusion for people making new tests based on existing ones like in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4346