### PR TITLE
Fix ppc64le flaky exit status codes

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -36,7 +36,7 @@ use Mojo::File 'path';
 use OpenQA::Qemu::BlockDevConf;
 use OpenQA::Qemu::ControllerConf;
 use OpenQA::Qemu::SnapshotConf;
-use osutils qw(gen_params runcmd runcmd_output);
+use osutils qw(gen_params runcmd simple_run);
 use Mojo::IOLoop::ReadWriteProcess 'process';
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 
@@ -132,7 +132,7 @@ sub configure_controllers {
 
 sub get_img_size {
     my ($self, $path) = @_;
-    my $json = runcmd_output($self->qemu_img_bin, 'info', '--output=json', $path);
+    my $json = simple_run($self->qemu_img_bin, 'info', '--output=json', $path);
     my $map = decode_json($json);
 
     die 'No size field in: ' . Dumper($map) unless defined $map->{'virtual-size'};

--- a/cpanfile
+++ b/cpanfile
@@ -29,7 +29,7 @@ requires 'JSON';
 requires 'JSON::XS';
 requires 'List::MoreUtils';
 requires 'List::Util';
-requires 'Mojo::IOLoop::ReadWriteProcess';
+requires 'Mojo::IOLoop::ReadWriteProcess', '0.21';
 requires 'Mojo::URL';
 requires 'Mojo::UserAgent';
 requires 'Mojo::Log';

--- a/docker/travis_test/run.sh
+++ b/docker/travis_test/run.sh
@@ -2,11 +2,20 @@
 
 set -e
 
+INSTALL_FROM_CPAN="${INSTALL_FROM_CPAN:-0}"
+
 # Prepare dir and chdir into it before executing the wanted action
 sudo cp -rd /opt/repo /opt/run
 sudo chown -R $NORMAL_USER:users /opt/run
 
 pushd /opt/run
+[ "$INSTALL_FROM_CPAN" -eq 1 ] && \
+  (cpanm --local-lib=~/perl5 local::lib && cpanm -n --installdeps . ) || \
+  cpanm -n --mirror http://no.where/ --installdeps .
+
+[ "$INSTALL_FROM_CPAN" -eq 1 ] && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+[ $? -eq 0 ] || echo "Missing dependencies. Please check output above"
+
 ./autogen.sh
 
 /bin/bash -c "$*"

--- a/docker/travis_test/run.sh
+++ b/docker/travis_test/run.sh
@@ -4,6 +4,8 @@ set -e
 
 INSTALL_FROM_CPAN="${INSTALL_FROM_CPAN:-0}"
 
+sudo zypper --gpg-auto-import-keys -n ref --force && sudo zypper up -l -y
+
 # Prepare dir and chdir into it before executing the wanted action
 sudo cp -rd /opt/repo /opt/run
 sudo chown -R $NORMAL_USER:users /opt/run

--- a/osutils.pm
+++ b/osutils.pm
@@ -33,7 +33,6 @@ our @EXPORT_OK = qw(
   qv
   quote
   runcmd
-  runcmd_output
   simple_run
   attempt
 );
@@ -94,17 +93,17 @@ sub quote {
 
 sub _run {
     diag "running " . join(' ', @_);
-    my $e    = pop;
     my @args = @_;
     my $out;
     my $buffer;
     open my $handle, '>', \$buffer;
-    my $p = process(sub { local *STDERR = $handle; exec(@args) })->separate_err($e)->start;
+    my $p = process(sub { local *STDERR = $handle; exec(@args) });
+    $p->channels(0)->quirkiness(1)->internal_pipes(0)->separate_err(0)->start;
     $p->on(stop => sub {
             while (defined(my $line = $p->getline)) {
                 $out .= $line;
             }
-            diag $buffer if $e && $buffer && length($buffer) > 0;
+            diag $buffer if defined $buffer && length($buffer) > 0;
     });
     $p->wait_stop;
     close($p->$_ ? $p->$_ : ()) for qw(read_stream write_stream error_stream);
@@ -113,23 +112,16 @@ sub _run {
 }
 
 # Do not check for anything - just execute and print
-sub simple_run { diag((_run(@_, 0))[1]) }
+sub simple_run { my $o = (_run(@_))[1]; diag($o); $o }
 
 # Open a process to run external program and check its return status
 sub runcmd {
-    my ($e, $out) = _run(@_, 0);
+    my ($e, $out) = _run(@_);
     diag $out if $out && length($out) > 0;
     die join(" ", RUNCMD_FAILURE_MESS, $e) unless $e == 0;
     return $e;
 }
 
-# Check for exit status and return the output
-sub runcmd_output {
-    my ($e, $out) = _run(@_, 1);
-    diag $out if $out && length($out) > 0;
-    die join(" ", RUNCMD_FAILURE_MESS, $e) unless $e == 0;
-    return $out;
-}
 ## use critic
 
 sub attempt {


### PR DESCRIPTION
This was a fallout of https://github.com/os-autoinst/os-autoinst/pull/1006 - it highlighted the problem we was having already to get the exit statuses, but the fallout was regarding only ppc64le (which made the thing bit more harsh to debug).  

This removes also runcmd_output (just used in OpenQA::Qemu::Proc) as now we can slim a bit more the duplicated code.

It requires also new RWP to treat the specific arches case (and also to make code bit slimmer) and to fix a minor bug i found while looking at this.

Also added on the Docker image the possibility to install the modules from CPAN (default is disabled)  when INSTALL_FROM_CPAN=1 is supplied to env variables.

( Travis tests will fail as new RWP still didn't hit repos )