### PR TITLE
Ballooning

### DIFF
--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -103,6 +103,7 @@ QEMU_DUMP_COMPRESS_METHOD;string;xz;The compression to use during a memory dump.
 QEMU_APPEND;string;;Append parameters on qemu command line. The first item will have '-' prepended to it.
 VIRTIO_CONSOLE;boolean;1;Enable/disable virtio console. (@see `-device virtconsole` qemu option)
 VIRTIO_CONSOLE_NUM;integer;1;Number of virtio consoles.
+QEMU_BALLOON_TARGET;integer;undef;The target guest RAM usage before a snapshot is taken. It is intended to speed up snapshots by forcing the guest to drop various caches. Setting this enables the virtio-balloon device which requires a kernel with a virtio-balloon driver. Setting this far below the RAM required by the guest will probably cause the guest to panic or deadlock. However it should be able to cope with it being set slightly below what is needed.
 RAIDLEVEL;;;
 SKIPTO;full name of test module;;Restore VM from snapshot and continue by running specified test module. Needs HDD image with snapshots present
 TAPDEV;device name;undef;TAP device name to which virtual NIC should be connected. Usually undef so automatic matching is used


### PR DESCRIPTION
Built on top of #1018 this allows the user to set a balloon target before a snapshot is called. In theory this should force the guest kernel to give up some RAM and make the snapshots smaller. In practice the snapshots don't appear to get any smaller although it seems there is some performance improvement taking the snapshot.