### PR TITLE
Prevent rendering unknown results

### DIFF
--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -288,7 +288,7 @@ subtest 'check_assert_screen' => sub {
         is_deeply($autotest::current_test->{details}, [
                 {
                     result     => 'unk',
-                    screenshot => 'basetest-17.png',
+                    screenshot => 'basetest-11.png',
                     frametime  => [qw(1.75 1.79)],
                     tags       => [qw(fake tags)],
                 }

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -115,35 +115,35 @@ subtest record_testresult => sub {
             test_count => 0,
     }, $basetest_class);
 
-    is_deeply(basetest::record_testresult($basetest), {result => 'unk'}, 'adding unknown result');
+    is_deeply($basetest->record_testresult(), {result => 'unk'}, 'adding unknown result');
     is($basetest->{result},     undef, 'test result unaffected');
     is($basetest->{test_count}, 1,     'test count increased');
 
-    is_deeply(basetest::record_testresult($basetest, 'ok'), {result => 'ok'}, 'adding "ok" result');
+    is_deeply($basetest->record_testresult('ok'), {result => 'ok'}, 'adding "ok" result');
     is($basetest->{result}, 'ok', 'test result is now "ok"');
 
-    is_deeply(basetest::record_testresult($basetest, 'softfail'), {result => 'softfail'}, 'adding "softfail" result');
+    is_deeply($basetest->record_testresult('softfail'), {result => 'softfail'}, 'adding "softfail" result');
     is($basetest->{result}, 'softfail', 'test result is now "softfail"');
 
-    is_deeply(basetest::record_testresult($basetest, 'ok'), {result => 'ok'}, 'adding one more "ok" result');
+    is_deeply($basetest->record_testresult('ok'), {result => 'ok'}, 'adding one more "ok" result');
     is($basetest->{result}, 'softfail', 'test result is still "softfail"');
 
-    is_deeply(basetest::record_testresult($basetest, 'fail'), {result => 'fail'}, 'adding "fail" result');
+    is_deeply($basetest->record_testresult('fail'), {result => 'fail'}, 'adding "fail" result');
     is($basetest->{result}, 'fail', 'test result is now "fail"');
 
-    is_deeply(basetest::record_testresult($basetest, 'ok'), {result => 'ok'}, 'adding one more "ok" result');
+    is_deeply($basetest->record_testresult('ok'), {result => 'ok'}, 'adding one more "ok" result');
     is($basetest->{result}, 'fail', 'test result is still "fail"');
 
-    is_deeply(basetest::record_testresult($basetest, 'softfail'), {result => 'softfail'}, 'adding one more "softfail" result');
+    is_deeply($basetest->record_testresult('softfail'), {result => 'softfail'}, 'adding one more "softfail" result');
     is($basetest->{result}, 'fail', 'test result is still "fail"');
 
-    is_deeply(basetest::record_testresult($basetest), {result => 'unk'}, 'adding one more "unk" result');
+    is_deeply($basetest->record_testresult(), {result => 'unk'}, 'adding one more "unk" result');
     is($basetest->{result}, 'fail', 'test result is still "fail"');
 
-    is_deeply(basetest::record_testresult($basetest, 'softfail', force_status => 1), {result => 'softfail'}, 'adding one more "softfail" result but forcing the status');
+    is_deeply($basetest->record_testresult('softfail', force_status => 1), {result => 'softfail'}, 'adding one more "softfail" result but forcing the status');
     is($basetest->{result}, 'softfail', 'test result was forced to "softfail"');
 
-    is_deeply(basetest::take_screenshot($basetest), {result => 'unk'},
+    is_deeply($basetest->take_screenshot(), {result => 'unk'},
         'unknown result from take_screenshot not added to details');
 
     my $nr_test_details = 9;

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -105,11 +105,15 @@ subtest parse_serial_output => sub {
 };
 
 subtest record_testresult => sub {
-    my $basetest = {
-        result     => undef,
-        details    => [],
-        test_count => 0,
-    };
+    my $basetest_class = 'basetest';
+    my $mock_basetest  = Test::MockModule->new($basetest_class);
+    $mock_basetest->mock(_result_add_screenshot => sub { });
+
+    my $basetest = bless({
+            result     => undef,
+            details    => [],
+            test_count => 0,
+    }, $basetest_class);
 
     is_deeply(basetest::record_testresult($basetest), {result => 'unk'}, 'adding unknown result');
     is($basetest->{result},     undef, 'test result unaffected');
@@ -138,6 +142,9 @@ subtest record_testresult => sub {
 
     is_deeply(basetest::record_testresult($basetest, 'softfail', force_status => 1), {result => 'softfail'}, 'adding one more "softfail" result but forcing the status');
     is($basetest->{result}, 'softfail', 'test result was forced to "softfail"');
+
+    is_deeply(basetest::take_screenshot($basetest), {result => 'unk'},
+        'unknown result from take_screenshot not added to details');
 
     my $nr_test_details = 9;
     is($basetest->{test_count},        $nr_test_details, 'test_count accumulated');


### PR DESCRIPTION
If no screenshot is available at the point one is taken os-autoinst previously rendered an empty/invalid result.

This change prevents that which should also fix the question marks in the openQA web UI (or rendering issues in previous version of the web UI), e.g. http://cfconrad-vm.qa.suse.de/tests/3541#step/sle15_workarounds/1.