### PR TITLE
Add current_console method

### DIFF
--- a/commands.pm
+++ b/commands.pm
@@ -318,7 +318,7 @@ sub run_daemon {
             }
 
             # Process input chunk
-            say "BYTES $bytes";
+            app->log->debug("BYTES $bytes");
         });
     Mojo::IOLoop->stream($stream);
 

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -182,7 +182,8 @@ like($details->{text}, qr/basetest-[0-9]+.*txt/, 'file for soft failure added');
 require distribution;
 testapi::set_distribution(distribution->new());
 select_console('a-console');
-is(is_serial_terminal, 0, 'Not a serial terminal');
+is(is_serial_terminal, 0,           'Not a serial terminal');
+is(current_console,    'a-console', 'Current console is the a-console');
 
 subtest 'script_run' => sub {
     my $module = new Test::MockModule('bmwqemu');

--- a/testapi.pm
+++ b/testapi.pm
@@ -734,8 +734,8 @@ For more info see consoles/virtio_console.pm and consoles/virtio_screen.pm.
 sub is_serial_terminal {
     state $ret;
     state $last_seen = '';
-    if (defined $autotest::selected_console && $autotest::selected_console ne $last_seen) {
-        $last_seen = $autotest::selected_console;
+    if (defined current_console() && current_console() ne $last_seen) {
+        $last_seen = current_console();
         $ret = query_isotovideo('backend_is_serial_terminal', {});
     }
     return $ret->{yesorno};
@@ -1449,7 +1449,7 @@ here.
 
 sub console {
     my ($testapi_console) = @_;
-    $testapi_console ||= $autotest::selected_console;
+    $testapi_console ||= current_console();
     bmwqemu::log_call(testapi_console => $testapi_console);
     if (!exists $testapi_console_proxies{$testapi_console}) {
         $testapi_console_proxies{$testapi_console} = backend::console_proxy->new($testapi_console);
@@ -1474,7 +1474,8 @@ sub reset_consoles {
 =head2
     current_console
 
-Return the currently selected console
+Return the currently selected console, a call when no console is selected, will
+return C<undef>.
 
 =cut
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -53,7 +53,7 @@ our @EXPORT = qw($realname $username $password $serialdev %cmd %vars
 
   start_audiocapture assert_recorded_sound check_recorded_sound
 
-  select_console console reset_consoles
+  select_console console reset_consoles current_console
 
   upload_asset data_url check_shutdown assert_shutdown parse_junit_log parse_extra_log upload_logs
 
@@ -1469,6 +1469,17 @@ if you did something to the system that affects the console (e.g. trigger reboot
 sub reset_consoles {
     query_isotovideo('backend_reset_consoles');
     return;
+}
+
+=head2
+    current_console
+
+Return the currently selected console
+
+=cut
+
+sub current_console {
+    return $autotest::selected_console;
 }
 
 =head1 audio support


### PR DESCRIPTION
With changes introduced in c670720 testapi no longer holds what is the
current console, leading to problems when test distributions rely on
this.