### PR TITLE
Fix pseudo encoding -261

### DIFF
--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -945,7 +945,7 @@ sub _receive_update {
         #bmwqemu::diag "UP $x,$y $w x $h $encoding_type";
 
         # work around buggy addrlink VNC
-        next if ($w * $h == 0);
+        next if $encoding_type > 0 && $w * $h == 0;
 
         my $bytes_per_pixel = $self->_bpp / 8;
 


### PR DESCRIPTION
qemu supports 'led state' through this pseudo encoding, but if we claim
we support -261 other vnc servers like tigervnc send us wildly encoded
PNG because they don't support led state (or if they do under a different
pseudo encoding)

As we only supported it to get some debug in the log (hoping to notice
kernel panics), we can easily remove it without loosing functionality
and tigervnc works again