### PR TITLE
openvswitch: change vlan_mode to dot1q-tunnel

### DIFF
--- a/os-autoinst-openvswitch
+++ b/os-autoinst-openvswitch
@@ -146,7 +146,7 @@ sub set_vlan {
     }
 
     # Connect tap device to given vlan
-    ($return_code, $ovs_vsctl_error, $ovs_vsctl_output) = _cmd( 'ovs-vsctl', 'set', 'port', $tap, "tag=$vlan" );
+    ($return_code, $ovs_vsctl_error, $ovs_vsctl_output) = _cmd( 'ovs-vsctl', 'set', 'port', $tap, 'vlan_mode=dot1q-tunnel', "tag=$vlan" );
 
     print STDERR $ovs_vsctl_error if length($ovs_vsctl_error) > 0;
     print $ovs_vsctl_output if length($ovs_vsctl_output) > 0;


### PR DESCRIPTION
Setting vlan_mode=dot1q-tunnel makes the VLAN configuration, which is used in
SUT, independent from the VLAN configuration needed by openqa-workers.
The problem was discovered during a VLAN test for wicked, where two VMs
setup a VLAN interface and try to ping each other.

Related Ticked: https://progress.opensuse.org/issues/45461
Verification run:
  http://fromm.arch.suse.de/tests/4794 (SUT) [worker on  fromm.arch.suse.de]
  http://fromm.arch.suse.de/tests/4793 (REF) [worker on cfconrad-vm.qa.suse.de]

Attached a pcap from the GRE tunnel between fromm and cfconrad-vm, which shows the ping of two parallel running wicked_startandstop testsuites. Each test has it's own tunnel VLAN (2 or 4), after this we see the VLAN:42 which comes from the wicked testsuite.
[gre_wicked_vlan_test.pcapng.zip](https://github.com/os-autoinst/os-autoinst/files/2757016/gre_wicked_vlan_test.pcapng.zip)


