### PR TITLE
Fix repository path from codecov reports

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -18,3 +18,5 @@ coverage:
     patch:
       default:
         branches: null
+fixes:
+  - "/opt/run/::"


### PR DESCRIPTION
Follow-up on https://github.com/os-autoinst/os-autoinst/pull/981. This allows codecov to resolve files in the Github repository for better
code path reporting (wasn't clearly visible until i could browse the first report for os-autoinst).

