### PR TITLE
Fix missing text thumbnail after needle related test failures

### DIFF
--- a/OpenQA/Exceptions.pm
+++ b/OpenQA/Exceptions.pm
@@ -1,4 +1,4 @@
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,13 +22,10 @@ use Exception::Class (
     'OpenQA::Exception::InternalException' => {
         description => 'internal errors not for the user'
     },
-
     'OpenQA::Exception::FailedNeedle' => {
         description => 'assert_screen failed',
-        isa         => 'OpenQA::Exception::InternalException',
         fields      => 'tags',
     },
-
     'OpenQA::Exception::VNCProtocolError' => {
         description => 'VNC Server interrupted connection'
     },

--- a/testapi.pm
+++ b/testapi.pm
@@ -334,7 +334,7 @@ possibly more than once per second which is default. Select this to check a
 screen which can change in a range faster than 1-2 seconds not to miss the
 screen to check for.
 
-Returns matched needle or throws C<NeedleFailed> exception if $timeout timeout
+Returns matched needle or throws C<FailedNeedle> exception if $timeout timeout
 is hit. Default timeout is 30s.
 
 =cut
@@ -402,7 +402,7 @@ JSON file. If C<$dclick> is set, do double click instead.  C<$mustmatch> can
 be string or C<ARRAYREF> of strings (C<['tag1', 'tag2']>).  C<$button> is by
 default C<'left'>. C<'left'> and C<'right'> is supported.
 
-Throws C<NeedleFailed> exception if C<$timeout> timeout is hit. Default timeout is 30s.
+Throws C<FailedNeedle> exception if C<$timeout> timeout is hit. Default timeout is 30s.
 
 =cut
 
@@ -1116,7 +1116,7 @@ Send specific key until needle with C<$tag> is not matched or C<$counter> is 0.
 C<$tag> can be string or C<ARRAYREF> (C<['tag1', 'tag2']>)
 Default counter is 20 steps, default timeout is 1s
 
-Throws C<NeedleFailed> exception if needle is not matched until C<$counter> is 0.
+Throws C<FailedNeedle> exception if needle is not matched until C<$counter> is 0.
 
 =cut
 


### PR DESCRIPTION
This fixes a regression that needle related test failures did not create a
message "# Test died: ..." in the logfile as well as no text thumbnail with
information and what happened. This regression must have been introduced about
at least a year ago. I could not go further in my bisecting without needing to
come up with test changes.

It feels like there should be a better solution than checking for
"InternalException" but then excluding "FailedNeedle" again.