### PR TITLE
Override test results if hard serial failure detected

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -332,7 +332,7 @@ sub runalltests {
                     # avoid duplicating the message
                     bmwqemu::diag $msg;
                 }
-                if ($flags->{fatal} || !$snapshots_supported || $bmwqemu::vars{TESTDEBUG}) {
+                if ($flags->{fatal} || $t->{fatal_failure} || !$snapshots_supported || $bmwqemu::vars{TESTDEBUG}) {
                     bmwqemu::stop_vm();
                     return 0;
                 }

--- a/autotest.pm
+++ b/autotest.pm
@@ -295,7 +295,6 @@ sub runalltests {
     my $vmloaded            = 0;
     my $snapshots_supported = query_isotovideo('backend_can_handle', {function => 'snapshots'});
     bmwqemu::diag "Snapshots are " . ($snapshots_supported ? '' : 'not ') . "supported";
-    my $serial_file_pos = 0;
 
     write_test_order();
 
@@ -324,10 +323,7 @@ sub runalltests {
                 make_snapshot($t->{fullname});
             }
 
-            eval {
-                $t->runtest;
-                $serial_file_pos = $t->search_for_expected_serial_failures($serial_file_pos);
-            };
+            eval { $t->runtest; };
             $t->save_test_result();
 
             if ($@) {


### PR DESCRIPTION
Initial mechanism was not good enough for scenarios where test fails
during execution. In case of scenario with kernel bug, test execution
may get affected and commands may time out. In that case serial won't be
parsed at all, there will be no hint and carry over also won't work as
test suite fails in random test modules.
In case of some bugs it doesn't worth it to continue executing test
suite further, even if test module doesn't have fatal flag set.

See [poo#38621](https://progress.opensuse.org/issues/38621).

#### Verification runs
  * [Failure with hard serial failure](http://g226.suse.de/tests/2319#)
  * [Failure with soft serial failure](http://g226.suse.de/tests/2320#)
  * [Soft serial failure](http://g226.suse.de/tests/2321#)
  * [Fatal serial failure](http://g226.suse.de/tests/2324#) (I've removed fatal flag from consoletest_setup)