### PR TITLE
Add python binding/import/wrapping code for testapi

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -53,7 +53,7 @@ loadtest is called.
 sub find_script {
     my ($script) = @_;
     my $casedir = $bmwqemu::vars{CASEDIR};
-    my $script_override_path = join('/', $bmwqemu::vars{PRJDIR}, 'factory/other', $script);
+    my $script_override_path = join('/', $bmwqemu::vars{PRJDIR} // '', 'factory/other', $script);
     if (-f $script_override_path) {
         bmwqemu::diag("Found override test module for $script: $script_override_path");
         return File::Spec->abs2rel($script_override_path, $casedir);

--- a/cpanfile
+++ b/cpanfile
@@ -18,6 +18,7 @@ requires 'File::Path';
 requires 'File::Spec';
 requires 'File::Temp';
 requires 'File::Which';
+requires 'Inline::Python';
 requires 'IO::Handle';
 requires 'IO::Select';
 requires 'IO::Socket';

--- a/t/04-testapi-python.t
+++ b/t/04-testapi-python.t
@@ -1,0 +1,26 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Fatal;
+use Test::Warnings;
+
+BEGIN {
+    unshift @INC, '..';
+}
+
+# This test merely shows how perl objects and modules can be accessed from
+# python
+
+# import all test API methods into global scope of python test modules so that
+# we do not need to write any prefix on each call like "perl.get_var"
+use testapi;
+use Inline Python => "for i in dir(perl): globals()[i] = getattr(perl, i)";
+
+use Inline 'Python';
+done_testing;
+__END__
+__Python__
+print(get_var('FOO', 'foo'))

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -109,7 +109,7 @@ subtest 'test always_rollback flag' => sub {
     # Test that no rollback is triggered if snapshots are not supported
     $mock_basetest->mock(test_flags       => sub { return {always_rollback => 1, milestone => 1}; });
     $mock_autotest->mock(query_isotovideo => sub { return 0; });
-    my $reverts_done = 0;
+    $reverts_done = 0;
     $mock_autotest->mock(load_snapshot => sub { $reverts_done++; });
 
     autotest::run_all;

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -33,8 +33,10 @@ stderr_like(
 );
 
 sub loadtest {
-    my ($test, $args) = @_;
-    stderr_like(sub { autotest::loadtest "tests/$test.pm" }, qr@scheduling $test#?[0-9]* tests/$test.pm|$test already scheduled@, \$args);
+    my ($test, $msg) = @_;
+    my $filename = $test =~ /\.p[my]$/ ? $test : $test . '.pm';
+    $test =~ s/\.p[my]//;
+    stderr_like(sub { autotest::loadtest "tests/$filename" }, qr@scheduling $test#?[0-9]* tests/$test|$test already scheduled@, $msg);
 }
 
 sub fake_send {
@@ -245,6 +247,8 @@ my $sharedir = '/home/tux/.local/lib/openqa/share';
 is(autotest::parse_test_path("$sharedir/tests/sle/tests/x11/firefox.pm"),        ('firefox', 'x11'));
 is(autotest::parse_test_path("$sharedir/tests/sle/tests/x11/toolkits/motif.pm"), ('motif',   'x11/toolkits'));
 is(autotest::parse_test_path("$sharedir/factory/other/sysrq.pm"),                ('sysrq',   'other'));
+
+loadtest 'test.py', 'we can also parse python test modules';
 
 done_testing();
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,6 +1,6 @@
 AM_MAKEFLAGS = \
 	PERL5OPT="-MDevel::Cover=-db,$(abs_builddir)/cover_db,-ignore,^*\.t|^data\/tests\/*|^fake\/tests\/*" \
 	PERL5LIB="..:../ppmclibs:../ppmclibs/blib/arch/auto/tinycv:$$PERL5LIB"
-TESTS = 00-compile-check-all.t 01-test_needle.t 02-test_ocr.t 03-testapi.t 04-check_vars_docu.t 05-pod.t 06-pod-coverage.t 07-commands.t 08-autotest.t 09-lockapi.t 10-terminal.t 11-image-ppm.t 12-bmwqemu.t 13-osutils.t 14-isotovideo.t 16-send_with_fd.t 17-basetest.t 18-qemu.t 18-qemu-options.t 20-openqa-benchmark-stopwatch-utils.t 99-full-stack.t
+TESTS = 00-compile-check-all.t 01-test_needle.t 02-test_ocr.t 03-testapi.t 04-testapi-python.t 04-check_vars_docu.t 05-pod.t 06-pod-coverage.t 07-commands.t 08-autotest.t 09-lockapi.t 10-terminal.t 11-image-ppm.t 12-bmwqemu.t 13-osutils.t 14-isotovideo.t 16-send_with_fd.t 17-basetest.t 18-qemu.t 18-qemu-options.t 20-openqa-benchmark-stopwatch-utils.t 99-full-stack.t
 
 EXTRA_DIST = $(TESTS)

--- a/t/data/tests/main.pm
+++ b/t/data/tests/main.pm
@@ -16,6 +16,8 @@
 use strict;
 use warnings;
 
+use Cwd 'abs_path';
+
 use testapi;
 use testdistribution;
 
@@ -34,6 +36,10 @@ sub cleanup_needles {
 
 $needle::cleanuphandler = \&cleanup_needles;
 
+# Add import path for local test python modules from pool directory
+use Inline Python => "import os.path, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.curdir, '../..')))";
+
+autotest::loadtest "tests/pre_boot.py";
 autotest::loadtest "tests/boot.pm";
 
 # openQA tests set this to 0 when reusing the os-autoinst tests

--- a/t/data/tests/tests/pre_boot.py
+++ b/t/data/tests/tests/pre_boot.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+import sys
+print(sys.path)
+from testapi import *
+
+def run(self):
+    send_key('esc')
+    if not check_screen('should_not_match', 0):
+        return
+    raise Exception('Should not reach here')
+
+
+def test_flags(self):
+    return dict([('fatal', 1)])

--- a/t/fake/tests/test.py
+++ b/t/fake/tests/test.py
@@ -1,0 +1,4 @@
+from testapi import *
+
+def run(self):
+    pass

--- a/testapi.py
+++ b/testapi.py
@@ -1,0 +1,21 @@
+# Copyright © 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# publish all test API methods over perl into the modules context.
+# Use with `import testapi; testapi.method()` or `from testapi import *`
+import perl
+perl.use('testapi')
+for i in dir(perl):
+    locals()[i] = getattr(perl, i)


### PR DESCRIPTION
This is based on bmwiedemann's work, see for example the initial idea in
https://github.com/os-autoinst/os-autoinst/pull/364 .
The idea for "python bindings" was recently brought up as well in
See https://trello.com/c/GSXjk2wZ/35-python-bindings-for-openqa

With this test modules can written in python code importing the testapi
module from python. All perl objects not within the testapi can still be
accessed using the dynamic python module "perl".

Detailed changes:

* 08-autotest.t: Add test for python test modules
* t: Add test for python test modules using perl testapi
* Add python testapi interface