### PR TITLE
Add username parameter for sshCommand

### DIFF
--- a/consoles/console.pm
+++ b/consoles/console.pm
@@ -52,9 +52,9 @@ sub screen {
 
 # helper function
 sub sshCommand {
-    my ($self, $host, $gui) = @_;
+    my ($self, $username, $host, $gui) = @_;
 
-    my $sshopts = "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no root\@$host";
+    my $sshopts = "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no $username\@$host";
 
     if ($gui) {
         $sshopts = "-X $sshopts";

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -65,8 +65,8 @@ sub activate {
     my $testapi_console = $self->{testapi_console};
     my $ssh_args        = $self->{args};
 
-    my $sshcommand = $self->sshCommand($hostname);
-    my $display    = $self->{DISPLAY};
+    my $sshcommand = $self->sshCommand('root', $hostname);
+    my $display = $self->{DISPLAY};
 
     $sshcommand = "TERM=xterm " . $sshcommand;
     my $xterm_vt_cmd = "xterm-console";

--- a/consoles/sshX3270.pm
+++ b/consoles/sshX3270.pm
@@ -23,7 +23,7 @@ use testapi 'get_var';
 sub activate {
     my ($self) = @_;
 
-    my $sshcommand  = $self->sshCommand(get_var("PARMFILE")->{Hostname});
+    my $sshcommand  = $self->sshCommand('root', get_var("PARMFILE")->{Hostname});
     my $display     = $self->{backend}->{consoles}->{worker}->{DISPLAY};
     my $sshpassword = $testapi::password;
 

--- a/consoles/sshXtermVt.pm
+++ b/consoles/sshXtermVt.pm
@@ -34,7 +34,8 @@ sub activate {
 
     my $hostname = $ssh_args->{hostname} || die('we need a hostname to ssh to');
     my $password = $ssh_args->{password} || $testapi::password;
-    my $sshcommand = $self->sshCommand($hostname, $gui);
+    my $username = $ssh_args->{username} || 'root';
+    my $sshcommand = $self->sshCommand($username, $hostname, $gui);
     my $serial = $self->{args}->{serial};
 
     $self->callxterm($sshcommand, "ssh:$testapi_console");


### PR DESCRIPTION
This partly contains the changes from #909 and enables consoles to use a different user then root when using sshCommand. See it as preparation for the future where we eventually want to user other users then root.