### PR TITLE
Reset serial console to ttyAMA0 for aarch64 test

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -125,6 +125,7 @@ sub init {
         $serialdev = 'ttyS0';
     }
     $serialdev = 'ttyS1' if check_var('BACKEND', 'ipmi');
+    $serialdev = 'ttyAMA0' if check_var('ARCH', 'aarch64');
     return;
 }
 


### PR DESCRIPTION
Reset serial console to ttyAMA0 for aarch64 test

    Related ticket: Virtualization Test
    Needles: n/a
    Verification run: http://10.162.187.154/tests/78

@alice-suse @XGWang0 @xguo @Julie-CAO