### PR TITLE
Avoid misleading stacktrace when backend dies

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -77,7 +77,7 @@ sub handle_command {
 
 sub die_handler {
     my $msg = shift;
-    cluck "DIE $msg\n";
+    bmwqemu::diag "Backend process died, backend errors are reported below in the following lines $msg";
     $backend->stop_vm();
     $backend->close_pipes();
 }


### PR DESCRIPTION
Whenever a VM fails to start, or a command fails to be executed, the
stacktrace comes before any other possible messages are shown, often
misleading when reading logs