### PR TITLE
Add recursive get data call

### DIFF
--- a/commands.pm
+++ b/commands.pm
@@ -27,6 +27,7 @@ use POSIX '_exit', 'strftime';
 use myjsonrpc;
 use bmwqemu 'diag';
 use Mojo::JSON 'to_json';
+use Mojo::File 'path';
 
 BEGIN {
     $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll';
@@ -75,9 +76,9 @@ sub _test_data_dir {
     $self->res->headers->content_type('application/x-cpio');
 
     my $data = '';
-    for my $file (glob $base . '*') {
-        next unless -f $file;
-        my @s = stat _;
+    for my $file (path($base)->list_tree->each) {
+        $file = $file->to_string();
+        my @s = stat $file;
         unless (@s) {
             $self->app->log->error("error stating $file: $!");
             next;

--- a/t/data/tests/data/mod1/sub/test2.txt
+++ b/t/data/tests/data/mod1/sub/test2.txt
@@ -1,0 +1,1 @@
+TEST_FILE_2

--- a/t/data/tests/data/mod1/test1.txt
+++ b/t/data/tests/data/mod1/test1.txt
@@ -1,0 +1,1 @@
+TEST_FILE_1


### PR DESCRIPTION
when requesting `curl autoinst_url . "/data"` and the requested URI
points to an directory, we do now retrieve the directory recursive.
The returned data is a cpio-achive.

In action: http://cfconrad-vm.qa.suse.de/tests/4620/file/serial_terminal.txt