### PR TITLE
export hotkey to os-autoinst-distri

### DIFF
--- a/consoles/console.pm
+++ b/consoles/console.pm
@@ -31,6 +31,7 @@ package consoles::console;
 use strict;
 use warnings;
 use autodie ':all';
+use testapi 'check_var';
 
 require IPC::System::Simple;
 use Class::Accessor 'antlers';
@@ -48,7 +49,15 @@ sub new {
 }
 
 sub init {
-    # nothing fancy
+    my ($self) = @_;
+    if ($self->{args}->{tty}) {
+        if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
+            $self->{console_key} = "alt-f" . $self->{args}->{tty};
+        }
+        else {
+            $self->{console_key} = "ctrl-alt-f" . $self->{args}->{tty};
+        }
+    }
 }
 
 # SUT was e.g. rebooted

--- a/t/10-terminal.t
+++ b/t/10-terminal.t
@@ -255,7 +255,9 @@ sub test_terminal_directly {
     my $tb = Test::More->builder;
     $tb->reset;
 
-    my $term = consoles::virtio_terminal->new('unit-test-console', []);
+    my $term = consoles::virtio_terminal->new('unit-test-console', {tty => 3});
+    ok($term->{console_key} eq "ctrl-alt-f3", 'console_key set correct');
+
     $term->activate;
     my $scrn = $term->screen;
     ok(defined($scrn), 'Create screen');
@@ -338,7 +340,7 @@ sub test_terminal_disabled {
 
     testapi::set_var('VIRTIO_CONSOLE', 0);
 
-    my $term = consoles::virtio_terminal->new('unit-test-console', []);
+    my $term = consoles::virtio_terminal->new('unit-test-console', {});
     $term->activate;
 }
 


### PR DESCRIPTION
Base on comment from Oliver https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6650
We already define this hotkey in os-autoinst. So better using the hotkey of os-autoinst in distribution.
@coolo  could you help give some suggestion? Thanks. I have update a new version for this.