### PR TITLE
testapi: Refactor script_output into distribution.pm and fix race

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -918,59 +918,7 @@ and can be tweaked by setting the C<$wait> positional parameter.
 =cut
 
 sub script_output {
-    my ($current_test_script, $wait, %args) = @_;
-    my $marker = hashed_string("SO$current_test_script");
-    # 80 is approximate quantity of chars typed during 'curl' approach
-    # if script length is lower there is no point to proceed with more complex solution
-    $args{type_command} //= length($current_test_script) < 80;
-    my $script_path = "/tmp/script$marker.sh";
-
-    if (is_serial_terminal) {
-        my $cat = "cat - > $script_path; echo $marker-\$?-";
-        type_string($cat . "\n");
-        wait_serial("$cat", undef, 0, no_regex => 1);
-        type_string($current_test_script);
-        type_string("\n", terminate_with => 'EOT');
-        wait_serial("$marker-0-");
-    }
-    elsif ($args{type_command}) {
-        my $cat = "cat - > $script_path;\n";
-        type_string($cat);
-        type_string($current_test_script . "\n");
-        send_key('ctrl-d');
-    }
-    else {
-        open my $fh, ">", 'current_script' or croak("Could not open file. $!");
-        print $fh $current_test_script;
-        close $fh;
-        assert_script_run "curl -f -v " . autoinst_url("/current_script") . " > $script_path";
-        script_run "clear";
-    }
-
-    # Surround the actual script output with special markers so that we can
-    # unambiguously separate the expected output from other content that we
-    # might encounter on the serial device depending on how it is used in the
-    # SUT
-    my $shell_cmd = is_serial_terminal() ? 'bash -oe pipefail' : 'bash -eox pipefail';
-    my $run_script = "echo $marker; $shell_cmd $script_path ; echo SCRIPT_FINISHED$marker-\$?-";
-    if (is_serial_terminal) {
-        wait_serial('# ', undef, 0, no_regex => 1);
-        type_string("$run_script\n");
-        wait_serial($run_script, undef, 0, no_regex => 1);
-    }
-    else {
-        type_string "($run_script) | tee /dev/$serialdev\n";
-    }
-    my $output = wait_serial("SCRIPT_FINISHED$marker-\\d+-", $wait, 0, record_output => 1)
-      || croak "script timeout";
-
-    croak "script failed" if $output !~ "SCRIPT_FINISHED$marker-0-";
-
-    # and the markers including internal exit catcher
-    my $out = $output =~ /$marker(?<expected_output>.+)SCRIPT_FINISHED$marker-0-/s ? $+ : '';
-    # trim whitespaces
-    $out =~ s/^\s+|\s+$//g;
-    return $out;
+    return $distri->script_output(@_);
 }
 
 


### PR DESCRIPTION
script_output's implementation is very specific to the Operating System and
even to a particular Linux distribution. This moves it into a place where it
can be overridden by the distribution and can also use distribution specific
variables more easily.

This also fixes a race condition with the serial terminal console by waiting
for the shell prompt to appear.