### PR TITLE
qemu: Enhance QEMU_APPEND option to handle multiple options

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -851,7 +851,13 @@ sub start_qemu {
 
     # Add parameters from QEMU_APPEND var, if any.
     # The first item will have '-' prepended to it.
-    sp("$vars->{QEMU_APPEND}") if $vars->{QEMU_APPEND};
+    if ($vars->{QEMU_APPEND}) {
+        # Split multiple options, if needed
+        my @spl = split(' -', $vars->{QEMU_APPEND});
+        foreach my $i (@spl) {
+            sp(split(' ', $i));
+        }
+    }
 
     $self->{qemupipe}  = $self->{proc}->exec_qemu();
     $self->{qmpsocket} = $self->{proc}->connect_qmp();


### PR DESCRIPTION
with or without params

Tested locally with os-autoinst with:
* no QEMU_APPEND in vars.json
* QEMU_APPEND with a single option
* QEMU_APPEND with 2 options: 1 without param, 1 with a single param