### PR TITLE
VMware: Reset VNC and serial console on snapshot revert

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -205,7 +205,14 @@ sub make_snapshot {
 sub load_snapshot {
     my ($sname) = @_;
     bmwqemu::diag("Loading a VM snapshot $sname");
-    return query_isotovideo('backend_load_snapshot', {name => $sname});
+    my $command = query_isotovideo('backend_load_snapshot', {name => $sname});
+    # On VMware VNC console needs to be re-selected after snapshot revert,
+    # so the screen is refreshed. Same with serial console.
+    if ($command eq 'vmware_fixup') {
+        testapi::select_console('sut');
+        query_isotovideo('backend_stop_serial_grab');
+        query_isotovideo('backend_start_serial_grab');
+    }
 }
 
 sub run_all {

--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -130,7 +130,7 @@ sub can_handle {
     my $vars = \%bmwqemu::vars;
     if ($args->{function} eq 'snapshots' && !check_var('HDDFORMAT', 'raw')) {
         # Snapshots via libvirt are supported on KVM and, perhaps, ESXi. Hyper-V uses native tools.
-        if (check_var('VIRSH_VMM_FAMILY', 'kvm') || check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
+        if (check_var('VIRSH_VMM_FAMILY', 'kvm') || check_var('VIRSH_VMM_FAMILY', 'hyperv') || check_var('VIRSH_VMM_FAMILY', 'vmware')) {
             return {ret => 1};
         }
     }

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -338,7 +338,7 @@ sub add_disk {
     my $name                    = $self->name;
     my $file                    = $name . $args->{dev_id} . ($self->vmm_family eq 'vmware' ? '.vmdk' : '.img');
     my $basedir                 = '/var/lib/libvirt/images/';
-    my $vmware_datastore        = get_var('VMWARE_DATASTORE');
+    my $vmware_datastore        = get_var('VMWARE_DATASTORE', '');
     my $vmware_openqa_datastore = "/vmfs/volumes/$vmware_datastore/openQA/";
     if ($args->{create}) {
         my $size = $args->{size} || '20G';


### PR DESCRIPTION
https://trello.com/c/BbvRHrrw/347-p2-snapshot-revert-leads-to-broken-keyboard-and-or-serial-console-on-vmware

Fails here: http://nilgiri.suse.cz/tests/100#step/keymap_or_locale/4

Reset VNC and serial console on snapshot revert.

On VMware VNC screen and serial console need to be reset on snapshot
revert otherwise both are stalled.

Validation run: http://nilgiri.suse.cz/tests/282

```
[2019-02-11T10:23:46.225 CET] [debug] LOAD snapshot lastgood to openQA-SUT-42, return code=0
[2019-02-11T10:23:46.226 CET] [debug] A: autotest::selected_console=<log-console>
[2019-02-11T10:23:46.226 CET] [debug] <<< testapi::select_console(testapi_console='sut')
[2019-02-11T10:23:46.252 CET] [debug] B: autotest::selected_console=<sut>
```

`load_snapshot` now does not return anything as no one was checking it anyway.