### PR TITLE
Don't modify backend vars when running test

### DIFF
--- a/t/04-check_vars_docu.t
+++ b/t/04-check_vars_docu.t
@@ -84,7 +84,7 @@ sub read_doc {
 
 sub write_doc {
     my $docfh;
-    open($docfh, '>', VARS_DOC);
+    open($docfh, '>', VARS_DOC . '.newvars');
     print $docfh <<EO_HEADER;
 Supported variables per backend
 -------------------------------


### PR DESCRIPTION
Unless `t/04-check_vars_docu.t` is run with `--write`.

Ticket: https://progress.opensuse.org/issues/34303