### PR TITLE
Use bootindex with non-uefi systems

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -142,7 +142,6 @@ sub configure_blockdevs {
     my ($self, $bootfrom, $basedir, $vars) = @_;
     my $bdc       = $self->blockdev_conf;
     my @scsi_ctrs = $self->controller_conf->get_controllers(qr/scsi/);
-    my $uefi      = $vars->{UEFI};
 
     $bdc->basedir($basedir);
 
@@ -163,7 +162,7 @@ sub configure_blockdevs {
             $drive = $bdc->add_new_drive($node_id, $hdd_model, $size);
         }
 
-        if ($i == 1 && $uefi && $bootfrom eq 'disk') {
+        if ($i == 1 && $bootfrom eq 'disk') {
             $drive->bootindex(0);
         }
 
@@ -182,12 +181,12 @@ sub configure_blockdevs {
         my $size = $self->get_img_size($iso);
         if ($vars->{USBBOOT}) {
             my $drive = $bdc->add_iso_drive('usbstick', $iso, 'usb-storage', $size);
-            $drive->bootindex(0) if $uefi && $bootfrom ne "disk";
+            $drive->bootindex(0) if $bootfrom ne "disk";
         }
         else {
             my $drive = $bdc->add_iso_drive('cd0', $iso, $vars->{CDMODEL}, $size);
             $drive->serial('cd0');
-            $drive->bootindex(0) if $uefi && $bootfrom eq "cdrom";
+            $drive->bootindex(0) if $bootfrom eq "cdrom";
         }
     }
     my $is_first = 1;
@@ -199,9 +198,9 @@ sub configure_blockdevs {
         my $size = $self->get_img_size($addoniso);
         my $drive = $bdc->add_iso_drive("cd$i", $addoniso, $vars->{CDMODEL}, $size);
         $drive->serial("cd$i");
-        # first connected cdrom gets ",bootindex=0" on UEFI when booting from
-        # cdrom and there wasn't `ISO` defined
-        if ($is_first && $uefi && $bootfrom eq "cdrom" && !$iso) {
+        # first connected cdrom gets ",bootindex=0 when booting from cdrom and
+        # there wasn't `ISO` defined
+        if ($is_first && $bootfrom eq "cdrom" && !$iso) {
             $drive->bootindex(0);
             $is_first = 0;
         }

--- a/t/18-qemu.t
+++ b/t/18-qemu.t
@@ -110,8 +110,8 @@ is_deeply(\@gcmdl, \@cmdl, 'Generate qemu-img command line for single existing U
 
   -blockdev driver=file,node-name=hd0-file,filename=raid/hd0,cache.no-flush=on
   -blockdev driver=qcow2,node-name=hd0,file=hd0-file,cache.no-flush=on
-  -device sega-mega,id=hd0-device-path0,drive=hd0,share-rw=true,bus=scsi0.0,serial=hd0
-  -device sega-mega,id=hd0-device-path1,drive=hd0,share-rw=true,bus=scsi1.0,serial=hd0
+  -device sega-mega,id=hd0-device-path0,drive=hd0,share-rw=true,bus=scsi0.0,bootindex=0,serial=hd0
+  -device sega-mega,id=hd0-device-path1,drive=hd0,share-rw=true,bus=scsi1.0,bootindex=0,serial=hd0
 
   -blockdev driver=file,node-name=hd1-file,filename=raid/hd1,cache.no-flush=on
   -blockdev driver=qcow2,node-name=hd1,file=hd1-file,cache.no-flush=on
@@ -149,7 +149,7 @@ is_deeply(\@gcmdl, \@cmdl, 'Multipath Command line after serialisation and deser
 
   -blockdev driver=file,node-name=hd0-file,filename=raid/hd0,cache.no-flush=on
   -blockdev driver=qcow2,node-name=hd0,file=hd0-file,cache.no-flush=on
-  -device scsi-hd,id=hd0-device,drive=hd0,serial=hd0
+  -device scsi-hd,id=hd0-device,drive=hd0,bootindex=0,serial=hd0
 
   -blockdev driver=file,node-name=cd0-overlay0-file,filename=raid/cd0-overlay0,cache.no-flush=on
   -blockdev driver=qcow2,node-name=cd0-overlay0,file=cd0-overlay0-file,cache.no-flush=on
@@ -179,7 +179,7 @@ my $ss;
 
   -blockdev driver=file,node-name=hd0-overlay1-file,filename=raid/hd0-overlay1,cache.no-flush=on
   -blockdev driver=qcow2,node-name=hd0-overlay1,file=hd0-overlay1-file,cache.no-flush=on
-  -device scsi-hd,id=hd0-device,drive=hd0-overlay1,serial=hd0
+  -device scsi-hd,id=hd0-device,drive=hd0-overlay1,bootindex=0,serial=hd0
 
   -blockdev driver=file,node-name=cd0-overlay1-file,filename=raid/cd0-overlay1,cache.no-flush=on
   -blockdev driver=qcow2,node-name=cd0-overlay1,file=cd0-overlay1-file,cache.no-flush=on
@@ -234,7 +234,7 @@ is_deeply(\@gcmdl, \@cmdl, 'Generate qemu-img convert with snapshots');
 
   -blockdev driver=file,node-name=hd0-overlay1-file,filename=raid/hd0-overlay1,cache.no-flush=on
   -blockdev driver=qcow2,node-name=hd0-overlay1,file=hd0-overlay1-file,cache.no-flush=on
-  -device scsi-hd,id=hd0-device,drive=hd0-overlay1,serial=hd0
+  -device scsi-hd,id=hd0-device,drive=hd0-overlay1,bootindex=0,serial=hd0
 
   -blockdev driver=file,node-name=cd0-overlay1-file,filename=raid/cd0-overlay1,cache.no-flush=on
   -blockdev driver=qcow2,node-name=cd0-overlay1,file=cd0-overlay1-file,cache.no-flush=on


### PR DESCRIPTION
Even non-uefi bios's support the bootindex device parameter now, which is more
flexible than the old '-boot order=<drive>' command line option. In particular
it supports setting USB devices as the first boot drive which eliminates the
need for selecting them in the bios boot menu (which is unreliable as the
order can change).