### PR TITLE
testapi: Relax regex in script_output filter out what to return

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -259,7 +259,7 @@ sub script_output {
     }
 
     # and the markers including internal exit catcher
-    my $out = $output =~ /$marker(?<expected_output>.+)SCRIPT_FINISHED$marker-0-/s ? $+ : '';
+    my $out = $output =~ /$marker(?<expected_output>.+)SCRIPT_FINISHED$marker-\d+-/s ? $+ : '';
     # trim whitespaces
     $out =~ s/^\s+|\s+$//g;
     return $out;

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -340,7 +340,7 @@ sub script_output_test {
     is(script_output('echo foo'), 'foo', 'script_output return only the actual output of the script');
 
     $mock_testapi->mock(wait_serial => sub { return "XXXfoo\nSCRIPT_FINISHEDXXX-1-" });
-    is(script_output('echo foo', undef, proceed_on_failure => 1), '', 'proceed_on_failure=1 retrieves empty string and do not die');
+    is(script_output('echo foo', undef, proceed_on_failure => 1), 'foo', 'proceed_on_failure=1 retrieves retrieves output of script and do not die');
 
     $mock_testapi->mock(wait_serial => sub { return 'none' if (shift !~ m/SCRIPT_FINISHEDXXX-\\d\+-/) });
     like(exception { script_output('timeout'); }, qr/timeout/, 'die expected with timeout');


### PR DESCRIPTION
Initially script_output was designed to return output only
from commands which pass ( return zero ). Later proceed_on_failure flag was introduced
This patch fixing last place which not allow to return
command output when command finished with non-zero result