### PR TITLE
Prevent error about cmd srv connection when test ends

### DIFF
--- a/OpenQA/Isotovideo/CommandHandler.pm
+++ b/OpenQA/Isotovideo/CommandHandler.pm
@@ -1,4 +1,4 @@
-# Copyright © 2018 SUSE LLC
+# Copyright © 2018-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -79,6 +79,12 @@ sub process_command {
     }
 
     die 'isotovideo: unknown command ' . $cmd;
+}
+
+sub stop_command_processing {
+    my ($self) = @_;
+
+    $self->_send_to_cmd_srv({stop_processing_isotovideo_commands => 1});
 }
 
 sub _postpone_backend_command_until_resumed {

--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -1,4 +1,4 @@
-# Copyright © 2018 SUSE LLC
+# Copyright © 2018-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -30,6 +30,6 @@ our $developer_mode_major_version = 1;
 # minor version of the (web socket) API relevant to the developer mode
 # -> reset to 0 when making non-backward compatible changes to that API
 # -> increment when making backward compatible changes to that API
-our $developer_mode_minor_version = 0;
+our $developer_mode_minor_version = 1;
 
 1;

--- a/commands.pm
+++ b/commands.pm
@@ -208,8 +208,8 @@ sub isotovideo_command {
     my $cmd = $mojo_lite_controller->param('command');
     return $mojo_lite_controller->reply->not_found unless grep { $cmd eq $_ } @$commands;
 
-    my $app        = $mojo_lite_controller->app;
-    my $isotovideo = $app->defaults('isotovideo') or return;
+    my $app = $mojo_lite_controller->app;
+    return unless my $isotovideo = $app->defaults('isotovideo');
 
     # send command to isotovideo and block until a response arrives
     myjsonrpc::send_json($isotovideo, {cmd => $cmd, params => $mojo_lite_controller->req->query_params->to_hash});

--- a/commands.pm
+++ b/commands.pm
@@ -29,7 +29,6 @@ use bmwqemu 'diag';
 use Mojo::JSON 'to_json';
 
 BEGIN {
-    # https://github.com/os-autoinst/openQA/issues/450
     $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll';
 }
 

--- a/isotovideo
+++ b/isotovideo
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -74,8 +74,10 @@ use Getopt::Long;
 require IPC::System::Simple;
 use POSIX qw(:sys_wait_h _exit);
 use Time::HiRes qw(gettimeofday tv_interval sleep time);
+use Try::Tiny;
 use File::Spec;
 use File::Path;
+use Mojo::UserAgent;
 use Mojo::IOLoop::ReadWriteProcess 'process';
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 Getopt::Long::Configure("no_ignore_case");
@@ -135,28 +137,69 @@ for my $arg (@ARGV) {
 }
 
 my $cmd_srv_process;
+my $command_handler;
 my $testprocess;
 my $cmd_srv_fd;
+my $cmd_srv_port;
 my $backend_process;
-
 my $loop = 1;
 
+# note: The subsequently defined kill_* functions are used to tear down the process tree.
+#       However, the worker also ensures that all processes are being terminated (and
+#       eventually killed).
+
 sub kill_commands {
+    my ($reason) = @_;
     return unless defined $cmd_srv_process;
+    return unless $cmd_srv_process->is_running;
+
+    my $pid = $cmd_srv_process->pid;
+    diag("killing command server $pid because $reason");
+
+    # inform websocket clients
+    # note: If the job is stopped by the worker because it has been aborted, the worker will send this command
+    #       on its own to the command server and also stop the command server. So this is only done in the case
+    #       the test execution just ends.
+    if ($cmd_srv_port && $reason && $reason eq 'test execution ended') {
+        my $job_token = $bmwqemu::vars{JOBTOKEN};
+        my $url       = "http://127.0.0.1:$cmd_srv_port/$job_token/broadcast";
+        diag('isotovideo: informing websocket clients before stopping command server: ' . $url);
+
+        my $ua = Mojo::UserAgent->new(request_timeout => 15);
+        my $tx = $ua->post($url, json => {stopping_test_execution => $reason});
+        try {
+            my $res = $tx->result;
+            if (!$res->is_success || $res->code != 200) {
+                diag('isotovideo: unable to inform websocket clients about stopping command server: ' . $res->to_string);
+            }
+        }
+        catch {
+            diag('isotovideo: unable to inform websocket clients about stopping command server: ' . $_);
+        };
+    }
+
+    # stop the command server
     $cmd_srv_process->stop() if $cmd_srv_process->is_running;
+    $cmd_srv_process = undef;
+    diag('done with command server');
 }
 
 sub kill_autotest {
     return unless defined $testprocess;
+
+    diag('killing autotest process ' . $testprocess->pid);
     $testprocess->stop() if $testprocess->is_running;
+    $testprocess = undef;
+    diag('done with autotest process');
 }
 
 sub kill_backend {
-    if (defined $bmwqemu::backend && $backend_process) {
-        diag "killing backend process " . $backend_process->pid;
-        $backend_process->stop if $backend_process->is_running;
-        diag("done with backend process");
-    }
+    return unless defined $bmwqemu::backend && $backend_process;
+
+    diag('killing backend process ' . $backend_process->pid);
+    $backend_process->stop if $backend_process->is_running;
+    $backend_process = undef;
+    diag('done with backend process');
 }
 
 sub signalhandler {
@@ -167,7 +210,7 @@ sub signalhandler {
         return;
     }
     kill_backend;
-    kill_commands;
+    kill_commands("received signal $sig");
     kill_autotest;
     _exit(1);
 }
@@ -216,7 +259,7 @@ $bmwqemu::vars{TEST_GIT_HASH} = OpenQA::Isotovideo::Utils::calculate_git_hash($b
 
 # start the command fork before we get into the backend, the command child
 # is not supposed to talk to the backend directly
-($cmd_srv_process, $cmd_srv_fd) = commands::start_server($bmwqemu::vars{QEMUPORT} + 1);
+($cmd_srv_process, $cmd_srv_fd) = commands::start_server($cmd_srv_port = $bmwqemu::vars{QEMUPORT} + 1);
 
 # set a default distribution if the tests don't have one
 $testapi::distri = distribution->new;
@@ -276,6 +319,7 @@ $io_select->add($testfd);
 $io_select->add($cmd_srv_fd);
 $io_select->add($backend_process->channel_out);
 
+# stop main loop as soon as one of the child processes terminates
 my $stop_loop = sub { $loop = 0 if $loop; };
 $testprocess->once(collected => $stop_loop);
 $backend_process->once(collected => $stop_loop);
@@ -284,7 +328,7 @@ $cmd_srv_process->once(collected => $stop_loop);
 # now we have everything, give the tests a go
 $testfd->write("GO\n");
 
-my $command_handler = OpenQA::Isotovideo::CommandHandler->new(
+$command_handler = OpenQA::Isotovideo::CommandHandler->new(
     cmd_srv_fd => $cmd_srv_fd,
     backend_fd => $backend_process->channel_in,
 );
@@ -335,6 +379,7 @@ sub check_asserted_screen {
 
 $return_code = 0;
 
+# enter the main loop: process messages from autotest, command server and backend
 while ($loop) {
     my ($ready_for_read, $ready_for_write, $exceptions) = IO::Select::select($io_select, undef, $io_select, $command_handler->timeout);
     for my $readable (@$ready_for_read) {
@@ -355,9 +400,14 @@ while ($loop) {
         check_asserted_screen($command_handler->no_wait);
     }
 }
-# don't leave the commands server open - it will no longer react anyway
-# as most of it ends up in the loop above
-kill_commands;
+
+# tell the command server that it should no longer process isotovideo commands since we've
+# just left the loop which would handle such commands (otherwise the command server would just
+# hang on the next isotovideo command)
+$command_handler->stop_command_processing;
+
+# terminate/kill the command server and let it inform its websocket clients before
+kill_commands('test execution ended');
 
 if ($testfd) {
     $return_code = 1;    # unusual shutdown
@@ -424,10 +474,12 @@ if (!$return_code && $command_handler->test_completed && $bmwqemu::vars{BACKEND}
 
 END {
     kill_backend;
-    kill_commands;
+    kill_commands('test execution ended through exception');
     kill_autotest;
+
     # in case of early exit, e.g. help display
     $return_code //= 0;
+
     print "$$: EXIT $return_code\n";
     $? = $return_code;
 }

--- a/isotovideo
+++ b/isotovideo
@@ -169,7 +169,7 @@ sub kill_commands {
         my $tx = $ua->post($url, json => {stopping_test_execution => $reason});
         try {
             my $res = $tx->result;
-            if (!$res->is_success || $res->code != 200) {
+            if ($res->code != 200) {
                 diag('isotovideo: unable to inform websocket clients about stopping command server: ' . $res->to_string);
             }
         }

--- a/t/07-commands.t
+++ b/t/07-commands.t
@@ -105,6 +105,17 @@ subtest 'web socket route' => sub {
     $t->message_ok('result from isotovideo is passed back');
     $t->json_message_is('/response_for' => 'set_pause_at_test');
     $t->json_message_is('/name'         => 'installation-welcome');
+
+    subtest 'broadcast messages to websocket clients' => sub {
+        my $t2 = Test::Mojo->new;
+        $t2->post_ok("$base_url/Hallo/broadcast", json => {
+                stopping_test_execution => 'foo',
+        });
+        $t2->status_is(200);
+        $t->message_ok('message from broadcast route received');
+        $t->json_message_is('/stopping_test_execution' => 'foo');
+    };
+
     $t->finish_ok();
 };
 


### PR DESCRIPTION
See https://progress.opensuse.org/issues/45191

---

This works by broadcasting a last message to all web-socket clients before the command server terminates. This change also unifies the different functions to kill isotovideo's sub processes.

See https://github.com/os-autoinst/openQA/pull/1981 for the worker and UI part. Both PRs must not necessarily be merged/deployed at the same time.

---

There are automated tests for the boroadcast and the UI part. The full stack has been tested manually: https://w3.suse.de/~mkittler/job-stopping.mkv  
The manual test covers the 2 cases: test just ends (after failure) and test is stopped by user (and therefore killed via the worker)