### PR TITLE
[WIP] Add 'no_wait' option to 'send_key_until_needlematch'

### DIFF
--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -451,6 +451,19 @@ subtest 'check_assert_shutdown' => sub {
 
 };
 
+subtest 'send_key_until_needlematch' => sub {
+    $mod->mock(
+        read_json => sub {
+            return {ret => {sim => 999}};
+        });
+    $fake_needle_found = 1;
+    ok(send_key_until_needlematch('foo', 'spc'), 'simple test');
+    ok(send_key_until_needlematch('foo', 'spc', 2). 'counter specified');
+    ok(send_key_until_needlematch('foo', 'spc', 2, 5). 'counter and old-fashion timeout specified');
+    ok(send_key_until_needlematch('foo', 'spc', 2, timeout => 10). 'counter and new-fashion timeout specified');
+    ok(!send_key_until_needlematch('foo', 'spc', 2, no_wait => 1). 'check_screen option specified');
+};
+
 done_testing;
 
 # vim: set sw=4 et:

--- a/testapi.pm
+++ b/testapi.pm
@@ -1144,22 +1144,27 @@ sub release_key {
 
 =head2 send_key_until_needlematch
 
-  send_key_until_needlematch($tag, $key [, $counter, $timeout]);
+  send_key_until_needlematch($tag, $key [, [$counter] | [timeout => $timeout]]);
 
 Send specific key until needle with C<$tag> is not matched or C<$counter> is 0.
-C<$tag> can be string or C<ARRAYREF> (C<['tag1', 'tag2']>)
-Default counter is 20 steps, default timeout is 1s
+C<$tag> can be string or C<ARRAYREF> (C<['tag1', 'tag2']>).
+Default counter is 20 steps, default timeout is 1s.
+
+As this function uses check_screen, all extra arguments are passed as-is to it.
 
 Throws C<FailedNeedle> exception if needle is not matched until C<$counter> is 0.
 
 =cut
 
 sub send_key_until_needlematch {
-    my ($tag, $key, $counter, $timeout) = @_;
+    my $tag     = shift;
+    my $key     = shift;
+    my $counter = shift;
+    $counter = 20 unless looks_like_number($counter);
+    my $timeout = looks_like_number($_[0]) ? shift : 1;
+    my %args = (timeout => $timeout, @_);
 
-    $counter //= 20;
-    $timeout //= 1;
-    while (!check_screen($tag, $timeout)) {
+    while (!check_screen($tag, %args)) {
         wait_screen_change {
             send_key $key;
         };


### PR DESCRIPTION
An issue on aarch64 uefi boot led to me to change a `send_key_until_needlematch` by a `check_screen` loop with `send_key` and `no_wait` options added to `check_screen`.

At the end it's better to directly add support of `no_wait` inside `send_key_until_needlematch`.

This was discussed in this PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4761

Ticket: https://progress.opensuse.org/issues/34501

Verification run: http://1b147.qa.suse.de/tests/4124#step/uefi_bootmenu/10 (test fails for another reason, uefi_bootmenu using UEFI bootmanager is working well).