### PR TITLE
Log best candidate needle also on timeout

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -1034,6 +1034,16 @@ sub check_asserted_screen {
         bmwqemu::diag "DEBUG_IO: \n" . $watch->summary() if (!$bmwqemu::vars{NO_DEBUG_IO} && $watch->{debug});
     }
 
+    my $no_match_diag = 'no match: ' . time_remaining_str($n);
+    if (my $best_candidate = $failed_candidates->[0]) {
+        $no_match_diag .= sprintf(
+            ", best candidate: %s (%.2f)",
+            $best_candidate->{needle}->{name},
+            1 - sqrt($best_candidate->{error})
+        );
+    }
+    bmwqemu::diag($no_match_diag);
+
     if ($n < 0) {
         # make sure we recheck later
         $self->assert_screen_last_check(undef);
@@ -1077,15 +1087,6 @@ sub check_asserted_screen {
             _reduce_to_biggest_changes($failed_screens, 20);
         }
     }
-    my $no_match_diag = 'no match: ' . time_remaining_str($n);
-    if (my $best_candidate = $failed_candidates->[0]) {
-        $no_match_diag .= sprintf(
-            ", best candidate: %s (%.2f)",
-            $best_candidate->{needle}->{name},
-            1 - sqrt($best_candidate->{error})
-        );
-    }
-    bmwqemu::diag($no_match_diag);
     $self->assert_screen_last_check([$img, $search_ratio]);
     return;
 }


### PR DESCRIPTION
There are two reasons for moving the diagnostic message up:
- In case of a timeout of 0, no "best candidate" message would ever be
  printed
- In case the best candidate changes on the last round, the log would
  show a best candidate which differs from the one in the web UI

Signed-off-by: Stefan Brüns <stefan.bruens@rwth-aachen.de>