### PR TITLE
Add test option _SKIP_POST_FAIL_HOOKS to save time on test development

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -302,6 +302,7 @@ sub post_run_hook {
 
 sub run_post_fail {
     my ($self, $msg) = @_;
+    return if $bmwqemu::vars{_SKIP_POST_FAIL_HOOKS};
     $self->{post_fail_hook_running} = 1;
     eval { $self->post_fail_hook; };
     bmwqemu::diag("post_fail_hook failed: $@") if $@;

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -8,6 +8,7 @@ Supported variables per backend
 Variable;Values allowed;Default value;Explanation
 EXCLUDE_MODULES;string;;comma separated names or fullnames of excluded test modules
 _EXIT_AFTER_SCHEDULE;boolean;0;Exit test execution immediately after evaluation of the test schedule, e.g. to check only which test modules would be executed
+_SKIP_POST_FAIL_HOOKS;boolean;0;Skip the execution of post_fail_hook methods if set. This can be useful to save test execution time during test development when the post_fail_hook is not expected to provide any value as most likely the test developer already knows what needs to be done as a next step on a test fail.
 NOVIDEO;boolean;0;Do not encode video if set
 NO_DEBUG_IO;boolean;0;Disable the I/O debug output in case of needle comparison times longer than expected
 SCREENSHOTINTERVAL;float;0.5;The interval in seconds at which screenshots are taken internally


### PR DESCRIPTION
Tested manually with a test on openQA.