### PR TITLE
qemu: use /dev/urandom as source for virtio RNG

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -745,11 +745,12 @@ sub start_qemu {
             sp('global', 'isa-fdc.driveA=');
         }
 
-        sp('m',       $vars->{QEMURAM})     if $vars->{QEMURAM};
-        sp('machine', $vars->{QEMUMACHINE}) if $vars->{QEMUMACHINE};
-        sp('cpu',     $vars->{QEMUCPU})     if $vars->{QEMUCPU};
-        sp('device',  'virtio-rng-pci')     if $vars->{QEMU_VIRTIO_RNG};
-        sp('net',     'none')               if $vars->{OFFLINE_SUT};
+        sp('m',       $vars->{QEMURAM})                           if $vars->{QEMURAM};
+        sp('machine', $vars->{QEMUMACHINE})                       if $vars->{QEMUMACHINE};
+        sp('cpu',     $vars->{QEMUCPU})                           if $vars->{QEMUCPU};
+        sp('object',  'rng-random,filename=/dev/urandom,id=rng0') if $vars->{QEMU_VIRTIO_RNG};
+        sp('device',  'virtio-rng-pci,rng=rng0')                  if $vars->{QEMU_VIRTIO_RNG};
+        sp('net',     'none')                                     if $vars->{OFFLINE_SUT};
 
         for (my $i = 0; $i < $num_networks; $i++) {
             if ($vars->{NICTYPE} eq "user") {


### PR DESCRIPTION
qemu by default uses the host's /dev/random as the source for
virtio-rng, which means we still *can* run out of entropy if a
bunch of guests demand a lot and exhaust /dev/random on the
host. Since nothing run inside os-autoinst should be used in
any kind of security-sensitive production context, let's just
use host /dev/urandom as the entropy source for os-autoinst VMs
instead.

For a case where this caused some problems, see:
https://bugzilla.redhat.com/show_bug.cgi?id=1663318

Signed-off-by: Adam Williamson <awilliam@redhat.com>