### PR TITLE
Print error message returned by VNC server if security types missing

### DIFF
--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -225,7 +225,11 @@ sub _handshake_security {
             $number_of_security_types = unpack('C', $number_of_security_types);
         }
         if ($number_of_security_types == 0) {
-            die 'Error authenticating';
+            my $generic_error_message = 'Error authenticating: server returned no "security types"';
+            $socket->read(my $error_message_length, 4) || die $generic_error_message;
+            $error_message_length = unpack('N', $error_message_length) || die $generic_error_message;
+            $socket->read(my $error_message, $error_message_length) || die $generic_error_message;
+            die "Error authenticating: $error_message";
         }
 
         my @security_types;


### PR DESCRIPTION
See https://progress.opensuse.org/issues/49793

---

So we would get at least a more helpful error message. It is WIP because I couldn't test this so far. I'd grab an svirt host from OSD to test this (when one is free).