### PR TITLE
qemu: Don't use deprecated/removed vlan option for multinet

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -533,7 +533,6 @@ sub start_qemu {
 
     die "no kvm-img/qemu-img found\n" unless $qemuimg;
     die "no Qemu/KVM found\n"         unless $qemubin;
-    die "MULTINET is not supported with NICTYPE==tap\n" if ($vars->{MULTINET} && $vars->{NICTYPE} eq "tap");
 
     $self->{proc}->qemu_bin($qemubin);
     $self->{proc}->qemu_img_bin($qemuimg);
@@ -801,11 +800,6 @@ sub start_qemu {
 
         foreach my $attribute (qw(KERNEL INITRD APPEND)) {
             sp(lc($attribute), $vars->{$attribute}) if $vars->{$attribute};
-        }
-
-        if ($vars->{MULTINET}) {
-            sp('net', [qv "nic vlan=1 model=$vars->{NICMODEL} macaddr=52:54:00:12:34:57"]);
-            sp('net', [qw(none vlan=1)]);
         }
 
         unless ($vars->{QEMU_NO_TABLET}) {

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -63,7 +63,6 @@ ISO_$i;filename;;Aditional ISO to be attached to VM. Up to 9
 KEEPHDDS;boolean;;Leave created HDD after test finishes. Useful for debugging tests
 LAPTOP;boolean or filename;0;If 1, loads Dell E6330 DMI. If filename, loads specified DMI
 MAKETESTSNAPSHOTS;boolean;0;Save snapshot for each test module in qcow image
-MULTINET;boolean;0;VM will have two virtual NIC. Can't be used with NICTYPE tap
 MULTIPATH;boolean;0;Add HDD drives as multipath devices. Override HDDMODEL to virtio-scsi-pci
 NBF;boolean;0;open source network boot firmware e.g. to attach iscsi target on boot http://ipxe.org/
 NICMAC;any MAC address;52:54:00:12:34:56;MAC address to be assigned to virtual network card

--- a/doc/networking.md
+++ b/doc/networking.md
@@ -1,24 +1,31 @@
-# Networking in OpenQA
-There are three possible network configurations for OpenQA virtual machines (VM).
-The configuration is controlled by NICTYPE and MULTINET variables passed from OpenQA.
+# Networking in openQA
+There are three possible network configurations for openQA virtual machines when using the
+qemu backend.
 
-## default situation
-By default NICTYPE is set to "user" and MULTINET is not set. In this case, each VM is created
+The configuration is controlled by NICTYPE, NICMAC and NICVLAN variables passed from openQA.
+
+## Default situation
+By default NICTYPE is set to "user". In this case, each VM is created
 with one network device, QEMU provided DHCP configuration. "User" network mode does have a
 limitation - only TCP and UDP are supported. However no additional configuration is needed.
 
-## options for "user" mode
+## Options for "user" mode
 If options for "user" mode are required, they can be set in NICTYPE_USER_OPTIONS variable.
-
-## multiple network devices
-When MULTINET variable is set, only NICTYPE set to "user" is supported. In this case, each VM
-is created with two network devices using "user" network mode.
 
 ## TAP device support
 When advanced configurations, routing or better performance is required, NICTYPE can be set to
 "tap". In this case, preconfigured TAP device on host system is used as VM network device.
 Which TAP device is used depends on TAPDEV variable which is automatically set to "tap" + worker id - 1,
-i.e. worker1 uses tap0, worker 6 uses tap5. This mode requires system administrator to create
-TAP device for each running worker and to manually prepare any routing or bridging before "tap"
+i.e. worker1 uses tap0, worker 6 uses tap5. This mode requires the system administrator to create
+a TAP device for each running worker and to manually prepare any routing or bridging before "tap"
 networking can be used. TAP devices need to be created with proper permissions so VMs can access
-them, e.g. "tunctl -u _openqa-worker -p -t tap0"
+them, e.g. "tunctl -u _openqa-worker -p -t tap0".
+
+## Multiple network devices
+To create multiple network devices, one can set multiple, comma-separated MAC addresses
+via NICMAC. The TAPDEV variable supports multiple, comma-separated values, too.
+
+---
+
+Also have a look at [Multi Machine Tests Setup](http://open.qa/docs/#_multi_machine_tests_setup)
+documentation.


### PR DESCRIPTION
Instead, just increase the number of network devices to be added to get another device (with different MAC address).

See https://progress.opensuse.org/issues/29419

@richiejp Am I'm missing something or is it really that easy? At least `ip addr` now shows the additional device with IP.