### PR TITLE
qemu: Allow multiple tap interfaces in one network

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -671,8 +671,11 @@ sub start_qemu {
         # always set proper TAPDEV for os-autoinst when using tap network mode
         my $instance = ($vars->{WORKER_INSTANCE} || 'manual') eq 'manual' ? 255 : $vars->{WORKER_INSTANCE};
         # use $instance for tap name so it is predicable, network is still configured staticaly
-        $tapdev[$i]  //= 'tap' . ($instance - 1 + $i * 64);
-        $nicvlan[$i] //= 0;
+        if (!defined($tapdev[$i]) || $tapdev[$i] eq 'auto') {
+            $tapdev[$i] = 'tap' . ($instance - 1 + $i * 64);
+        }
+        my $vlan = (@nicvlan) ? $nicvlan[-1] : 0;
+        $nicvlan[$i] //= $vlan;
     }
     push @tapscript,     "no" until @tapscript >= $num_networks;        #no TAPSCRIPT by default
     push @tapdownscript, "no" until @tapdownscript >= $num_networks;    #no TAPDOWNSCRIPT by default


### PR DESCRIPTION
There is the need to have 2 network cards in one Network (e.g.
bonding). Without "hardcoding" TAPDEV and NICVLAN variables.

The idea of this patch is to specify the number of nics using the TAPDEV
variable, but use the automated mechanism of openQA to decide the
tapdev name.

If the VLAN tag isn't specified, the last specified VLAN-Tag will be
used. This ensure, if openqa-ui allocates a VLAN tag to that job,
the tag is used for both interfaces.

A test-module which will use this is https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/7218

A prove run, with such changes looks like:
  * http://cfconrad-vm.qa.suse.de/tests/3830
  * http://cfconrad-vm.qa.suse.de/tests/3829

Important testsuite settings:
```
NICTYPE=tap
TAPDEV=auto,auto
```

`ovs-vsctl show` while test is running:

```
    Bridge "br1"
        Port "tap0"
            tag: 1
            Interface "tap0"
        Port "tap65"
            Interface "tap65"
        Port "tap66"
            Interface "tap66"
        Port "tap2"
            Interface "tap2"
        Port "tap1"
            tag: 1
            Interface "tap1"
        Port "tap64"
            tag: 1
            Interface "tap64"
        Port "br1"
            Interface "br1"
                type: internal
    ovs_version: "2.10.1"
```
