### PR TITLE
Do not quote -append qemu parameter

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -714,7 +714,7 @@ sub start_qemu {
         if ($vars->{NBF}) {
             die "Need variable WORKER_HOSTNAME\n" unless $vars->{WORKER_HOSTNAME};
             gen_params @params, 'kernel', '/usr/share/qemu/ipxe.lkrn';
-            gen_params @params, 'append', "dhcp && sanhook iscsi:$vars->{WORKER_HOSTNAME}::3260:1:$vars->{NBF}";
+            gen_params @params, 'append', "dhcp && sanhook iscsi:$vars->{WORKER_HOSTNAME}::3260:1:$vars->{NBF}", no_quotes => 1;
         }
         gen_params @params, 'device', [qv "$vars->{SCSICONTROLLER} id=scsi0"] if $vars->{SCSICONTROLLER};
         gen_params @params, 'device', [qv "$vars->{SCSICONTROLLER} id=scsi1"] if ($vars->{SCSICONTROLLER} && $vars->{MULTIPATH});

--- a/osutils.pm
+++ b/osutils.pm
@@ -50,20 +50,22 @@ sub find_bin {
 ## no critic
 # An helper to full a parameter list, typically used to build option arguments for executing external programs.
 # mimics perl's push, this why it's a prototype: first argument is the array, second is the argument option and the third is the parameter.
-# the (optional) fourth argument is the prefix argument for the array, if not specified '-' (dash) is assumed by default
+# the (optional) hash argument which can include the prefix argument for the array, if not specified '-' (dash) is assumed by default
+# and if parameter should not be quoted, for that one can use no_quotes. NOTE: this is applicable for string parameters only.
 # if the parameter is equal to "", the value is not pushed to the array.
-sub gen_params(\@$$;$) {
-    my ($array, $argument, $parameter, $prefix) = @_;
+# For example: gen_params \@params, 'device', 'scsi', prefix => '--', no_quotes => 1;
+sub gen_params(\@$$;%) {
+    my ($array, $argument, $parameter, %args) = @_;
 
     return unless ($parameter);
-    $prefix = "-" unless $prefix;
+    $args{prefix} = "-" unless $args{prefix};
 
     if (ref($parameter) eq "") {
-        $parameter = quote($parameter) if $parameter =~ /\s+/;
-        push(@$array, "${prefix}${argument}", $parameter);
+        $parameter = quote($parameter) if $parameter =~ /\s+/ && !$args{no_quotes};
+        push(@$array, $args{prefix} . "${argument}", $parameter);
     }
     elsif (ref($parameter) eq "ARRAY") {
-        push(@$array, "${prefix}${argument}", join(',', @$parameter));
+        push(@$array, $args{prefix} . "${argument}", join(',', @$parameter));
     }
 
 }
@@ -71,7 +73,7 @@ sub gen_params(\@$$;$) {
 # doubledash shortcut version. Same can be achieved with gen_params.
 sub dd_gen_params(\@$$) {
     my ($array, $argument, $parameter) = @_;
-    gen_params(@{$array}, $argument, $parameter, "--");
+    gen_params(@{$array}, $argument, $parameter, prefix => "--");
 }
 
 # It merely splits a string into pieces interpolating variables inside it.

--- a/t/13-osutils.t
+++ b/t/13-osutils.t
@@ -77,12 +77,20 @@ subtest gen_params => sub {
 
 
     @params = qw(!!foo bar);
-    gen_params @params, "test", [qv "$apple $tree $bar"], "!!";
+    gen_params @params, "test", [qv "$apple $tree $bar"], prefix => "!!";
     is_deeply(\@params, [qw(!!foo bar !!test 1,2,3)], "Added parameter if parameter is an arrayref and with custom prefix");
 
     @params = qw(-kernel vmlinuz -initrd initrd);
     gen_params @params, "append", "ro root=/dev/sda1";
     is_deeply(\@params, [('-kernel', 'vmlinuz', '-initrd', 'initrd', '-append', "\'ro root=/dev/sda1\'")], "Quote itself if parameter contains whitespace");
+
+    @params = qw(-kernel vmlinuz -initrd initrd);
+    gen_params @params, "append", "ro root=/dev/sda1", no_quotes => 1;
+    is_deeply(\@params, [('-kernel', 'vmlinuz', '-initrd', 'initrd', '-append', "ro root=/dev/sda1")], "Do not quote itself if pass no_quotes argument");
+
+    @params = qw(-kernel vmlinuz);
+    gen_params @params, "append", "ro root=/dev/sda1", no_quotes => 1, prefix => '--';
+    is_deeply(\@params, [('-kernel', 'vmlinuz', '--append', "ro root=/dev/sda1")], "Do not quote itself if pass no_quotes argument with custom prefix");
 };
 
 subtest dd_gen_params => sub {


### PR DESCRIPTION
For some reason quoting doesn't work well with kernel parameters we pass
to iPXE kernel. We were able to see the error which was "' dhcp" command
not found. This regression was introduced in [5467a37f8](https://github.com/os-autoinst/os-autoinst/commit/5467a37f8) when iBFT test stopped working.

Also, when running qemu from console with quotes, it's able to configure network.

We used openqaworker12 and were able to reproduce issue there and tried hot patch. 

[Verification run](http://g226.suse.de/tests/1720).
[Run with old code](http://g226.suse.de/tests/1721#).
See [poo#23554](https://progress.opensuse.org/issues/23554).