### PR TITLE
Correct HDDMODEL / CDMODEL deprecation message

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -102,7 +102,7 @@ sub configure_controllers {
     # deprecated for a long time.
     for my $var (qw(HDDMODEL CDMODEL)) {
         if ($vars->{$var} =~ /virtio-scsi.*/) {
-            die "Set $var to scsi-" . lc(substr($var, 0, 1)) . ' and SCSICONTROLLER to '
+            die "Set $var to scsi-" . lc(substr($var, 0, 1)) . 'd and SCSICONTROLLER to '
               . $vars->{$var};
         }
     }


### PR DESCRIPTION
The current code produces a message like this:

"Set HDDMODEL to scsi-h ..."

If it was CDMODEL, the message would say "scsi-c". In both cases
it's missing a 'd'. The old code which actually parsed this form
added a 'd' after the letter that's parsed out of the variable
name; when the parse code was turned into the deprecation message
code, that 'd' got lost.

Signed-off-by: Adam Williamson <awilliam@redhat.com>