### PR TITLE
testapi: Output all arguments in log_call

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -492,7 +492,7 @@ sub wait_screen_change(&@) {
     $timeout ||= 10;
     $args{similarity_level} //= 50;
 
-    bmwqemu::log_call(timeout => $timeout);
+    bmwqemu::log_call(timeout => $timeout, %args);
 
     # get the initial screen
     query_isotovideo('backend_set_reference_screenshot');
@@ -1853,7 +1853,7 @@ sub upload_logs {
         record_info('upload skipped', "Skipped uploading log file '$file' as we are offline");
         return;
     }
-    bmwqemu::log_call(file => $file, %args);
+    bmwqemu::log_call(file => $file, failok => $failok, timeout => $timeout, %args);
     my $basename = basename($file);
     my $upname   = ($args{log_name} || $autotest::current_test->{name}) . '-' . $basename;
     my $cmd      = "curl --form upload=\@$file --form upname=$upname ";


### PR DESCRIPTION
I checked all references to log_call in testapi.pm and I could find two
locations where not all parameters to the corresponding testapi calls have
been logged.