### PR TITLE
Enhance VMware support

### DIFF
--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -73,8 +73,9 @@ sub do_stop_vm {
             $self->run_cmd("$ps Remove-VM -Force -VMName $vmname");
         }
         else {
-            $self->run_cmd("virsh destroy $vmname");
-            $self->run_cmd("virsh undefine $vmname");
+            my $libvirt_connector = get_var('VMWARE_REMOTE_VMM');
+            $self->run_cmd("virsh $libvirt_connector destroy $vmname");
+            $self->run_cmd("virsh $libvirt_connector undefine --snapshots-metadata $vmname");
         }
     }
     return {};
@@ -126,7 +127,7 @@ sub can_handle {
     my $vars = \%bmwqemu::vars;
     if ($args->{function} eq 'snapshots' && !check_var('HDDFORMAT', 'raw')) {
         # Snapshots via libvirt are supported on KVM and, perhaps, ESXi. Hyper-V uses native tools.
-        if (check_var('VIRSH_VMM_FAMILY', 'kvm') || check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
+        if (check_var('VIRSH_VMM_FAMILY', 'kvm') || check_var('VIRSH_VMM_FAMILY', 'hyperv') || check_var('VIRSH_VMM_FAMILY', 'vmware')) {
             return {ret => 1};
         }
     }
@@ -141,7 +142,8 @@ sub is_shutdown {
         $rsp = $self->run_cmd("powershell -Command \"if (\$(Get-VM -VMName $vmname \| Where-Object {\$_.state -eq 'Off'})) { exit 1 } else { exit 0 }\"");
     }
     else {
-        $rsp = $self->run_cmd("! virsh dominfo $vmname | grep -w 'shut off'");
+        my $libvirt_connector = get_var('VMWARE_REMOTE_VMM');
+        $rsp = $self->run_cmd("! virsh $libvirt_connector dominfo $vmname | grep -w 'shut off'");
     }
     return $rsp;
 }
@@ -157,10 +159,11 @@ sub save_snapshot {
         $rsp = $self->run_cmd("$ps Checkpoint-VM -VMName $vmname -SnapshotName $snapname");
     }
     else {
-        $self->run_cmd("virsh snapshot-delete $vmname $snapname");
-        $rsp = $self->run_cmd("virsh snapshot-create-as $vmname $snapname");
+        my $libvirt_connector = get_var('VMWARE_REMOTE_VMM');
+        $self->run_cmd("virsh $libvirt_connector snapshot-delete $vmname $snapname");
+        $rsp = $self->run_cmd("virsh $libvirt_connector snapshot-create-as $vmname $snapname");
     }
-    bmwqemu::diag "SAVE VM \"$vmname\" as \"$snapname\" snapshot, return code=$rsp";
+    bmwqemu::diag "SAVE VM $vmname as $snapname snapshot, return code=$rsp";
     die unless ($rsp == 0);
     return;
 }
@@ -187,9 +190,10 @@ sub load_snapshot {
         }
     }
     else {
-        $rsp = $self->run_cmd("virsh snapshot-revert $vmname $snapname");
+        my $libvirt_connector = get_var('VMWARE_REMOTE_VMM');
+        $rsp = $self->run_cmd("virsh $libvirt_connector snapshot-revert $vmname $snapname");
     }
-    bmwqemu::diag "LOAD snapshot \"$snapname\" to \"$vmname\", return code=$rsp";
+    bmwqemu::diag "LOAD snapshot $snapname to $vmname, return code=$rsp";
     die unless ($rsp == 0);
     return $rsp;
 }

--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -239,7 +239,7 @@ sub start_serial_grab {
         # libvirt esx driver does not support `virsh console', so
         # we have to connect to VM's serial port via TCP which is
         # provided by ESXi server.
-        $chan->exec('nc ' . get_var('VMWARE_SERVER') . ' ' . get_var('VMWARE_SERIAL_PORT'));
+        $chan->exec('nc ' . get_var('VMWARE_HOST') . ' ' . get_var('VMWARE_SERIAL_PORT'));
     }
     elsif (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
         # Hyper-V does not support serial console export via TCP, just

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -58,7 +58,7 @@ sub activate {
     );
     if ($self->vmm_family eq 'vmware') {
         $self->{sshVMwareServer} = $self->backend->new_ssh_connection(
-            hostname => get_required_var('VMWARE_SERVER'),
+            hostname => get_required_var('VMWARE_HOST'),
             password => get_required_var('VMWARE_PASSWORD'));
     }
 
@@ -479,11 +479,10 @@ password=" . get_required_var('VMWARE_PASSWORD') . "
 credentials=vmware
 __END"
         );
-        my $user       = get_required_var('VMWARE_USERNAME');
-        my $host       = get_required_var('VMWARE_HOST');
-        my $datacenter = get_required_var('VMWARE_DATACENTER');
-        my $server     = get_required_var('VMWARE_SERVER');
-        $remote_vmm = "-c vpx://$user@$host/$datacenter/$server/?no_verify=1\\&authfile=$libvirtauthfilename ";
+        my $user = get_required_var('VMWARE_USERNAME');
+        my $host = get_required_var('VMWARE_HOST');
+        $remote_vmm = "-c esx://$user\@$host/?no_verify=1\\&authfile=$libvirtauthfilename ";
+        set_var('VMWARE_REMOTE_VMM', $remote_vmm);
     }
 
     my $instance = $self->instance;

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -635,7 +635,8 @@ sub get_cmd_output {
     my ($self, $cmd, $args) = @_;
 
     my $wantarray = $args->{wantarray};
-    my $chan      = $self->{ssh}->channel();
+    my $domain    = $args->{domain} // 'ssh';
+    my $chan      = $self->{$domain}->channel();
     $chan->exec($cmd);
     bmwqemu::diag "Command executed: $cmd";
     my @cmd_output = get_ssh_output($chan);

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -449,13 +449,15 @@ sub add_disk {
 
 sub suspend {
     my ($self) = @_;
-    $self->run_cmd("virsh suspend " . $self->name) && die "Can't suspend VM ";
+    my $libvirt_connector = get_var('VMWARE_REMOTE_VMM');
+    $self->run_cmd("virsh $libvirt_connector suspend " . $self->name) && die "Can't suspend VM ";
     bmwqemu::diag "VM " . $self->name . " suspended";
 }
 
 sub resume {
     my ($self) = @_;
-    $self->run_cmd("virsh resume " . $self->name) && die "Can't resume VM ";
+    my $libvirt_connector = get_var('VMWARE_REMOTE_VMM');
+    $self->run_cmd("virsh $libvirt_connector resume " . $self->name) && die "Can't resume VM ";
     bmwqemu::diag "VM " . $self->name . " resumed";
 }
 

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -330,43 +330,98 @@ sub add_interface {
 sub add_disk {
     my ($self, $args) = @_;
 
-    my $file = $self->name . $args->{dev_id} . (($self->vmm_family eq 'vmware') ? ".vmdk" : ".img");
+    my $backingfile             = $args->{backingfile};
+    my $cdrom                   = $args->{cdrom};
+    my $name                    = $self->name;
+    my $file                    = $name . $args->{dev_id} . ($self->vmm_family eq 'vmware' ? '.vmdk' : '.img');
+    my $basedir                 = '/var/lib/libvirt/images/';
+    my $vmware_datastore        = get_var('VMWARE_DATASTORE');
+    my $vmware_openqa_datastore = "/vmfs/volumes/$vmware_datastore/openQA/";
     if ($args->{create}) {
-        my $size = $args->{size} || '4G';
+        my $size = $args->{size} || '20G';
         if ($self->vmm_family eq 'vmware') {
-            my $vmware_disk_path = "/vmfs/volumes/" . get_required_var('VMWARE_DATASTORE') . "/openQA/$file";
-            my $chan             = $self->{sshVMwareServer}->channel();
+            my $vmware_disk_path = $vmware_openqa_datastore . $file;
             # Power VM off, delete it's disk image, and create it again.
             # Than wait for some time for the VM to *really* turn off.
-            my $name = $self->name;
-            $chan->exec(
-"vmid=\$(vim-cmd vmsvc/getallvms | awk '/ $name / { print \$1 }'); vim-cmd vmsvc/power.getstate \$vmid; vim-cmd vmsvc/power.off \$vmid; vim-cmd vmsvc/power.getstate \$vmid; vmkfstools -v1 -U $vmware_disk_path; vmkfstools -v1 -c $size --diskformat thin $vmware_disk_path; sleep 10"
+            my $vmware_chan = $self->{sshVMwareServer}->channel();
+            $vmware_chan->exec(
+                "( set -x; vmid=\$(vim-cmd vmsvc/getallvms | awk \'/$name/ { print \$1 }\');" .
+                  'if [ $vmid ]; then ' .
+                  'vim-cmd vmsvc/power.off $vmid;' .
+                  'vim-cmd vmsvc/destroy $vmid;' .
+                  'fi;' .
+                  "vmkfstools -v1 -U $vmware_disk_path;" .
+                  "vmkfstools -v1 -c $size --diskformat thin $vmware_disk_path; sleep 10 ) 2>&1"
             );
-            $chan->send_eof;
-            get_ssh_output($chan);
-            $chan->close();
-            die "Can't create VMware image" if $chan->exit_status();
+            $vmware_chan->send_eof;
+            get_ssh_output($vmware_chan);
+            $vmware_chan->close();
+            die "Can't create VMware image $vmware_disk_path" if $vmware_chan->exit_status();
         }
         else {
-            $file = "/var/lib/libvirt/images/$file";
+            $file = $basedir . $file;
             $self->run_cmd("qemu-img create $file $size -f qcow2") && die "qemu-img create failed";
         }
     }
     else {    # Copy image to VM host
-        my $dir = "/var/lib/libvirt/images";
-        die "No file given" unless $args->{file};
-        if ($args->{cdrom} or $args->{backingfile}) {
-            $self->run_cmd(sprintf("rsync -av '$args->{file}' '${dir}/%s'", basename($args->{file}))) && die 'rsync failed';
+        die 'No file given' unless $args->{file};
+        my $file_basename             = basename($args->{file});
+        my $vmware_disk_path          = $vmware_openqa_datastore . $file_basename;
+        my $vmware_disk_path_thinfile = $vmware_disk_path =~ s/\.vmdk/_${name}_thinfile\.vmdk/r;
+        if ($cdrom || $backingfile) {
+            if ($self->vmm_family eq 'vmware') {
+                # If the file exists, make sure someone else is not copying it there right now,
+                # otherwise copy image from NFS datastore.
+                my $nfs_dir              = $backingfile ? 'hdd' : 'iso';
+                my $vmware_nfs_datastore = get_required_var('VMWARE_NFS_DATASTORE');
+                my $vmware_chan          = $self->{sshVMwareServer}->channel();
+                $vmware_chan->exec(
+                    "if test -e $vmware_openqa_datastore$file_basename; then " .
+                      "while lsof | grep 'cp.*$file_basename'; do " .
+                      "echo File $file_basename is being copied by other process, sleeping for 60 seconds; sleep 60;" .
+                      'done;' .
+                      'else ' .
+                      "cp /vmfs/volumes/$vmware_nfs_datastore/$nfs_dir/$file_basename $vmware_openqa_datastore;" .
+                      'fi;'
+                );
+                $vmware_chan->send_eof;
+                get_ssh_output($vmware_chan);
+                $vmware_chan->close();
+                die "Can't copy VMware image $file_basename" if $vmware_chan->exit_status();
+                if ($backingfile) {
+                    # Power VM off, delete it's disk image, and create it again.
+                    # Than wait for some time for the VM to *really* turn off.
+                    $vmware_chan = $self->{sshVMwareServer}->channel();
+                    $vmware_chan->exec(
+                        "( set -x; vmid=\$(vim-cmd vmsvc/getallvms | awk \'/$name/ { print \$1 }\');" .
+                          'if [ $vmid ]; then ' .
+                          'vim-cmd vmsvc/power.off $vmid;' .
+                          'fi;' .
+                          "vmkfstools -v1 -U $vmware_disk_path_thinfile;" .
+                          "vmkfstools -v1 -i $vmware_disk_path --diskformat thin $vmware_disk_path_thinfile; sleep 10 ) 2>&1"
+                    );
+                    $vmware_chan->send_eof;
+                    get_ssh_output($vmware_chan);
+                    $vmware_chan->close();
+                    die "Can't create thin VMware image" if $vmware_chan->exit_status();
+                }
+            }
+            else {
+                $self->run_cmd(sprintf("rsync -av '$args->{file}' '$basedir/%s'", $file_basename)) && die 'rsync failed';
+            }
         }
-        if ($args->{backingfile}) {
-            if ($self->vmm_family ne 'vmware') {
-                $file = "/var/lib/libvirt/images/$file";
-                $self->run_cmd(sprintf("qemu-img create '${file}' -f qcow2 -b '$dir/%s'", basename($args->{file})))
-                  && die "qemu-img create with backing file failed";
+        if ($backingfile) {
+            if ($self->vmm_family eq 'vmware') {
+                $file = basename($vmware_disk_path_thinfile);
+            }
+            else {
+                $file = $basedir . $file;
+                $self->run_cmd(sprintf("qemu-img create '${file}' -f qcow2 -b '$basedir/%s'", $file_basename))
+                  && die 'qemu-img create with backing file failed';
             }
         }
         else {    # e.g. cdrom
-            $file = "/var/lib/libvirt/images/" . basename($args->{file});
+            $file = ($self->vmm_family eq 'vmware' ? '' : $basedir) . $file_basename;
         }
     }
 
@@ -375,7 +430,7 @@ sub add_disk {
 
     my $disk = $doc->createElement('disk');
     $disk->setAttribute(type => 'file');
-    if ($args->{cdrom}) {
+    if ($cdrom) {
         $disk->setAttribute(device => 'cdrom');
     }
     else {
@@ -389,7 +444,7 @@ sub add_disk {
     if ($self->vmm_family ne 'vmware') {
         $elem = $doc->createElement('driver');
         $elem->setAttribute(name => 'qemu');
-        if ($args->{cdrom}) {
+        if ($cdrom) {
             $elem->setAttribute(type => 'raw');
         }
         else {
@@ -403,7 +458,7 @@ sub add_disk {
     my $bus_type;
     my $dev_id = $args->{dev_id};
     if ($self->vmm_family eq 'xen') {
-        if ($args->{cdrom}) {
+        if ($cdrom) {
             $dev_type = "sd$dev_id";
             $bus_type = 'scsi';
         }
@@ -415,7 +470,7 @@ sub add_disk {
         $bus_type = 'ide';
     }
     elsif ($self->vmm_family eq 'kvm') {
-        if ($args->{cdrom}) {
+        if ($cdrom) {
             $dev_type = "hd$dev_id";
             $bus_type = 'ide';
         }
@@ -431,7 +486,7 @@ sub add_disk {
 
     $elem = $doc->createElement('source');
     if ($self->vmm_family eq 'vmware') {
-        $elem->setAttribute(file => '[' . get_required_var('VMWARE_DATASTORE') . "] openQA/$file");
+        $elem->setAttribute(file => "[$vmware_datastore] openQA/$file");
     }
     else {
         $elem->setAttribute(file => $file);

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -118,20 +118,21 @@ Variable;Values allowed;Default value;Explanation
 HDDSIZEGB;integer;15;Disk size in GB
 QEMUCPUS;integer;1;Number of CPUs to assign to VM
 QEMURAM;integer;1024;Size of RAM of VM in MiB
-VIRSH_HOSTNAME;string;SSH Host with virtsh;
+VIRSH_HOSTNAME;string;SSH Host with virsh;
 VIRSH_PASSWORD;string;Password for root account on above host;
 VIRSH_VMM_FAMILY;string;Host's hypervisor ('kvm', 'xen');
 VIRSH_VMM_TYPE;string;Host's hypervisor type ('hvm' for full virtualization on 'kvm' and 'xen' families, 'linux' for paravirtualization on 'xen' family);
 VIRSH_GUEST;string;Where to look for VNC server (SUT or VM);
+VIRSH_GUEST_PASSWORD;string;VNC password of the guest
 VIRSH_INSTANCE;integer;VM's instance number on VIRSH_HOSTNAME;
 VMWARE_USERNAME;string;Administrator's username ('@' is '%40');
 VMWARE_PASSWORD;string;Administrator's password;
 VMWARE_HOST;string;VCS server for autentication;
-VMWARE_DATACENTER;string;VMware datacenter;
-VMWARE_SERVER;string;ESX server to start VM on;
 VMWARE_DATASTORE;string;VMware datastore;
+VMWARE_NFS_DATASTORE;string;VMware datastore with openQA NFS directories;
 VMWARE_SERIAL_PORT;string;TCP port where is VM's serial port stream to be expected on the ESX server;
 VMWARE_BRIDGE;string;VMware's bridge name (usual default is 'VM Network');
+VMWARE_REMOTE_VMM;string;
 HYPERV_USERNAME;string;Administrator account name;
 HYPERV_PASSWORD;string;Password for above account;
 HYPERV_SERVER;string;Windows Server (2008 R2, 2012 R2, or 2016) instance IP address;


### PR DESCRIPTION
https://trello.com/c/O104uCeQ/178-p1-vmware-guest-install-support-in-openqa

This brings VMware via svirt support up-to-date.

Validation runs (it's enough that VM boots):
* default_install@svirt-vmware: http://nilgiri.suse.cz/tests/1951
* jeos-extratest@svirt-vmware: http://nilgiri.suse.cz/tests/1999
* jeos-main@svirt-vmware: http://nilgiri.suse.cz/tests/1998

Regression testing (it's enough that VM boots):
* jeos-extratest@svirt-xen-pv: http://nilgiri.suse.cz/tests/2003
* allpatterns@svirt-xen-hvm: http://nilgiri.suse.cz/tests/2002

Test code changes (but this can be merged independently): https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6326.