### PR TITLE
tidy: Fix path detection for os-autoinst-distri-opensuse

### DIFF
--- a/tools/tidy
+++ b/tools/tidy
@@ -15,15 +15,15 @@ if ! which perltidy > /dev/null 2>&1; then
     exit 1
 fi
 
+dir="$(dirname $(readlink -f $0))/.."
 perltidy_version_found=$(perltidy -version | sed -n '1s/^.*perltidy, v\([0-9]*\)\s*$/\1/p')
-perltidy_version_expected=$(sed -n "s/^.*Tidy[^0-9]*\([0-9]*\)['];$/\1/p" ${0%/*}/../cpanfile)
+perltidy_version_expected=$(sed -n "s/^.*Tidy[^0-9]*\([0-9]*\)['];$/\1/p" $dir/cpanfile)
 if [ "$perltidy_version_found" != "$perltidy_version_expected" ]; then
     echo "Wrong version of perltidy. Found '$perltidy_version_found', expected '$perltidy_version_expected'"
     exit 1
 fi
 
-
-cd "${0%/*}/.."
+cd $dir
 
 # just to make sure we are at the right location
 test -e tools/tidy || exit 1


### PR DESCRIPTION
This fixes error:
Wrong version of perltidy. Found '20181120', expected ''

Previous implementation found cpanfile from os-autoinst-distri-opensuse,
but it's meant to read the one from os-autoinst, where Perl::Tidy is
specified.

Fixes: 16ad93ea ("Check for correct tidy version on execution")