### PR TITLE
Allow to pause on assert screen timeout

### DIFF
--- a/OpenQA/Benchmark/Stopwatch.pm
+++ b/OpenQA/Benchmark/Stopwatch.pm
@@ -38,7 +38,7 @@ The stopwatch analogy is that at some point you get a C<new> stopwatch and
 C<start> timing. Then you note certain events using C<lap>. Finally you
 C<stop> the watch and then print out a C<summary>.
 
-The summary shows all the events in order, what time they occured at, how long
+The summary shows all the events in order, what time they occurred at, how long
 since the last lap and the percentage of the total time. Hopefully this will
 give you a good idea of where your code is spending most of its time.
 
@@ -138,7 +138,7 @@ sub total_time {
 
     my $summary_text = $stopwatch->summary;
 
-Returns text summarizing the events that occured. Example output from a script
+Returns text summarizing the events that occurred. Example output from a script
 that fetches the homepages of the web's five busiest sites and times how long
 each took.
 

--- a/cpanfile
+++ b/cpanfile
@@ -60,6 +60,7 @@ on 'test' => sub {
   requires 'Test::Pod';
   requires 'Test::Simple';
   requires 'Test::Warnings';
+  requires 'Test::Exception';
   requires 'Socket::MsgHdr';
 };
 

--- a/isotovideo
+++ b/isotovideo
@@ -381,7 +381,7 @@ sub handle_paused_test_execution {
     my ($io_handle, $rsp) = @_;
     my $cmd = $rsp->{cmd};
 
-    # write debugging info
+    # emit info
     myjsonrpc::send_json($cmd_srv_fd, {paused => $rsp});
     print("isotovideo: paused, so not passing $cmd to backend\n");
 
@@ -409,6 +409,23 @@ sub process_command {
         myjsonrpc::send_json($backend_process->channel_in, {cmd => $cmd, arguments => $rsp});
         return;
     }
+    if ($rsp->{cmd} eq 'report_timeout') {
+        if (!$pause_on_assert_screen_timeout) {
+            myjsonrpc::send_json($io_handle, {ret => 0});
+            return;
+        }
+
+        $stop_passing_commands_to_backend = 1;
+
+        # emit info
+        myjsonrpc::send_json($cmd_srv_fd, {paused => $rsp, reason => 'timeout'});
+        print("isotovideo: pausing test execution at $current_test_full_name because a timeout occured\n");
+
+        # postpone sending the reply
+        $postponed_io_handle = $io_handle;
+        $postponed_command   = undef;
+        return;
+    }
     if ($rsp->{cmd} eq 'set_pause_at_test') {
         $pause_test_name = $rsp->{name};
 
@@ -422,7 +439,7 @@ sub process_command {
     if ($rsp->{cmd} eq 'set_pause_on_assert_screen_timeout') {
         $pause_on_assert_screen_timeout = $rsp->{flag};
 
-        # print/send debugging info
+        # send debugging info
         myjsonrpc::send_json($cmd_srv_fd, {set_pause_on_assert_screen_timeout => $pause_on_assert_screen_timeout});
 
         myjsonrpc::send_json($io_handle, {ret => 1});
@@ -439,16 +456,19 @@ sub process_command {
         # no longer stop passing commands to backend
         $stop_passing_commands_to_backend = 0;
 
-        # resume with postponed command so autotest can continue
-        if ($postponed_command) {
-            my $cmd = $postponed_command->{cmd};
-            print("isotovideo: resuming, continue passing $cmd to backend\n");
-            process_command($postponed_io_handle, $postponed_command);
+        # if no command has been postponed (because paused due to timeout) just return 1
+        if (!$postponed_command) {
+            myjsonrpc::send_json($postponed_io_handle, {ret => 1});
             $postponed_io_handle = undef;
-            $postponed_command   = undef;
             return;
         }
-        myjsonrpc::send_json($io_handle, {ret => 1});
+
+        # resume with postponed command so autotest can continue
+        my $cmd = $postponed_command->{cmd};
+        print("isotovideo: resuming, continue passing $cmd to backend\n");
+        process_command($postponed_io_handle, $postponed_command);
+        $postponed_io_handle = undef;
+        $postponed_command   = undef;
         return;
     }
     if ($rsp->{cmd} eq 'set_current_test') {
@@ -463,7 +483,7 @@ sub process_command {
             && $current_test_full_name
             && ($pause_test_name eq $current_test_name || $pause_test_name eq $current_test_full_name))
         {
-            print("isotovideo: pausing test execution of $pause_test_name\n");
+            print("isotovideo: pausing test execution of $pause_test_name because we're supposed to pause there\n");
             $stop_passing_commands_to_backend = 1;
         }
         myjsonrpc::send_json($io_handle, {ret => 1});

--- a/isotovideo
+++ b/isotovideo
@@ -305,6 +305,9 @@ my $current_test_full_name;
 # store the name of the test where the test execution should be paused
 my $pause_test_name = $bmwqemu::vars{PAUSE_AT};
 
+# store whether to stop on next assert_screen timeout
+my $pause_on_assert_screen_timeout = $bmwqemu::vars{PAUSE_ON_ASSERT_SCREEN_TIMEOUT} // 0;
+
 # when paused, stop passing commands to the backend
 my $stop_passing_commands_to_backend = 0;
 
@@ -416,6 +419,15 @@ sub process_command {
         myjsonrpc::send_json($io_handle, {ret => 1});
         return;
     }
+    if ($rsp->{cmd} eq 'set_pause_on_assert_screen_timeout') {
+        $pause_on_assert_screen_timeout = $rsp->{flag};
+
+        # print/send debugging info
+        myjsonrpc::send_json($cmd_srv_fd, {set_pause_on_assert_screen_timeout => $pause_on_assert_screen_timeout});
+
+        myjsonrpc::send_json($io_handle, {ret => 1});
+        return;
+    }
     if ($rsp->{cmd} eq 'resume_test_execution') {
         # print/send debug info
         print($stop_passing_commands_to_backend ?
@@ -488,11 +500,12 @@ sub process_command {
     # handle HTTP commands
     if ($rsp->{cmd} eq 'status') {
         my $result = {
-            tags                   => $tags,
-            running                => $current_test_name,
-            current_test_full_name => $current_test_full_name,
-            pause_test_name        => $pause_test_name,
-            test_execution_paused  => $stop_passing_commands_to_backend
+            tags                           => $tags,
+            running                        => $current_test_name,
+            current_test_full_name         => $current_test_full_name,
+            pause_test_name                => $pause_test_name,
+            pause_on_assert_screen_timeout => $pause_on_assert_screen_timeout,
+            test_execution_paused          => $stop_passing_commands_to_backend,
         };
 
         myjsonrpc::send_json($io_handle, $result);

--- a/isotovideo
+++ b/isotovideo
@@ -63,7 +63,7 @@ BEGIN {
 
 # this shall be an integer increased by every change of the API
 # either to the worker or the tests
-our $INTERFACE = 12;
+our $INTERFACE = 13;
 
 use bmwqemu;
 use needle;

--- a/isotovideo
+++ b/isotovideo
@@ -477,7 +477,10 @@ sub process_command {
         $current_test_full_name = $rsp->{full_name};
 
         # send debugging info for ws clients
-        myjsonrpc::send_json($cmd_srv_fd, {set_current_test => $current_test_name});
+        myjsonrpc::send_json($cmd_srv_fd, {
+                set_current_test       => $current_test_name,
+                current_test_full_name => $current_test_full_name,
+        });
         if ($pause_test_name
             && $current_test_name
             && $current_test_full_name

--- a/isotovideo
+++ b/isotovideo
@@ -383,7 +383,7 @@ sub handle_paused_test_execution {
 
     # emit info
     myjsonrpc::send_json($cmd_srv_fd, {paused => $rsp, reason => $test_execution_paused});
-    print("isotovideo: paused, so not passing $cmd to backend\n");
+    diag("isotovideo: paused, so not passing $cmd to backend");
 
     # postpone execution of command
     $postponed_io_handle = $io_handle;
@@ -419,7 +419,7 @@ sub process_command {
 
         # emit info
         myjsonrpc::send_json($cmd_srv_fd, {paused => $rsp, reason => $test_execution_paused});
-        print("isotovideo: pausing test execution at $current_test_full_name because a timeout occurred\n");
+        diag('isotovideo: pausing test execution on timeout as requested at ' . $current_test_full_name);
 
         # postpone sending the reply
         $postponed_io_handle = $io_handle;
@@ -430,7 +430,7 @@ sub process_command {
         $pause_test_name = $rsp->{name};
 
         # print/send debugging info
-        print("isotovideo: test execution will be paused at test $pause_test_name\n");
+        diag('isotovideo: test execution will be paused at test ' . $pause_test_name);
         myjsonrpc::send_json($cmd_srv_fd, {set_pause_at_test => $pause_test_name});
 
         myjsonrpc::send_json($io_handle, {ret => 1});
@@ -447,9 +447,9 @@ sub process_command {
     }
     if ($rsp->{cmd} eq 'resume_test_execution') {
         # print/send debug info
-        print($test_execution_paused ?
-              "isotovideo: test execution will be resumed\n"
-            : "isotovideo: resuming test execution requested but not paused anyways\n"
+        diag($test_execution_paused ?
+              'isotovideo: test execution will be resumed'
+            : 'isotovideo: resuming test execution requested but not paused anyways'
         );
         myjsonrpc::send_json($cmd_srv_fd, {resume_test_execution => $postponed_command});
 
@@ -465,7 +465,7 @@ sub process_command {
 
         # resume with postponed command so autotest can continue
         my $cmd = $postponed_command->{cmd};
-        print("isotovideo: resuming, continue passing $cmd to backend\n");
+        diag("isotovideo: resuming, continue passing $cmd to backend");
         process_command($postponed_io_handle, $postponed_command);
         $postponed_io_handle = undef;
         $postponed_command   = undef;
@@ -486,7 +486,7 @@ sub process_command {
             && $current_test_full_name
             && ($pause_test_name eq $current_test_name || $pause_test_name eq $current_test_full_name))
         {
-            print("isotovideo: pausing test execution of $pause_test_name because we're supposed to pause there\n");
+            diag("isotovideo: pausing test execution of $pause_test_name because we're supposed to pause at this test module");
             $test_execution_paused = 'reached module ' . $pause_test_name;
         }
         myjsonrpc::send_json($io_handle, {ret => 1});

--- a/isotovideo
+++ b/isotovideo
@@ -308,8 +308,8 @@ my $pause_test_name = $bmwqemu::vars{PAUSE_AT};
 # store whether to stop on next assert_screen timeout
 my $pause_on_assert_screen_timeout = $bmwqemu::vars{PAUSE_ON_ASSERT_SCREEN_TIMEOUT} // 0;
 
-# when paused, stop passing commands to the backend
-my $stop_passing_commands_to_backend = 0;
+# when paused, the reason for the pause (as a string); otherwise 0
+my $test_execution_paused = 0;
 
 # when paused, save the command from autotest which has been postponed to be able to resume
 my $postponed_io_handle;
@@ -376,13 +376,13 @@ sub check_asserted_screen {
 }
 
 sub handle_paused_test_execution {
-    return unless ($stop_passing_commands_to_backend);
+    return unless ($test_execution_paused);
 
     my ($io_handle, $rsp) = @_;
     my $cmd = $rsp->{cmd};
 
     # emit info
-    myjsonrpc::send_json($cmd_srv_fd, {paused => $rsp});
+    myjsonrpc::send_json($cmd_srv_fd, {paused => $rsp, reason => $test_execution_paused});
     print("isotovideo: paused, so not passing $cmd to backend\n");
 
     # postpone execution of command
@@ -415,10 +415,10 @@ sub process_command {
             return;
         }
 
-        $stop_passing_commands_to_backend = 1;
+        $test_execution_paused = $rsp->{msg};
 
         # emit info
-        myjsonrpc::send_json($cmd_srv_fd, {paused => $rsp, reason => 'timeout'});
+        myjsonrpc::send_json($cmd_srv_fd, {paused => $rsp, reason => $test_execution_paused});
         print("isotovideo: pausing test execution at $current_test_full_name because a timeout occured\n");
 
         # postpone sending the reply
@@ -447,14 +447,14 @@ sub process_command {
     }
     if ($rsp->{cmd} eq 'resume_test_execution') {
         # print/send debug info
-        print($stop_passing_commands_to_backend ?
+        print($test_execution_paused ?
               "isotovideo: test execution will be resumed\n"
             : "isotovideo: resuming test execution requested but not paused anyways\n"
         );
         myjsonrpc::send_json($cmd_srv_fd, {resume_test_execution => $postponed_command});
 
-        # no longer stop passing commands to backend
-        $stop_passing_commands_to_backend = 0;
+        # unset paused state to continue passing commands to backend
+        $test_execution_paused = 0;
 
         # if no command has been postponed (because paused due to timeout) just return 1
         if (!$postponed_command) {
@@ -484,7 +484,7 @@ sub process_command {
             && ($pause_test_name eq $current_test_name || $pause_test_name eq $current_test_full_name))
         {
             print("isotovideo: pausing test execution of $pause_test_name because we're supposed to pause there\n");
-            $stop_passing_commands_to_backend = 1;
+            $test_execution_paused = 'reached module ' . $pause_test_name;
         }
         myjsonrpc::send_json($io_handle, {ret => 1});
         return;
@@ -525,7 +525,7 @@ sub process_command {
             current_test_full_name         => $current_test_full_name,
             pause_test_name                => $pause_test_name,
             pause_on_assert_screen_timeout => $pause_on_assert_screen_timeout,
-            test_execution_paused          => $stop_passing_commands_to_backend,
+            test_execution_paused          => $test_execution_paused,
         };
 
         myjsonrpc::send_json($io_handle, $result);

--- a/isotovideo
+++ b/isotovideo
@@ -419,7 +419,7 @@ sub process_command {
 
         # emit info
         myjsonrpc::send_json($cmd_srv_fd, {paused => $rsp, reason => $test_execution_paused});
-        print("isotovideo: pausing test execution at $current_test_full_name because a timeout occured\n");
+        print("isotovideo: pausing test execution at $current_test_full_name because a timeout occurred\n");
 
         # postpone sending the reply
         $postponed_io_handle = $io_handle;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,6 +1,6 @@
 AM_MAKEFLAGS = \
 	PERL5OPT="-MDevel::Cover=-db,$(abs_builddir)/cover_db,-ignore,^*\.t|^data\/tests\/*|^fake\/tests\/*" \
-	PERL5LIB="..:$$PERL5LIB"
+	PERL5LIB="..:../ppmclibs:../ppmclibs/blib/arch/auto/tinycv:$$PERL5LIB"
 TESTS = 00-compile-check-all.t 01-test_needle.t 02-test_ocr.t 03-testapi.t 04-check_vars_docu.t 05-pod.t 06-pod-coverage.t 07-commands.t 08-autotest.t 09-lockapi.t 10-terminal.t 11-image-ppm.t 12-bmwqemu.t 13-osutils.t 14-isotovideo.t 16-send_with_fd.t 17-basetest.t 18-qemu.t 20-openqa-benchmark-stopwatch-utils.t 99-full-stack.t
 
 EXTRA_DIST = $(TESTS)

--- a/t/data/tests/tests/boot.pm
+++ b/t/data/tests/tests/boot.pm
@@ -25,7 +25,14 @@ sub run {
     assert_screen 'core', no_wait => 1;
     send_key 'ret';
 
-    assert_screen 'on_prompt';
+    # set timeout to 15 seconds so we don't waste too much time here when testing for
+    #  pausing on assert_screen timeout
+    if (get_var('TESTING_ASSERT_SCREEN_TIMEOUT')) {
+        assert_screen 'on_prompt', timeout => 15;
+    }
+    else {
+        assert_screen 'on_prompt';
+    }
 
     assert_script_run 'cat /proc/cpuinfo';
     type_string "cat > text <<EOF\n";

--- a/testapi.pm
+++ b/testapi.pm
@@ -239,6 +239,11 @@ sub _check_backend_response {
     elsif ($rsp->{timeout}) {
         bmwqemu::fctres("match=" . join(',', @$tags) . " timed out after $timeout");
 
+        # make and upload a screenshot because we might want to create a new needle from this so far unexpected screen
+        my $current_test = $autotest::current_test;
+        $current_test->take_screenshot();
+        $current_test->save_test_result();
+
         # do a special rpc call to isotovideo which will block if the test should be paused
         # (if the test should not be paused this call will return 0; on resume (after pause) it will return 1)
         query_isotovideo('report_timeout') and return 'try_again';

--- a/testapi.pm
+++ b/testapi.pm
@@ -330,7 +330,7 @@ sub _check_or_assert {
 
         # check backend response
         # (implemented as separate function because it needs to call itself)
-        my $backend_response = _check_backend_response($rsp, $check, $args{timeout}, $mustmatch, $args{no_wait});
+        my $backend_response = _check_backend_response($rsp, $check, $args{timeout}, $mustmatch);
 
         # return the response unless we should try again after resuming from paused state
         return $backend_response if (!$backend_response || $backend_response ne 'try_again');

--- a/testapi.pm
+++ b/testapi.pm
@@ -237,7 +237,8 @@ sub _check_backend_response {
         return _handle_found_needle($foundneedle, $rsp, $tags);
     }
     elsif ($rsp->{timeout}) {
-        bmwqemu::fctres("match=" . join(',', @$tags) . " timed out after $timeout");
+        my $status_message = "match=" . join(',', @$tags) . " timed out after $timeout";
+        bmwqemu::fctres($status_message);
 
         # make and upload a screenshot because we might want to create a new needle from this so far unexpected screen
         my $current_test = $autotest::current_test;
@@ -246,7 +247,10 @@ sub _check_backend_response {
 
         # do a special rpc call to isotovideo which will block if the test should be paused
         # (if the test should not be paused this call will return 0; on resume (after pause) it will return 1)
-        query_isotovideo('report_timeout') and return 'try_again';
+        query_isotovideo('report_timeout', {
+                tags => $tags,
+                msg  => $status_message,
+        }) and return 'try_again';
 
         my $failed_screens = $rsp->{failed_screens};
         my $final_mismatch = $failed_screens->[-1];

--- a/testapi.pm
+++ b/testapi.pm
@@ -240,17 +240,19 @@ sub _check_backend_response {
         my $status_message = "match=" . join(',', @$tags) . " timed out after $timeout";
         bmwqemu::fctres($status_message);
 
-        # make and upload a screenshot because we might want to create a new needle from this so far unexpected screen
-        my $current_test = $autotest::current_test;
-        $current_test->take_screenshot();
-        $current_test->save_test_result();
+        if (!$check) {
+            # make and upload a screenshot because we might want to create a new needle from this so far unexpected screen
+            my $current_test = $autotest::current_test;
+            $current_test->take_screenshot();
+            $current_test->save_test_result();
 
-        # do a special rpc call to isotovideo which will block if the test should be paused
-        # (if the test should not be paused this call will return 0; on resume (after pause) it will return 1)
-        query_isotovideo('report_timeout', {
-                tags => $tags,
-                msg  => $status_message,
-        }) and return 'try_again';
+            # do a special rpc call to isotovideo which will block if the test should be paused
+            # (if the test should not be paused this call will return 0; on resume (after pause) it will return 1)
+            query_isotovideo('report_timeout', {
+                    tags => $tags,
+                    msg  => $status_message,
+            }) and return 'try_again';
+        }
 
         my $failed_screens = $rsp->{failed_screens};
         my $final_mismatch = $failed_screens->[-1];


### PR DESCRIPTION
https://progress.opensuse.org/issues/38510

---

This is very WIP. I'm just trying out things.

My current approach is to call a certain isotovideo command from autotest on timeout:

* It will block in case the test should be paused. In this case the regular assertion handling in autotest is aborted. Instead the assertion is repeated after resuming from the blocking isotovideo command.
* It will not block in case the test shouldn't be paused. In this case autotest continues with the assertion as usual.

---

PR for updating the UI accordingly: https://github.com/os-autoinst/openQA/pull/1727
