### PR TITLE
testapi: Adapt check_screen timeout default to proposal in documentation

### DIFF
--- a/isotovideo
+++ b/isotovideo
@@ -63,7 +63,7 @@ BEGIN {
 
 # this shall be an integer increased by every change of the API
 # either to the worker or the tests
-our $INTERFACE = 11;
+our $INTERFACE = 12;
 
 use bmwqemu;
 use needle;

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -196,7 +196,7 @@ subtest 'check_assert_screen' => sub {
     stderr_like { assert_screen('foo', 3, timeout => 2) } qr/timeout=2/, 'named over positional';
     stderr_like { assert_screen('foo') } qr/timeout=30/, 'default timeout';
     stderr_like { assert_screen('foo', no_wait => 1) } qr/no_wait=1/, 'no wait option';
-    stderr_like { check_screen('foo') } qr/timeout=30/, 'check_screen with same default timeout';
+    stderr_like { check_screen('foo') } qr/timeout=0/, 'check_screen with timeout of 0';
     stderr_like { check_screen('foo', 42) } qr/timeout=42/, 'check_screen with timeout variable';
 };
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -363,7 +363,7 @@ can be replaced by C<assert_screen> with multiple tags using an C<ARRAYREF> in
 combination with C<match_has_tag> or another synchronization call in before,
 for example C<wait_screen_change> or C<wait_still_screen>.
 
-Returns matched needle or C<undef> if timeout is hit. Default timeout is 30s.
+Returns matched needle or C<undef> if timeout is hit. Default timeout is 0s.
 
 =cut
 
@@ -371,7 +371,7 @@ sub check_screen {
     my ($mustmatch) = shift;
     my $timeout;
     $timeout = shift if (@_ % 2);
-    my %args = (timeout => $timeout // $bmwqemu::default_timeout, @_);
+    my %args = (timeout => $timeout // 0, @_);
     bmwqemu::log_call(mustmatch => $mustmatch, %args);
     return _check_or_assert($mustmatch, 1, %args);
 }


### PR DESCRIPTION
The doc string of the method check_screen already suggested to use a timeout
of 0 seconds for a long time. This change adjusts the timeout to a default of
0 seconds. This can be considered a breaking change :)