### PR TITLE
[WIP][AARCH64 Automation] Save the original value of SERIALDEV for grub configuration

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -121,6 +121,8 @@ sub init {
     }
     elsif (get_var('SERIALDEV')) {
         $serialdev = get_var('SERIALDEV');
+        set_var('SERIALDEVORIG', $serialdev);
+        bmwqemu::save_vars();
     }
     else {
         $serialdev = 'ttyS0';


### PR DESCRIPTION
This commit should be merged together with https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6800

There is a defect found during openQA integration with aarch64 automation. Firstly, not all aarch64 machines use ttyAMA0 as their serial console. Some vendor meachines like xgene has only ttyS0 as their serial console. Secondly, the SERIALDEV variable is overridden by some other functionalities
during automation run. So it is necessary to save its orignal value to SERIALDEVORIG variable which is only for internal use. It should not be referred to from outside of live test run, for example, assign a value to it explicitly in test suite or machine settings.

Verification run: http://10.162.187.154/tests/1050

@alice-suse @xguo @Julie-CAO