### PR TITLE
Search for patterns in the SERIAL file and raise failures

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -364,10 +364,9 @@ sub parse_serial_output_qemu {
     myjsonrpc::send_json($isotovideo, {cmd => 'read_serial', position => $serial_file_pos});
     my $json = myjsonrpc::read_json($isotovideo);
 
-    # loop line by line
-    open my $ifh, '<', \$json->{serial} or die "Unable to process serial text: $!";
     my $die = 0;
-    while (defined(my $line = <$ifh>)) {
+    # loop line by line
+    for my $line (split(/^/, $json->{serial})) {
         chomp $line;
         # only two keys allowed
         for my $type (qw(soft hard)) {
@@ -390,7 +389,6 @@ sub parse_serial_output_qemu {
         }
     }
 
-    close $ifh;
     die if $die;
     return $json->{position};
 }

--- a/autotest.pm
+++ b/autotest.pm
@@ -389,7 +389,7 @@ sub parse_serial_output_qemu {
         }
     }
 
-    die if $die;
+    die "Got serial hard failure" if $die;
     return $json->{position};
 }
 

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -699,13 +699,26 @@ Returns the output on the serial device since the last call to set_serial_offset
 
 sub serial_text {
     my ($self) = @_;
+    return ($self->read_serial($self->{serial_offset}))[0];
+}
+
+=head2 read_serial
+
+Returns the output and the offset after reading on the serial device from position
+
+=cut
+
+sub read_serial {
+    my ($self, $position, $whence) = @_;
 
     open(my $SERIAL, "<", $self->{serialfile});
-    seek($SERIAL, $self->{serial_offset}, 0);
+    seek($SERIAL, $position, $whence // 0);
     local $/;
-    my $data = <$SERIAL>;
+    my $data   = <$SERIAL>;
+    my $offset = tell $SERIAL;
     close($SERIAL);
-    return $data;
+
+    return ($data, $offset);
 }
 
 sub wait_serial {

--- a/basetest.pm
+++ b/basetest.pm
@@ -50,6 +50,7 @@ sub new {
     $self->{timeoutcounter}         = 0;
     $self->{activated_consoles}     = [];
     $self->{name}                   = $class;
+    $self->{serial_failures}        = {};
     return bless $self, $class;
 }
 

--- a/distribution.pm
+++ b/distribution.pm
@@ -25,7 +25,8 @@ sub new {
     my ($class) = @_;
 
     my $self = bless {}, $class;
-    $self->{consoles} = {};
+    $self->{consoles}        = {};
+    $self->{serial_failures} = {};
 
 =head2 serial_term_prompt
 
@@ -238,6 +239,25 @@ sub script_output {
     # trim whitespaces
     $out =~ s/^\s+|\s+$//g;
     return $out;
+}
+
+=head2 set_expected_serial_failures
+
+    set_expected_serial_failures(%failures)
+
+Define the patterns to look for in the serial console.
+The patterns can be either I<hard> or I<soft>.
+
+Example:
+    set_expected_serial_failures(soft=>[qr/Pattern1/], hard=>[qr/Pattern2/]);
+
+=cut
+sub set_expected_serial_failures {
+    my ($self, %failures) = @_;
+
+    # To be sure that we only store soft and hard keys
+    $self->{serial_failures}{soft} = $failures{soft} if $failures{soft};
+    $self->{serial_failures}{hard} = $failures{hard} if $failures{hard};
 }
 
 # override

--- a/isotovideo
+++ b/isotovideo
@@ -477,6 +477,12 @@ while ($loop) {
             check_asserted_screen(1, $no_wait);
             next;
         }
+        if ($rsp->{cmd} eq 'read_serial') {
+            # This will stop to work if we change the serialfile after the initialization because of the fork
+            my ($serial, $pos) = $bmwqemu::backend->{backend}->read_serial($rsp->{position});
+            myjsonrpc::send_json($r, {serial => $serial, position => $pos});
+            next;
+        }
         die "Unknown command $rsp->{cmd}";
     }
 


### PR DESCRIPTION
Search for patterns in the SERIAL file and raise failures

With these changes the tester can now define if he wants to raise a soft or a hard
failure when a pattern appears in a test.

There's two ways to use this functionality:
1- On main.pm the developer after setting the distribution, can set the serial failures interface
   Example:

> $testapi::distri->set_serial_failures(soft=>['gcc version 4.8.5 (SUSE Linux)'], hard=>[qr/No iBFT detected/]);

2- On the tests the developer needs to set the serial_failures variable of the test
   object

The patterns defined in main.pm file are going to be available to all tests, the
developer can then override those patterns by setting the instance variable.

The hashref (case 2) needs to have this structure:
> \%SERIAL_FAILURES = (
>                  soft => [quotemeta "pattern 1", qr/pattern2(?!pattern3)/],
>                  hard => [qr/pattern 3/]
> );

The SERIAL_FAILURES keys needs to be soft or hard.
The "soft" key will raise a softfail warning in the test.
The "hard" key will raise a hard fail in the test.

Both keys need to have an arrayref containing strings.
The strings represent the patterns to look in the serial file.

The comparation will be done line by line (please pay attention to the $/ var)
and comparing the pattern string/regexp as-is with the line. 