### PR TITLE
Remove support for backend.crashed file

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -353,17 +353,6 @@ sub alive {
     return 0;
 }
 
-my $iscrashedfile = 'backend.crashed';
-sub unlink_crash_file {
-    unlink($iscrashedfile) if -e $iscrashedfile;
-}
-
-sub write_crash_file {
-    open(my $fh, ">", $iscrashedfile);
-    print $fh "crashed\n";
-    close $fh;
-}
-
 # new api end
 
 # virtual methods

--- a/backend/generalhw.pm
+++ b/backend/generalhw.pm
@@ -102,8 +102,6 @@ sub relogin_vnc {
 sub do_start_vm {
     my ($self) = @_;
 
-    # remove backend.crashed
-    $self->unlink_crash_file;
     $self->restart_host;
     $self->relogin_vnc;
     $self->start_serial_grab;

--- a/backend/ikvm.pm
+++ b/backend/ikvm.pm
@@ -64,8 +64,6 @@ sub relogin_vnc {
 sub do_start_vm {
     my ($self) = @_;
 
-    # remove backend.crashed
-    $self->unlink_crash_file;
     $self->get_mc_status;
     $self->restart_host;
     $self->relogin_vnc;

--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -94,8 +94,6 @@ sub restart_host {
 sub do_start_vm {
     my ($self) = @_;
 
-    # remove backend.crashed
-    $self->unlink_crash_file;
     $self->get_mc_status;
     $self->restart_host;
 

--- a/backend/pvm.pm
+++ b/backend/pvm.pm
@@ -40,7 +40,6 @@ sub new {
 
 sub do_start_vm {
     my $self = shift;
-    $self->unlink_crash_file;
     $self->start_lpar();
     return {};
 }

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -111,8 +111,6 @@ sub cpu_stat {
 sub do_start_vm {
     my $self = shift;
 
-    # remove backend.crashed
-    $self->unlink_crash_file();
     $self->start_qemu();
     return {};
 }

--- a/backend/s390x.pm
+++ b/backend/s390x.pm
@@ -41,7 +41,6 @@ sub do_start_vm {
     open(my $sf, '>', $self->{serialfile});
     close($sf);
 
-    $self->unlink_crash_file();
     my $console = $testapi::distri->add_console('x3270', 's3270');
     $console->backend($self);
     $self->select_console({testapi_console => 'x3270'});

--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -54,8 +54,6 @@ sub do_start_vm {
 
     $ssh->backend($self);
 
-    # remove backend.crashed
-    $self->unlink_crash_file;
     bmwqemu::save_vars();    # update variables
     return {};
 }


### PR DESCRIPTION
The worker is now responsible to detect dead children - isotovideo
is just incapable of doing this reliable