### PR TITLE
Ensure main.pm is still used for proper initialization on SCHEDULE

### DIFF
--- a/isotovideo
+++ b/isotovideo
@@ -224,11 +224,12 @@ unshift @INC, $bmwqemu::vars{CASEDIR} . '/lib';
 if ($bmwqemu::vars{SCHEDULE}) {
     diag 'Enforced test schedule by \'SCHEDULE\' variable in action';
     autotest::loadtest($_ . '.pm') foreach split(',', $bmwqemu::vars{SCHEDULE});
+    $bmwqemu::vars{INCLUDE_MODULES} = 'none';
 }
-elsif (-e $bmwqemu::vars{PRODUCTDIR} . '/main.pm') {
+if (-e $bmwqemu::vars{PRODUCTDIR} . '/main.pm') {
     require $bmwqemu::vars{PRODUCTDIR} . '/main.pm';
 }
-else {
+elsif (!$bmwqemu::vars{SCHEDULE}) {
     die '\'SCHEDULE\' not set and ' . $bmwqemu::vars{PRODUCTDIR} . '/main.pm not found, need one of both';
 }
 @INC = @oldINC;


### PR DESCRIPTION
For os-autoinst-distri-opensuse the main.pm does the initialization of the
distribution which we need to execute most of the test modules successfully.
When defining the schedule using the test variable SCHEDULE we therefore need
to load the main.pm but ignore all "loadtest" calls in there.

Verification run: http://lord.arch/tests/1886