### PR TITLE
[remoteVnc] Override reset method for remoteVnc

### DIFF
--- a/consoles/remoteVnc.pm
+++ b/consoles/remoteVnc.pm
@@ -38,6 +38,16 @@ sub activate {
         });
 }
 
+sub reset {
+    my ($self) = @_;
+
+    if ($self->{activated}) {
+        $self->SUPER::disable();
+        $self->{activated} = 0;
+    }
+    return;
+}
+
 # override
 sub select {
 }


### PR DESCRIPTION
Ensure `remoteVnc` connection is disconnected/disabled when `->reset()` is called (reset_consoles), to prevent backend crashes when connected to certain hardware manufacturers.

Crash: http://mango.suse.de/tests/596
Verification Run: http://mango.suse.de/tests/600
Backend: IPMI
Server: Dell PowerEdge R640

This is a follow up to https://github.com/os-autoinst/os-autoinst/pull/1021, which performed a similar fix on `sshXtermIPMI`.