### PR TITLE
Prevent recording empty soft failure test detail

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -27,6 +27,7 @@ use POSIX;
 use testapi  ();
 use autotest ();
 use MIME::Base64 'decode_base64';
+use Mojo::File 'path';
 
 my $serial_file_pos = 0;
 
@@ -417,9 +418,7 @@ sub next_resultname {
 sub write_resultfile {
     my ($self, $filename, $output) = @_;
 
-    open my $fh, '>', bmwqemu::result_dir() . "/$filename";
-    print $fh $output;
-    close $fh;
+    path(bmwqemu::result_dir(), $filename)->spurt($output);
 }
 
 =head2 record_resultfile

--- a/basetest.pm
+++ b/basetest.pm
@@ -414,6 +414,14 @@ sub next_resultname {
     }
 }
 
+sub write_resultfile {
+    my ($self, $filename, $output) = @_;
+
+    open my $fh, '>', bmwqemu::result_dir() . "/$filename";
+    print $fh $output;
+    close $fh;
+}
+
 =head2 record_resultfile
 
     $self->record_resultfile($title, $output [, result => $result] [, resultname => $name]);
@@ -430,9 +438,7 @@ sub record_resultfile {
         text   => $filename,
     };
     push @{$self->{details}}, $detail;
-    open my $fh, '>', bmwqemu::result_dir() . "/$filename";
-    print $fh $output;
-    close $fh;
+    $self->write_resultfile($filename, $output);
 }
 
 sub record_serialresult {
@@ -449,17 +455,19 @@ sub record_serialresult {
     $output .= "# Result:\n";
     $output .= "$string\n";
     $self->record_resultfile('wait_serial', $output, result => $res);
-    return;
+    return undef;
 }
 
 sub record_soft_failure_result {
     my ($self, $reason, %args) = @_;
     $reason //= '(no reason specified)';
 
-    my $result = $self->record_testresult('softfail', %args);
-    my $output = "# Soft Failure:\n$reason\n";
-    $self->record_resultfile('Soft Failed', $output, %$result);
-    return;
+    my $result   = $self->record_testresult('softfail', %args);
+    my $filename = $self->next_resultname('txt');
+    $result->{title} = 'Soft Failed';
+    $result->{text}  = $filename;
+    $self->write_resultfile($filename, "# Soft Failure:\n$reason\n");
+    return undef;
 }
 
 sub register_extra_test_results {
@@ -470,7 +478,7 @@ sub register_extra_test_results {
         $t->{script} = $self->{script} if (!defined($t->{script}) || $t->{script} eq 'unk');
         push @{$self->{extra_test_results}}, $t;
     }
-    return;
+    return undef;
 }
 
 =head2 record_testresult

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -182,9 +182,12 @@ $mock_bmwqemu->mock(result_dir => File::Temp->newdir());
 
 is($autotest::current_test->{dents}, 0, 'no soft failures so far');
 stderr_like(\&record_soft_failure, qr/record_soft_failure\(reason=undef\)/, 'soft failure recorded in log');
-is($autotest::current_test->{dents}, 1, 'soft failure recorded');
+is($autotest::current_test->{dents},             1, 'one dent recorded');
+is(scalar @{$autotest::current_test->{details}}, 1, 'exactly one detail added recorded');
+
 stderr_like(sub { record_soft_failure('workaround for bug#1234') }, qr/record_soft_failure.*reason=.*workaround for bug#1234.*/, 'soft failure with reason');
-is($autotest::current_test->{dents}, 2, 'another');
+is($autotest::current_test->{dents},             2, 'one more dent recorded');
+is(scalar @{$autotest::current_test->{details}}, 2, 'exactly one more detail added recorded');
 my $details    = $autotest::current_test->{details}[-1];
 my $details_ok = is($details->{title}, 'Soft Failed', 'title for soft failure added');
 $details_ok &= is($details->{result}, 'softfail', 'result correct');


### PR DESCRIPTION
See https://progress.opensuse.org/issues/48758

---

os-autoinst actually recorded 2 test details for one soft-failure. The first one was empty and causing the issue linked above.

I extended the unit tests and did a local verification run. I've also tested whether the extended unit test fails without that change.