### PR TITLE
Allow setting console tty and other args

### DIFF
--- a/backend/console_proxy.pm
+++ b/backend/console_proxy.pm
@@ -37,6 +37,9 @@ sub DESTROY {
     # nothing to destroy but avoid AUTOLOAD
 }
 
+# handles the attempt to invoke an undefined method on the proxy console object
+# using query_isotovideo() to invoke the method on the actual console object in
+# the right process
 sub AUTOLOAD {
 
     my $function = our $AUTOLOAD;

--- a/consoles/console.pm
+++ b/consoles/console.pm
@@ -90,4 +90,23 @@ sub is_serial_terminal {
     return 0;
 }
 
+sub set_args {
+    my ($self, %args) = @_;
+
+    my $my_args = $self->{args};
+    for my $arg (keys %args) {
+        $my_args->{$arg} = $args{$arg};
+    }
+    # no need to send changes to right process; console proxy already takes care
+    # that this method is called in the right process
+}
+
+sub set_tty {
+    my ($self, $tty) = @_;
+
+    $self->{args}->{tty} = $tty;
+    # no need to send changes to right process; console proxy already takes care
+    # that this method is called in the right process
+}
+
 1;

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use consoles::console;
 use Test::More;
 use Test::Output;
 use Test::Fatal;
@@ -254,6 +255,40 @@ subtest 'wait_still_screen' => sub {
     ok(wait_still_screen(stilltime => 2, no_wait => 1), 'no_wait option can be specified');
     ok(!wait_still_screen(timeout => 4, no_wait => 1), 'two named args, with timeout below stilltime - which will always return false');
     ok(wait_still_screen(1, 2, timeout => 3), 'named over positional');
+};
+
+subtest 'set console tty and other args' => sub {
+    # ensure previously emitted commands are cleared
+    $cmds = ();
+
+    console->set_tty(4);
+    console->set_args(tty => 5, foo => 'bar');
+
+    is_deeply(
+        $cmds,
+        [
+            {
+                cmd      => 'backend_proxy_console_call',
+                console  => 'a-console',
+                function => 'set_tty',
+                args     => [4],
+            },
+            {
+                cmd      => 'backend_proxy_console_call',
+                console  => 'a-console',
+                function => 'set_args',
+                args     => ['tty', 5, 'foo', 'bar'],
+            },
+        ]);
+
+    # test console's methods manually since promoting the commands is mocked in this test
+    my $console = consoles::console->new('dummy-console', {tty => 3});
+    is($console->{args}->{tty}, 3);
+    $console->set_tty(42);
+    is($console->{args}->{tty}, 42);
+    $console->set_args(tty => 43, foo => 'bar');
+    is($console->{args}->{tty}, 43);
+    is($console->{args}->{foo}, 'bar');
 };
 
 done_testing;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,4 +1,6 @@
-AM_MAKEFLAGS = PERL5OPT="-MDevel::Cover=-db,$(abs_builddir)/cover_db"
+AM_MAKEFLAGS = \
+	PERL5OPT="-MDevel::Cover=-db,$(abs_builddir)/cover_db" \
+	PERL5LIB="..:$$PERL5LIB"
 TESTS = 00-compile-check-all.t 01-test_needle.t 02-test_ocr.t 03-testapi.t 04-check_vars_docu.t 05-pod.t 06-pod-coverage.t 07-commands.t 08-autotest.t 09-lockapi.t 10-terminal.t 11-image-ppm.t 12-bmwqemu.t 13-osutils.t 14-isotovideo.t 16-send_with_fd.t 20-openqa-benchmark-stopwatch-utils.t 99-full-stack.t
 
 EXTRA_DIST = $(TESTS)


### PR DESCRIPTION
This allows to alter the console's arguments after
the initialization via add_console():

* console('x11')->set_arg(tty => 7);
* console('x11')->set_tty(7);

See https://progress.opensuse.org/issues/25702

---

Contains test-cases, but I haven't tested whether this works in a test run.