### PR TITLE
Allow where parameter for mutex unlocking

### DIFF
--- a/lockapi.pm
+++ b/lockapi.pm
@@ -72,10 +72,13 @@ sub mutex_try_lock {
 }
 
 sub mutex_unlock {
-    my ($name) = @_;
+    my ($name, $where) = @_;
+    my $param = {action => 'unlock'};
+    $param->{where} = $where if $where;
+
     bmwqemu::mydie('missing lock name') unless $name;
     bmwqemu::diag("mutex unlock '$name'");
-    my $res = api_call('post', "mutex/$name", {action => 'unlock'})->code;
+    my $res = api_call('post', "mutex/$name", $param)->code;
     return 1 if ($res == 200);
     bmwqemu::fctwarn("Unknown return code $res for lock api") if ($res != 409);
     return 0;
@@ -104,7 +107,7 @@ sub mutex_wait {
     my $start = time;
     mutex_lock $name, $where;
     my $delay = time - $start;
-    mutex_unlock $name;
+    mutex_unlock $name, $where;
 
     # Ammend info with time spent waiting
     $autotest::current_test->remove_last_result;


### PR DESCRIPTION
Any cluster job can be locked by jobid ($where) parameter.
Only children & parent jobs can be unlocked ($where not implemented).

Outcome is that we can't lock & unlock resource if it's sibling job.
First job in queue gets lock and it won't release until it dies.

Related PR: https://github.com/os-autoinst/openQA/pull/1677