### PR TITLE
[sshXtermIPMI] Overrides reset function for ipmi console

### DIFF
--- a/consoles/sshXtermIPMI.pm
+++ b/consoles/sshXtermIPMI.pm
@@ -34,9 +34,19 @@ sub activate {
     my @command = $self->backend->ipmi_cmdline;
     push(@command, qw(sol activate));
     my $serial = $self->{args}->{serial};
-
     my $cstr = join(' ', @command);
     $self->callxterm($cstr, "ipmitool:$testapi_console");
+}
+
+sub reset {
+    my ($self) = @_;
+
+    # Deactivate sol connection if it is activated
+    if ($self->{activated}) {
+        $self->backend->ipmitool("sol deactivate");
+        $self->{activated} = 0;
+    }
+    return;
 }
 
 1;


### PR DESCRIPTION
Make sure sol connection is deactivated after reset (rest_consoles) operation, which  guarantees it is successful for sol connecting again.

    Related ticket:
    poo#40544

    Verification run:
    test on super-micro machine : http://10.67.19.191/tests/209
    test on dell machine : http://10.67.19.191/tests/201
    test for xen on dell machine: http://10.67.132.86/tests/170
