### PR TITLE
Use here tag in script_out

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -213,8 +213,8 @@ sub script_output {
         testapi::wait_serial($self->{serial_term_prompt}, undef, 0, no_regex => 1);
         testapi::type_string($cat . "\n");
         testapi::wait_serial("$cat", undef, 0, no_regex => 1);
-        testapi::type_string($script);
-        testapi::type_string("\n$heretag\n");
+        testapi::type_string("$script\n$heretag\n");
+        testapi::wait_serial("> $heretag", undef, 0, no_regex => 1);
         testapi::wait_serial("$marker-0-");
     }
     elsif ($args{type_command}) {

--- a/distribution.pm
+++ b/distribution.pm
@@ -208,12 +208,13 @@ sub script_output {
     }
 
     if (testapi::is_serial_terminal) {
-        my $cat = "cat - > $script_path; echo $marker-\$?-";
+        my $heretag = 'EOT_' . $marker;
+        my $cat     = "cat > $script_path << '$heretag'; echo $marker-\$?-";
         testapi::wait_serial($self->{serial_term_prompt}, undef, 0, no_regex => 1);
         testapi::type_string($cat . "\n");
         testapi::wait_serial("$cat", undef, 0, no_regex => 1);
         testapi::type_string($script);
-        testapi::type_string("\n", terminate_with => 'EOT');
+        testapi::type_string("\n$heretag\n");
         testapi::wait_serial("$marker-0-");
     }
     elsif ($args{type_command}) {


### PR DESCRIPTION
Use the "cat > FILE << 'HERE_TAG'" approach to write the script.
The here tag is build from 'EOT_' plus the marker, this
should make collisions less possible with the
content of the script itself.

Related ticket: https://progress.opensuse.org/issues/40913
Testrun: http://cfconrad-vm.qa.suse.de/tests/1008