### PR TITLE
Revert of commit 0b557ea

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -127,10 +127,7 @@ sub script_run {
     if ($wait > 0) {
         my $str = testapi::hashed_string("SR$cmd$wait");
         if (testapi::is_serial_terminal) {
-            my $marker = " ; echo $str-\$?-";
-            testapi::type_string($marker);
-            testapi::wait_serial($cmd . $marker, undef, 0, no_regex => 1);
-            testapi::type_string("\n");
+            testapi::type_string " ; echo $str-\$?-\n";
         }
         else {
             testapi::type_string " ; echo $str-\$?- > /dev/$testapi::serialdev\n";


### PR DESCRIPTION
Waiting for whole command additionally to marker introduce some regressions
in case of complex multiline commands. Also from commit 0b557ea it was not clear
what benefits we getting when waiting for more complex things