### PR TITLE
Avoid rolling back to undefined console

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -18,7 +18,7 @@ package autotest;
 use strict;
 use bmwqemu;
 use Exporter 'import';
-our @EXPORT_OK = qw(loadtest $current_test query_isotovideo);
+our @EXPORT_OK = qw(loadtest $current_test $selected_console $last_milestone_console query_isotovideo);
 
 use File::Basename;
 use File::Spec;

--- a/basetest.pm
+++ b/basetest.pm
@@ -622,9 +622,11 @@ sub rollback_activated_consoles {
         autotest::query_isotovideo('backend_reset_console', {testapi_console => $console});
     }
 
-    my $ret = autotest::query_isotovideo('backend_select_console',
-        {testapi_console => $autotest::last_milestone_console});
-    die $ret->{error} if $ret->{error};
+    if (defined($autotest::last_milestone_console)) {
+        my $ret = autotest::query_isotovideo('backend_select_console',
+            {testapi_console => $autotest::last_milestone_console});
+        die $ret->{error} if $ret->{error};
+    }
 
     return;
 }


### PR DESCRIPTION
We can only roll back to the last selected console if the user selected one
before the snapshot. If they didn't then we have to rely on the backend's
default console.