### PR TITLE
svirt/Xen: Expect the image to be located on the svirt host

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -320,7 +320,6 @@ sub add_disk {
         my $dir = "/var/lib/libvirt/images";
         die "No file given" unless $args->{file};
         if ($args->{cdrom} or $args->{backingfile}) {
-            die "File $args->{file} not readable" unless -r $args->{file};
             $self->run_cmd(sprintf("rsync -av '$args->{file}' '${dir}/%s'", basename($args->{file}))) && die 'rsync failed';
         }
         if ($args->{backingfile}) {


### PR DESCRIPTION
rather than on the worker

See https://progress.opensuse.org/issues/32281

---

required for https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6191