### PR TITLE
Add support to override HDDMODEL per disk

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -202,7 +202,7 @@ sub can_handle {
         return if $vars->{QEMU_DISABLE_SNAPSHOTS};
 
         for my $i (1 .. $vars->{NUMDISKS}) {
-            return if $vars->{"HDDMODEL_$i"} eq 'nvme';
+            return if (defined $vars->{"HDDMODEL_$i"} && $vars->{"HDDMODEL_$i"} eq 'nvme');
         }
 
         return {ret => 1};

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -718,7 +718,8 @@ sub start_qemu {
                 my $diskmodel;
                 if (defined $vars->{"HDDMODEL_$i"}) {
                     $diskmodel = $vars->{"HDDMODEL_$i"};
-                } else {
+                }
+                else {
                     $diskmodel = $vars->{HDDMODEL};
                 }
                 # when booting from disk on UEFI, first connected disk gets ",bootindex=0"

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -201,6 +201,10 @@ sub can_handle {
 
         return if $vars->{QEMU_DISABLE_SNAPSHOTS};
 
+        for my $i (1 .. $vars->{NUMDISKS}) {
+            return if $vars->{"HDDMODEL_$i"} eq 'nvme';
+        }
+
         return {ret => 1};
     }
     return;
@@ -711,10 +715,16 @@ sub start_qemu {
                 }
             }
             else {
+                my $diskmodel;
+                if (defined $vars->{"HDDMODEL_$i"}) {
+                    $diskmodel = $vars->{"HDDMODEL_$i"};
+                } else {
+                    $diskmodel = $vars->{HDDMODEL};
+                }
                 # when booting from disk on UEFI, first connected disk gets ",bootindex=0"
                 my $bootindex = ($i == 1 && $vars->{UEFI} && $bootfrom eq "disk") ? "bootindex=0" : "";
                 my $serial = "serial=$i";
-                gen_params @params, 'device', [qv "$vars->{HDDMODEL} drive=hd$i $bootindex $serial"];
+                gen_params @params, 'device', [qv "$diskmodel drive=hd$i $bootindex $serial"];
                 gen_params @params, 'drive',  [qv "file=$basedir/l$i cache=unsafe if=none id=hd$i format=$vars->{HDDFORMAT}"];
             }
         }

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -43,6 +43,7 @@ CDMODEL;see qemu -device ?;undef;Storage device for virtualized CD
 DELAYED_START;boolean;;delay vm cpu start until resume_vm() is called
 HDDFORMAT;;;
 HDDMODEL;see qemu -device ?;virtio-blk;Storage device for virtualized HDD.
+HDDMODEL_$i;see qemu -device ?;virtio-blk;Storage device for virtualized HDD. Overrides global HDDMODEL for HDD_$i
 HDDSIZEGB;integer;10;Creates HDD with specified size in GiB
 HDD_$i;filename;;Filename of HDD image to be used for VM. Up to 9
 ISO;filename;;Filename of ISO file to be attached to VM


### PR DESCRIPTION
HDDMODEL can be set to 'nvme' to make qemu use this disk type. However,
sometimes it is desired to just have this extra NVMe disk in addition to
a classical setup.
This commit adds a a new variable HDDMODEL_$i available for all disks.
When it is set, the specified disk will be made availabe as NVMe-disk,
and the snapshot-feature will be disabled, like with the global
HDDMODEL='nvme'.
The HDDMODEL_$i will override the global HDDMODEL, but does not replace
the parameter in order to not break anything.

Signed-off-by: Michael Moese <mmoese@suse.de>