### PR TITLE
Configure bootindex for first path only

### DIFF
--- a/OpenQA/Qemu/DriveDevice.pm
+++ b/OpenQA/Qemu/DriveDevice.pm
@@ -111,8 +111,9 @@ sub gen_cmdline {
         if (defined $path->controller) {
             push(@params, 'bus=' . $path->controller->id . '.0');
         }
-        $self->_push_ifdef(\@params, 'bootindex=', $self->bootindex);
-        $self->_push_ifdef(\@params, 'serial=',    $self->serial);
+        # Configure bootindex only for first path
+        $self->_push_ifdef(\@params, 'bootindex=', $self->bootindex) if (($path->id eq 'path0') || (!$path->id));
+        $self->_push_ifdef(\@params, 'serial=', $self->serial);
         push(@cmdln, ('-device', join(',', @params)));
     }
 

--- a/t/18-qemu.t
+++ b/t/18-qemu.t
@@ -113,7 +113,7 @@ is_deeply(\@gcmdl, \@cmdl, 'Generate qemu-img command line for single existing U
   -blockdev driver=file,node-name=hd0-file,filename=raid/hd0,cache.no-flush=on
   -blockdev driver=qcow2,node-name=hd0,file=hd0-file,cache.no-flush=on
   -device sega-mega,id=hd0-device-path0,drive=hd0,share-rw=true,bus=scsi0.0,bootindex=0,serial=hd0
-  -device sega-mega,id=hd0-device-path1,drive=hd0,share-rw=true,bus=scsi1.0,bootindex=0,serial=hd0
+  -device sega-mega,id=hd0-device-path1,drive=hd0,share-rw=true,bus=scsi1.0,serial=hd0
 
   -blockdev driver=file,node-name=hd1-file,filename=raid/hd1,cache.no-flush=on
   -blockdev driver=qcow2,node-name=hd1,file=hd1-file,cache.no-flush=on


### PR DESCRIPTION
Fix poo#48155: When is MULTIPATH variable enabled, qemu command line
options contain bootindex for each device and qemu will not start.
Option bootindex needs to be configured only once.

Progress : https://progress.opensuse.org/issues/48155
Verification: http://10.100.12.105/tests/1546