### PR TITLE
Don't write _SECRET_* vars in vars.json

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -217,7 +217,7 @@ sub run_all {
         $died = 1;    # test execution died
     }
     eval {
-        bmwqemu::save_vars();
+        bmwqemu::save_vars(no_secret => 1);
         myjsonrpc::send_json($isotovideo, {cmd => 'tests_done', died => $died, completed => $completed});
     };
     close $isotovideo;

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -85,15 +85,22 @@ sub load_vars {
 }
 
 sub save_vars {
+    my (%args) = @_;
     my $fn = "vars.json";
     unlink "vars.json" if -e "vars.json";
     open(my $fd, ">", $fn);
     flock($fd, LOCK_EX) or die "cannot lock vars.json: $!\n";
     truncate($fd, 0) or die "cannot truncate vars.json: $!\n";
 
+    my $write_vars = \%vars;
+    if ($args{no_secret}) {
+        $write_vars = {};
+        $write_vars->{$_} = $vars{$_} for (grep !/^_SECRET_/, keys(%vars));
+    }
+
     # make sure the JSON is sorted
     my $json = Cpanel::JSON::XS->new->pretty->canonical;
-    print $fd $json->encode(\%vars);
+    print $fd $json->encode($write_vars);
     close($fd);
     return;
 }

--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -103,6 +103,40 @@ subtest 'test PRJDIR default' => sub {
     is($vars{PRJDIR},  $data_dir, 'PRJDIR set to default');
 };
 
+subtest 'save_vars' => sub {
+    my $dir = "$data_dir/tests";
+    create_vars({CASEDIR => $dir, _SECRET_TEST => 'my_credentials'});
+    $bmwqemu::openqa_default_share = $data_dir;
+
+    eval {
+        use bmwqemu ();
+        bmwqemu::init;
+        bmwqemu::save_vars();
+    };
+    ok(!$@, 'init successful');
+
+    my %vars = %{read_vars()};
+    is($vars{_SECRET_TEST}, 'my_credentials', '_SECRET_TEST unchanged');
+    is($vars{CASEDIR},      $dir,             'CASEDIR unchanged');
+};
+
+subtest 'save_vars no_secret' => sub {
+    my $dir = "$data_dir/tests";
+    create_vars({CASEDIR => $dir, _SECRET_TEST => 'my_credentials'});
+    $bmwqemu::openqa_default_share = $data_dir;
+
+    eval {
+        use bmwqemu ();
+        bmwqemu::init;
+        bmwqemu::save_vars(no_secret => 1);
+    };
+    ok(!$@, 'init successful');
+
+    my %vars = %{read_vars()};
+    ok(!$vars{_SECRET_TEST}, '_SECRET_TEST not written to vars.json');
+    is($vars{CASEDIR}, $dir, 'CASEDIR unchanged');
+};
+
 done_testing;
 
 END {

--- a/testapi.pm
+++ b/testapi.pm
@@ -691,6 +691,7 @@ sub get_required_var {
   set_var($variable, $value [, reload_needles => 1] );
 
 Set test variable C<$variable> to value C<$value>.
+Variables starting with C<_SECRET_> will not appear in the vars.json file.
 
 Specify a true value for the C<reload_needles> flag to trigger a reloading
 of needles in the backend and call the cleanup handler with the new variables


### PR DESCRIPTION
If a variable name starts with `_SECRET_*`, it is excluded from
writing in to the final vars.json file.
During the JOB, the variable is accessible via the normal functions
e.g. get_var().

Why: This is needed to store sensitive data (credentials) in workers.ini
and prevent them to be visible via the web-ui.

This change is related to https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6346. The discussion on how to provide credentials, turns in the direction of better having hidden vars, then introduce a new configuration file.

Variables which are passed via job configuration or openqa-client are not affected and not in the focus of this PR. These variables still  visible in the settings tab.

Ticket: https://progress.opensuse.org/issues/42155
Verification run: http://cfconrad-vm.qa.suse.de/tests/3134#step/extra_log_test/14
