### PR TITLE
Improve error handling when using Net::SSH2 library

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -1204,14 +1204,15 @@ sub start_ssh_serial {
 
     $self->stop_ssh_serial;
 
-    $self->{serial} = $self->new_ssh_connection(%args);
-    my $chan = $self->{serial}->channel();
-    die "No channel found" unless $chan;
-    $self->{serial_chan} = $chan;
+    my $ssh  = $self->{serial}      = $self->new_ssh_connection(%args);
+    my $chan = $self->{serial_chan} = $ssh->channel();
+    if (!$chan) {
+        $ssh->die_with_error("Unable to establish SSH channel for serial console");
+    }
     $chan->blocking(0);
     $chan->pty(1);
     $self->{select}->add($self->{serial}->sock);
-    return $chan;
+    return ($ssh, $chan);
 }
 
 sub check_ssh_serial {

--- a/backend/spvm.pm
+++ b/backend/spvm.pm
@@ -67,14 +67,14 @@ sub run_cmd {
     $hostname ||= get_required_var('NOVALINK_HOSTNAME');
     $password ||= get_required_var('NOVALINK_PASSWORD');
 
-    $self->{ssh} = $self->new_ssh_connection(
+    my $ssh = $self->{ssh} = $self->new_ssh_connection(
         hostname => $hostname,
         password => $password,
         username => get_var('NOVALINK_USERNAME', 'root'));
-    my $chan = $self->{ssh}->channel();
-    $chan->exec($cmd);
+    my $chan = $ssh->channel() || $ssh->die_with_error();
+    $chan->exec($cmd) || $ssh->die_with_error();
     get_ssh_output($chan);
-    $chan->send_eof;
+    $chan->send_eof();
     my $ret = $chan->exit_status();
     bmwqemu::diag "Command executed: $cmd, ret=$ret";
     $chan->close();

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -149,13 +149,14 @@ sub login {
         );
         if (!$socket) {
             $err_cnt++;
+            my $error_message = "Error connecting to VNC server <$hostname:$port>: $@";
             if (time > $endtime) {
-                OpenQA::Exception::VNCSetupError->throw(error => "Error connecting to host <$hostname>: $@");
+                OpenQA::Exception::VNCSetupError->throw(error => $error_message);
             }
             # we might be too fast trying to connect to the VNC host (e.g.
             # qemu) so ignore the first occurences of a failed
             # connection attempt.
-            bmwqemu::diag "Error connecting to host <$hostname>: $@" if $err_cnt > $connect_failure_limit;
+            bmwqemu::diag($error_message) if $err_cnt > $connect_failure_limit;
             sleep 1;
             next;
         }

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -1,5 +1,5 @@
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -50,26 +50,39 @@ sub new {
 
 sub activate {
     my ($self) = @_;
-
     my $args = $self->{args};
 
-    my $hostname = $args->{hostname} || die('we need a hostname to ssh to');
-    my $password = $args->{password};
-    $self->{ssh} = $self->backend->new_ssh_connection(
-        username => $args->{username},
-        hostname => $hostname,
-        password => $password,
-    );
-    if ($self->vmm_family eq 'vmware') {
-        $self->{sshVMwareServer} = $self->backend->new_ssh_connection(
-            hostname => get_required_var('VMWARE_HOST'),
-            password => get_required_var('VMWARE_PASSWORD'));
-    }
+    # initialize SSH console(s)
+    $self->_init_ssh(ssh             => $args);
+    $self->_init_ssh(sshVMwareServer => $args) if ($self->vmm_family eq 'vmware');
 
     # start Xvnc
     $self->SUPER::activate;
 
     $self->_init_xml();
+}
+
+# initializes the SSH console(s), $domain is used to distinguish between the regular SSH console and the one to the VMware server
+sub _init_ssh {
+    my ($self, $domain, $args) = @_;
+
+    my %connection_settings;
+    if ($domain eq 'ssh') {
+        %connection_settings = (
+            hostname => ($args->{hostname} || die('we need a hostname to ssh to')),
+            username => $args->{username},
+            password => $args->{password},
+        );
+    } elsif ($domain eq 'sshVMwareServer') {
+        %connection_settings = (
+            hostname => get_required_var('VMWARE_HOST'),
+            password => get_required_var('VMWARE_PASSWORD'),
+        );
+    } else {
+        die "can not initialize SSH console for domain \"$domain\"";
+    }
+
+    return $self->{$domain} = $self->backend->new_ssh_connection(%connection_settings);
 }
 
 # creates an XML document to configure the libvirt domain
@@ -347,7 +360,8 @@ sub add_disk {
             my $vmware_disk_path = $vmware_openqa_datastore . $file;
             # Power VM off, delete it's disk image, and create it again.
             # Than wait for some time for the VM to *really* turn off.
-            my $vmware_chan = $self->{sshVMwareServer}->channel();
+            my $ssh         = $self->{sshVMwareServer};
+            my $vmware_chan = $ssh->channel() || $ssh->die_with_error("Unable to create SSH channel for adding disk");
             $vmware_chan->exec(
                 "( set -x; vmid=\$(vim-cmd vmsvc/getallvms | awk \'/$name/ { print \$1 }\');" .
                   'if [ $vmid ]; then ' .
@@ -356,7 +370,7 @@ sub add_disk {
                   'fi;' .
                   "vmkfstools -v1 -U $vmware_disk_path;" .
                   "vmkfstools -v1 -c $size --diskformat thin $vmware_disk_path; sleep 10 ) 2>&1"
-            );
+            ) || $ssh->die_with_error("Unable to execute command for adding disk");
             $vmware_chan->send_eof;
             get_ssh_output($vmware_chan);
             $vmware_chan->close();
@@ -378,7 +392,8 @@ sub add_disk {
                 # otherwise copy image from NFS datastore.
                 my $nfs_dir              = $backingfile ? 'hdd' : 'iso';
                 my $vmware_nfs_datastore = get_required_var('VMWARE_NFS_DATASTORE');
-                my $vmware_chan          = $self->{sshVMwareServer}->channel();
+                my $ssh                  = $self->{sshVMwareServer};
+                my $vmware_chan          = $ssh->channel() || $ssh->die_with_error("Unable to create SSH channel for adding disk");
                 $vmware_chan->exec(
                     "if test -e $vmware_openqa_datastore$file_basename; then " .
                       "while lsof | grep 'cp.*$file_basename'; do " .
@@ -387,7 +402,7 @@ sub add_disk {
                       'else ' .
                       "cp /vmfs/volumes/$vmware_nfs_datastore/$nfs_dir/$file_basename $vmware_openqa_datastore;" .
                       'fi;'
-                );
+                ) || $ssh->die_with_error("Unable to execute command to copy VMware image $file_basename");
                 $vmware_chan->send_eof;
                 get_ssh_output($vmware_chan);
                 $vmware_chan->close();
@@ -395,7 +410,7 @@ sub add_disk {
                 if ($backingfile) {
                     # Power VM off, delete it's disk image, and create it again.
                     # Than wait for some time for the VM to *really* turn off.
-                    $vmware_chan = $self->{sshVMwareServer}->channel();
+                    $vmware_chan = $ssh->channel() || $ssh->die_with_error("Unable to create SSH channel for adding disk");
                     $vmware_chan->exec(
                         "( set -x; vmid=\$(vim-cmd vmsvc/getallvms | awk \'/$name/ { print \$1 }\');" .
                           'if [ $vmid ]; then ' .
@@ -403,7 +418,7 @@ sub add_disk {
                           'fi;' .
                           "vmkfstools -v1 -U $vmware_disk_path_thinfile;" .
                           "vmkfstools -v1 -i $vmware_disk_path --diskformat thin $vmware_disk_path_thinfile; sleep 10 ) 2>&1"
-                    );
+                    ) || $ssh->die_with_error("Unable to execute command to create thin VMware image");
                     $vmware_chan->send_eof;
                     get_ssh_output($vmware_chan);
                     $vmware_chan->close();
@@ -548,15 +563,14 @@ __END"
         set_var('VMWARE_REMOTE_VMM', $remote_vmm);
     }
 
-    my $instance = $self->instance;
-
-    my $doc = $self->{domainxml};
-
+    my $instance    = $self->instance;
+    my $doc         = $self->{domainxml};
     my $xmlfilename = "/var/lib/libvirt/images/" . $self->name . ".xml";
-    my $chan        = $self->{ssh}->channel();
+    my $ssh         = $self->{ssh};
+    my $chan        = $ssh->channel() || $ssh->die_with_error("Unable to create SSH channel for writing virsh config");
     # scp_put is unfortunately unreliable (RT#61771)
-    $chan->exec("cat > $xmlfilename");
-    $chan->write($doc->toString(2));
+    $chan->exec("cat > $xmlfilename") || $ssh->die_with_error();
+    $chan->write($doc->toString(2))   || $ssh->die_with_error();
     $chan->close();
 
     # shut down possibly running previous test (just to be sure) - ignore errors
@@ -636,12 +650,29 @@ sub get_cmd_output {
 
     my $wantarray = $args->{wantarray};
     my $domain    = $args->{domain} // 'ssh';
-    my $chan      = $self->{$domain}->channel();
-    $chan->exec($cmd);
+    my $ssh       = $self->{$domain};
+    if (!$ssh) {
+        die "get_cmd_output has been called with domain \"$domain\" but no such SSH console has been activated";
+    }
+
+    # create a new channel; try to re-establish the SSH connection on failure
+    my $channel = $ssh->channel();
+    if (!$channel) {
+        $ssh     = $self->_init_ssh($domain);
+        $channel = $ssh->channel() || $ssh->die_with_error("unable to create channel for SSH console \"$domain\"");
+    }
+
+    # execute command
+    if (!$channel->exec($cmd)) {
+        $ssh->die_with_error("unable to execute command \"$cmd\" via SSH console \"$domain\"");
+    }
+
+    # read output and close channel
     bmwqemu::diag "Command executed: $cmd";
-    my @cmd_output = get_ssh_output($chan);
-    $chan->send_eof;
-    $chan->close();
+    my @cmd_output = get_ssh_output($channel);
+    $channel->send_eof();
+    $channel->close();
+
     return $wantarray ? \@cmd_output : $cmd_output[0];
 }
 

--- a/consoles/sshXtermVt.pm
+++ b/consoles/sshXtermVt.pm
@@ -46,14 +46,16 @@ sub activate {
     if ($serial) {
 
         # ssh connection to SUT for iucvconn
-        my $serialchan = $self->backend->start_ssh_serial(
+        my ($ssh, $serialchan) = $self->backend->start_ssh_serial(
             hostname => $hostname,
             password => $password,
             username => 'root'
         );
 
         # start iucvconn
-        $serialchan->exec($serial);
+        if (!$serialchan->exec($serial)) {
+            bmwqemu::diag('Unable to grab serial console at this point: ' . ($ssh->error // 'unknown SSH error'));
+        }
     }
 }
 


### PR DESCRIPTION
The library unfortunately does not throw any exceptions. So the return value of most function invocations must be checked manually and the error handled.

I made it die in most cases. The notable exception is the `get_cmd_output` function of the sshVirsh console where I implemented a reconnect to prevent test failures due to connection issues (see https://progress.opensuse.org/issues/44771 for that).

This is still completely untested and hence WIP. I'll do some tests on my own but it would be nice if someone could give it a try, too.