### PR TITLE
VMware: Delay boot & single-purpose routine/workaround

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -566,7 +566,10 @@ __END"
     $self->run_cmd("virsh $remote_vmm undefine --snapshots-metadata " . $self->name . $ignore);
 
     # define the new domain
-    $self->run_cmd("virsh $remote_vmm define $xmlfilename")  && die "virsh define failed";
+    $self->run_cmd("virsh $remote_vmm define $xmlfilename") && die "virsh define failed";
+    if ($self->vmm_family eq 'vmware') {
+        $self->get_cmd_output('echo bios.bootDelay = \"10000\" >> /vmfs/volumes/datastore1/openQA/' . $self->name . '.vmx', {domain => 'sshVMwareServer'});
+    }
     $self->run_cmd("virsh $remote_vmm start " . $self->name) && die "virsh start failed";
 
     $self->backend->start_serial_grab($self->name);

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -524,6 +524,10 @@ sub resume {
     bmwqemu::diag "VM " . $self->name . " resumed";
 }
 
+sub get_remote_vmm {
+    return get_var('VMWARE_REMOTE_VMM', '');
+}
+
 sub define_and_start {
     my ($self, $args) = @_;
 


### PR DESCRIPTION
**VMware: Delay boot by 10 seconds**

Delaying boot by 10 seconds makes room for test code to configure boot
device in BIOS Setup Utility.

Validation run:
* `media_upgrade_sles15@svirt-vmware`: http://nilgiri.suse.cz/tests/411#step/bootloader_svirt/39
***
**VMware: Retrieve console-only variable**

Setting `VMWARE_REMOTE_VMM` test variable in sshVirtsh console makes it
unavailable from test code and svirt backend code after `load_vars()`.

See http://nilgiri.suse.cz/tests/396/file/autoinst-log.txt and notice
that before needle reload (via `set_var(..., reload_needles => 1)`,
`virsh` has '-c URI' connector (specific to VMware), after that no
connector is present, because `VMWARE_REMOTE_VMM` is retrieved empty
from backend::svirt::save_snapshot() context.

```
[2019-03-07T09:36:35.656 CET] [debug] ||| finished reboot_to_upgrade migration at 2019-03-07 08:36:35 (5 s)
...
[2019-03-07T09:36:40.438 CET] [debug] Command executed: virsh -c esx://root@openqaw8-vmware.qa.suse.de/?no_verify=1\&authfile=/tmp/WHC4C2UK6Y  snapshot-create-as openQA-SUT-41 lastgood, ret=0
[2019-03-07T09:36:40.438 CET] [debug] SAVE VM openQA-SUT-41 as lastgood snapshot, return code=0
[2019-03-07T09:36:40.439 CET] [debug] ||| starting version_switch_upgrade_target tests/migration/version_switch_upgrade_target.pm
[2019-03-07T09:36:40.860 CET] [debug] init needles from /var/lib/openqa/share/tests/sle/products/sle/needles/
[2019-03-07T09:36:42.646 CET] [debug] loaded 8604 needles
...
[2019-03-07T09:36:44.226 CET] [debug] Command executed: virsh  snapshot-create-as openQA-SUT-41 lastgood, ret=1
[2019-03-07T09:36:44.226 CET] [debug] SAVE VM openQA-SUT-41 as lastgood snapshot, return code=1
[2019-03-07T09:36:44.226 CET] [debug] Backend process died, backend errors are reported below in the following lines:
Died at /home/newman/openQA/os-autoinst-distri-opensuse/os-autoinst/backend/svirt.pm line 183.
```

If I re-set the `VMWARE_REMOTE_VMM` test variable in test code, it
survives needles reload.

Validation run:
* `media_upgrade_sles15`: http://nilgiri.suse.cz/tests/411

`get_remote_vmm()` is to be used from test code (see https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6991).