### PR TITLE
No console reset

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -569,9 +569,19 @@ sub disable_consoles {
 
     for my $console (keys %{$testapi::distri->{consoles}}) {
         my $console_info = $self->console($console);
-        $console_info->reset();
         if ($console_info->can('disable')) {
             $console_info->disable();
+        }
+    }
+}
+
+sub reenable_consoles {
+    my ($self) = @_;
+
+    for my $console (keys %{$testapi::distri->{consoles}}) {
+        my $console_info = $self->console($console);
+        if ($console_info->can('disable')) {
+            $console_info->activate();
         }
     }
 }

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -493,6 +493,7 @@ sub load_snapshot {
     # query-migrate does not seem to work for an incoming migration
     $self->_wait_while_status_is(qr/migrate/, 300, 'Timed out while loading snapshot');
 
+    $self->reenable_consoles();
     $self->select_console({testapi_console => 'sut'});
     diag('Restored snapshot');
     $self->cont_vm();

--- a/basetest.pm
+++ b/basetest.pm
@@ -621,6 +621,7 @@ sub rollback_activated_consoles {
         # able to activate a 2nd time, but that's up to the console class
         autotest::query_isotovideo('backend_reset_console', {testapi_console => $console});
     }
+    $self->{activated_consoles} = [];
 
     if (defined($autotest::last_milestone_console)) {
         my $ret = autotest::query_isotovideo('backend_select_console',


### PR DESCRIPTION
Fix problem with logging into consoles after reverting to a snapshot.

https://progress.opensuse.org/issues/38813

Verification (previously zbar and weechat were failing):
http://10.160.67.78/tests/646
http://10.160.67.78/tests/647

"All consoles need to be "disabled", but not "reset". Resetting consoles causes
the SUT to try logging into the them again, but they may already be logged in
at the point the snapshot was taken. Disabling just disconnects os-autoinst
from the console which is necessary while restarting QEMU. After restarting
QEMU we can reconnect by calling activate directly.

It is assumed that consoles which can't be disabled don't need to be
reënabled."