### PR TITLE
Prevent double timestamps on QEMU command line log entry

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -354,11 +354,11 @@ sub exec_qemu {
             bmwqemu::diag("Collected unknown process with pid " . $p->pid . " and exit status: " . $p->exit_status);
         });
 
+    bmwqemu::diag("starting: " . join(" ", @params));
     session->enable_subreaper;
     $self->_process->code(sub {
             $SIG{__DIE__} = undef;    # overwrite the default - just exit
             system $self->qemu_bin, '-version';
-            bmwqemu::diag("starting: " . join(" ", @params));
             # don't try to talk to the host's PA
             $ENV{QEMU_AUDIO_DRV} = "none";
 


### PR DESCRIPTION
By avoiding nesting calls to Mojo log. This may also prevent error messages
from QEMU being dropped and the command line being truncated.

https://progress.opensuse.org/issues/40046