### PR TITLE
Bump testapi version as per change to select_console

### DIFF
--- a/isotovideo
+++ b/isotovideo
@@ -52,7 +52,7 @@ BEGIN {
 
 # this shall be an integer increased by every change of the API
 # either to the worker or the tests
-our $INTERFACE = 8;
+our $INTERFACE = 9;
 
 use bmwqemu;
 use needle;


### PR DESCRIPTION
As per discussion in [PR#945](https://github.com/os-autoinst/os-autoinst/pull/945) increasing os-autoinst version.

Now we can pass parameters to activate-console as well to gain more
flexibility in the callback function implementation.