### PR TITLE
Add serial console for svirt backend

### DIFF
--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -49,6 +49,7 @@ sub do_start_vm {
         'ssh-virtsh',
         {
             hostname => get_required_var('VIRSH_HOSTNAME'),
+            username => get_var('VIRSH_USERNAME'),
             password => get_var('VIRSH_PASSWORD'),
         });
 

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -51,7 +51,11 @@ sub activate {
 
     my $hostname = $args->{hostname} || die('we need a hostname to ssh to');
     my $password = $args->{password};
-    $self->{ssh} = $self->backend->new_ssh_connection(hostname => $hostname, password => $password);
+    $self->{ssh} = $self->backend->new_ssh_connection(
+        username => $args->{username},
+        hostname => $hostname,
+        password => $password,
+    );
     if ($self->vmm_family eq 'vmware') {
         $self->{sshVMwareServer} = $self->backend->new_ssh_connection(
             hostname => get_required_var('VMWARE_SERVER'),

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -246,7 +246,9 @@ sub add_vnc {
     $graphics->setAttribute(autoport    => 'no');
     $graphics->setAttribute(listen      => '0.0.0.0');
     $graphics->setAttribute(sharePolicy => 'force-shared');
-    $graphics->setAttribute(passwd      => $testapi::password);
+    if (my $vnc_password = $testapi::password) {
+        $graphics->setAttribute(passwd => $vnc_password);
+    }
     $devices->appendChild($graphics);
 
     my $elem = $doc->createElement('listen');

--- a/consoles/sshVirtshSUT.pm
+++ b/consoles/sshVirtshSUT.pm
@@ -1,0 +1,65 @@
+# Copyright © 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package consoles::sshVirtshSUT;
+use base 'consoles::console';
+use strict;
+use warnings;
+use testapi 'get_var';
+use consoles::virtio_screen;
+
+sub new {
+    my ($class, $testapi_console, $args) = @_;
+
+    my $self = $class->SUPER::new($testapi_console, $args);
+    $self->{libvirt_domain} = $args->{libvirt_domain} // 'openQA-SUT-1';
+    $self->{serial_port_no} = $args->{serial_port_no} // 1;
+    return $self;
+}
+
+sub screen {
+    my ($self) = @_;
+    return $self->{screen};
+}
+
+sub disable {
+    my ($self) = @_;
+
+    if (my $shell = $self->{shell}) {
+        $shell->close();
+    }
+    if (my $ssh = $self->{ssh}) {
+        $ssh->disconnect;
+        $self->{ssh} = $self->{chan} = $self->{screen} = undef;
+    }
+    return;
+}
+
+sub activate {
+    my ($self) = @_;
+
+    my $backend = $self->{backend};
+    my ($ssh, $chan) = $backend->open_serial_console_via_ssh($self->{libvirt_domain}, $self->{serial_port_no});
+
+    $self->{ssh} = $ssh;
+    $self->{screen} = consoles::virtio_screen->new($chan, $ssh->sock);
+    return;
+}
+
+sub is_serial_terminal {
+    return 1;
+}
+
+1;

--- a/consoles/virtio_screen.pm
+++ b/consoles/virtio_screen.pm
@@ -23,9 +23,10 @@ use Carp 'croak';
 our $VERSION;
 
 sub new {
-    my ($class, $socket_fd) = @_;
+    my ($class, $socket_fd, $select_fd) = @_;
     my $self = bless {class => $class}, $class;
     $self->{socket_fd}    = $socket_fd;
+    $self->{select_fd}    = $select_fd;
     $self->{carry_buffer} = '';
     return $self;
 }
@@ -182,6 +183,7 @@ and { matched => 0, string => 'text from the terminal' } on failure.
 sub read_until {
     my ($self, $pattern, $timeout) = @_[0 .. 2];
     my $fd       = $self->{socket_fd};
+    my $sel_fd   = $self->{select_fd} || $fd;
     my %nargs    = @_[3 .. $#_];
     my $buflen   = $nargs{buffer_size} || 4096;
     my $overflow = $nargs{record_output} ? '' : undef;
@@ -197,7 +199,7 @@ sub read_until {
     bmwqemu::log_call(%nargs);
 
     my $rin = '';
-    vec($rin, fileno($fd), 1) = 1;
+    vec($rin, fileno($sel_fd), 1) = 1;
 
   READ: while (1) {
         $loops++;

--- a/cpanfile
+++ b/cpanfile
@@ -63,6 +63,7 @@ on 'test' => sub {
   requires 'Test::Warnings';
   requires 'Test::Exception';
   requires 'Socket::MsgHdr';
+  requires 'XML::SemanticDiff';
 };
 
 feature 'coverage', 'coverage for travis' => sub {

--- a/distribution.pm
+++ b/distribution.pm
@@ -51,16 +51,17 @@ sub add_console {
     my ($self, $testapi_console, $backend_console, $backend_args) = @_;
 
     my %class_names = (
-        'tty-console'     => 'ttyConsole',
-        'ssh-xterm'       => 'sshXtermVt',
-        'ssh-virtsh'      => 'sshVirtsh',
-        'vnc-base'        => 'vnc_base',
-        'local-Xvnc'      => 'localXvnc',
-        'ssh-iucvconn'    => 'sshIucvconn',
-        'virtio-terminal' => 'virtio_terminal',
-        'amt-sol'         => 'amtSol',
-        'ipmi-sol'        => 'ipmiSol',
-        'ipmi-xterm'      => 'sshXtermIPMI',
+        'tty-console'       => 'ttyConsole',
+        'ssh-xterm'         => 'sshXtermVt',
+        'ssh-virtsh'        => 'sshVirtsh',
+        'ssh-virtsh-serial' => 'sshVirtshSUT',
+        'vnc-base'          => 'vnc_base',
+        'local-Xvnc'        => 'localXvnc',
+        'ssh-iucvconn'      => 'sshIucvconn',
+        'virtio-terminal'   => 'virtio_terminal',
+        'amt-sol'           => 'amtSol',
+        'ipmi-sol'          => 'ipmiSol',
+        'ipmi-xterm'        => 'sshXtermIPMI',
     );
     my $required_type = $class_names{$backend_console} || $backend_console;
     my $location      = "consoles/$required_type.pm";

--- a/doc/backends.md
+++ b/doc/backends.md
@@ -1,0 +1,49 @@
+# Backends in openQA
+OpenQA (or actually os-autoinst) supports multiple backends to run the SUT.
+This document is meant to describe their particularities. So far only svirt
+is covered, though.
+
+For backend specific variables, there is a [separate documentation](backend_vars.asciidoc).
+
+## svirt
+This backend establishes an SSH connection to another machine to start there
+a virtual machine using libvirt/virsh which uses QEMU, Xen, Hyper-V or VMWare
+under the hood.
+
+### Local setup
+Simply configure it to connect to the local machine and install libvirt/virsh.
+
+#### Worker configuration
+Example configuration for using QEMU under the hood (add to `$OPENQA_CONFIG/workers.ini`):
+```
+[2]
+BACKEND=svirt
+VIRSH_HOSTNAME=127.0.0.1 # use our own machine as svirt host
+VIRSH_USERNAME=root # see notes
+VIRSH_CMDLINE=ifcfg=dhcp
+VIRSH_MAC=52:54:00:12:34:56
+VIRSH_OPENQA_BASEDIR=/var/lib # set in accordance with OPENQA_BASEDIR (by default /var/lib)
+WORKER_CLASS=svirt,svirt-kvm
+VIRSH_INSTANCE=1
+#VIRSH_PASSWORD=# see notes
+VIRSH_GUEST=127.0.0.1
+VIRSH_VMM_FAMILY=kvm
+VIRSH_VMM_TYPE=hvm
+```
+
+##### Notes
+To allow an SSH connection to your local machine, either put your (root) password
+in the worker configuration or add your key to `$HOME/.ssh/authorized_keys`.
+
+#### libvirt configuration
+Packages to install and services to start (example for openSUSE):
+```
+zypper in libvirt-client libvirt-daemon libvirt-daemon-driver-interface libvirt-daemon-driver-qemu libvirt-daemon-qemu
+zypper in virt-manager # a GUI for libvirt, not really required for openQA but sometimes still useful
+systemctl start libvirtd sshd
+```
+
+Otherwise there is no configuration required. The test will configure libvirt on its
+own. By default, the openSUSE test distribution uses the domain name `openQA-SUT-1`.
+So you can for instance use `virsh dumpxml openQA-SUT-1` to investigate the configuration
+of the running virtual machine.

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -1,0 +1,81 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More;
+use Test::MockModule;
+use Test::Warnings;
+use Test::Output 'stderr_like';
+use XML::SemanticDiff;
+use backend::svirt;
+use distribution;
+use testapi qw(get_var get_required_var check_var set_var);
+
+BEGIN {
+    unshift @INC, '..';
+}
+
+set_var(WORKER_HOSTNAME => 'foo');
+set_var(VIRSH_HOSTNAME  => 'bar');
+set_var(VIRSH_PASSWORD  => 'password');
+
+my $distri = $testapi::distri = distribution->new();
+my $svirt = backend::svirt->new();
+
+is_deeply($svirt->read_credentials_from_virsh_variables, {
+        hostname => 'bar',
+        username => 'root',
+        password => 'password',
+}, 'read credentials');
+
+$svirt->do_start_vm;
+$distri->add_console('sut-serial', 'ssh-virtsh-serial', {});
+
+my $consoles          = $distri->{consoles};
+my $svirt_console     = $consoles->{svirt};
+my $svirt_sut_console = $consoles->{'sut-serial'};
+
+subtest 'svirt console correctly initialized' => sub {
+    ok($svirt_console);
+    is($svirt_console->{class},           'consoles::sshVirtsh');
+    is($svirt_console->{backend},         $svirt);
+    is($svirt_console->{name},            'openQA-SUT-1');
+    is($svirt_console->{testapi_console}, 'svirt');
+    is($svirt_console->{instance},        1);
+    is($svirt_console->{vmm_family},      'kvm');
+    is($svirt_console->{vmm_type},        'hvm');
+};
+
+is_deeply($svirt_sut_console, {
+        activated       => 0,
+        args            => {},
+        class           => 'consoles::sshVirtshSUT',
+        libvirt_domain  => 'openQA-SUT-1',
+        serial_port_no  => 1,
+        testapi_console => 'sut-serial',
+}, 'SUT serial console correctly initialized') or diag explain $consoles;
+
+subtest 'XML config for VNC and serial console' => sub {
+    $svirt_console->_init_xml();
+    $svirt_console->add_vnc({port => 5901});
+    $svirt_console->add_pty({target_port => 0});
+    $svirt_console->add_serial_console();
+
+    my $produced_xml = $svirt_console->{domainxml}->toString(2);
+    my $expected_xml = '22-svirth-virsh-config.xml';
+    $expected_xml = 't/' . $expected_xml unless (-f $expected_xml);
+
+    my $diff = XML::SemanticDiff->new(keeplinenums => 1);
+    if (my @changes = $diff->compare($produced_xml, $expected_xml)) {
+        fail('XML not as expected');
+        note('differences:');
+        diag explain \@changes;
+        note('produced XML:');
+        note($produced_xml);
+    }
+    else {
+        ok('XML looks as expected');
+    }
+};
+
+done_testing;

--- a/t/22-svirth-virsh-config.xml
+++ b/t/22-svirth-virsh-config.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!-- basic virsh config for KVM with VNC serial console and additional serial console -->
+<domain type="kvm">
+  <name>openQA-SUT-1</name>
+  <description>openQA Instance 1</description>
+  <memory unit="MiB">1024</memory>
+  <vcpu>1</vcpu>
+  <os>
+    <type>hvm</type>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>
+  <on_reboot>destroy</on_reboot>
+  <devices>
+    <graphics type="vnc"  port="5901" autoport="no" listen="0.0.0.0" sharePolicy="force-shared">
+      <listen type="address" address="0.0.0.0"/>
+    </graphics>
+    <console type="pty">
+      <target port="0"/>
+    </console>
+    <serial type="pty">
+      <target port="1"/>
+      <alias name="serial1"/>
+    </serial>
+  </devices>
+</domain>


### PR DESCRIPTION
Allows to add an additional serial console (beside the one used for the serial log) when using the svirt backend.

<s>Still WIP, see https://progress.opensuse.org/issues/36457#note-21</s> see latest comments