### PR TITLE
Add messages to serial failures

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -104,7 +104,7 @@ sub loadtest {
     $test             = $name->new($category);
     $test->{script}   = $script;
     $test->{fullname} = $fullname;
-    $test->{serial_failures} = $testapi::distri->{serial_failures} // {};
+    $test->{serial_failures} = $testapi::distri->{serial_failures} // [];
 
     if (defined $args{run_args}) {
         unless (blessed($args{run_args}) && $args{run_args}->isa('OpenQA::Test::RunArgs')) {

--- a/basetest.pm
+++ b/basetest.pm
@@ -50,7 +50,7 @@ sub new {
     $self->{timeoutcounter}         = 0;
     $self->{activated_consoles}     = [];
     $self->{name}                   = $class;
-    $self->{serial_failures}        = {};
+    $self->{serial_failures}        = [];
     return bless $self, $class;
 }
 
@@ -638,34 +638,44 @@ sub search_for_expected_serial_failures {
     }
 }
 
+sub get_serial_output_json {
+    my ($self, $from_position) = @_;
+
+    myjsonrpc::send_json($autotest::isotovideo, {cmd => 'read_serial', position => $from_position});
+    return myjsonrpc::read_json($autotest::isotovideo);
+}
+
 sub parse_serial_output_qemu {
     my ($self, $from_position) = @_;
     # serial failures defined in distri (test can override them)
     my $failures = $self->{serial_failures};
 
-    myjsonrpc::send_json($autotest::isotovideo, {cmd => 'read_serial', position => $from_position});
-    my $json = myjsonrpc::read_json($autotest::isotovideo);
+    my $json = $self->get_serial_output_json;
 
     my $die = 0;
+    my %regexp_matched;
     # loop line by line
     for my $line (split(/^/, $json->{serial})) {
         chomp $line;
-        # only two keys allowed
-        for my $type (qw(soft hard)) {
-            for my $regexp (@{$failures->{$type}}) {
-                # If you want to match a simple string please be sure that you create it with quotemeta
-                if ($line =~ /$regexp/) {
-                    my $fail_type = 'softfail';
-                    if ($type eq 'hard') {
-                        $die       = 1;
-                        $fail_type = 'fail';
-                    }
+        for my $regexp_table (@{$failures}) {
+            my $regexp  = $regexp_table->{pattern};
+            my $message = $regexp_table->{message};
+            my $type    = $regexp_table->{type};
+            die "Wrong type defined for serial failure. Only 'soft' or 'hard' allowed. Got: $type" if $type !~ /soft|hard/;
+            die "Message not defined for serial failure for the pattern: '$regexp', type: $type"   if !defined $message;
 
-                    $self->record_testresult($fail_type);
-                    $self->record_resultfile('Serial Failure', "Serial error: $line", result => $fail_type);
-                    $self->{result} = $fail_type;
-
+            # If you want to match a simple string please be sure that you create it with quotemeta
+            if (!exists $regexp_matched{$regexp} and $line =~ /$regexp/) {
+                $regexp_matched{$regexp} = 1;
+                my $fail_type = 'softfail';
+                if ($type eq 'hard') {
+                    $die       = 1;
+                    $fail_type = 'fail';
                 }
+
+                $self->record_testresult($fail_type);
+                $self->record_resultfile('Serial Failure', $message . " - Serial error: $line", result => $fail_type);
+                $self->{result} = $fail_type;
             }
         }
     }

--- a/basetest.pm
+++ b/basetest.pm
@@ -650,7 +650,7 @@ sub parse_serial_output_qemu {
     # serial failures defined in distri (test can override them)
     my $failures = $self->{serial_failures};
 
-    my $json = $self->get_serial_output_json;
+    my $json = $self->get_serial_output_json($from_position);
 
     my $die = 0;
     my %regexp_matched;
@@ -674,7 +674,7 @@ sub parse_serial_output_qemu {
                 }
 
                 $self->record_testresult($fail_type);
-                $self->record_resultfile('Serial Failure', $message . " - Serial error: $line", result => $fail_type);
+                $self->record_resultfile($message, $message . " - Serial error: $line", result => $fail_type);
                 $self->{result} = $fail_type;
             }
         }

--- a/distribution.pm
+++ b/distribution.pm
@@ -26,7 +26,7 @@ sub new {
 
     my $self = bless {}, $class;
     $self->{consoles}        = {};
-    $self->{serial_failures} = {};
+    $self->{serial_failures} = [];
 
 =head2 serial_term_prompt
 
@@ -259,21 +259,24 @@ sub script_output {
 
 =head2 set_expected_serial_failures
 
-    set_expected_serial_failures(%failures)
+    set_expected_serial_failures($failures)
 
 Define the patterns to look for in the serial console.
-The patterns can be either I<hard> or I<soft>.
+Each pattern comes along with a type either I<hard> or I<soft> and a message,
+for instance, to label the match with a bug/ticket
 
 Example:
-    set_expected_serial_failures(soft=>[qr/Pattern1/], hard=>[qr/Pattern2/]);
+    set_expected_serial_failures([
+        { type => 'soft', message => 'Message 1', pattern => qr/Pattern1/ },
+        { type => 'soft', message => 'Message 2', pattern => qr/Pattern2/ },
+        { type => 'hard', message => 'Message 3', pattern => qr/Pattern3/ },]
+    );
 
 =cut
 sub set_expected_serial_failures {
-    my ($self, %failures) = @_;
+    my ($self, $failures) = @_;
 
-    # To be sure that we only store soft and hard keys
-    $self->{serial_failures}{soft} = $failures{soft} if $failures{soft};
-    $self->{serial_failures}{hard} = $failures{hard} if $failures{hard};
+    $self->{serial_failures} = $failures;
 }
 
 # override

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use Test::MockModule;
 use Test::More;
 use Test::Fatal;
 
@@ -11,19 +12,70 @@ BEGIN {
 
 use basetest;
 
-ok(my $basetest = basetest->new('installation'), 'module can be created');
-$basetest->{class}    = 'foo';
-$basetest->{fullname} = 'installation-foo';
-ok($basetest->is_applicable, 'module is applicable by default');
-$bmwqemu::vars{EXCLUDE_MODULES} = 'foo,bar';
-ok(!$basetest->is_applicable, 'module can be excluded');
-$bmwqemu::vars{EXCLUDE_MODULES} = '';
-$bmwqemu::vars{INCLUDE_MODULES} = 'bar,baz';
-ok(!$basetest->is_applicable, 'modules can be excluded based on a whitelist');
-$bmwqemu::vars{INCLUDE_MODULES} = 'bar,baz,foo';
-ok($basetest->is_applicable, 'a whitelisted module shows up');
-$bmwqemu::vars{EXCLUDE_MODULES} = 'foo';
-ok(!$basetest->is_applicable, 'whitelisted modules are overriden by blacklist');
+subtest modules_test => sub {
+    ok(my $basetest = basetest->new('installation'), 'module can be created');
+    $basetest->{class}    = 'foo';
+    $basetest->{fullname} = 'installation-foo';
+    ok($basetest->is_applicable, 'module is applicable by default');
+    $bmwqemu::vars{EXCLUDE_MODULES} = 'foo,bar';
+    ok(!$basetest->is_applicable, 'module can be excluded');
+    $bmwqemu::vars{EXCLUDE_MODULES} = '';
+    $bmwqemu::vars{INCLUDE_MODULES} = 'bar,baz';
+    ok(!$basetest->is_applicable, 'modules can be excluded based on a whitelist');
+    $bmwqemu::vars{INCLUDE_MODULES} = 'bar,baz,foo';
+    ok($basetest->is_applicable, 'a whitelisted module shows up');
+    $bmwqemu::vars{EXCLUDE_MODULES} = 'foo';
+    ok(!$basetest->is_applicable, 'whitelisted modules are overriden by blacklist');
+};
 
+subtest parse_serial_output => sub {
+    my $mock_basetest = new Test::MockModule('basetest');
+    # Mock reading of the serial output
+    $mock_basetest->mock(get_serial_output_json => sub {
+            return {
+                serial   => "Serial to match\n1q2w333\nMore text",
+                position => '100'
+            };
+    });
+    my $basetest = basetest->new('installation');
+    my $message;
+    $mock_basetest->mock(record_resultfile => sub {
+            my ($self, $title, $output, %nargs) = @_;
+            $message = $output;
+    });
+
+    is($basetest->parse_serial_output_qemu(0), 100, 'expected json result position returned');
+
+    $basetest->{serial_failures} = [
+        {type => 'soft', message => 'DoNotMatch', pattern => qr/DoNotMatch/},
+    ];
+    $basetest->parse_serial_output_qemu(0);
+    is($basetest->{result}, undef, 'test result untouched without match');
+    is($message,            undef, 'test details do not have extra message');
+
+    $basetest->{serial_failures} = [
+        {type => 'soft', message => 'SimplePattern', pattern => qr/Serial/},
+    ];
+
+    $basetest->parse_serial_output_qemu(0);
+    is($basetest->{result}, 'softfail', 'test result set to soft failure');
+    is($message, 'SimplePattern - Serial error: Serial to match', 'log message matches output');
+
+    $basetest->{serial_failures} = [
+        {type => 'soft', message => 'Proper regexp', pattern => qr/\d{3}/},
+    ];
+    $basetest->parse_serial_output_qemu(0);
+    is($basetest->{result}, 'softfail', 'test result set to soft failure');
+    is($message, 'Proper regexp - Serial error: 1q2w333', 'log message matches output');
+
+    $basetest->{serial_failures} = [
+        {type => 'hard', message => 'Message1', pattern => qr/Serial/},
+    ];
+
+    eval { $basetest->parse_serial_output_qemu(0) };
+    like($@, qr(Got serial hard failure at.*), 'test died hard after match');
+    is($basetest->{result}, 'fail', 'test result set to hard failure');
+
+};
 
 done_testing;


### PR DESCRIPTION
Resurrection of #977 with the fix with proper initialization + unit tests for parse_serial_output_qemu.

[Verification run](http://g226.suse.de/tests/2079#step/welcome/8).

See [poo#36448](https://progress.opensuse.org/issues/36448).
