### PR TITLE
Introduce check_shutdown for testapi

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -59,6 +59,7 @@ on 'test' => sub {
   requires 'Test::Pod';
   requires 'Test::Simple';
   requires 'Test::Warnings';
+  requires 'Test::Exception';
   requires 'Socket::MsgHdr';
 };
 

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -9,6 +9,7 @@ use Test::Fatal;
 use Test::Mock::Time;
 use Test::Warnings;
 use File::Temp;
+use Test::Exception;
 
 BEGIN {
     unshift @INC, '..';
@@ -289,6 +290,30 @@ subtest 'set console tty and other args' => sub {
     $console->set_args(tty => 43, foo => 'bar');
     is($console->{args}->{tty}, 43);
     is($console->{args}->{foo}, 'bar');
+};
+
+subtest 'check_assert_shutdown' => sub {
+    # Test cases, when shutdown is finished before timeout is hit
+    $mod->mock(
+        read_json => sub {
+            return {ret => 1};
+        });
+    ok(check_shutdown, 'check_shutdown should return "true" if shutdown finished before timeout is hit');
+    is(assert_shutdown, undef, 'assert_shutdown should return "undef" if shutdown finished before timeout is hit');
+    $mod->mock(
+        read_json => sub {
+            return {ret => -1};
+        });
+    ok(check_shutdown, 'check_shutdown should return "true" if backend does not implement is_shutdown');
+    is(assert_shutdown, undef, 'assert_shutdown should return "undef" if backend does not implement is_shutdown');
+    # Test cases, when shutdown is not finished if timeout is hit
+    $mod->mock(
+        read_json => sub {
+            return {ret => 0};
+        });
+    is(check_shutdown, 0, 'check_shutdown should return "false" if timeout is hit');
+    throws_ok { assert_shutdown } qr/Machine didn't shut down!/, 'assert_shutdown should throw exception if timeout is hit';
+
 };
 
 done_testing;

--- a/t/data/tests/tests/shutdown.pm
+++ b/t/data/tests/tests/shutdown.pm
@@ -21,7 +21,12 @@ sub run {
     wait_idle 1;
     type_string "sudo su\n";
     type_string "poweroff\n";
-    assert_shutdown;
+    if (get_var('INTEGRATION_TESTS')) {
+        assert_shutdown(90);
+    }
+    else {
+        assert_shutdown;
+    }
 }
 
 sub test_flags {

--- a/testapi.pm
+++ b/testapi.pm
@@ -55,7 +55,7 @@ our @EXPORT = qw($realname $username $password $serialdev %cmd %vars
 
   select_console console reset_consoles
 
-  upload_asset data_url assert_shutdown parse_junit_log parse_extra_log upload_logs
+  upload_asset data_url check_shutdown assert_shutdown parse_junit_log parse_extra_log upload_logs
 
   wait_idle wait_screen_change assert_screen_change wait_still_screen wait_serial
   record_soft_failure record_info
@@ -1527,18 +1527,17 @@ sub power {
     query_isotovideo('backend_power', {action => $action});
 }
 
-=head2 assert_shutdown
+=head2 check_shutdown
 
-  assert_shutdown([$timeout]);
+  check_shutdown([$timeout]);
 
 Periodically check backend for status until C<'shutdown'>. Does I<not> initiate shutdown.
-Default timeout is 60s
 
-Returns C<undef> on success, throws exception on timeout.
+Returns true on success and false if C<$timeout> timeout is hit. Default timeout is 60s.
 
 =cut
 
-sub assert_shutdown {
+sub check_shutdown {
     my ($timeout) = @_;
     $timeout //= 60;
     bmwqemu::log_call(timeout => $timeout);
@@ -1551,14 +1550,36 @@ sub assert_shutdown {
         }
         # -1 counts too
         if ($is_shutdown) {
-            $autotest::current_test->take_screenshot('ok');
-            return;
+            return 1;
         }
         sleep 1;
         --$timeout;
     }
-    $autotest::current_test->take_screenshot('fail');
-    croak "Machine didn't shut down!";
+    return 0;
+}
+
+=head2 assert_shutdown
+
+  assert_shutdown([$timeout]);
+
+Periodically check backend for status until C<'shutdown'>. Does I<not> initiate shutdown.
+
+Returns C<undef> on success, marks the test as failed and throws exception
+if C<$timeout> timeout is hit. Default timeout is 60s.
+
+=cut
+
+sub assert_shutdown {
+    my ($timeout) = @_;
+    $timeout //= 60;
+    if (check_shutdown($timeout)) {
+        $autotest::current_test->take_screenshot('ok');
+        return;
+    }
+    else {
+        $autotest::current_test->take_screenshot('fail');
+        croak "Machine didn't shut down!";
+    }
 }
 
 =head2 eject_cd


### PR DESCRIPTION
The check_shutdown function is added to have ability to decide on further actions in case of shutdown failure, instead of marking a test as failed immediately.

In tests it might be used to make soft failure checks, for example.

Related ticket: [poo#35215](https://progress.opensuse.org/issues/35215)