### PR TITLE
Correct return values for match_has_tag

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -380,7 +380,9 @@ sub check_screen {
 
   match_has_tag($tag);
 
-Returns true if last matched needle has C<$tag> else return C<undef>.
+Returns true (1) if last matched needle has C<$tag>, false (0) if last
+matched needle does not have C<$tag>, and C<undef> if no needle has yet
+been matched at the time of the call.
 
 =cut
 


### PR DESCRIPTION
Happened to notice today the explanation of `match_has_tag`'s
return values is, strictly speaking, incorrect. It only returns
undef if no needle match has yet taken place when it is called.
If there is a most recent needle match but it does not have the
specified tag, it returns 0, not undef.

Signed-off-by: Adam Williamson <awilliam@redhat.com>