### PR TITLE
Add INCLUDE_MODULES to only schedule whitelisted modules on request

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -65,8 +65,15 @@ This code is run during test.
 
 Return false if the test should be skipped.
 
-By default it check the test name and fullname against comma-separated
-blacklist in EXCLUDE_MODULES variable and returns false if it is found there.
+By default it checks the test name and fullname against a comma-separated
+blacklist in C<EXCLUDE_MODULES> variable and returns false if it is found there.
+
+If C<INCLUDE_MODULES> is set it will only return true for modules matching the
+whitelist specified in a comma-separated list in C<EXCLUDE_MODULES> matching
+either test name or fullname.
+
+C<EXCLUDE_MODULES> has precedence over C<INCLUDE_MODULES> and can be combined
+to blacklist test modules from the whitelist specified in C<INCLUDE_MODULES>.
 
 Can eg. check vars{BIGTEST}, vars{LIVETEST}
 
@@ -80,7 +87,11 @@ sub is_applicable {
         return 0 if $excluded{$self->{class}};
         return 0 if $excluded{$self->{fullname}};
     }
+    if ($bmwqemu::vars{INCLUDE_MODULES}) {
+        my %included = map { $_ => 1 } split(/\s*,\s*/, $bmwqemu::vars{INCLUDE_MODULES});
 
+        return 0 unless ($included{$self->{class}} || $included{$self->{fullname}});
+    }
     return 1;
 }
 

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -6,7 +6,8 @@ Supported variables per backend
 [options="header",cols="^m,^m,^m,v",separator=";"]
 |====================
 Variable;Values allowed;Default value;Explanation
-EXCLUDE_MODULES;string;;comma separated names or fullnames of excluded test modules
+INCLUDE_MODULES;string;;comma separated names or fullnames of test modules to be included while excluding all that do not match, e.g. "boot,mod1"
+EXCLUDE_MODULES;string;;comma separated names or fullnames of test modules to exclude. Can be combined with INCLUDE_MODULES and has precedence, e.g. to additionally exclude modules based on an include-list
 _EXIT_AFTER_SCHEDULE;boolean;0;Exit test execution immediately after evaluation of the test schedule, e.g. to check only which test modules would be executed
 _SKIP_POST_FAIL_HOOKS;boolean;0;Skip the execution of post_fail_hook methods if set. This can be useful to save test execution time during test development when the post_fail_hook is not expected to provide any value as most likely the test developer already knows what needs to be done as a next step on a test fail.
 NOVIDEO;boolean;0;Do not encode video if set

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -1,0 +1,29 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More;
+use Test::Fatal;
+
+BEGIN {
+    unshift @INC, '..';
+}
+
+use basetest;
+
+ok(my $basetest = basetest->new('installation'), 'module can be created');
+$basetest->{class}    = 'foo';
+$basetest->{fullname} = 'installation-foo';
+ok($basetest->is_applicable, 'module is applicable by default');
+$bmwqemu::vars{EXCLUDE_MODULES} = 'foo,bar';
+ok(!$basetest->is_applicable, 'module can be excluded');
+$bmwqemu::vars{EXCLUDE_MODULES} = '';
+$bmwqemu::vars{INCLUDE_MODULES} = 'bar,baz';
+ok(!$basetest->is_applicable, 'modules can be excluded based on a whitelist');
+$bmwqemu::vars{INCLUDE_MODULES} = 'bar,baz,foo';
+ok($basetest->is_applicable, 'a whitelisted module shows up');
+$bmwqemu::vars{EXCLUDE_MODULES} = 'foo';
+ok(!$basetest->is_applicable, 'whitelisted modules are overriden by blacklist');
+
+
+done_testing;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,6 +1,6 @@
 AM_MAKEFLAGS = \
 	PERL5OPT="-MDevel::Cover=-db,$(abs_builddir)/cover_db" \
 	PERL5LIB="..:$$PERL5LIB"
-TESTS = 00-compile-check-all.t 01-test_needle.t 02-test_ocr.t 03-testapi.t 04-check_vars_docu.t 05-pod.t 06-pod-coverage.t 07-commands.t 08-autotest.t 09-lockapi.t 10-terminal.t 11-image-ppm.t 12-bmwqemu.t 13-osutils.t 14-isotovideo.t 16-send_with_fd.t 20-openqa-benchmark-stopwatch-utils.t 99-full-stack.t
+TESTS = 00-compile-check-all.t 01-test_needle.t 02-test_ocr.t 03-testapi.t 04-check_vars_docu.t 05-pod.t 06-pod-coverage.t 07-commands.t 08-autotest.t 09-lockapi.t 10-terminal.t 11-image-ppm.t 12-bmwqemu.t 13-osutils.t 14-isotovideo.t 16-send_with_fd.t 17-basetest.t 20-openqa-benchmark-stopwatch-utils.t 99-full-stack.t
 
 EXTRA_DIST = $(TESTS)


### PR DESCRIPTION
This is a new mode next to EXCLUDE_MODULES and also can be used in
combination. This can be helpful for local test development as well as
on production instances without the need to change test code.