### PR TITLE
Allow relative paths in PRODUCTDIR as well

### DIFF
--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -7,7 +7,7 @@ Supported variables per backend
 |====================
 Variable;Values allowed;Default value;Explanation
 CASEDIR;string;;Path to test distribution. Can be a git repository URL of a test distribution to checkout with an optional refspec into the current directory. Tries to follow the definition of https://docs.npmjs.com/files/package.json#git-urls-as-dependencies , for example `git@github.com:os-autoinst/os-autoinst-distri-opensuse.git#feature/test`
-PRODUCTDIR;string;;Path to optional "product directory" which includes the test schedule entry point "main.pm" as well as a "needles" subdirectory with the needles to load.
+PRODUCTDIR;string;;Path to optional "product directory" which includes the test schedule entry point "main.pm" as well as a "needles" subdirectory with the needles to load. Can be relative path.
 NEEDLES_DIR;string;;Path to needles subdirectory to use, defaults to "needles" within `PRODUCTDIR`. Can be a git repository URL, comparable to `CASEDIR`
 INCLUDE_MODULES;string;;comma separated names or fullnames of test modules to be included while excluding all that do not match, e.g. "boot,mod1"
 EXCLUDE_MODULES;string;;comma separated names or fullnames of test modules to exclude. Can be combined with INCLUDE_MODULES and has precedence, e.g. to additionally exclude modules based on an include-list

--- a/isotovideo
+++ b/isotovideo
@@ -230,6 +230,7 @@ if ($bmwqemu::vars{SCHEDULE}) {
     autotest::loadtest($_ . '.pm') foreach split(',', $bmwqemu::vars{SCHEDULE});
     $bmwqemu::vars{INCLUDE_MODULES} = 'none';
 }
+unshift @INC, '.' unless File::Spec->file_name_is_absolute($bmwqemu::vars{PRODUCTDIR});
 if (-e $bmwqemu::vars{PRODUCTDIR} . '/main.pm') {
     require $bmwqemu::vars{PRODUCTDIR} . '/main.pm';
 }


### PR DESCRIPTION
This for example allows to use custom git clones on workers which load
tests and/or needles from cache as well and run perl5.26 or newer which
does not include '.' in @INC by default anymore.

Related progress issue: https://progress.opensuse.org/issues/44327