### PR TITLE
Allow failing for matching regex in autoinst log

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -120,7 +120,8 @@ sub loadtest {
     $test             = $name->new($category);
     $test->{script}   = $script;
     $test->{fullname} = $fullname;
-    $test->{serial_failures} = $testapi::distri->{serial_failures} // [];
+    $test->{serial_failures}   = $testapi::distri->{serial_failures}   // [];
+    $test->{autoinst_failures} = $testapi::distri->{autoinst_failures} // [];
 
     if (defined $args{run_args}) {
         unless (blessed($args{run_args}) && $args{run_args}->isa('OpenQA::Test::RunArgs')) {

--- a/cpanfile
+++ b/cpanfile
@@ -40,6 +40,7 @@ requires 'Net::SSH2';
 requires 'POSIX';
 requires 'Thread::Queue';
 requires 'Time::HiRes';
+requires 'Try::Tiny';
 requires 'XML::LibXML';
 requires 'base';
 requires 'constant';

--- a/distribution.pm
+++ b/distribution.pm
@@ -25,8 +25,9 @@ sub new {
     my ($class) = @_;
 
     my $self = bless {}, $class;
-    $self->{consoles}        = {};
-    $self->{serial_failures} = [];
+    $self->{consoles}          = {};
+    $self->{serial_failures}   = [];
+    $self->{autoinst_failures} = [];
 
 =head2 serial_term_prompt
 
@@ -287,6 +288,28 @@ sub set_expected_serial_failures {
     my ($self, $failures) = @_;
 
     $self->{serial_failures} = $failures;
+}
+
+=head2 set_expected_autoinst_failures
+
+    set_expected_autoinst_failures($failures)
+
+Define the patterns to look for in the os-autoinst-log.txt
+Each pattern comes along with a type either I<hard> or I<soft> and a message,
+for instance, to label the match with a bug/ticket
+
+Example:
+    set_expected_serial_failures([
+        { type => 'soft', message => 'Message 1', pattern => qr/Pattern1/ },
+        { type => 'soft', message => 'Message 2', pattern => qr/Pattern2/ },
+        { type => 'hard', message => 'Message 3', pattern => qr/Pattern3/ },]
+    );
+
+=cut
+sub set_expected_autoinst_failures {
+    my ($self, $failures) = @_;
+
+    $self->{autoinst_failures} = $failures;
 }
 
 # override

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -74,6 +74,8 @@ is($died,      1, 'run_all with no tests should catch runalltests dying');
 is($completed, 0, 'run_all with no tests should not complete');
 @sent = [];
 
+`touch autoinst-log.txt`;
+
 loadtest 'start';
 loadtest 'next';
 is(keys %autotest::tests, 2, 'two tests have been scheduled');
@@ -246,6 +248,7 @@ is(autotest::parse_test_path("$sharedir/tests/sle/tests/x11/firefox.pm"),       
 is(autotest::parse_test_path("$sharedir/tests/sle/tests/x11/toolkits/motif.pm"), ('motif',   'x11/toolkits'));
 is(autotest::parse_test_path("$sharedir/factory/other/sysrq.pm"),                ('sysrq',   'other'));
 
+unlink 'autoinst-log.txt';
 done_testing();
 
 # vim: set sw=4 et:


### PR DESCRIPTION
https://progress.opensuse.org/issues/45011