### PR TITLE
Improve keys sent when expecting needle

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -1131,7 +1131,9 @@ sub send_key_until_needlematch {
     $counter //= 20;
     $timeout //= 1;
     while (!check_screen($tag, $timeout)) {
-        send_key $key;
+        wait_screen_change {
+            send_key $key;
+        };
         if (!$counter--) {
             assert_screen $tag, 1;
         }


### PR DESCRIPTION
In some cases the screen was refreshed with a delay
so the needle still didn't match.
Sending the key again brings the screen to a later step
where the needle never matches.

Step before: https://openqa.opensuse.org/tests/697378#step/disable_grub_timeout/10
Step with delayed refreshing: https://openqa.opensuse.org/tests/697378#step/disable_grub_timeout/11
Step matching while screen is refreshing: https://openqa.opensuse.org/tests/697378#step/disable_grub_timeout/12
On the next step the screen is refreshed to a not wanted step: https://openqa.opensuse.org/tests/697378#step/disable_grub_timeout/13