### PR TITLE
Merge qemu output failure conditions

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -636,17 +636,16 @@ sub parse_serial_output_qemu {
             for my $regexp (@{$failures->{$type}}) {
                 # If you want to match a simple string please be sure that you create it with quotemeta
                 if ($line =~ /$regexp/) {
-                    if ($type eq 'soft') {
-                        $self->record_testresult('softfail');
-                        $self->record_resultfile('Serial Failure', "Serial error: $line", result => 'softfail');
-                        $self->{result} = 'softfail';
+                    my $fail_type = 'softfail';
+                    if ($type eq 'hard') {
+                        $die       = 1;
+                        $fail_type = 'fail';
                     }
-                    else {
-                        $self->record_testresult('fail');
-                        $self->record_resultfile('Serial Failure', "Serial error: $line", result => 'fail');
-                        $self->{result} = 'fail';
-                        $die = 1;
-                    }
+
+                    $self->record_testresult($fail_type);
+                    $self->record_resultfile('Serial Failure', "Serial error: $line", result => $fail_type);
+                    $self->{result} = $fail_type;
+
                 }
             }
         }

--- a/isotovideo
+++ b/isotovideo
@@ -52,7 +52,7 @@ BEGIN {
 
 # this shall be an integer increased by every change of the API
 # either to the worker or the tests
-our $INTERFACE = 7;
+our $INTERFACE = 8;
 
 use bmwqemu;
 use needle;


### PR DESCRIPTION
There are two failure conditions, either soft or hard.
The only thing that changes in their behaviour is the ability to raise
an exception.
This change will merge the two "if" code blocks into one.

related: pr#932