### PR TITLE
Make ssh failures to remote systems debuggable

### DIFF
--- a/consoles/console.pm
+++ b/consoles/console.pm
@@ -60,7 +60,7 @@ sub sshCommand {
         $sshopts = "-X $sshopts";
     }
 
-    return "ssh $sshopts";
+    return "ssh $sshopts; read";
 }
 
 # to be overloaded


### PR DESCRIPTION
In case ssh fails, the xterm just closes and leaves the reviewer
clueless. So adding a blocking 'read' call afterwards make sure
the xterm stays open with the ssh error.

https://progress.opensuse.org/issues/34003