### PR TITLE
Fix skipping needles with missing PNGs

### DIFF
--- a/ppmclibs/tinycv.pm
+++ b/ppmclibs/tinycv.pm
@@ -71,7 +71,7 @@ sub search_ {
     my $needle_image = $needle->get_image;
     unless ($needle_image) {
         bmwqemu::diag("skipping $needle->{name}: missing PNG");
-        return;
+        return undef;
     }
     $stopwatch->lap("**++ search__: get image") if $stopwatch;
 

--- a/ppmclibs/tinycv_impl.cc
+++ b/ppmclibs/tinycv_impl.cc
@@ -325,7 +325,8 @@ Image* image_read(const char* filename)
     image->img = imread(filename, CV_LOAD_IMAGE_COLOR);
     if (!image->img.data) {
         std::cerr << "Could not open image " << filename << std::endl;
-        return 0L;
+        delete image;
+        return nullptr;
     }
     return image;
 }


### PR DESCRIPTION
The error handling was just done too late - after attempting to the the (non-existent) image. I also fixed a memory leak in the case this error happens.

(see https://progress.opensuse.org/issues/47372)