### PR TITLE
Remove extra leading zero from log timestamps

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -130,7 +130,7 @@ sub init {
             my ($time, $level, @lines) = @_;
             # Unfortunately $time doesn't have the precision we want. So we need to use Time::HiRes
             $time = gettimeofday;
-            return sprintf(strftime("[%FT%T.%%04d %Z] [$level] ", localtime($time)), 1000 * ($time - int($time))) . join("\n", @lines, '');
+            return sprintf(strftime("[%FT%T.%%03d %Z] [$level] ", localtime($time)), 1000 * ($time - int($time))) . join("\n", @lines, '');
 
         });
 }
@@ -190,7 +190,7 @@ sub log_format_callback {
     my ($time, $level, @lines) = @_;
     # Unfortunately $time doesn't have the precision we want. So we need to use Time::HiRes
     $time = gettimeofday;
-    return sprintf(strftime("[%FT%T.%%04d %Z] [$level] ", localtime($time)), 1000 * ($time - int($time))) . join("\n", @lines, '');
+    return sprintf(strftime("[%FT%T.%%03d %Z] [$level] ", localtime($time)), 1000 * ($time - int($time))) . join("\n", @lines, '');
 }
 
 sub diag {

--- a/commands.pm
+++ b/commands.pm
@@ -300,7 +300,7 @@ sub run_daemon {
             my ($time, $level, @lines) = @_;
             # Unfortunately $time doesn't have the precision we want. So we need to use Time::HiRes
             $time = gettimeofday;
-            return sprintf(strftime("[%FT%T.%%04d %Z] [$level] ", localtime($time)), 1000 * ($time - int($time))) . join("\n", @lines, '');
+            return sprintf(strftime("[%FT%T.%%03d %Z] [$level] ", localtime($time)), 1000 * ($time - int($time))) . join("\n", @lines, '');
         });
 
     # process json messages from isotovideo


### PR DESCRIPTION
The millisecond resolution timestamp has at most 3 digits, no need to
make the field 4 digits wide.