### PR TITLE
Use _QUIET_SCRIPT_CALLS variable for script_run/output

### DIFF
--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -25,6 +25,7 @@ TIMEOUT_SCALE;integer;1;This scale parameter can be used based on performance of
 PAUSE_AT;string;;Test module (name or fullname) to pause test execution at. To be used together with the openQA developer mode to continue test execution. Be aware that the openQA web UI will only reflect this within the developer mode after confirming to control the test.
 PAUSE_ON_SCREEN_MISMATCH;boolean;0;Pause test execution on the next screen mismatch. Same notes as for `PAUSE_AT` apply.
 PAUSE_ON_NEXT_COMMAND;boolean;0;Pause test execution on the next test API command. Same notes as for `PAUSE_AT` apply.
+_QUIET_SCRIPT_CALLS;boolean;0;Add quiet flag to all the calls to script_run, script_output and validate_script_output. It will omit all the squares "wait_serial expected" on the Details view of the test case. This option might be useful for serial terminal tests.
 
 |====================
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -904,7 +904,7 @@ sub _handle_script_run_ret {
 
 =head2 assert_script_run
 
-  assert_script_run($cmd [, timeout => $timeout] [, fail_message => $fail_message]);
+  assert_script_run($cmd [, timeout => $timeout] [, fail_message => $fail_message] [,quiet => $quiet]);
 
 Deprecated mode
 
@@ -932,7 +932,7 @@ sub assert_script_run {
             # not change default timeout.
             timeout      => 90,
             fail_message => '',
-            quiet        => undef
+            quiet        => testapi::get_var('_QUIET_SCRIPT_CALLS')
         }, ['timeout', 'fail_message'], @_);
 
     bmwqemu::log_call(cmd => $cmd, %args);
@@ -970,7 +970,7 @@ sub script_run {
     my %args = compat_args(
         {
             timeout => undef,
-            quiet   => undef
+            quiet   => testapi::get_var('_QUIET_SCRIPT_CALLS')
         }, ['timeout'], @_);
 
     bmwqemu::log_call(cmd => $cmd, %args);
@@ -1026,7 +1026,7 @@ sub script_sudo {
 
 =head2 script_output
 
-  script_output($script [, $wait, type_command => 1, proceed_on_failure => 1])
+  script_output($script [, $wait, type_command => 1, proceed_on_failure => 1] [,quiet => $quiet])
 
 Executing script inside SUT with C<bash -eox> (in case of serial console with C<bash -eo>)
 and directs C<stdout> (I<not> C<stderr>!) to the serial console and returns
@@ -1049,7 +1049,16 @@ and can be tweaked by setting the C<$wait> positional parameter.
 =cut
 
 sub script_output {
-    return $distri->script_output(@_);
+    my $script = shift;
+    my %args   = testapi::compat_args(
+        {
+            timeout            => undef,
+            proceed_on_failure => undef,                                     # fail on error by default
+            quiet              => testapi::get_var('_QUIET_SCRIPT_CALLS'),
+            type_command       => undef,
+        }, ['timeout'], @_);
+
+    return $distri->script_output($script, %args);
 }
 
 
@@ -1126,7 +1135,7 @@ sub validate_script_output {
     my %args = compat_args(
         {
             timeout => 30,
-            quiet   => undef
+            quiet   => testapi::get_var('_QUIET_SCRIPT_CALLS')
         }, ['timeout'], @_);
 
     my $output = script_output($script, %args);


### PR DESCRIPTION
This complements PR https://github.com/os-autoinst/os-autoinst/pull/1151 
which adds the flag `quiet` to script_run and script_output.
Using variables, we can make all the calls to those functions in quiet mode without
specifying the flag `quiet => 1` in every call.

Verification RUNs: 
With       : http://fromm.arch.suse.de/tests/6259
Without :  http://fromm.arch.suse.de/tests/6152