### PR TITLE
virtio_terminal: Avoid connecting to already connected socket

### DIFF
--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -133,7 +133,7 @@ sub open_socket {
 sub activate {
     my ($self) = @_;
     if (get_var('VIRTIO_CONSOLE')) {
-        $self->{socket_fd}              = $self->open_socket;
+        $self->{socket_fd}              = $self->open_socket unless $self->{socket_fd};
         $self->{screen}                 = consoles::virtio_screen::->new($self->{socket_fd});
         $self->{screen}->{carry_buffer} = $self->{preload_buffer};
         $self->{preload_buffer}         = '';


### PR DESCRIPTION
Another day another os-autoinst PR :-). This only effects one test to my knowledge, but it is quite an important test because it is for an important product bug.

The console can be reset (e.g. when rebooting the SUT) without closing the
console socket because QEMU is not restarted. So keep using the currently open
socket if there is one.

Verification: http://10.160.67.78/tests/669