### PR TITLE
Include full folder hierachy in category name

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -98,11 +98,7 @@ sub loadtest {
     my ($script, %args) = @_;
     my $casedir     = $bmwqemu::vars{CASEDIR};
     my $script_path = find_script($script);
-    unless ($script_path =~ m,(\w+)/([^/]+)\.pm$,) {
-        die "loadtest: script path '$script_path' does not match required pattern \\w.+/[^/]+.pm\n";
-    }
-    my $category = $1;
-    my $name     = $2;
+    my ($name, $category) = parse_test_path($script_path);
     my $test;
     my $fullname = "$category-$name";
     # perl code generating perl code is overcool
@@ -152,6 +148,23 @@ our $current_test;
 our $selected_console;
 our $last_milestone;
 our $last_milestone_console;
+
+sub parse_test_path {
+    my ($script_path) = @_;
+    unless ($script_path =~ m,(\w+)/([^/]+)\.pm$,) {
+        die "loadtest: script path '$script_path' does not match required pattern \\w.+/[^/]+.pm\n";
+    }
+    my $category = $1;
+    my $name     = $2;
+    if ($category ne 'other') {
+        # show full folder hierachy as category for non-sideloaded tests
+        my $pattern = qr,(tests/[^/]+/)?tests/([\w/]+)/([^/]+)\.pm$,;
+        if ($script_path =~ $pattern) {
+            $category = $2;
+        }
+    }
+    return ($name, $category);
+}
 
 sub set_current_test {
     ($current_test) = @_;

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -240,6 +240,11 @@ is(@{$autotest::tests{'tests-fatal'}}{@opts}, @{$autotest::tests{'tests-fatal' .
   && is(@{$autotest::tests{'tests-fatal' . $_}}{name}, 'fatal#' . $_)
   for 1 .. 10;
 
+my $sharedir = '/home/tux/.local/lib/openqa/share';
+is(autotest::parse_test_path("$sharedir/tests/sle/tests/x11/firefox.pm"),        ('firefox', 'x11'));
+is(autotest::parse_test_path("$sharedir/tests/sle/tests/x11/toolkits/motif.pm"), ('motif',   'x11/toolkits'));
+is(autotest::parse_test_path("$sharedir/factory/other/sysrq.pm"),                ('sysrq',   'other'));
+
 done_testing();
 
 # vim: set sw=4 et:


### PR DESCRIPTION
Eg. a file with the path `tests/sle/tests/x11/toolkits/xterm.pm` will be
put into category `x11/toolkits` instead of just `toolkits`.

Superseeds: https://github.com/os-autoinst/os-autoinst/pull/1058

Verification: http://artemis.suse.de/tests/958

The verification was scheduled by:
```
openqa_clone_job_artemis_from_osd --skip-chained-deps 2261417 TEST=sched SCHEDULE=tests/boot/boot_to_desktop,tests/console/consoletest_setup,tests/x11/toolkits/prepare,sysrq ASSET_1_URL=https://w3.suse.de/~okurz/sysrq.pm
```