### PR TITLE
qemu: virtio terminal is enabled by default

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -505,6 +505,10 @@ sub start_qemu {
 
     local *sp = sub { $self->{proc}->static_param(@_); };
 
+    if ($vars->{VIRTIO_CONSOLE} ne 0) {
+        $vars->{VIRTIO_CONSOLE} = 1;
+    }
+
     unless ($qemubin) {
         if ($vars->{QEMU}) {
             $qemubin = find_bin('/usr/bin/', 'qemu-system-' . $vars->{QEMU});

--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -23,7 +23,7 @@ use Carp 'croak';
 use Scalar::Util 'blessed';
 use Cwd;
 use consoles::virtio_screen ();
-use testapi 'get_var';
+use testapi 'check_var';
 
 use base 'consoles::console';
 
@@ -132,14 +132,14 @@ sub open_socket {
 
 sub activate {
     my ($self) = @_;
-    if (get_var('VIRTIO_CONSOLE')) {
+    if (!check_var('VIRTIO_CONSOLE', 0)) {
         $self->{socket_fd}              = $self->open_socket unless $self->{socket_fd};
         $self->{screen}                 = consoles::virtio_screen::->new($self->{socket_fd});
         $self->{screen}->{carry_buffer} = $self->{preload_buffer};
         $self->{preload_buffer}         = '';
     }
     else {
-        croak 'VIRTIO_CONSOLE is not set, so no virtio-serial and virtconsole devices will be available to use with this console.';
+        croak 'VIRTIO_CONSOLE is set 0, so no virtio-serial and virtconsole devices will be available to use with this console.';
     }
     return;
 }


### PR DESCRIPTION
Before virtio console required variable VIRTIO_CONSOLE=1.
Now it's enabled by default, tests requiring it switch off need to set
variable NO_VIRTIO_CONSOLE=1.