### PR TITLE
qemu: Multiple virtio-consoles

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -847,10 +847,12 @@ sub start_qemu {
         }
 
         if ($vars->{VIRTIO_CONSOLE}) {
-            my $id = 'virtio_console';
             sp('device', 'virtio-serial');
-            sp('chardev', [qv "socket path=$id server nowait id=$id logfile=$id.log logappend=on"]);
-            sp('device',  [qv "virtconsole chardev=$id name=org.openqa.console.$id"]);
+            for (my $i = 0; $i < ($vars->{VIRTIO_CONSOLE_NUM} // 1); $i++) {
+                my $name = 'virtio_console' . ($i ? $i : '');
+                sp('chardev', [qv "socket path=$name server nowait id=$name logfile=$name.log logappend=on"]);
+                sp('device',  [qv "virtconsole chardev=$name name=org.openqa.console.$name"]);
+            }
         }
 
         my $qmpid = 'qmp_socket';

--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -59,7 +59,7 @@ sub new {
     my ($class, $testapi_console, $args) = @_;
     my $self = $class->SUPER::new($testapi_console, $args);
     $self->{socket_fd}      = 0;
-    $self->{socket_path}    = cwd() . '/virtio_console';
+    $self->{socket_path}    = $self->{args}->{socked_path} // cwd() . '/virtio_console';
     $self->{snapshots}      = {};
     $self->{preload_buffer} = '';
     return $self;

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -98,6 +98,8 @@ QEMU_COMPRESS_THREADS;integer;QEMUCPUS;Number of threads used for compressing me
 QEMU_MAX_BANDWIDTH;integer;INT_MAX;Limits the transfer rate during a snapshot.
 QEMU_DUMP_COMPRESS_METHOD;string;xz;The compression to use during a memory dump. Can be set to xz, bzip2 or internal (QEMU's internal compression, not compatible with crash or gdb). If xz is set, but not available, it will fallback to bzip2. Also see QEMU_COMPRESSION_LEVEL.
 QEMU_APPEND;string;;Append parameters on qemu command line. The first item will have '-' prepended to it.
+VIRTIO_CONSOLE;boolean;1;Enable/disable virtio console. (@see `-device virtconsole` qemu option)
+VIRTIO_CONSOLE_NUM;integer;1;Number of virtio consoles.
 RAIDLEVEL;;;
 SKIPTO;full name of test module;;Restore VM from snapshot and continue by running specified test module. Needs HDD image with snapshots present
 TAPDEV;device name;undef;TAP device name to which virtual NIC should be connected. Usually undef so automatic matching is used


### PR DESCRIPTION
Specify VIRTIO_CONSOLE_NUM to get more virtio-consoles.

Like you could see in http://cfconrad-vm.qa.suse.de/tests/4601/file/autoinst-log.txt

Later on, we would need to add such console with:

```
$self->add_console('root-virtio-terminal' . $num, 'virtio-terminal', {socked_path => cwd() . '/virtio_console' . $num});
```