### PR TITLE
Fix scale timeout issues

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -1859,13 +1859,13 @@ Default timeout is 19s.
 
 sub wait_idle {
     my $timeout = shift || 19;
-    $timeout = bmwqemu::scale_timeout($timeout);
 
     # report wait_idle calls while we work on
     # https://progress.opensuse.org/issues/5830
     cluck "DEPRECATED: wait_idle called, update your test code";
 
     bmwqemu::log_call(timeout => $timeout);
+    $timeout = bmwqemu::scale_timeout($timeout);
 
     my $rsp = query_isotovideo('backend_wait_idle', {timeout => $timeout});
     bmwqemu::fctres("slept $timeout seconds");

--- a/testapi.pm
+++ b/testapi.pm
@@ -565,6 +565,7 @@ sub wait_screen_change(&@) {
     $args{similarity_level} //= 50;
 
     bmwqemu::log_call(timeout => $timeout, %args);
+    $timeout = bmwqemu::scale_timeout($timeout);
 
     # get the initial screen
     query_isotovideo('backend_set_reference_screenshot');


### PR DESCRIPTION
This PR fixes 2 issues when TIMEOUT_SCALE is set.

- Function `wait_screen_change` doesn't support TIMEOUT_SCALE variable, this can lead to timeout issues on slow hardware even if the variable is set.

- All call to `scale_timeout` function are done after `log_call` but not in `wait_idle` function. This is useful because we want to log the *unscaled* timeout, not the scaled one.

Failing test: http://ix64hae1001.qa.suse.de/tests/215
Verification run: http://ix64hae1001.qa.suse.de/tests/223

*Note:* I know that adding a test could be good, but I still have one to create for #1065 but I honestly don't have enough Perl knowledge to do this...