### PR TITLE
Use a fixed version of perltidy

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -48,7 +48,7 @@ requires 'warnings';
 on 'test' => sub {
   requires 'Devel::Cover';
   requires 'Perl::Critic';
-  requires 'Perl::Tidy', '>= 20180101, != 20180219';
+  requires 'Perl::Tidy', '== 20180220';
   requires 'Pod::Coverage';
   requires 'Test::Compile';
   requires 'Test::Fatal';


### PR DESCRIPTION
We should avoid suprises on travis - but update explicitly whenever
we feel the need to do so