### PR TITLE
Avoid enabling unused consoles after reverting to a snapshot

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -580,7 +580,7 @@ sub reenable_consoles {
 
     for my $console (keys %{$testapi::distri->{consoles}}) {
         my $console_info = $self->console($console);
-        if ($console_info->can('disable')) {
+        if ($console_info->{activated} && $console_info->can('disable')) {
             $console_info->activate();
         }
     }


### PR DESCRIPTION
Only reënable consoles which are currently active. Any other consoles are
either not being used or will be reënabled during reactivation when next
selected. This avoids activating consoles which are not used in the test.