### PR TITLE
Add hard_reset API to the console sshXtermVt

### DIFF
--- a/consoles/sshXtermVt.pm
+++ b/consoles/sshXtermVt.pm
@@ -61,4 +61,10 @@ sub kill_ssh {
     $self->backend->stop_ssh_serial;
 }
 
+# be be called when normal reboot is no avaiable
+sub hard_reset {
+    my ($self) = @_;
+    $self->backend->restart_host;
+}
+
 1;


### PR DESCRIPTION
When using ipmi backend , installation will performed in ssh-root console which need ssh.
(also installation will reboot in himself)
prepare_system_shutdown function will break this connection ,  which break the reboot .

reboot should not triggered in installation self, use this api after prepare_system_shutdown.