### PR TITLE
testapi: Make get_var_array return values consistent

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -738,8 +738,9 @@ Return the given variable as array reference (split variable value by , | or ; )
 
 sub get_var_array {
     my ($var, $default) = @_;
-    my @vars = split(/,|;/, $bmwqemu::vars{$var} || '');
-    return $default if !@vars;
+    my @vars    = split(/,|;/, $bmwqemu::vars{$var} || '');
+    my @default = split(/,|;/, $default             || '');
+    return \@default if !@vars;
     return \@vars;
 }
 


### PR DESCRIPTION
If "$var" value exists, return a array referrence "@var", but return a string if "$var" doesn't exist. This is ugly. I just make the returned value consistent, both array referrence. And this also conforms to the document of "get_var_array".

NOTE: sorry for re-creating a PR because I make a mistake to delete my os-autoinst repository. Sorry, I will be carefull.