### PR TITLE
Run tidy on the correct directory

### DIFF
--- a/tools/tidy
+++ b/tools/tidy
@@ -23,7 +23,7 @@ if [ "$perltidy_version_found" != "$perltidy_version_expected" ]; then
     exit 1
 fi
 
-cd $dir
+cd "${0%/*}/.."
 
 # just to make sure we are at the right location
 test -e tools/tidy || exit 1


### PR DESCRIPTION
In #1097 we got the change to fix Perl::Tidy version check, but it runs
on the wrong directory in case of tests repo.