### PR TITLE
Send Ctrl-Alt-Fx more times

### DIFF
--- a/consoles/ttyConsole.pm
+++ b/consoles/ttyConsole.pm
@@ -39,7 +39,10 @@ sub trigger_select {
         $key = "ctrl-alt-f" . $self->{args}->{tty};
     }
 
-    $self->screen->send_key({key => $key});
+    # Sometimes the screen can not change after send key, so try to send key more times
+    for my $i (1 .. 3) {
+        $self->screen->send_key({key => $key});
+    }
     return;
 }
 


### PR DESCRIPTION
Sometimes the console can not switch after send Ctrl-Alt-Fx in openqa
env, but can not easy reproduce in local env, so maybe caused by worker
performance or network issue, so try to send key more times, this is a
workround. 

Related ticket: https://progress.opensuse.org/issues/45575
Needles: None
Verification run: http://10.67.17.238/tests/29#