### PR TITLE
Avoid "unitialized value in string eq" warning

### DIFF
--- a/OpenQA/Qemu/DriveDevice.pm
+++ b/OpenQA/Qemu/DriveDevice.pm
@@ -112,7 +112,7 @@ sub gen_cmdline {
             push(@params, 'bus=' . $path->controller->id . '.0');
         }
         # Configure bootindex only for first path
-        $self->_push_ifdef(\@params, 'bootindex=', $self->bootindex) if (($path->id eq 'path0') || (!$path->id));
+        $self->_push_ifdef(\@params, 'bootindex=', $self->bootindex) if (!$path->id || $path->id eq 'path0');
         $self->_push_ifdef(\@params, 'serial=', $self->serial);
         push(@cmdln, ('-device', join(',', @params)));
     }


### PR DESCRIPTION
Avoid such warning:

```
Use of uninitialized value in string eq at /usr/lib/os-autoinst/OpenQA/Qemu/DriveDevice.pm line 115.
```

Like in this file: https://openqa.suse.de/tests/2917507/file/autoinst-log.txt