### PR TITLE
Fix error message in consoles::network_console

### DIFF
--- a/consoles/network_console.pm
+++ b/consoles/network_console.pm
@@ -22,6 +22,7 @@ use warnings;
 use base 'consoles::console';
 
 use Try::Tiny;
+use Scalar::Util 'blessed';
 
 sub activate {
     my ($self) = @_;


### PR DESCRIPTION
Turns e.g.:
```
Can't locate object method "blessed" via package "actual error message
" (perhaps you forgot to load "actual error message
"?) at /hdd/openqa-devel/repos/os-autoinst/consoles/network_console.pm line 34.
```

into

```
actual error message
```

See https://progress.opensuse.org/issues/49793

---

Tested by playing around with the perl debugger.