### PR TITLE
Set script when using extra test results

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -465,7 +465,10 @@ sub register_extra_test_results {
     my ($self, $tests) = @_;
 
     $self->{extra_test_results} //= [];
-    push @{$self->{extra_test_results}}, @$tests;
+    foreach my $t (@{$tests}) {
+        $t->{script} = $self->{script} if (!defined($t->{script}) || $t->{script} eq 'unk');
+        push @{$self->{extra_test_results}}, $t;
+    }
     return;
 }
 

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -135,4 +135,36 @@ subtest record_testresult => sub {
     is(scalar @{$basetest->{details}}, 8, '8 details added');
 };
 
+subtest 'register_extra_test_results' => sub {
+    my $test = basetest->new('foo');
+    $test->{script} = '/tests/foo/bar.pm';
+
+    my $extra_tests = [
+        {
+            category => 'foo',
+            name     => 'extra1',
+            flags    => {},
+            script   => 'unk'
+        },
+        {
+            category => 'foo',
+            name     => 'extra2',
+            flags    => {},
+            script   => '/test/foo/baz.pm'
+        },
+        {
+            category => 'foo',
+            name     => 'extra3',
+            flags    => {},
+            script   => undef
+        }
+    ];
+
+    $test->register_extra_test_results($extra_tests);
+    is(@{$test->{extra_test_results}},             @{$extra_tests},             'add extra test results');
+    is($test->{extra_test_results}->[0]->{script}, $test->{script},             'unknown script is replaced with self->{script}.');
+    is($test->{extra_test_results}->[1]->{script}, $extra_tests->[1]->{script}, 'existing script is untouched.');
+    is($test->{extra_test_results}->[2]->{script}, $test->{script},             'undefined script is replaced with self->{script}.');
+};
+
 done_testing;


### PR DESCRIPTION
When using parse_extra_log(), the "test-module-links" in details
ui view pointing to 404.
This happens cause the Parser do not know to which test-module
the extra-log corresponding to.
Patch the script value, when the extra-test is added to the
basetest.

Testrun: http://cfconrad-vm.qa.suse.de/tests/1558
