### PR TITLE
ppmclibs/tinycv_impl.cc code improvements

### DIFF
--- a/ppmclibs/tinycv.h
+++ b/ppmclibs/tinycv.h
@@ -21,7 +21,7 @@ struct Image;
 void image_destroy(Image *s);
 Image *image_new(long width, long height);
 Image *image_read(const char *filename);
-bool image_write(Image *s, const char *filename);
+bool image_write(const Image* const s, const char* filename);
 // returns copy to static buffer
 std::vector<unsigned char> *image_ppm(Image *s);
 Image *image_from_ppm(const unsigned char *data, size_t len);


### PR DESCRIPTION
- Remove using std to avoid namespace clash with cv
- Pass by reference for speeding up
- Include c++ libraries instead of c
- Adding const for unwanted changes

Builds fine on all platforms [1] and passes tests.

[1] https://build.opensuse.org/package/show/home:aliffey:branches:devel:openQA/os-autoinst