### PR TITLE
Wait for command typed in serial terminal before running it

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -127,7 +127,10 @@ sub script_run {
     if ($wait > 0) {
         my $str = testapi::hashed_string("SR$cmd$wait");
         if (testapi::is_serial_terminal) {
-            testapi::type_string " ; echo $str-\$?-\n";
+            my $marker = " ; echo $str-\$?-";
+            testapi::type_string($marker);
+            testapi::wait_serial($cmd . $marker, undef, 0, no_regex => 1);
+            testapi::type_string("\n");
         }
         else {
             testapi::type_string " ; echo $str-\$?- > /dev/$testapi::serialdev\n";


### PR DESCRIPTION
- inspired by the way script_output waits for typed in command
- helps with reading results and also in my case it dramatically improve reliability of assert_script_run call