### PR TITLE
qemu: log that state file is being saved

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -455,6 +455,7 @@ sub save_state {
     my ($self) = @_;
 
     if ($self->has_state) {
+        bmwqemu::fctinfo('Saving QEMU state to ' . STATE_FILE);
         path(STATE_FILE)->spurt($self->serialise_state());
     } else {
         bmwqemu::fctinfo('Refusing to save an empty state file to avoid overwriting a useful one');


### PR DESCRIPTION
May help with debugging problems using snapshots and SKIPTO where it appears
the state file is wrong.