### PR TITLE
Unset vlan on qemu process turndown and runcmd fixes

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -46,7 +46,10 @@ use constant STATE_FILE => 'qemu_state.json';
 
 has qemu_bin     => 'qemu-kvm';
 has qemu_img_bin => 'qemu-img';
-has '_process';
+has _process     => sub { process(
+        pidfile       => 'qemu.pid',
+        separate_err  => 0,
+        blocking_stop => 1) };
 
 has _static_params => sub { return []; };
 has _mut_params    => sub { return []; };
@@ -60,11 +63,6 @@ has snapshot_conf   => sub { return OpenQA::Qemu::SnapshotConf->new(); };
 sub new {
     my $self = shift->SUPER::new(@_);
 
-    $self->_process(process(
-            pidfile       => 'qemu.pid',
-            separate_err  => 0,
-            blocking_stop => 1)
-    );
     $self->_push_mut($self->controller_conf);
     $self->_push_mut($self->blockdev_conf);
     $self->_push_mut($self->snapshot_conf);

--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -356,7 +356,7 @@ sub exec_qemu {
         });
 
     session->enable_subreaper;
-    $self->_process->code(sub { $SIG{TERM} = sub { Mojo::IOLoop::ReadWriteProcess::_exit(1) }; exec(@params) })->start();
+    $self->_process->code(sub { exec(@params) })->start();
     fcntl($self->_process->read_stream, Fcntl::F_SETFL, Fcntl::O_NONBLOCK) or die "can't setfl(): $!\n";
 
     return $self->_process->read_stream;

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -839,7 +839,6 @@ sub similiarity_to_reference {
 sub wait_idle {
     my ($self, $args) = @_;
     my $timeout = $args->{timeout};
-
     bmwqemu::diag("wait_idle sleeping for $timeout seconds");
     $self->run_capture_loop($timeout);
     return;

--- a/backend/driver.pm
+++ b/backend/driver.pm
@@ -31,13 +31,7 @@ use autodie ':all';
 use Mojo::IOLoop::ReadWriteProcess 'process';
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 use myjsonrpc;
-
-# TODO: move the whole printing out of bmwqemu
-sub diag {
-    my ($text) = @_;
-
-    print "$text\n";
-}
+use bmwqemu;    # TODO: move the whole printing out of bmwqemu
 
 sub new {
     my ($class, $name) = @_;
@@ -50,7 +44,7 @@ sub new {
     session->on(
         collected_orphan => sub {
             my ($session, $p) = @_;
-            printf STDERR "Driver backend collected unknown process with pid " . $p->pid . " and exit status: " . $p->exit_status . "\n";
+            bmwqemu::diag("Driver backend collected unknown process with pid " . $p->pid . " and exit status: " . $p->exit_status);
         });
 
     $self->start();
@@ -84,7 +78,7 @@ sub start {
             _exit(0);
     })->blocking_stop(1)->separate_err(0)->subreaper(1)->start;
 
-    $backend_process->on(collected => sub { diag "backend process exited: " . shift->exit_status; });
+    $backend_process->on(collected => sub { bmwqemu::diag("backend process exited: " . shift->exit_status) });
 
     printf STDERR "$$: channel_out %d, channel_in %d\n", fileno($backend_process->channel_out), fileno($backend_process->channel_in);
     $self->{backend_pid}     = $backend_process->pid;

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -33,7 +33,7 @@ use bmwqemu qw(fileContent diag save_vars);
 require IPC::System::Simple;
 use autodie ':all';
 use Try::Tiny;
-use osutils qw(find_bin gen_params qv runcmd runcmd_output);
+use osutils qw(find_bin gen_params qv simple_run runcmd);
 use List::Util 'max';
 use Data::Dumper;
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
@@ -702,7 +702,7 @@ sub start_qemu {
     mkpath($basedir);
 
     # do not use autodie here, it can fail on tmpfs, xfs, ...
-    runcmd_output('/usr/bin/chattr', '-f', '+C', $basedir);
+    simple_run('/usr/bin/chattr', '-f', '+C', $basedir);
 
     my $keephdds = $vars->{KEEPHDDS} || $vars->{SKIPTO};
 

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -33,7 +33,7 @@ use bmwqemu qw(fileContent diag save_vars);
 require IPC::System::Simple;
 use autodie ':all';
 use Try::Tiny;
-use osutils qw(find_bin gen_params qv runcmd);
+use osutils qw(find_bin gen_params qv runcmd runcmd_output);
 use List::Util 'max';
 use Data::Dumper;
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
@@ -700,8 +700,9 @@ sub start_qemu {
     bmwqemu::save_vars();                     # update variables
 
     mkpath($basedir);
-    # do not use runcmd or autodie here, it can fail on tmpfs, xfs, ...
-    CORE::system('/usr/bin/chattr', '-f', '+C', $basedir);
+
+    # do not use autodie here, it can fail on tmpfs, xfs, ...
+    runcmd_output('/usr/bin/chattr', '-f', '+C', $basedir);
 
     my $keephdds = $vars->{KEEPHDDS} || $vars->{SKIPTO};
 

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -36,7 +36,7 @@ use Try::Tiny;
 use osutils qw(find_bin gen_params qv runcmd);
 use List::Util 'max';
 use Data::Dumper;
-
+use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 use OpenQA::Qemu::Proc;
 
 # The maximum value of the system's native signed integer. Which will probably
@@ -1018,11 +1018,6 @@ sub cont_vm {
     my ($self) = @_;
     $self->update_request_interval(delete $self->{_qemu_saved_request_interval}) if $self->{_qemu_saved_request_interval};
     return $self->handle_qmp_command({execute => 'cont'});
-}
-
-sub DESTROY {
-    # Make sure we don't leave any process behind and that vlans are unset
-    session->all->each(sub { $_->emit('cleanup'); shift->stop });
 }
 
 1;

--- a/commands.pm
+++ b/commands.pm
@@ -25,7 +25,7 @@ use POSIX '_exit', 'strftime';
 use autodie ':all';
 use JSON 'from_json';
 use myjsonrpc;
-
+use bmwqemu 'diag';
 
 BEGIN {
     # https://github.com/os-autoinst/openQA/issues/450
@@ -356,7 +356,7 @@ sub start_server {
     })->blocking_stop(1)->internal_pipes(0)->set_pipes(0)->start;
 
     close($isotovideo);
-    $process->on(collected => sub { print STDERR "commands process exited: " . shift->exit_status . "\n"; });
+    $process->on(collected => sub { diag("commands process exited: " . shift->exit_status); });
     return ($process, $child);
 }
 

--- a/cpanfile
+++ b/cpanfile
@@ -29,6 +29,7 @@ requires 'JSON';
 requires 'JSON::XS';
 requires 'List::MoreUtils';
 requires 'List::Util';
+requires 'Mojo::IOLoop::ReadWriteProcess';
 requires 'Mojo::URL';
 requires 'Mojo::UserAgent';
 requires 'Mojo::Log';

--- a/isotovideo
+++ b/isotovideo
@@ -81,7 +81,12 @@ use Carp 'cluck';
 use Time::HiRes qw(gettimeofday tv_interval sleep time);
 use File::Spec;
 use File::Path;
+use Mojo::IOLoop::ReadWriteProcess 'process';
+use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 Getopt::Long::Configure("no_ignore_case");
+
+session->enable;
+session->enable_subreaper;
 
 my %options;
 # global exit status
@@ -139,52 +144,35 @@ for my $arg (@ARGV) {
 die "CASEDIR environment variable not set, unknown test case directory" if !defined $bmwqemu::vars{CASEDIR};
 die "No scripts in $bmwqemu::vars{CASEDIR}" if !-e "$bmwqemu::vars{CASEDIR}";
 
-my $cmd_srv_pid;
-my $testpid;
+my $cmd_srv_process;
+my $testprocess;
 my $cmd_srv_fd;
+my $backend_process;
 
 my $loop = 1;
 
 sub kill_commands {
-    return unless $cmd_srv_pid;
-    # create a copy as cpid is overwritten by SIGCHLD
-    my $pid = $cmd_srv_pid;
-    if (kill('TERM', $pid)) {
-        diag "awaiting death of commands process";
-        my $ret = waitpid($pid, 0);
-        diag "commands process exited: $ret";
-    }
-    $cmd_srv_pid = 0;
+    return unless defined $cmd_srv_process;
+    $cmd_srv_process->stop() if $cmd_srv_process->is_running;
 }
 
 sub kill_autotest {
-    return unless $testpid;
-    # create a copy as cpid is overwritten by SIGCHLD
-    my $pid = $testpid;
-    if (kill('TERM', $pid)) {
-        diag "awaiting death of testpid $pid";
-        my $ret = waitpid($pid, 0);
-        diag "test process exited: $ret";
-    }
-    $testpid = 0;
+    return unless defined $testprocess;
+    $testprocess->stop() if $testprocess->is_running;
 }
 
 sub kill_backend {
-    if (defined $bmwqemu::backend && $bmwqemu::backend->{backend_pid}) {
-        # save the pid in a scalar - signal handlers will reset it
-        my $bpid = $bmwqemu::backend->{backend_pid};
-        diag "killing backend process $bpid";
-        kill('-TERM', $bpid);
-        waitpid($bpid, 0);
+    if (defined $bmwqemu::backend && $backend_process) {
+        diag "killing backend process " . $backend_process->pid;
+        $backend_process->stop if $backend_process->is_running;
         diag("done with backend process");
-        $bmwqemu::backend->{backend_pid} = 0;
     }
 }
 
 sub signalhandler {
 
     my ($sig) = @_;
-    diag("signalhandler got $sig - loop $loop");
+    diag("signalhandler got $sig");
     if ($loop) {
         $loop = 0;
         return;
@@ -193,31 +181,6 @@ sub signalhandler {
     kill_commands;
     kill_autotest;
     _exit(1);
-}
-
-sub signalhandler_chld {
-
-    while ((my $child = waitpid(-1, WNOHANG)) > 0) {
-        if ($child == $cmd_srv_pid) {
-            diag("commands webserver died");
-            $loop        = 0;
-            $cmd_srv_pid = 0;
-            next;
-        }
-        if ($bmwqemu::backend->{backend_pid} && $child == $bmwqemu::backend->{backend_pid}) {
-            diag("backend $child died");
-            $bmwqemu::backend->{backend_pid} = 0;
-            $loop = 0;
-            next;
-        }
-        if ($child == $testpid) {
-            diag("tests died");
-            $testpid = 0;
-            $loop    = 0;
-            next;
-        }
-        diag("unknown child $child died");
-    }
 }
 
 our $test_git_hash;
@@ -251,7 +214,6 @@ sub calculate_git_hash {
 $SIG{TERM} = \&signalhandler;
 $SIG{INT}  = \&signalhandler;
 $SIG{HUP}  = \&signalhandler;
-$SIG{CHLD} = \&signalhandler_chld;
 
 # make sure all commands coming from the backend will not be in the
 # developers's locale - but a defined english one. This is SUSE's
@@ -277,7 +239,7 @@ $bmwqemu::vars{TEST_GIT_HASH} = $test_git_hash;
 
 # start the command fork before we get into the backend, the command child
 # is not supposed to talk to the backend directly
-($cmd_srv_pid, $cmd_srv_fd) = commands::start_server($bmwqemu::vars{QEMUPORT} + 1);
+($cmd_srv_process, $cmd_srv_fd) = commands::start_server($bmwqemu::vars{QEMUPORT} + 1);
 
 # set a default distribution if the tests don't have one
 $testapi::distri = distribution->new;
@@ -300,7 +262,7 @@ testapi::init();
 bmwqemu::save_vars();
 
 my $testfd;
-($testpid, $testfd) = autotest::start_process();
+($testprocess, $testfd) = autotest::start_process();
 
 init_backend();
 
@@ -322,10 +284,16 @@ if ($ENV{RUN_DEBUGVIEWER}) {
 
 use IO::Select;
 
+$backend_process = $bmwqemu::backend->{backend_process};
 my $io_select = IO::Select->new();
 $io_select->add($testfd);
 $io_select->add($cmd_srv_fd);
-$io_select->add($bmwqemu::backend->{from_child});
+$io_select->add($backend_process->channel_out);
+
+my $stop_loop = sub { if ($loop) { diag "Stopping LOOOP"; $loop = 0; } };
+$testprocess->once(collected => $stop_loop);
+$backend_process->once(collected => $stop_loop);
+$cmd_srv_process->once(collected => $stop_loop);
 
 # now we have everything, give the tests a go
 $testfd->write("GO\n");
@@ -435,7 +403,7 @@ sub process_command {
         # send debugging info for ws clients
         myjsonrpc::send_json($cmd_srv_fd, {$cmd => $rsp});
         # pass command to backend
-        myjsonrpc::send_json($bmwqemu::backend->{to_child}, {cmd => $cmd, arguments => $rsp});
+        myjsonrpc::send_json($backend_process->channel_in, {cmd => $cmd, arguments => $rsp});
         return;
     }
     if ($rsp->{cmd} eq 'set_pause_at_test') {
@@ -571,7 +539,7 @@ while ($loop) {
             $loop     = 0;
             last;
         }
-        if ($readable == $bmwqemu::backend->{from_child}) {
+        if ($readable == $backend_process->channel_out) {
             myjsonrpc::send_json($backend_requester, {ret => $rsp->{rsp}});
             $backend_requester = undef;
             next;
@@ -583,7 +551,6 @@ while ($loop) {
         check_asserted_screen($no_wait);
     }
 }
-
 # don't leave the commands server open - it will no longer react anyway
 # as most of it ends up in the loop above
 kill_commands;
@@ -602,6 +569,7 @@ if (!$return_code) {
         $clean_shutdown = $bmwqemu::backend->_send_json({cmd => 'is_shutdown'});
         diag "BACKEND SHUTDOWN $clean_shutdown";
     };
+
     # don't rely on the backend in a sane state if we failed - just kill it later
     eval { bmwqemu::stop_vm(); };
     if ($@) {

--- a/isotovideo
+++ b/isotovideo
@@ -290,7 +290,7 @@ $io_select->add($testfd);
 $io_select->add($cmd_srv_fd);
 $io_select->add($backend_process->channel_out);
 
-my $stop_loop = sub { if ($loop) { diag "Stopping LOOOP"; $loop = 0; } };
+my $stop_loop = sub { $loop = 0 if $loop; };
 $testprocess->once(collected => $stop_loop);
 $backend_process->once(collected => $stop_loop);
 $cmd_srv_process->once(collected => $stop_loop);

--- a/osutils.pm
+++ b/osutils.pm
@@ -114,7 +114,7 @@ sub simple_run { diag((_run(@_, 0))[1]) }
 # Open a process to run external program and check its return status
 sub runcmd {
     my ($e, $out) = _run(@_, 0);
-    diag $out;
+    diag $out if $out && length($out) > 0;
     die join(" ", RUNCMD_FAILURE_MESS, $e) unless $e == 0;
     return $e;
 }
@@ -122,7 +122,7 @@ sub runcmd {
 # Check for exit status and return the output
 sub runcmd_output {
     my ($e, $out) = _run(@_, 1);
-    diag $out;
+    diag $out if $out && length($out) > 0;
     die join(" ", RUNCMD_FAILURE_MESS, $e) unless $e == 0;
     return $out;
 }

--- a/t/07-commands.t
+++ b/t/07-commands.t
@@ -53,7 +53,7 @@ sub wait_for_server {
 $bmwqemu::vars{JOBTOKEN} = 'Hallo';
 
 # now this is a game of luck
-my ($cpid, $cfd) = commands::start_server($mojoport);
+my ($cserver, $cfd) = commands::start_server($mojoport);
 
 my $spid = fork();
 if ($spid == 0) {
@@ -108,13 +108,8 @@ subtest 'web socket route' => sub {
     $t->finish_ok();
 };
 
-done_testing;
+kill TERM => $spid;
+waitpid($spid, 0);
+eval { $cserver->stop() };
 
-END {
-    return unless $spid;
-    kill TERM => $spid;
-    waitpid($spid, 0);
-    kill TERM => $cpid;
-    waitpid($cpid, 0);
-    wait_for_server($t->ua);
-}
+done_testing;


### PR DESCRIPTION
This is part and continuation of work on top of the QEMU backend rewrite (https://github.com/os-autoinst/os-autoinst/pull/985) and a slightly retake on https://github.com/os-autoinst/os-autoinst/pull/829

Boils down to:
- Move qemu process to event emitter model ( untag of vlan with this change happens when qemu process status is finally gathered - although it might still not yet cover all edge cases, i need more feedback )
- Replace IPC::Open3 logic in runcmd_* in osutils.pm
- Refactor pipe communication among internal processes - move internal communication to channels and create classes for the relevant involved processes
- Depends on [Mojo::IOLoop::ReadWriteProcess](https://metacpan.org/pod/Mojo::IOLoop::ReadWriteProcess), but we are already using it in the worker code
- With this change, to ease debug os-autoinst processes, you can enable [MOJO_PROCESS_DEBUG=1](https://metacpan.org/pod/Mojo::IOLoop::ReadWriteProcess#DEBUGGING) and see all the processes-related events, you can also enable [MOJO_EVENTEMITTER_DEBUG=1](https://metacpan.org/pod/Mojo::EventEmitter#DEBUGGING) to inspect all the emitted events as well (bit noisy)

This will require still work later, but it may allows us to cut more code in the long-term as well if we will slowly move towards an Event based approach ( See also discussion https://github.com/os-autoinst/os-autoinst/pull/829#issuecomment-379685717). 
There is still a large room for improvement, this is just a little step towards it.

This is in a unique PR because the changes are tightly related to each other. 

Not ready yet, i need to polish it and double check on real instances - it's working on staging and fullstack tests are passing, who is ready for another haircut? ahem, nice ride? :smile: 

![haircut](https://media.giphy.com/media/Gj2iZfSI1rMmQ/giphy.gif)

See: https://progress.opensuse.org/issues/35895, https://progress.opensuse.org/issues/32293, https://progress.opensuse.org/issues/33514
