### PR TITLE
Add option to override status of test modules with soft-fail

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -452,10 +452,10 @@ sub record_serialresult {
 }
 
 sub record_soft_failure_result {
-    my ($self, $reason) = @_;
+    my ($self, $reason, %args) = @_;
     $reason //= '(no reason specified)';
 
-    my $result = $self->record_testresult('softfail');
+    my $result = $self->record_testresult('softfail', %args);
     my $output = "# Soft Failure:\n$reason\n";
     $self->record_resultfile('Soft Failed', $output, %$result);
     return;
@@ -477,7 +477,7 @@ test details and returns it.
 =cut
 
 sub record_testresult {
-    my ($self, $result) = @_;
+    my ($self, $result, %args) = @_;
     $result //= 'unk';
 
     # assign result as overall result unless it is already worse
@@ -486,7 +486,7 @@ sub record_testresult {
         $$current_result = 'fail';
     }
     elsif ($result eq 'softfail') {
-        if (!$$current_result || $$current_result ne 'fail') {
+        if (!$$current_result || $$current_result ne 'fail' || $args{force_status}) {
             $$current_result = 'softfail';
         }
     }

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -131,8 +131,12 @@ subtest record_testresult => sub {
     is_deeply(basetest::record_testresult($basetest), {result => 'unk'}, 'adding one more "unk" result');
     is($basetest->{result}, 'fail', 'test result is still "fail"');
 
-    is($basetest->{test_count},        8, 'test_count accumulated');
-    is(scalar @{$basetest->{details}}, 8, '8 details added');
+    is_deeply(basetest::record_testresult($basetest, 'softfail', force_status => 1), {result => 'softfail'}, 'adding one more "softfail" result but forcing the status');
+    is($basetest->{result}, 'softfail', 'test result was forced to "softfail"');
+
+    my $nr_test_details = 9;
+    is($basetest->{test_count},        $nr_test_details, 'test_count accumulated');
+    is(scalar @{$basetest->{details}}, $nr_test_details, 'all details added');
 };
 
 done_testing;


### PR DESCRIPTION
This allows to mark a failing test as a "known issue" from a
post_fail_hook, for example when the post_fail_hook executes a generic
method to investigate failures.

https://github.com/os-autoinst/openQA/pull/1837 is the according
proposal to extend the actual definition of "soft-fail".

Related progress issue: https://progress.opensuse.org/issues/39719