### PR TITLE
qemu: enable discard support for disks

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -707,7 +707,7 @@ sub start_qemu {
                     # when booting from disk on UEFI, first connected disk gets ",bootindex=0"
                     my $bootindex = ($i == 1 && $c == 1 && $vars->{UEFI} && $bootfrom eq "disk") ? "bootindex=0" : "";
                     gen_params @params, 'device', [qv "$vars->{HDDMODEL} drive=$id bus=$bus $bootindex"];
-                    gen_params @params, 'drive',  [qv "file=$basedir/l$i cache=none if=none id=$id serial=mpath$i format=$vars->{HDDFORMAT}"];
+                    gen_params @params, 'drive',  [qv "file=$basedir/l$i cache=none if=none id=$id serial=mpath$i format=$vars->{HDDFORMAT} discard=on"];
                 }
             }
             else {
@@ -715,7 +715,7 @@ sub start_qemu {
                 my $bootindex = ($i == 1 && $vars->{UEFI} && $bootfrom eq "disk") ? "bootindex=0" : "";
                 my $serial = "serial=$i";
                 gen_params @params, 'device', [qv "$vars->{HDDMODEL} drive=hd$i $bootindex $serial"];
-                gen_params @params, 'drive',  [qv "file=$basedir/l$i cache=unsafe if=none id=hd$i format=$vars->{HDDFORMAT}"];
+                gen_params @params, 'drive',  [qv "file=$basedir/l$i cache=unsafe if=none id=hd$i format=$vars->{HDDFORMAT} discard=on"];
             }
         }
 


### PR DESCRIPTION
Add 'discard=on' option to disks. This allows using `fstrim` in SUT to
make its disk image smaller - especially helpful when using STORE_HDD_*
or PUBLISH_HDD_*. In extreme cases it helps avoiding 20GB upload size
limit.

To make it really working, one need also HDDMODEL=scsi-hd, qemu
apparently ignore it for virtio-blk devices.