### PR TITLE
Use video captions to overlay wallclock time

### DIFF
--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -1,0 +1,37 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More;
+use Test::MockModule;
+use Test::Warnings;
+use backend::baseclass;
+use POSIX 'tzset';
+
+BEGIN {
+    unshift @INC, '..';
+}
+
+# make the test time-zone neutral
+$ENV{TZ} = 'UTC';
+tzset;
+
+my $baseclass = backend::baseclass->new();
+
+subtest 'format_vtt_timestamp' => sub {
+    my $timestamp = 1543917024;
+
+    $baseclass->{video_frame_number} = 0;
+    is($baseclass->format_vtt_timestamp($timestamp),
+        "\n0\n00:00:00.000 --> 00:00:00.041\n[2018-12-04T09:50:24.000]\n",
+        'frame number 0'
+    );
+
+    $baseclass->{video_frame_number} = 1;
+    is($baseclass->format_vtt_timestamp($timestamp),
+        "\n1\n00:00:00.041 --> 00:00:00.083\n[2018-12-04T09:50:24.000]\n",
+        'frame number 1'
+    );
+};
+
+done_testing;


### PR DESCRIPTION
Although durations and absolute time can be somewhat derived using the
framerate (it is captured with nominally 2 fps), this is cumbersome and
not always correct. There are occasional frame drops due to stalls or long
running screen matches, especially on e.g. aarch64.

Create a caption file which shows the same time stamps as the autoinst.log,
these can be overlaid over the actual video.

See poo#42050 for details.