### PR TITLE
Extend type_password arguments

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -1313,18 +1313,21 @@ sub type_string {
 
 =head2 type_password
 
-  type_password([$password]);
+  type_password($password [, max_interval => <num> ] [, wait_screen_changes => <num> ] [, wait_still_screen => <num> ] [, timeout => <num>]
+  [, similarity_level => <num>] );
 
 A convenience wrapper around C<type_string>, which doesn't log the string.
 
 Uses C<$testapi::password> if no string is given.
+
+You can pass same optional parameters as for C<type_string> function.
 
 =cut
 
 sub type_password {
     my ($string, %args) = @_;
     $string //= $password;
-    type_string $string, secret => 1, max_interval => ($args{max_interval} // 100);
+    type_string $string, secret => 1, max_interval => ($args{max_interval} // 100), %args;
 }
 
 =head1 mouse support


### PR DESCRIPTION
Fix#50045: Function `type_password` use `type_string` for text input, but
not all arguments from type_string are supported. Arguments of `type_password`
function were extended to cover all from `type_string`.

Original reason was https://progress.opensuse.org/issues/49655. Function `type_password`
don't support `wait_still_screen`, although it is supported in `type_string`. 
* Old use:
```
type_password "password123";
wait_still_screen(1);
```
* New use:
```
type_password "password123", wait_still_screen => 1;
```

Progress: https://progress.opensuse.org/issues/50045
Verification: http://10.100.12.105/tests/1928