### PR TITLE
isotovideo: Add support to forward command line parameters as test settings

### DIFF
--- a/isotovideo
+++ b/isotovideo
@@ -18,7 +18,7 @@
 
 =head1 SYNOPSIS
 
-isotovideo [OPTIONS]
+isotovideo [OPTIONS] [TEST PARAMETER]
 
 Parses vars.json and tests the given assets/ISOs.
 
@@ -30,9 +30,20 @@ Parses vars.json and tests the given assets/ISOs.
 
 Enable direct output to STDERR instead of autoinst-log.txt
 
+=item B<-v, --version>
+
+Show the current program version and test API version
+
 =item B<-h, -?, --help>
 
 Show this help.
+
+=head1 TEST PARAMETER
+
+All additional command line arguments specified in the C<key=value> format are
+parsed as test parameters which take precedence over the settings in the
+vars.json file. Lower case key names are transformed into upper case
+automatically for convenience.
 
 =cut
 
@@ -115,6 +126,14 @@ $| = 1;
 
 $bmwqemu::scriptdir = $installprefix;
 bmwqemu::init();
+
+for my $arg (@ARGV) {
+    if ($arg =~ /^([[:alnum:]_\[\]\.]+)=(.+)/) {
+        my $key = uc $1;
+        $bmwqemu::vars{$key} = $2;
+        diag("Setting forced test parameter $key -> $2");
+    }
+}
 
 # Sanity checks
 die "CASEDIR environment variable not set, unknown test case directory" if !defined $bmwqemu::vars{CASEDIR};

--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -106,12 +106,12 @@ print $var <<EOV;
    "CDMODEL" : "ide-cd",
    "HDDMODEL" : "ide-drive",
    "INTEGRATION_TESTS" : "1",
-   "VERSION" : "1",
-   "QEMU_DISABLE_SNAPSHOTS" : "1"
+   "VERSION" : "1"
 }
 EOV
 
-system("perl $toplevel_dir/isotovideo -d 2>&1 | tee autoinst-log.txt");
+# call isotovideo with additional test parameters provided by command line
+system("perl $toplevel_dir/isotovideo -d qemu_disable_snapshots=1 2>&1 | tee autoinst-log.txt");
 isnt(system('grep -q "assert_screen_fail_test" autoinst-log.txt'), 0, 'assert screen test not scheduled');
 is(system('grep -q "\d* Snapshots are not supported" autoinst-log.txt'), 0, 'Snapshots are not supported');
 is(system('grep -q "isotovideo done" autoinst-log.txt'),                 0, 'isotovideo is done');


### PR DESCRIPTION
isotovideo does not have many command line parameters. Adding a mode to
forward test settings as we already have on for example the openQA client and
clone-job applications can be useful for isotovideo itself as well.