### PR TITLE
Avoid overriding SERIALDEV obtained from testsuite or machine settings

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -125,6 +125,7 @@ sub init {
         $serialdev = 'ttyS0';
     }
     $serialdev = 'ttyS1' if check_var('BACKEND', 'ipmi');
+    $serialdev = 'ttyAMA0' if check_var('ARCH', 'aarch64');
     return;
 }
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -115,15 +115,17 @@ Used for internal initialization, do not call from tests.
 =cut
 
 sub init {
-    $serialdev = 'ttyS1' if check_var('BACKEND', 'ipmi');
-    if (get_var('SERIALDEV')) {
-        $serialdev = get_var('SERIALDEV');
+    if (check_var('BACKEND', 'ipmi')) {
+	$serialdev = 'ttyS1';
     }
     elsif (get_var('OFW') || check_var('BACKEND', 's390x')) {
         $serialdev = "hvc0";
     }
+    elsif (get_var('SERIALDEV')) {
+        $serialdev = get_var('SERIALDEV');
+    }
     else {
-        $serialdev = 'ttyS0';
+	$serialdev = 'ttyS0';
     }
     return;
 }

--- a/testapi.pm
+++ b/testapi.pm
@@ -115,10 +115,7 @@ Used for internal initialization, do not call from tests.
 =cut
 
 sub init {
-    if (check_var('BACKEND', 'ipmi')) {
-        $serialdev = 'ttyS1';
-    }
-    elsif (get_var('OFW') || check_var('BACKEND', 's390x')) {
+    if (get_var('OFW') || check_var('BACKEND', 's390x')) {
         $serialdev = "hvc0";
     }
     elsif (get_var('SERIALDEV')) {

--- a/testapi.pm
+++ b/testapi.pm
@@ -115,6 +115,7 @@ Used for internal initialization, do not call from tests.
 =cut
 
 sub init {
+    $serialdev = 'ttyS1' if check_var('BACKEND', 'ipmi');
     if (get_var('SERIALDEV')) {
         $serialdev = get_var('SERIALDEV');
     }
@@ -124,8 +125,6 @@ sub init {
     else {
         $serialdev = 'ttyS0';
     }
-    $serialdev = 'ttyS1' if check_var('BACKEND', 'ipmi');
-    $serialdev = 'ttyAMA0' if check_var('ARCH', 'aarch64');
     return;
 }
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -116,7 +116,7 @@ Used for internal initialization, do not call from tests.
 
 sub init {
     if (check_var('BACKEND', 'ipmi')) {
-	$serialdev = 'ttyS1';
+        $serialdev = 'ttyS1';
     }
     elsif (get_var('OFW') || check_var('BACKEND', 's390x')) {
         $serialdev = "hvc0";
@@ -125,7 +125,7 @@ sub init {
         $serialdev = get_var('SERIALDEV');
     }
     else {
-	$serialdev = 'ttyS0';
+        $serialdev = 'ttyS0';
     }
     return;
 }


### PR DESCRIPTION
If different SERIALDEV setting is given through testsuite or machine, whose value will be overriden by the last assignment operation in this function. So move it to the beginning. 

