### PR TITLE
Update to handle xz compressed images

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -412,6 +412,10 @@ sub add_disk {
             }
             else {
                 $self->run_cmd(sprintf("rsync -av '$args->{file}' '$basedir/%s'", $file_basename)) && die 'rsync failed';
+                if ($file_basename =~ /(.*)\.xz$/) {
+                    $self->run_cmd(sprintf("nice ionice unxz -f -k '$basedir/%s'", $file_basename)) unless -e "$basedir$1";
+                    $file_basename = $1;
+                }
             }
         }
         if ($backingfile) {


### PR DESCRIPTION
This change uncompresses the image and sets the name of the image to the uncompressed one.

Progress ticket: https://progress.opensuse.org/issues/49523
Validation runs: 
  - Compressed image: http://ccret.suse.cz/tests/3184, http://ccret.suse.cz/tests/3181
  - Uncompressed image: http://ccret.suse.cz/tests/3183