### PR TITLE
qemu: Prevent serial logs from being truncated on revert

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -758,7 +758,8 @@ sub start_qemu {
     $self->{proc}->init_blockdev_images();
 
     sp('only-migratable') if $self->can_handle({function => 'snapshots', no_warn => 1});
-    sp('serial',  'file:serial0');
+    sp('chardev', 'ringbuf,id=serial0,logfile=serial0,logappend=on');
+    sp('serial',  'chardev:serial0');
     sp('soundhw', 'ac97');
     {
         sp('m',       $vars->{QEMURAM})     if $vars->{QEMURAM};
@@ -859,12 +860,12 @@ sub start_qemu {
         if ($vars->{VIRTIO_CONSOLE}) {
             my $id = 'virtio_console';
             sp('device', 'virtio-serial');
-            sp('chardev', [qv "socket path=$id server nowait id=$id logfile=$id.log"]);
+            sp('chardev', [qv "socket path=$id server nowait id=$id logfile=$id.log logappend=on"]);
             sp('device',  [qv "virtconsole chardev=$id name=org.openqa.console.$id"]);
         }
 
         my $qmpid = 'qmp_socket';
-        sp('chardev', [qv "socket path=$qmpid server nowait id=$qmpid logfile=$qmpid.log logappend"]);
+        sp('chardev', [qv "socket path=$qmpid server nowait id=$qmpid logfile=$qmpid.log logappend=on"]);
         sp('qmp', "chardev:$qmpid");
         sp('S');
     }


### PR DESCRIPTION
QEMU overwrites the serial file by default. Because we now restart QEMU during
revert to snapshot, this results in the serial file being truncated. However
we can make use of the logfile and logappend chardev options to overcome this.

Verification run: http://10.160.67.78/tests/641

This is low priority.