### PR TITLE
make get_var_array return values consistent

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -739,7 +739,8 @@ Return the given variable as array reference (split variable value by , | or ; )
 sub get_var_array {
     my ($var, $default) = @_;
     my @vars = split(/,|;/, $bmwqemu::vars{$var} || '');
-    return $default if !@vars;
+    my @default = split(/,|;/, $default || '');
+    return \@default if !@vars;
     return \@vars;
 }
 


### PR DESCRIPTION
if $var value exists, return a array referrence "\@var", but return a string if $var doesn't exist. This is ugly. I just make the returned value consistent, both array referrence. And this alsoconforms to the document of "get_var_array".