### PR TITLE
Declare wait_screen_change earlier

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -86,7 +86,7 @@ sub send_key;
 sub check_screen;
 sub type_string;
 sub type_password;
-
+sub wait_screen_change;
 
 =head1 introduction
 
@@ -601,7 +601,7 @@ Example:
 =cut
 
 sub assert_screen_change(&@) {
-    ::wait_screen_change(@_) or die 'assert_screen_change failed to detect a screen change';
+    wait_screen_change(@_) or die 'assert_screen_change failed to detect a screen change';
 }
 
 


### PR DESCRIPTION
When ::wait_screen_change it is translated internally to
&main::wait_screen_change which means that the symbol will be looked
into the current program instead of the proper library where the method
is defined