### PR TITLE
Add support to checkout git repos+refspecs

### DIFF
--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -15,9 +15,9 @@
 
 package OpenQA::Isotovideo::Utils;
 use Mojo::Base -base;
+use Mojo::URL;
 
 use File::Spec;
-use File::Path;
 use Cwd;
 use testapi 'diag';
 use bmwqemu;
@@ -31,6 +31,37 @@ sub calculate_git_hash {
     chdir($dir);
     diag "git hash in $git_repo_dir: $git_hash";
     return $git_hash;
+}
+
+=head2 checkout_git_repo_and_branch
+
+    checkout_git_repo_and_branch($dir [, clone_depth => <num>]);
+
+Takes a test or needles distribution directory parameter and checks out the
+referenced git repository into a local working copy with an additional,
+optional git refspec to checkout. The git clone depth can be specified in the
+argument C<clone_depth> which defaults to 1.
+
+=cut
+sub checkout_git_repo_and_branch {
+    my ($dir, %args) = @_;
+    my $url = Mojo::URL->new($bmwqemu::vars{$dir});
+    # assume we have a remote git URL to clone only if this looks like a remote URL
+    return unless $url->scheme;
+    $args{clone_depth} //= 1;
+    my $branch     = $url->fragment;
+    my $clone_url  = $url->fragment(undef)->to_string;
+    my $local_path = $url->path->parts->[-1] =~ s/.git//r;
+    my $clone_args = "--depth $args{clone_depth}";
+    if ($branch) {
+        diag "Checking out git refspec/branch '$branch'";
+        $clone_args .= " --branch $branch";
+    }
+    if (!-e $local_path) {
+        diag "Cloning git URL '$clone_url' to use as test distribution";
+        qx{env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git clone $clone_args $clone_url};
+    }
+    $bmwqemu::vars{$dir} = File::Spec->rel2abs($local_path);
 }
 
 1;

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -6,6 +6,9 @@ Supported variables per backend
 [options="header",cols="^m,^m,^m,v",separator=";"]
 |====================
 Variable;Values allowed;Default value;Explanation
+CASEDIR;string;;Path to test distribution. Can be a git repository URL of a test distribution to checkout with an optional refspec into the current directory. Tries to follow the definition of https://docs.npmjs.com/files/package.json#git-urls-as-dependencies , for example `git@github.com:os-autoinst/os-autoinst-distri-opensuse.git#feature/test`
+PRODUCTDIR;string;;Path to optional "product directory" which includes the test schedule entry point "main.pm" as well as a "needles" subdirectory with the needles to load.
+NEEDLES_DIR;string;;Path to needles subdirectory to use, defaults to "needles" within `PRODUCTDIR`. Can be a git repository URL, comparable to `CASEDIR`
 INCLUDE_MODULES;string;;comma separated names or fullnames of test modules to be included while excluding all that do not match, e.g. "boot,mod1"
 EXCLUDE_MODULES;string;;comma separated names or fullnames of test modules to exclude. Can be combined with INCLUDE_MODULES and has precedence, e.g. to additionally exclude modules based on an include-list
 SCHEDULE;string;;comma separated list of relative paths to test modules within CASEDIR without the implicit file extension '.pm' to be scheduled instead of evaluating a schedule from the test distributions main.pm file, e.g. "boot,console/mod1"

--- a/isotovideo
+++ b/isotovideo
@@ -133,7 +133,6 @@ for my $arg (@ARGV) {
         diag("Setting forced test parameter $key -> $2");
     }
 }
-bmwqemu::ensure_valid_vars();
 
 my $cmd_srv_process;
 my $testprocess;
@@ -178,9 +177,8 @@ sub init_backend {
     $bmwqemu::vars{BACKEND} ||= "qemu";
 
     # make sure the needles are initialized
-    my $needles_dir = $bmwqemu::vars{PRODUCTDIR} . '/needles';
-    needle::init($needles_dir);
-    $bmwqemu::vars{NEEDLES_GIT_HASH} = OpenQA::Isotovideo::Utils::calculate_git_hash($needles_dir);
+    needle::init($bmwqemu::vars{NEEDLES_DIR});
+    $bmwqemu::vars{NEEDLES_GIT_HASH} = OpenQA::Isotovideo::Utils::calculate_git_hash($bmwqemu::vars{NEEDLES_DIR});
 
     $bmwqemu::backend = backend::driver->new($bmwqemu::vars{BACKEND});
     return $bmwqemu::backend;
@@ -196,6 +194,8 @@ $SIG{HUP}  = \&signalhandler;
 $ENV{LC_ALL} = 'en_US.UTF-8';
 $ENV{LANG}   = 'en_US.UTF-8';
 
+OpenQA::Isotovideo::Utils::checkout_git_repo_and_branch('CASEDIR');
+
 # Try to load the main.pm from one of the following in this order:
 #  - product dir
 #  - casedir
@@ -204,11 +204,14 @@ $ENV{LANG}   = 'en_US.UTF-8';
 # multiple distributions or flavors in one repository.
 $bmwqemu::vars{PRODUCTDIR} ||= $bmwqemu::vars{CASEDIR};
 
+$bmwqemu::vars{NEEDLES_DIR} //= $bmwqemu::vars{PRODUCTDIR} . '/needles';
+OpenQA::Isotovideo::Utils::checkout_git_repo_and_branch('NEEDLES_DIR');
+
+bmwqemu::ensure_valid_vars();
+
 # as we are about to load the test modules store the git hash that has been
 # used. If it is not a git repo fail silently, i.e. store an empty variable
 
-# TODO find a better place to store hash in than vars.json, see
-# https://github.com/os-autoinst/os-autoinst/pull/393#discussion_r50143013
 $bmwqemu::vars{TEST_GIT_HASH} = OpenQA::Isotovideo::Utils::calculate_git_hash($bmwqemu::vars{CASEDIR});
 
 # start the command fork before we get into the backend, the command child

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Test::More;
 use File::Basename;
-use File::Path;
+use File::Path 'remove_tree';
 use Cwd 'abs_path';
 
 my $toplevel_dir = abs_path(dirname(__FILE__) . '/..');
@@ -45,6 +45,20 @@ EOV
     isotovideo;
     is_in_log('\d*: EXIT 1',              'test exited early as requested');
     is_in_log('\d* scheduling.*shutdown', 'schedule has been evaluated');
+};
+
+subtest 'isotovideo with custom git repo parameters specified' => sub {
+    chdir($pool_dir);
+    unlink('vars.json');
+    mkdir('repo.git');
+    qx{git init -q --bare repo.git};
+    # Ensure the checkout folder does not exist so that git clone tries to
+    # create a new checkout on every test run
+    remove_tree('repo');
+    isotovideo(opts => "casedir=file://$pool_dir/repo.git#foo needles_dir=$data_dir _exit_after_schedule=1");
+    is_in_log('git URL.*\<repo\>', 'git repository would be cloned');
+    is_in_log('branch.*foo',       'branch in git repository would be checked out');
+    is_in_log('No scripts',        'the repo actually has no test definitions');
 };
 
 done_testing();


### PR DESCRIPTION
As a test developer I want to execute an openQA test on a production
server based on a pull request to a test distribution to not need a
local openQA instance.

So far I tested this with the included integration test as well as
manually by specifying a real valid remote test distribution and branch
which has shown to be successful. The next steps to test would be
including the full openQA stack with remote workers including their
caching setup.

Related progress issue: https://progress.opensuse.org/issues/44327