### PR TITLE
Add wait_screen_change option on send_key

### DIFF
--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -90,7 +90,7 @@ sub fake_read_json {
         return {ret => {x => 100, y => 100}};
     }
     else {
-        print "not implemented \$cmd: $cmd\n";
+        print "mock method not implemented \$cmd: $cmd\n";
     }
     return {};
 }
@@ -108,46 +108,62 @@ $autotest::current_test = basetest->new();
 # that use it, as it doesn't work with the fake send_json and read_json
 my $mod2 = Test::MockModule->new('testapi');
 
-sub fake_wait_screen_change(&@) {
-    my ($callback, $timeout) = @_;
-    $callback->() if $callback;
-}
+subtest 'type_string' => sub {
+    ## no critic (ProhibitSubroutinePrototypes)
+    sub fake_wait_screen_change(&@) {
+        my ($callback, $timeout) = @_;
+        $callback->() if $callback;
+    }
 
-$mod2->mock(wait_screen_change => \&fake_wait_screen_change);
+    $mod2->mock(wait_screen_change => \&fake_wait_screen_change);
 
-type_string 'hallo';
-is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 250, text => 'hallo'}]);
-$cmds = [];
+    type_string 'hallo';
+    is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 250, text => 'hallo'}]);
+    $cmds = [];
 
-type_string 'hallo', 4;
-is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 4, text => 'hallo'}]);
-$cmds = [];
+    type_string 'hallo', 4;
+    is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 4, text => 'hallo'}]);
+    $cmds = [];
 
-type_string 'hallo', secret => 1;
-is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 250, text => 'hallo'}]);
-$cmds = [];
+    type_string 'hallo', secret => 1;
+    is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 250, text => 'hallo'}]);
+    $cmds = [];
 
-type_string 'hallo', secret => 1, max_interval => 10;
-is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 10, text => 'hallo'}]);
-$cmds = [];
+    type_string 'hallo', secret => 1, max_interval => 10;
+    is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 10, text => 'hallo'}]);
+    $cmds = [];
 
-type_string 'hallo', wait_screen_change => 3;
-is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 250, text => 'hal'}, {cmd => 'backend_type_string', max_interval => 250, text => 'lo'},]);
-$cmds = [];
+    type_string 'hallo', wait_screen_change => 3;
+    is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 250, text => 'hal'}, {cmd => 'backend_type_string', max_interval => 250, text => 'lo'},]);
+    $cmds = [];
 
-type_string 'hallo', wait_screen_change => 2;
-is_deeply(
-    $cmds,
-    [
-        {cmd => 'backend_type_string', max_interval => 250, text => 'ha'},
-        {cmd => 'backend_type_string', max_interval => 250, text => 'll'},
-        {cmd => 'backend_type_string', max_interval => 250, text => 'o'},
-    ]);
-$cmds = [];
+    type_string 'hallo', wait_screen_change => 2;
+    is_deeply(
+        $cmds,
+        [
+            {cmd => 'backend_type_string', max_interval => 250, text => 'ha'},
+            {cmd => 'backend_type_string', max_interval => 250, text => 'll'},
+            {cmd => 'backend_type_string', max_interval => 250, text => 'o'},
+        ]);
+    $cmds = [];
 
-type_string 'hallo', wait_screen_change => 3, max_interval => 10;
-is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 10, text => 'hal'}, {cmd => 'backend_type_string', max_interval => 10, text => 'lo'},]);
-$cmds = [];
+    type_string 'hallo', wait_screen_change => 3, max_interval => 10;
+    is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 10, text => 'hal'}, {cmd => 'backend_type_string', max_interval => 10, text => 'lo'},]);
+    $cmds = [];
+
+    $testapi::password = 'stupid';
+    type_password;
+    is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 100, text => 'stupid'}]);
+    $cmds = [];
+
+    type_password 'hallo';
+    is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 100, text => 'hallo'}]);
+    $cmds = [];
+
+    type_password 'hallo', max_interval => 5;
+    is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 5, text => 'hallo'}]);
+    $cmds = [];
+};
 
 subtest 'type_string with wait_still_screen' => sub {
     my $wait_still_screen_called = 0;
@@ -173,16 +189,31 @@ type_password;
 is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 100, text => 'stupid'}]);
 $cmds = [];
 
-type_password 'hallo';
-is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 100, text => 'hallo'}]);
+send_key 'ret';
+is_deeply($cmds, [{cmd => 'backend_send_key', key => 'ret'}], 'send_key with no default arguments') || diag explain $cmds;
 $cmds = [];
 
-type_password 'hallo', max_interval => 5;
-is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 5, text => 'hallo'}]);
-$cmds = [];
+subtest 'send_key with wait_idle' => sub {
+    my $mock_testapi     = Test::MockModule->new('testapi');
+    my $wait_idle_called = 0;
+    $mock_testapi->mock(wait_idle => sub { $wait_idle_called = 1 });
+    send_key 'ret', 1;
+    ok($wait_idle_called, 'wait idle has been called by send_key');
+    $cmds = [];
+};
 
 my $mock_bmwqemu = Test::MockModule->new('bmwqemu');
 $mock_bmwqemu->mock(result_dir => File::Temp->newdir());
+
+subtest 'send_key with wait_screen_change' => sub {
+    my $mock_testapi              = Test::MockModule->new('testapi');
+    my $wait_screen_change_called = 0;
+    $mock_testapi->mock(wait_screen_change => sub(&@) { shift->(); $wait_screen_change_called = 1 });
+    send_key 'ret', wait_screen_change => 1;
+    is(scalar @$cmds, 1, 'send_key waits for screen change') || diag explain $cmds;
+    $cmds = [];
+    ok($wait_screen_change_called, 'wait_screen_change called by send_key');
+};
 
 is($autotest::current_test->{dents}, 0, 'no soft failures so far');
 stderr_like(\&record_soft_failure, qr/record_soft_failure\(reason=undef\)/, 'soft failure recorded in log');

--- a/testapi.pm
+++ b/testapi.pm
@@ -1266,9 +1266,15 @@ sub hashed_string {
 
 =head2 send_key
 
+  send_key($key [, wait_screen_change => $wait_screen_change]);
+
+Deprecated mode
+
   send_key($key [, $do_wait]);
 
-Send one C<$key> to SUT keyboard input.
+Send one C<$key> to SUT keyboard input. Waits for the screen to change when
+C<$wait_screen_change> is true.
+I<Deprecated: C<$do_wait> instructs to wait with <$wait_idle>.>
 
 Special characters naming:
 
@@ -1279,11 +1285,18 @@ Special characters naming:
 =cut
 
 sub send_key {
-    my ($key, $do_wait) = @_;
-    $do_wait //= 0;
-    bmwqemu::log_call(key => $key, do_wait => $do_wait);
-    query_isotovideo('backend_send_key', {key => $key});
-    wait_idle() if $do_wait;
+    my $key  = shift;
+    my %args = (@_ == 1) ? (do_wait => +shift()) : @_;
+    $args{do_wait}            //= 0;
+    $args{wait_screen_change} //= 0;
+    bmwqemu::log_call(key => $key, %args);
+    if ($args{wait_screen_change}) {
+        wait_screen_change { query_isotovideo('backend_send_key', {key => $key}) };
+    }
+    else {
+        query_isotovideo('backend_send_key', {key => $key});
+    }
+    wait_idle() if $args{do_wait};
 }
 
 =head2 hold_key


### PR DESCRIPTION
While doing this, deprecating do_wait which is calling wait_idle which we want
to avoid as it is too much relying on a backend specific implementation which
can not be made available on enough backends.