### PR TITLE
[WIP] Add ssh backend

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,7 +38,7 @@ consolesexec_DATA = \
 	consoles/sshXtermIPMI.pm \
 	consoles/sshXtermVt.pm \
 	consoles/ttyConsole.pm \
-	consoles/virtio_screen.pm \
+	consoles/serial_screen.pm \
 	consoles/virtio_terminal.pm \
 	consoles/vnc_base.pm \
 	consoles/VNC.pm

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -35,6 +35,7 @@ use OpenQA::Benchmark::Stopwatch;
 use MIME::Base64 'encode_base64';
 use List::Util 'min';
 use List::MoreUtils 'uniq';
+use Data::Dumper;
 
 # should be a singleton - and only useful in backend process
 our $backend;
@@ -1140,7 +1141,10 @@ sub new_ssh_connection {
     $args{username} ||= 'root';
     $args{port}     ||= 22;
 
+    print(Dumper(%args));
     my $ssh = Net::SSH2->new;
+
+    print("HOSTNAME: " . $args{hostname} . " PORT:" . $args{port});
 
     # Retry 5 times, in case of the guest is not running yet
     my $counter = 5;

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -1138,13 +1138,14 @@ sub retry_assert_screen {
 sub new_ssh_connection {
     my ($self, %args) = @_;
     $args{username} ||= 'root';
+    $args{port}     ||= 22;
 
     my $ssh = Net::SSH2->new;
 
     # Retry 5 times, in case of the guest is not running yet
     my $counter = 5;
     while ($counter > 0) {
-        if ($ssh->connect($args{hostname})) {
+        if ($ssh->connect($args{hostname}, $args{port})) {
 
             if ($args{password}) {
                 $ssh->auth(username => $args{username}, password => $args{password});
@@ -1153,17 +1154,17 @@ sub new_ssh_connection {
                 # this relies on agent to be set up correctly
                 $ssh->auth_agent($args{username});
             }
-            bmwqemu::diag "Connection to $args{username}\@$args{hostname} established" if $ssh->auth_ok;
+            bmwqemu::diag "Connection to $args{username}\@$args{hostname}:$args{port} established" if $ssh->auth_ok;
             last;
         }
         else {
-            bmwqemu::diag "Could not connect to $args{username}\@$args{hostname}, Retry";
+            bmwqemu::diag "Could not connect to $args{username}\@$args{hostname}:$args{port}, Retry";
             sleep(10);
             $counter--;
             next;
         }
     }
-    die "Failed to login to $args{username}\@$args{hostname}" unless $ssh->auth_ok;
+    die "Failed to login to $args{username}\@$args{hostname}:$args{port}" unless $ssh->auth_ok;
 
     return $ssh;
 }

--- a/backend/ssh.pm
+++ b/backend/ssh.pm
@@ -1,0 +1,143 @@
+# Copyright © 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package backend::ssh;
+use strict;
+use base 'backend::baseclass';
+use testapi 'get_required_var';
+use Carp 'cluck';
+
+use IO::Select;
+
+sub new {
+    my $class = shift;
+    my $self  = $class->SUPER::new;
+
+    return $self;
+}
+
+sub do_start_vm {
+    my ($self) = @_;
+
+    my $hostname = get_required_var('SSH_HOSTNAME');
+    my $password = get_required_var('SSH_PASSWORD');
+    my $username = get_required_var('SSH_USERNAME', 'root');
+
+    # truncate the serial file
+    open(my $sf, '>', $self->{serialfile});
+    close($sf);
+
+    my $ssh_console = $testapi::distri->add_console(
+        'sut',
+        'ssh_console',
+        {
+            hostname => $hostname,
+            password => $password,
+            username => $username
+        });
+    $ssh_console->backend($self);
+    $self->select_console({testapi_console => 'sut'});
+
+    # TODO use unique filename or exit if file exists
+    my $serial_file = "/dev/" . $testapi::serialdev;
+    $self->run_cmd("mkfifo $serial_file", $hostname, $password, $username);
+
+    # Listen on serial file
+    my $chan = $self->start_ssh_serial(hostname => $hostname, password => $password, username => $username);
+    $chan->exec("tail -F $serial_file");
+
+    return {};
+}
+
+sub do_stop_vm {
+
+    my ($self) = @_;
+    my $serial_file = "/dev/" . $testapi::serialdev;
+
+    $self->stop_ssh_serial;
+    $self->run_cmd("rm $serial_file");
+    $self->deactivate_console({testapi_console => 'sut'});
+
+    return {};
+}
+
+# In list context returns pair ($stdout, $stderr). In void (and scalar)
+# context just logs stdout and stderr, returns nothing.
+# TODO used from svirt.pm, move to baseclass?!
+sub get_ssh_output {
+    my ($chan) = @_;
+
+    my ($stdout, $errout) = ('', '');
+    while (!$chan->eof) {
+        if (my ($o, $e) = $chan->read2) {
+            $stdout .= $o;
+            $errout .= $e;
+        }
+    }
+    if (wantarray) {
+        return ($stdout, $errout);
+    }
+    else {
+        bmwqemu::diag "Command's stdout:\n$stdout" if length($stdout);
+        bmwqemu::diag "Command's stderr:\n$errout" if length($errout);
+    }
+}
+
+# TODO used from svirt.pm, move to baseclass?!
+sub run_cmd {
+    my ($self, $cmd, $hostname, $password, $username) = @_;
+
+    $hostname //= get_required_var('SSH_HOSTNAME');
+    $password //= get_required_var('SSH_PASSWORD');
+    $username //= get_required_var('SSH_USERNAME', 'root');
+
+    $self->{ssh} = $self->new_ssh_connection(
+        hostname => $hostname,
+        password => $password,
+        username => $username
+    ) unless defined($self->{ssh});
+    my $chan = $self->{ssh}->channel();
+    $chan->exec($cmd);
+    get_ssh_output($chan);
+    $chan->send_eof;
+    my $ret = $chan->exit_status();
+    bmwqemu::diag "Command executed: $cmd, ret=$ret";
+    $chan->close();
+    return $ret;
+}
+
+sub can_handle {
+    my ($self, $args) = @_;
+    return;
+}
+
+sub is_shutdown {
+    my ($self) = @_;
+    return 0;
+}
+
+
+sub check_socket {
+    my ($self, $fh, $write) = @_;
+
+    if ($self->check_ssh_serial($fh)) {
+        return 1;
+    }
+    return $self->SUPER::check_socket($fh, $write);
+}
+
+1;
+
+# vim: set sw=4 et:

--- a/consoles/serial_screen.pm
+++ b/consoles/serial_screen.pm
@@ -12,7 +12,7 @@
 #
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
-package consoles::virtio_screen;
+package consoles::serial_screen;
 use 5.018;
 use warnings;
 use English -no_match_vars;
@@ -269,7 +269,7 @@ sub read_until {
 =head2 peak
 
 Read and return pending data without consuming it. This is useful if you are
-about to destroy the virtio_screen instance, but want to keep any pending
+about to destroy the serial_screen instance, but want to keep any pending
 data. However this does not wait for any data in particular so this races with
 the backend and data transport. Therefor it should only be used when there is
 no information available about what data is expected to be available.

--- a/consoles/ssh_console.pm
+++ b/consoles/ssh_console.pm
@@ -57,15 +57,18 @@ sub activate {
     my $username = $self->{username};
 
     $self->{ssh} = $self->backend->new_ssh_connection(hostname => $hostname, password => $password, username => $username);
-    $self->{shell} = $self->{ssh}->channel();
-    $self->{shell}->shell();
+    my $chan = $self->{shell} = $self->{ssh}->channel();
+    $chan->pty(1);
+    $chan->shell();
+    print $chan "PS1='# '\n";
+    print $chan "exec 2>&1\n";
 
-    $self->{screen} = consoles::virtio_screen->new($self->{shell});
+    $self->{screen} = consoles::virtio_screen->new($chan, $self->{ssh}->sock);
     return;
 }
 
 sub is_serial_terminal {
-    return 0;
+    return 1;
 }
 
 1;

--- a/consoles/ssh_console.pm
+++ b/consoles/ssh_console.pm
@@ -18,7 +18,7 @@ use warnings;
 use autodie;
 use Scalar::Util 'blessed';
 use Cwd;
-use consoles::virtio_screen;
+use consoles::serial_screen;
 
 use base 'consoles::console';
 
@@ -63,7 +63,7 @@ sub activate {
     print $chan "PS1='# '\n";
     print $chan "exec 2>&1\n";
 
-    $self->{screen} = consoles::virtio_screen->new($chan, $self->{ssh}->sock);
+    $self->{screen} = consoles::serial_screen->new($chan, $self->{ssh}->sock);
     return;
 }
 

--- a/consoles/ssh_console.pm
+++ b/consoles/ssh_console.pm
@@ -30,6 +30,7 @@ sub new {
     $self->{hostname}       = $args->{hostname};
     $self->{password}       = $args->{password};
     $self->{username}       = $args->{username};
+    $self->{port}           = $args->{port};
     $self->{preload_buffer} = '';
     return $self;
 }
@@ -55,10 +56,17 @@ sub activate {
     my $hostname = $self->{hostname} || die('we need a hostname to ssh to');
     my $password = $self->{password};
     my $username = $self->{username};
+    my $port     = $self->{port};
 
-    $self->{ssh} = $self->backend->new_ssh_connection(hostname => $hostname, password => $password, username => $username);
+    $self->{ssh} = $self->backend->new_ssh_connection(
+        hostname => $hostname,
+        password => $password,
+        username => $username,
+        port     => $port
+    );
     my $chan = $self->{shell} = $self->{ssh}->channel();
-    $chan->pty(1);
+    $chan->pty('vt100', {echo => 1});
+    $chan->pty_size(1024, 24);
     $chan->shell();
     print $chan "PS1='# '\n";
     print $chan "exec 2>&1\n";

--- a/consoles/ssh_console.pm
+++ b/consoles/ssh_console.pm
@@ -1,0 +1,71 @@
+# Copyright © 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+package consoles::ssh_console;
+use 5.018;
+use warnings;
+use autodie;
+use Scalar::Util 'blessed';
+use Cwd;
+use consoles::virtio_screen;
+
+use base 'consoles::console';
+
+our $VERSION;
+
+sub new {
+    my ($class, $testapi_console, $args) = @_;
+    my $self = $class->SUPER::new($testapi_console, $args);
+    $self->{hostname}       = $args->{hostname};
+    $self->{password}       = $args->{password};
+    $self->{username}       = $args->{username};
+    $self->{preload_buffer} = '';
+    return $self;
+}
+
+sub screen {
+    my ($self) = @_;
+    return $self->{screen};
+}
+
+sub disable {
+    my ($self) = @_;
+    if ($self->{shell}) {
+        $self->{shell}->close();
+        $self->{ssh}->disconnect;
+        $self->{ssh}    = undef;
+        $self->{screen} = undef;
+    }
+}
+
+sub activate {
+    my ($self, $args) = @_;
+
+    my $hostname = $self->{hostname} || die('we need a hostname to ssh to');
+    my $password = $self->{password};
+    my $username = $self->{username};
+
+    $self->{ssh} = $self->backend->new_ssh_connection(hostname => $hostname, password => $password, username => $username);
+    $self->{shell} = $self->{ssh}->channel();
+    $self->{shell}->shell();
+
+    $self->{screen} = consoles::virtio_screen->new($self->{shell});
+    return;
+}
+
+sub is_serial_terminal {
+    return 0;
+}
+
+1;

--- a/consoles/virtio_screen.pm
+++ b/consoles/virtio_screen.pm
@@ -23,9 +23,10 @@ use Carp 'croak';
 our $VERSION;
 
 sub new {
-    my ($class, $socket_fd) = @_;
+    my ($class, $socket_fd, $select_fd) = @_;
     my $self = bless {class => $class}, $class;
     $self->{socket_fd}    = $socket_fd;
+    $self->{select_fd}    = $select_fd;
     $self->{carry_buffer} = '';
     return $self;
 }
@@ -182,6 +183,7 @@ and { matched => 0, string => 'text from the terminal' } on failure.
 sub read_until {
     my ($self, $pattern, $timeout) = @_[0 .. 2];
     my $fd       = $self->{socket_fd};
+    my $sel_fd   = $self->{select_fd} || $fd;
     my %nargs    = @_[3 .. $#_];
     my $buflen   = $nargs{buffer_size} || 4096;
     my $overflow = $nargs{record_output} ? '' : undef;
@@ -197,7 +199,7 @@ sub read_until {
     bmwqemu::log_call(%nargs);
 
     my $rin = '';
-    vec($rin, fileno($fd), 1) = 1;
+    vec($rin, fileno($sel_fd), 1) = 1;
 
   READ: while (1) {
         $loops++;

--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -22,7 +22,7 @@ use English -no_match_vars;
 use Carp 'croak';
 use Scalar::Util 'blessed';
 use Cwd;
-use consoles::virtio_screen ();
+use consoles::serial_screen ();
 use testapi 'get_var';
 
 use base 'consoles::console';
@@ -134,7 +134,7 @@ sub activate {
     my ($self) = @_;
     if (get_var('VIRTIO_CONSOLE')) {
         $self->{socket_fd}              = $self->open_socket unless $self->{socket_fd};
-        $self->{screen}                 = consoles::virtio_screen::->new($self->{socket_fd});
+        $self->{screen}                 = consoles::serial_screen::->new($self->{socket_fd});
         $self->{screen}->{carry_buffer} = $self->{preload_buffer};
         $self->{preload_buffer}         = '';
     }

--- a/testapi.pm
+++ b/testapi.pm
@@ -733,7 +733,8 @@ rely on needles. This sub is not exported by default as most tests I<will not
 benefit> from changing their behaviour depending on if communication happens
 over serial or VNC.
 
-For more info see consoles/virtio_console.pm and consoles/virtio_screen.pm.
+For more info see consoles/virtio_console.pm, consoles/ssh_console.pm and
+consoles/serial_screen.pm.
 
 =cut
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -122,7 +122,9 @@ sub init {
     elsif (get_var('SERIALDEV')) {
         $serialdev = get_var('SERIALDEV');
     }
-    else {
+    elsif (check_var('BACKEND', 'ssh')) {
+        $serialdev = "ssh_fake_serial";
+    } else {
         $serialdev = 'ttyS0';
     }
     return;


### PR DESCRIPTION
It is a first proposal to discuss, if I'm on the right track.

Related ticket: https://progress.opensuse.org/issues/38744

Why do we need a SSH only backend:
We need it in public cloud release chain, to launch openqa tests on an already 
running instance. Only SSH credentials and not CSP framework
credentials get shared between MESH and openQA.

Abstract:
Create a named pipe on SUT. Use it as $testapi::serialdev so exit codes can parsed.
Use a second SSH connection to execute scripts.

Further I would like discuss the following:
* How to log executed scripts and its output
* Could this be used with localXvnc console
* Log kernel messages
* Where should we locate the named pipe

thx for help