### PR TITLE
svirt: Fix serial terminal for s390x + other svirt fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -39,7 +39,7 @@ consolesexec_DATA = \
 	consoles/sshXtermIPMI.pm \
 	consoles/sshXtermVt.pm \
 	consoles/ttyConsole.pm \
-	consoles/virtio_screen.pm \
+	consoles/serial_screen.pm \
 	consoles/virtio_terminal.pm \
 	consoles/vnc_base.pm \
 	consoles/network_console.pm \

--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -322,7 +322,7 @@ sub start_serial_grab {
 =head2 ($ssh, $chan) = $self->backend->start_serial_grab($name, %args)
 
 Opens SSH connection to grab serial terminal log
-(using consoles::virtio_screen, saved into serial_terminal.txt).
+(using consoles::serial_screen, saved into serial_terminal.txt).
 
 This method is not supposed to be called twice for test run due logging
 into file.

--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -94,25 +94,22 @@ sub do_stop_vm {
     return {};
 }
 
-# In list context returns pair ($stdout, $stderr). In void (and scalar)
-# context just logs stdout and stderr, returns nothing.
+# Log stdout and stderr and return them in a list (comped).
 sub get_ssh_output {
     my ($chan) = @_;
+    die 'No channel found' unless $chan;
 
-    my ($stdout, $errout) = ('', '');
+    my ($stdout, $stderr) = ('', '');
     while (!$chan->eof) {
         if (my ($o, $e) = $chan->read2) {
             $stdout .= $o;
-            $errout .= $e;
+            $stderr .= $e;
         }
     }
-    if (wantarray) {
-        return ($stdout, $errout);
-    }
-    else {
-        bmwqemu::diag "Command's stdout:\n$stdout" if length($stdout);
-        bmwqemu::diag "Command's stderr:\n$errout" if length($errout);
-    }
+    chomp($stdout, $stderr);
+    bmwqemu::diag("Command's stdout:\n$stdout") if length($stdout);
+    bmwqemu::diag("Command's stderr:\n$stderr") if length($stderr);
+    return ($stdout, $stderr);
 }
 
 # Sends command to libvirt host, logs stdout and stderr of the command,

--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -291,11 +291,6 @@ sub open_serial_console_via_ssh {
     my $credentials = $self->read_credentials_from_virsh_variables;
     my $ssh         = $self->new_ssh_connection(%$credentials);
     my $chan        = $ssh->channel() || $ssh->die_with_error('Unable to create SSH channel for serial console');
-    $chan->blocking(0);
-    $chan->pty('vt100', {echo => 1});
-    $chan->pty_size(1024, 24);
-    $chan->shell() || $ssh->die_with_error('Unable to start shell for serial console');
-    print($chan "PS1='# '\n");
 
     # note: see comments in start_serial_grab for the special handling of vmware/hyperv
     my $command;

--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -1,5 +1,5 @@
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,8 +21,17 @@ use warnings;
 
 use base 'backend::virt';
 
-use testapi qw(get_var get_required_var check_var);
 use IO::Select;
+use testapi qw(get_var get_required_var check_var);
+
+use constant SERIAL_CONSOLE_DEFAULT_PORT   => 0;
+use constant SERIAL_CONSOLE_DEFAULT_DEVICE => 'console';
+
+use constant SERIAL_TERMINAL_DEFAULT_PORT   => 1;
+use constant SERIAL_TERMINAL_DEFAULT_DEVICE => 'console';
+
+use Exporter 'import';
+our @EXPORT_OK = qw(SERIAL_CONSOLE_DEFAULT_PORT SERIAL_CONSOLE_DEFAULT_DEVICE SERIAL_TERMINAL_DEFAULT_PORT SERIAL_TERMINAL_DEFAULT_DEVICE);
 
 # this is a fake backend to some extend. We don't start VMs, but provide ssh access
 # to a libvirt running host (KVM for System Z in mind)
@@ -276,7 +285,7 @@ sub start_serial_grab {
 
 # opens another SSH connection to grab the serial console with the specified port
 sub open_serial_console_via_ssh {
-    my ($self, $name, $port) = @_;
+    my ($self, $name, $devname, $port) = @_;
 
     bmwqemu::diag("Starting SSH connection to connect to libvirt domain $name via serial port $port");
     my $credentials = $self->read_credentials_from_virsh_variables;
@@ -299,7 +308,7 @@ sub open_serial_console_via_ssh {
         $command = "nc $server $port";
     }
     else {
-        $command = "virsh console \"$name\" \"serial$port\"";
+        $command = "virsh console \"$name\" \"$devname$port\"";
     }
     $chan->exec($command) || $ssh->die_with_error('Unable to start serial console');
 

--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -255,17 +255,6 @@ sub read_credentials_from_virsh_variables {
 sub start_serial_grab {
     my ($self, $name) = @_;
 
-    # Connect to VM host, or, in case of Hyper-V, to intermediary from which we gather
-    # remote serial console output.
-    my ($hostname, $password);
-    if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
-        $hostname = get_required_var('VIRSH_GUEST');
-        $password = get_var('VIRSH_GUEST_PASSWORD');
-    }
-    else {
-        $hostname = get_required_var('VIRSH_HOSTNAME');
-        $password = get_var('VIRSH_PASSWORD');
-    }
     my $credentials = $self->read_credentials_from_virsh_variables;
     my ($ssh, $chan) = $self->start_ssh_serial(%$credentials);
     my $command;

--- a/consoles/serial_screen.pm
+++ b/consoles/serial_screen.pm
@@ -1,4 +1,4 @@
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -12,7 +12,7 @@
 #
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
-package consoles::virtio_screen;
+package consoles::serial_screen;
 
 use 5.018;
 use strict;
@@ -35,9 +35,9 @@ sub new {
 }
 
 my $trying_to_use_keys = <<'FIN.';
-Virtio terminal does not support send_key. Use type_string (possibly with an
-ANSI/XTERM escape sequence), or switch to a console which sends key presses, not
-terminal codes.
+Virtio terminal and svirt serial terminal do not support send_key. Use
+type_string (possibly with an ANSI/XTERM escape sequence), or switch to a
+console which sends key presses, not terminal codes.
 FIN.
 
 =head2 send_key
@@ -104,10 +104,10 @@ sub type_string {
     $text .= $term if defined $term;
     my $written = syswrite $fd, $text;
     unless (defined $written) {
-        croak "Error writing to virtio terminal: $ERRNO";
+        croak "Error writing to virtio/svirt serial terminal: $ERRNO";
     }
     if ($written < length($text)) {
-        croak "Was not able to write entire message to virtio terminal. Only $written of $nargs->{text}";
+        croak "Was not able to write entire message to virtio/svirt serial terminal. Only $written of $nargs->{text}";
     }
 }
 
@@ -159,7 +159,7 @@ sub normalise_pattern {
                      no_regex => 0
   ]);
 
-Monitor the virtio console socket $file_descriptor for a character sequence
+Monitor the virtio/svirt serial console socket $file_descriptor for a character sequence
 which matches $pattern. Bytes are read from the socket in up to $buffer_size/2
 chunks and each chunk is added to a ring buffer which is $buffer_size
 long. The regular expression is tested against the ring buffer after each read
@@ -242,7 +242,7 @@ sub read_until {
             if ($ERRNO{EAGAIN} || $ERRNO{EWOULDBLOCK}) {
                 next READ;
             }
-            croak "Failed to read from virtio console char device: $ERRNO";
+            croak "Failed to read from virtio/svirt serial console char device: $ERRNO";
         }
 
         # If there is not enough free space in the ring buffer; remove an amount
@@ -272,7 +272,7 @@ sub read_until {
 =head2 peak
 
 Read and return pending data without consuming it. This is useful if you are
-about to destroy the virtio_screen instance, but want to keep any pending
+about to destroy the serial_screen instance, but want to keep any pending
 data. However this does not wait for any data in particular so this races with
 the backend and data transport. Therefor it should only be used when there is
 no information available about what data is expected to be available.

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -630,22 +630,22 @@ sub get_cmd_output {
     }
 
     # create a new channel; try to re-establish the SSH connection on failure
-    my $channel = $ssh->channel();
-    if (!$channel) {
-        $ssh     = $self->_init_ssh($domain);
-        $channel = $ssh->channel() || $ssh->die_with_error("unable to create channel for SSH console \"$domain\"");
+    my $chan = $ssh->channel();
+    if (!$chan) {
+        $ssh  = $self->_init_ssh($domain);
+        $chan = $ssh->channel() || $ssh->die_with_error("unable to create channel for SSH console \"$domain\"");
     }
 
     # execute command
-    if (!$channel->exec($cmd)) {
+    if (!$chan->exec($cmd)) {
         $ssh->die_with_error("unable to execute command \"$cmd\" via SSH console \"$domain\"");
     }
 
     # read output and close channel
     bmwqemu::diag "Command executed: $cmd";
-    my @cmd_output = backend::svirt::get_ssh_output($channel);
-    $channel->send_eof();
-    $channel->close();
+    my @cmd_output = backend::svirt::get_ssh_output($chan);
+    $chan->send_eof();
+    $chan->close();
     return $wantarray ? \@cmd_output : $cmd_output[0];
 }
 

--- a/consoles/sshVirtshSUT.pm
+++ b/consoles/sshVirtshSUT.pm
@@ -1,4 +1,4 @@
-# Copyright © 2018 SUSE LLC
+# Copyright © 2018-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -27,8 +27,12 @@ sub new {
     my ($class, $testapi_console, $args) = @_;
 
     my $self = $class->SUPER::new($testapi_console, $args);
-    $self->{libvirt_domain} = $args->{libvirt_domain} // 'openQA-SUT-1';
+
+    # TODO: inherit from consoles::sshVirtsh
+    my $instance = get_var('VIRSH_INSTANCE', 1);
+    $self->{libvirt_domain} = $args->{libvirt_domain} // "openQA-SUT-$instance";
     $self->{serial_port_no} = $args->{serial_port_no} // 1;
+
     return $self;
 }
 

--- a/consoles/sshVirtshSUT.pm
+++ b/consoles/sshVirtshSUT.pm
@@ -64,9 +64,8 @@ sub activate {
     my ($self) = @_;
 
     my $backend = $self->{backend};
-    my ($ssh, $chan) = $backend->open_serial_console_via_ssh($self->{libvirt_domain}, $self->{pty_dev}, $self->{serial_port_no});
-
-    $self->{ssh}    = $ssh;
+    my ($ssh, $chan) = $backend->open_serial_console_via_ssh($self->{libvirt_domain},
+        devname => $self->{pty_dev}, port => $self->{serial_port_no}, is_terminal => 1);
     $self->{screen} = consoles::virtio_screen->new($chan, $ssh->sock);
     return;
 }

--- a/consoles/sshVirtshSUT.pm
+++ b/consoles/sshVirtshSUT.pm
@@ -22,7 +22,7 @@ use base 'consoles::console';
 
 use testapi 'get_var';
 use backend::svirt qw(SERIAL_TERMINAL_DEFAULT_PORT SERIAL_TERMINAL_DEFAULT_DEVICE);
-use consoles::virtio_screen;
+use consoles::serial_screen;
 
 sub new {
     my ($class, $testapi_console, $args) = @_;
@@ -66,7 +66,7 @@ sub activate {
     my $backend = $self->{backend};
     my ($ssh, $chan) = $backend->open_serial_console_via_ssh($self->{libvirt_domain},
         devname => $self->{pty_dev}, port => $self->{serial_port_no}, is_terminal => 1);
-    $self->{screen} = consoles::virtio_screen->new($chan, $ssh->sock);
+    $self->{screen} = consoles::serial_screen->new($chan, $ssh->sock);
     return;
 }
 

--- a/consoles/sshVirtshSUT.pm
+++ b/consoles/sshVirtshSUT.pm
@@ -21,6 +21,7 @@ use warnings;
 use base 'consoles::console';
 
 use testapi 'get_var';
+use backend::svirt qw(SERIAL_TERMINAL_DEFAULT_PORT SERIAL_TERMINAL_DEFAULT_DEVICE);
 use consoles::virtio_screen;
 
 sub new {
@@ -31,7 +32,15 @@ sub new {
     # TODO: inherit from consoles::sshVirtsh
     my $instance = get_var('VIRSH_INSTANCE', 1);
     $self->{libvirt_domain} = $args->{libvirt_domain} // "openQA-SUT-$instance";
-    $self->{serial_port_no} = $args->{serial_port_no} // 1;
+    $self->{serial_port_no} = $args->{serial_port_no} // SERIAL_TERMINAL_DEFAULT_PORT;
+
+    # QEMU on s390x fails to start when added <serial> device due arch limitation
+    # on SCLP console, see "Multiple VT220 operator consoles are not supported"
+    # error at
+    # https://github.com/qemu/qemu/blob/master/hw/char/sclpconsole.c#L226
+    # Therefore <console> must be used for s390x.
+    # ATM there is only s390x using this console, let's make it the default.
+    $self->{pty_dev} = $args->{pty_dev} // SERIAL_TERMINAL_DEFAULT_DEVICE;
 
     return $self;
 }
@@ -58,7 +67,7 @@ sub activate {
     my ($self) = @_;
 
     my $backend = $self->{backend};
-    my ($ssh, $chan) = $backend->open_serial_console_via_ssh($self->{libvirt_domain}, $self->{serial_port_no});
+    my ($ssh, $chan) = $backend->open_serial_console_via_ssh($self->{libvirt_domain}, $self->{pty_dev}, $self->{serial_port_no});
 
     $self->{ssh}    = $ssh;
     $self->{screen} = consoles::virtio_screen->new($chan, $ssh->sock);

--- a/consoles/sshVirtshSUT.pm
+++ b/consoles/sshVirtshSUT.pm
@@ -53,9 +53,6 @@ sub screen {
 sub disable {
     my ($self) = @_;
 
-    if (my $shell = $self->{shell}) {
-        $shell->close();
-    }
     if (my $ssh = $self->{ssh}) {
         $ssh->disconnect;
         $self->{ssh} = $self->{chan} = $self->{screen} = undef;

--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -1,4 +1,4 @@
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -27,7 +27,7 @@ use English -no_match_vars;
 use Carp 'croak';
 use Scalar::Util 'blessed';
 use Cwd;
-use consoles::virtio_screen ();
+use consoles::serial_screen ();
 use testapi 'check_var';
 
 our $VERSION;
@@ -137,7 +137,7 @@ sub activate {
     my ($self) = @_;
     if (!check_var('VIRTIO_CONSOLE', 0)) {
         $self->{socket_fd}              = $self->open_socket unless $self->{socket_fd};
-        $self->{screen}                 = consoles::virtio_screen::->new($self->{socket_fd});
+        $self->{screen}                 = consoles::serial_screen::->new($self->{socket_fd});
         $self->{screen}->{carry_buffer} = $self->{preload_buffer};
         $self->{preload_buffer}         = '';
     }

--- a/cpanfile
+++ b/cpanfile
@@ -19,6 +19,7 @@ requires 'File::Spec';
 requires 'File::Temp';
 requires 'File::Which';
 requires 'IO::Handle';
+requires 'IO::Scalar';
 requires 'IO::Select';
 requires 'IO::Socket';
 requires 'IO::Socket::UNIX';

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# Copyright © 2018-2019 SUSE LLC
 
 use strict;
 use warnings;
@@ -10,6 +11,7 @@ use XML::SemanticDiff;
 use backend::svirt;
 use distribution;
 use testapi qw(get_var get_required_var check_var set_var);
+use backend::svirt qw(SERIAL_CONSOLE_DEFAULT_PORT SERIAL_TERMINAL_DEFAULT_DEVICE SERIAL_TERMINAL_DEFAULT_PORT);
 
 BEGIN {
     unshift @INC, '..';
@@ -53,13 +55,16 @@ is_deeply($svirt_sut_console, {
         libvirt_domain  => 'openQA-SUT-1',
         serial_port_no  => 1,
         testapi_console => 'sut-serial',
+        pty_dev         => SERIAL_TERMINAL_DEFAULT_DEVICE,
 }, 'SUT serial console correctly initialized') or diag explain $consoles;
 
 subtest 'XML config for VNC and serial console' => sub {
     $svirt_console->_init_xml();
     $svirt_console->add_vnc({port => 5901});
-    $svirt_console->add_pty({target_port => 0});
-    $svirt_console->add_serial_console();
+    $svirt_console->add_pty({target_port => SERIAL_CONSOLE_DEFAULT_PORT});
+    $svirt_console->add_serial_console({
+            pty_dev     => SERIAL_TERMINAL_DEFAULT_DEVICE,
+            target_port => SERIAL_TERMINAL_DEFAULT_PORT});
 
     my $produced_xml = $svirt_console->{domainxml}->toString(2);
     my $expected_xml = '22-svirth-virsh-config.xml';

--- a/t/22-svirth-virsh-config.xml
+++ b/t/22-svirth-virsh-config.xml
@@ -15,15 +15,14 @@
   </features>
   <on_reboot>destroy</on_reboot>
   <devices>
-    <graphics type="vnc"  port="5901" autoport="no" listen="0.0.0.0" sharePolicy="force-shared">
+    <graphics type="vnc" port="5901" autoport="no" listen="0.0.0.0" sharePolicy="force-shared">
       <listen type="address" address="0.0.0.0"/>
     </graphics>
     <console type="pty">
       <target port="0"/>
     </console>
-    <serial type="pty">
+    <console type="pty">
       <target port="1"/>
-      <alias name="serial1"/>
-    </serial>
+    </console>
   </devices>
 </domain>

--- a/testapi.pm
+++ b/testapi.pm
@@ -775,7 +775,7 @@ rely on needles. This sub is not exported by default as most tests I<will not
 benefit> from changing their behaviour depending on if communication happens
 over serial or VNC.
 
-For more info see consoles/virtio_console.pm and consoles/virtio_screen.pm.
+For more info see consoles/virtio_console.pm and consoles/serial_screen.pm.
 
 =cut
 
@@ -1220,7 +1220,7 @@ sub send_key_until_needlematch {
 
 =head2 type_string
 
-  type_string($string [, max_interval => <num> ] [, wait_screen_changes => <num> ] [, wait_still_screen => <num> ] [, secret => 1 ] 
+  type_string($string [, max_interval => <num> ] [, wait_screen_changes => <num> ] [, wait_still_screen => <num> ] [, secret => 1 ]
   [, timeout => <num>] [, similarity_level => <num>] );
 
 send a string of characters, mapping them to appropriate key names as necessary
@@ -1233,7 +1233,7 @@ C<max_interval> the slower the typing.
 C<wait_screen_change> if set, type only this many characters at a time
 C<wait_screen_change> and wait for the screen to change between sets.
 
-C<wait_still_screen> if set, C<wait_still_screen> returns true if screen is not 
+C<wait_still_screen> if set, C<wait_still_screen> returns true if screen is not
 changed for given C<$wait_still_screen> seconds or false if the screen is not still
 for the given seconds within defined C<timeout> after the whole string is typed.
 Default timeout is 30s, default stilltime is 0s.


### PR DESCRIPTION
Fixes for svirt serial implementation.
Fixes: poo#45863

It brings new perl dependency (`IO::Scalar`).

Also requires changes of other two components:
https://github.com/os-autoinst/openQA/pull/2003 (already merged)
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6841 which actually adds serial console to s390x (not to other svirt users e.g. Hyper-V, VMware, etc.; going to be merged after this is deployed).

**Verification run**:
install_ltp
http://quasar.suse.cz/tests/2408 (default, 21:06 min)
http://quasar.suse.cz/tests/2411 (`SERIAL_CONSOLE=1`, 23:59 min)
http://quasar.suse.cz/tests/2412 (over `root-console`, serial console `root-sut-serial` disabled via `SERIAL_CONSOLE=0`)

ltp_syscalls
http://quasar.suse.cz/tests/2416
http://quasar.suse.cz/tests/2420 (over `root-console`, serial console `root-sut-serial` disabled via `SERIAL_CONSOLE=0`)

ltp_net_ipv6_lib
http://quasar.suse.cz/tests/2414 (04:26 min)
http://quasar.suse.cz/tests/2419 (06:28 min, over `root-console`, serial console `root-sut-serial` disabled via `SERIAL_CONSOLE=0`)

ltp_cve
http://quasar.suse.cz/tests/2421
http://quasar.suse.cz/tests/2422 (25:26 min, over `root-console`, serial console `root-sut-serial` disabled via `SERIAL_CONSOLE=0`)

VIRTIO_CONSOLE_TEST
http://quasar.suse.cz/tests/2424
QEMU: TODO

Verification, that other fixes didn't bring a regression to Hyper-V or VMware. All are run over root-console, serial console disabled with `SERIAL_CONSOLE=0` (otherwise it fails at least on sshd expecting http://quasar.suse.cz/tests/2402#step/sshd/17). We need to decide whether 
1) enable `root-sut-serial` also for Hyper-V / VMware
2) reflect the fact `root-sut-serial` used only for s390x in `select_serial_terminal()`
3) stop using `select_serial_terminal()` in some tests (at least `tests/console/sshd.pm`), but I'd try to avoid this.

textmode@svirt-hyperv-uefi
http://quasar.suse.cz/tests/2409 (45:23 min)

textmode@svirt-vmware
http://quasar.suse.cz/tests/2410

proxyscc_upgrade_sles12sp4_hyperv@svirt-hyperv
http://quasar.suse.cz/tests/2417

media_upgrade_sles15_allpatterns_hyperv@svirt-hyperv-uefi
http://quasar.suse.cz/tests/2418