### PR TITLE
Avoid conflicting block device options

### DIFF
--- a/OpenQA/Qemu/BlockDev.pm
+++ b/OpenQA/Qemu/BlockDev.pm
@@ -138,12 +138,6 @@ sub gen_cmdline {
     my ($self) = @_;
     my @cmdl = ();
 
-    my $backing = '';
-    if (defined $self->backing_file && !$self->backing_file->implicit) {
-        push(@cmdl, $self->backing_file->gen_cmdline);
-        $backing = $self->backing_file->node_name;
-    }
-
     # The first blockdev defines the data store, we only use files, but in
     # theory it could be a http address, ISCSI or a link to an object store
     # item (like Ceph).
@@ -157,8 +151,7 @@ sub gen_cmdline {
             join(',', ('driver=' . $self->driver,
                     'node-name=' . $self->node_name,
                     'file=' . $self->node_name . FILE_POSTFIX,
-                    'cache.no-flush=on',
-                    ('backing=' . $backing) x !!$backing))));
+                    'cache.no-flush=on'))));
 
     return @cmdl;
 }

--- a/t/18-qemu.t
+++ b/t/18-qemu.t
@@ -177,16 +177,12 @@ my $ss;
 @cmdl = qw(qemu-kvm -static-args
   -device virtio-scsi-device,id=scsi0
 
-  -blockdev driver=file,node-name=hd0-file,filename=raid/hd0,cache.no-flush=on
-  -blockdev driver=qcow2,node-name=hd0,file=hd0-file,cache.no-flush=on
   -blockdev driver=file,node-name=hd0-overlay1-file,filename=raid/hd0-overlay1,cache.no-flush=on
-  -blockdev driver=qcow2,node-name=hd0-overlay1,file=hd0-overlay1-file,cache.no-flush=on,backing=hd0
+  -blockdev driver=qcow2,node-name=hd0-overlay1,file=hd0-overlay1-file,cache.no-flush=on
   -device scsi-hd,id=hd0-device,drive=hd0-overlay1,serial=hd0
 
-  -blockdev driver=file,node-name=cd0-overlay0-file,filename=raid/cd0-overlay0,cache.no-flush=on
-  -blockdev driver=qcow2,node-name=cd0-overlay0,file=cd0-overlay0-file,cache.no-flush=on
   -blockdev driver=file,node-name=cd0-overlay1-file,filename=raid/cd0-overlay1,cache.no-flush=on
-  -blockdev driver=qcow2,node-name=cd0-overlay1,file=cd0-overlay1-file,cache.no-flush=on,backing=cd0-overlay0
+  -blockdev driver=qcow2,node-name=cd0-overlay1,file=cd0-overlay1-file,cache.no-flush=on
   -device scsi-cd,id=cd0-device,drive=cd0-overlay1,serial=cd0
   -incoming defer);
 $ssc = $proc->snapshot_conf;
@@ -236,16 +232,12 @@ is_deeply(\@gcmdl, \@cmdl, 'Generate qemu-img convert with snapshots');
 @cmdl = qw(qemu-kvm -static-args
   -device virtio-scsi-device,id=scsi0
 
-  -blockdev driver=file,node-name=hd0-file,filename=raid/hd0,cache.no-flush=on
-  -blockdev driver=qcow2,node-name=hd0,file=hd0-file,cache.no-flush=on
   -blockdev driver=file,node-name=hd0-overlay1-file,filename=raid/hd0-overlay1,cache.no-flush=on
-  -blockdev driver=qcow2,node-name=hd0-overlay1,file=hd0-overlay1-file,cache.no-flush=on,backing=hd0
+  -blockdev driver=qcow2,node-name=hd0-overlay1,file=hd0-overlay1-file,cache.no-flush=on
   -device scsi-hd,id=hd0-device,drive=hd0-overlay1,serial=hd0
 
-  -blockdev driver=file,node-name=cd0-overlay0-file,filename=raid/cd0-overlay0,cache.no-flush=on
-  -blockdev driver=qcow2,node-name=cd0-overlay0,file=cd0-overlay0-file,cache.no-flush=on
   -blockdev driver=file,node-name=cd0-overlay1-file,filename=raid/cd0-overlay1,cache.no-flush=on
-  -blockdev driver=qcow2,node-name=cd0-overlay1,file=cd0-overlay1-file,cache.no-flush=on,backing=cd0-overlay0
+  -blockdev driver=qcow2,node-name=cd0-overlay1,file=cd0-overlay1-file,cache.no-flush=on
   -device scsi-cd,id=cd0-device,drive=cd0-overlay1,serial=cd0
   -incoming defer);
 $proc = OpenQA::Qemu::Proc->new()
@@ -297,16 +289,12 @@ is_deeply(\@gcmdl, \@cmdl, 'Generate qemu command line after deserialising and r
 @cmdl = qw(qemu-kvm -static-args
   -device virtio-scsi-device,id=scsi0
 
-  -blockdev driver=file,node-name=hd0-file,filename=raid/hd0,cache.no-flush=on
-  -blockdev driver=qcow2,node-name=hd0,file=hd0-file,cache.no-flush=on
   -blockdev driver=file,node-name=hd0-overlay1-file,filename=raid/hd0-overlay1,cache.no-flush=on
-  -blockdev driver=qcow2,node-name=hd0-overlay1,file=hd0-overlay1-file,cache.no-flush=on,backing=hd0
+  -blockdev driver=qcow2,node-name=hd0-overlay1,file=hd0-overlay1-file,cache.no-flush=on
   -device scsi-hd,id=hd0-device,drive=hd0-overlay1,bootindex=0,serial=hd0
 
-  -blockdev driver=file,node-name=cd0-overlay0-file,filename=raid/cd0-overlay0,cache.no-flush=on
-  -blockdev driver=qcow2,node-name=cd0-overlay0,file=cd0-overlay0-file,cache.no-flush=on
   -blockdev driver=file,node-name=cd0-overlay1-file,filename=raid/cd0-overlay1,cache.no-flush=on
-  -blockdev driver=qcow2,node-name=cd0-overlay1,file=cd0-overlay1-file,cache.no-flush=on,backing=cd0-overlay0
+  -blockdev driver=qcow2,node-name=cd0-overlay1,file=cd0-overlay1-file,cache.no-flush=on
   -device scsi-cd,id=cd0-device,drive=cd0-overlay1,serial=cd0
 
   -drive id=pflash-code-overlay1,if=pflash,file=raid/pflash-code-overlay1


### PR DESCRIPTION
Only specify the final overlay in a block device chain and rely on the backing
files to be read from the qcow2 image. Otherwise we get errors from QEMU as
block devices specified as backing files try to inherit the overlay's
properties.

Only specifying the last block in the chain prevents raw format from being
used as an overlay. However this is an unlikely scenario.