### PR TITLE
Extend arguments for type_string

### DIFF
--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -154,6 +154,14 @@ subtest 'type_string with wait_still_screen' => sub {
     is_deeply($cmds, [{cmd => 'backend_type_string', text => 'hallo', max_interval => 250}]);
     $cmds = [];
     ok($wait_still_screen_called, 'wait still screen should have been called');
+    type_string 'test2_adding_timeout', wait_still_screen => 1, timeout => 5, max_interval => 100;
+    is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 100, text => 'test2_adding_timeout'}]);
+    $cmds = [];
+    ok($wait_still_screen_called, 'wait still screen should have been called');
+    type_string 'test3_with_sim_level', wait_still_screen => 1, timeout => 5, similarity_level => 38, max_interval => 100;
+    is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 100, text => 'test3_with_sim_level'}]);
+    $cmds = [];
+    ok($wait_still_screen_called, 'wait still screen should have been called');
 };
 
 
@@ -409,6 +417,7 @@ subtest 'wait_still_screen' => sub {
     ok(wait_still_screen(3), 'still time specified');
     ok(wait_still_screen(2, 4), 'still time and timeout');
     ok(wait_still_screen(stilltime => 2, no_wait => 1), 'no_wait option can be specified');
+    ok(wait_still_screen(stilltime => 2, timeout => 5, no_wait => 1, similarity_level => 30), 'Add similarity_level & timeout');
     ok(!wait_still_screen(timeout => 4, no_wait => 1), 'two named args, with timeout below stilltime - which will always return false');
     ok(wait_still_screen(1, 2, timeout => 3), 'named over positional');
 };

--- a/testapi.pm
+++ b/testapi.pm
@@ -1215,7 +1215,8 @@ sub send_key_until_needlematch {
 
 =head2 type_string
 
-  type_string($string [, max_interval => <num> ] [, wait_screen_changes => <num> ] [, wait_still_screen => <num> ] [, secret => 1 ] );
+  type_string($string [, max_interval => <num> ] [, wait_screen_changes => <num> ] [, wait_still_screen => <num> ] [, secret => 1 ] 
+  [, timeout => <num>] [, similarity_level => <num>] );
 
 send a string of characters, mapping them to appropriate key names as necessary
 
@@ -1227,8 +1228,12 @@ C<max_interval> the slower the typing.
 C<wait_screen_change> if set, type only this many characters at a time
 C<wait_screen_change> and wait for the screen to change between sets.
 
-C<wait_still_screen> if set, C<wait_still_screen> for the given seconds
-after the whole string is typed.
+C<wait_still_screen> if set, C<wait_still_screen> returns true if screen is not 
+changed for given C<$wait_still_screen> seconds or false if the screen is not still
+for the given seconds within defined C<timeout> after the whole string is typed.
+Default timeout is 30s, default stilltime is 0s.
+
+C<similarity_level> can be passed as argument for wrapped C<wait_still_screen> calls.
 
 C<secret (bool)> suppresses logging of the actual string typed.
 
@@ -1252,25 +1257,27 @@ sub type_string {
         return;
     }
 
-    my $max_interval = $args{max_interval}       // 250;
-    my $wait         = $args{wait_screen_change} // 0;
-    my $wait_still   = $args{wait_still_screen}  // 0;
-    bmwqemu::log_call(string => $log, max_interval => $max_interval, wait_screen_changes => $wait, wait_still_screen => $wait_still);
+    my $max_interval   = $args{max_interval}       // 250;
+    my $wait           = $args{wait_screen_change} // 0;
+    my $wait_still     = $args{wait_still_screen}  // 0;
+    my $wait_timeout   = $args{timeout}            // 30;
+    my $wait_sim_level = $args{similarity_level}   // 47;
+    bmwqemu::log_call(string => $log, max_interval => $max_interval, wait_screen_changes => $wait, wait_still_screen => $wait_still,
+        timeout => $wait_timeout, similarity_level => $wait_sim_level);
+    my @pieces;
     if ($wait) {
         # split string into an array of pieces of specified size
         # https://stackoverflow.com/questions/372370
-        my @pieces = unpack("(a${wait})*", $string);
-        for my $piece (@pieces) {
-            wait_screen_change { query_isotovideo('backend_type_string', {text => $piece, max_interval => $max_interval}); };
-            if ($wait_still) {
-                wait_still_screen($wait_still);
-            }
-        }
+        @pieces = unpack("(a${wait})*", $string);
     }
     else {
-        query_isotovideo('backend_type_string', {text => $string, max_interval => $max_interval});
-        if ($wait_still) {
-            wait_still_screen($wait_still);
+        push @pieces, $string;
+    }
+    for my $piece (@pieces) {
+        wait_screen_change { query_isotovideo('backend_type_string', {text => $piece, max_interval => $max_interval}); };
+        if ($wait_still && !wait_still_screen(stilltime => $wait_still,
+                timeout => $wait_timeout, similarity_level => $wait_sim_level)) {
+            die "wait_still_screen timed out after ${wait_timeout}s!";
         }
     }
 }


### PR DESCRIPTION
I would like to make return values from ``wait_still_screen`` somehow useful in our test suites. If I correctly understand ``wait_still_screen``, it's basically letting us know whether the SUT had still screen for some certain amount of time, then it returns success. Otherwise it reports a failure which we tend to ignore. I have found it useful use case in our yast2 gui tests, when we are filling some forms using ``type_string``.

* failure: http://eris.suse.cz/tests/11922#step/yast2_hostnames/31
* success: http://eris.suse.cz/tests/12008#step/yast2_hostnames/27