### PR TITLE
Use always $bmwqemu::vars{NEEDLES_DIR} directly

### DIFF
--- a/OpenQA/Isotovideo/NeedleDownloader.pm
+++ b/OpenQA/Isotovideo/NeedleDownloader.pm
@@ -25,7 +25,6 @@ use POSIX 'strftime';
 use bmwqemu;
 
 has files_to_download => sub { [] };
-has needle_dir        => sub { needle::default_needle_dir() };
 has openqa_url        => sub {
     # deduce the default openQA URL from OPENQA_URL/OPENQA_HOSTNAME
     # note: OPENQA_URL is sometimes just the hostname (eg. e212.suse.de) but might be a proper URL
@@ -72,7 +71,7 @@ sub _add_download {
 
     my $needle_name     = $needle->{name};
     my $latest_update   = $needle->{t_updated};
-    my $needle_dir      = $self->needle_dir;
+    my $needle_dir      = $bmwqemu::vars{NEEDLES_DIR};
     my $download_target = "$needle_dir/$needle_name.$extension";
 
     if (my $target_stat = stat($download_target)) {

--- a/isotovideo
+++ b/isotovideo
@@ -247,7 +247,7 @@ OpenQA::Isotovideo::Utils::checkout_git_repo_and_branch('CASEDIR');
 # multiple distributions or flavors in one repository.
 $bmwqemu::vars{PRODUCTDIR} ||= $bmwqemu::vars{CASEDIR};
 
-$bmwqemu::vars{NEEDLES_DIR} //= $bmwqemu::vars{PRODUCTDIR} . '/needles';
+$bmwqemu::vars{NEEDLES_DIR} //= "$bmwqemu::vars{PRODUCTDIR}/needles";
 OpenQA::Isotovideo::Utils::checkout_git_repo_and_branch('NEEDLES_DIR');
 
 bmwqemu::ensure_valid_vars();

--- a/needle.pm
+++ b/needle.pm
@@ -277,14 +277,10 @@ sub wanted_ {
     }
 }
 
-sub default_needle_dir {
-    return "$bmwqemu::vars{PRODUCTDIR}/needles/";
-}
-
 sub init {
     ($needledir) = @_;
 
-    $needledir //= default_needle_dir();
+    $needledir //= $bmwqemu::vars{NEEDLES_DIR};
     -d $needledir || die "needledir not found: $needledir (check vars.json?)";
 
     %needles = ();

--- a/t/21-needle-downloader.t
+++ b/t/21-needle-downloader.t
@@ -28,6 +28,7 @@ $user_agent_mock->mock(get => sub {
 # setup needle directory
 my $needle_dir = path(tempdir, 'needle_dir');
 ok(make_path($needle_dir), 'create test needle dir under ' . $needle_dir);
+$bmwqemu::vars{NEEDLES_DIR} = $needle_dir;
 
 subtest 'deduce URL for needle download from test variable OPENQA_URL' => sub {
     $bmwqemu::vars{OPENQA_URL} = 'https://openqa1-opensuse';
@@ -44,9 +45,7 @@ subtest 'deduce URL for needle download from test variable OPENQA_URL' => sub {
 
 # setup a NeedleDownloader instance
 $bmwqemu::vars{OPENQA_URL} = 'openqa';
-my $downloader = OpenQA::Isotovideo::NeedleDownloader->new(
-    needle_dir => $needle_dir,
-);
+my $downloader = OpenQA::Isotovideo::NeedleDownloader->new;
 is($downloader->download_limit, 150, 'by default limited to 150 downloads');
 
 subtest 'add relevant downloads' => sub {


### PR DESCRIPTION
This variable is initialized at the beginning to a default path if not specified explicitely. So let's just use that and get rid of the function `default_needle_dir`.

That should prevent https://progress.opensuse.org/issues/48452.