### PR TITLE
Improve feedback on "half-open socket"

### DIFF
--- a/OpenQA/Exceptions.pm
+++ b/OpenQA/Exceptions.pm
@@ -35,6 +35,9 @@ use Exception::Class (
     'OpenQA::Exception::SSHConnectionError' => {
         description => 'Failed to connect to SSH Server'
     },
+    'OpenQA::Exception::ConsoleReadError' => {
+        description => 'Failed to receive data from console'
+    },
 );
 
 1;

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -242,7 +242,8 @@ sub run_capture_loop {
                     # Very high limits! On a working socket, the maximum hits per 10 seconds will be around 60.
                     # The maximum hits per 10 seconds saw on a half open socket was >100k
                     if (check_select_rate($buckets, $wait_time_limit, $hits_limit, fileno $fh)) {
-                        die "The console isn't responding correctly. Maybe half-open socket?";
+                        my $console = $self->{current_console}->{testapi_console};
+                        OpenQA::Exception::ConsoleReadError->throw(error => "The console '$console' is not responding (half-open socket?). Make sure the console is reachable or disable stall detection on expected disconnects with '\$console->disable_vnc_stalls', for example in case of intended machine shutdown");
                     }
                 }
 


### PR DESCRIPTION
The die-message for "half-open socket" is replaced by an exception and
extended with hints as well as the output of the actual console that is the
culprit.

Verification run: http://lord.arch/tests/2039/file/autoinst-log.txt shows the
additional output in the log files with helpful pointers into what went
wrong and how to fix it.

Related progress issue: https://progress.opensuse.org/issues/48260