### PR TITLE
tidy: exclude .git/ from search path

### DIFF
--- a/tools/tidy
+++ b/tools/tidy
@@ -22,7 +22,7 @@ test -e tools/tidy || exit 1
 
 find -name '*.tdy' -delete
 
-find . \( -name '*.p[lm]' -o -name '*.t' \) -print0 | xargs -0 perltidy --pro=.../.perltidyrc
+find . \( -name '*.p[lm]' -o -name '*.t' \) -not -path '*/.git/*' -print0 | xargs -0 perltidy --pro=.../.perltidyrc
 
 isotovideo=$(ls isotovideo 2>/dev/null)
 find tools/absolutize $isotovideo -print0 | xargs -0 perltidy $TIDY_ARGS


### PR DESCRIPTION
`tools/tidy` tries to "tidy" files in .git/ which it should not touch.
```
 tools/tidy --check
 ## Please see file ./.git/logs/refs/heads/install_Commands.pm.ERR
 ## Please see file ./.git/refs/heads/install_Commands.pm.ERR
 ...
```