### PR TITLE
Fix missing or double output in autoinst-log.txt with partial revert

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -28,7 +28,6 @@ use testapi  ();
 use autotest ();
 use MIME::Base64 'decode_base64';
 use Mojo::File 'path';
-use Try::Tiny;
 
 my $serial_file_pos  = 0;
 my $autoinst_log_pos = 0;
@@ -368,27 +367,13 @@ sub runtest {
         }
     }
 
-    # Detect serial failures and override result if die
-    try {
-        $self->search_for_expected_serial_failures();
-    }
-    catch {
-        # Process serial dectection failure
-        bmwqemu::diag($_);
-        $self->record_resultfile('Failed', $_, result => 'fail');
+    eval { $self->search_for_expected_serial_failures(); };
+    # Process serial dectection failure
+    if ($@) {
+        bmwqemu::diag($@);
+        $self->record_resultfile('Failed', $@, result => 'fail');
         $died = 1;
     }
-
-    # Detect autoinst failures and override result if die
-    try {
-        $self->search_for_expected_autoinst_failures();
-    }
-    catch {
-        # Process autoinst dectection failure
-        bmwqemu::diag($_);
-        $self->record_resultfile('Failed', $_, result => 'fail');
-        $died = 1;
-    };
 
     $self->run_post_fail("test $name died") if ($died);
 
@@ -728,51 +713,6 @@ sub parse_serial_output_qemu {
     }
     $serial_file_pos = $json->{position};
     die "Got serial hard failure" if $die;
-    return;
-}
-
-sub search_for_expected_autoinst_failures {
-    my ($self) = @_;
-    # autoinst failures defined in distri (test can override them)
-    my $failures = $self->{autoinst_failures};
-
-    my $die = 0;
-    my %regexp_matched;
-    # loop line by line
-    open(my $AUTOINSTLOG, "<", "autoinst-log.txt") || die('Could not open autoinst-log.txt for reading');
-    seek($AUTOINSTLOG, $autoinst_log_pos, 0) || die('Could not seek within autoinst-log.txt');
-    while (my $line = <$AUTOINSTLOG>) {
-        chomp $line;
-        for my $regexp_table (@{$failures}) {
-            my $regexp  = $regexp_table->{pattern};
-            my $message = $regexp_table->{message};
-            my $type    = $regexp_table->{type};
-
-            # Input parameters validation
-            die "Wrong type defined for serial failure. Only 'soft' or 'hard' allowed. Got: $type" if $type !~ /^soft|hard|fatal$/;
-            die "Message not defined for serial failure for the pattern: '$regexp', type: $type" if !defined $message;
-
-            # If you want to match a simple string please be sure that you create it with quotemeta
-            if (!exists $regexp_matched{$regexp} and $line =~ /$regexp/) {
-                $regexp_matched{$regexp} = 1;
-                my $fail_type = 'softfail';
-                if ($type =~ 'hard|fatal') {
-                    $die                   = 1;
-                    $fail_type             = 'fail';
-                    $self->{fatal_failure} = $type eq 'fatal';
-                }
-                $self->record_resultfile($message, $message . " - autoinst-log error: $line", result => $fail_type);
-                $self->{result} = $fail_type;
-            }
-        }
-    }
-    my $fp_pos = tell $AUTOINSTLOG;
-    if ($fp_pos == -1) {
-        die('Error reading from autoinst-log.txt - tell returned -1');
-    }
-    $autoinst_log_pos = $fp_pos;
-    close($AUTOINSTLOG);
-    die "Got autoinst hard failure" if $die;
     return;
 }
 

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -127,25 +127,21 @@ sub init {
     mkdir result_dir;
     mkdir join('/', result_dir, 'ulogs');
 
-    $logger = Mojo::Log->new(level => 'debug', path => 'autoinst-log.txt');
-    $logger->format(\&format_log);
-
     if ($direct_output) {
-        my $logger_stderr = Mojo::Log->new(level => 'debug');
-        $logger_stderr->format(\&format_log);
-        $logger->on(message => sub {
-                my ($log, $level, @lines) = @_;
-                $logger_stderr->$level(@lines);
-        });
+        $logger = Mojo::Log->new(level => 'debug');
+    }
+    else {
+        $logger = Mojo::Log->new(level => 'debug', path => catfile(result_dir, 'autoinst-log.txt'));
     }
 
-}
+    $logger->format(
+        sub {
+            my ($time, $level, @lines) = @_;
+            # Unfortunately $time doesn't have the precision we want. So we need to use Time::HiRes
+            $time = gettimeofday;
+            return sprintf(strftime("[%FT%T.%%03d %Z] [$level] ", localtime($time)), 1000 * ($time - int($time))) . join("\n", @lines, '');
 
-sub format_log {
-    my ($time, $level, @lines) = @_;
-    # Unfortunately $time doesn't have the precision we want. So we need to use Time::HiRes
-    $time = gettimeofday;
-    return sprintf(strftime("[%FT%T.%%03d %Z] [$level] ", localtime($time)), 1000 * ($time - int($time))) . join("\n", @lines, '');
+        });
 }
 
 sub ensure_valid_vars {

--- a/cpanfile
+++ b/cpanfile
@@ -40,7 +40,6 @@ requires 'Net::SSH2';
 requires 'POSIX';
 requires 'Thread::Queue';
 requires 'Time::HiRes';
-requires 'Try::Tiny';
 requires 'XML::LibXML';
 requires 'base';
 requires 'constant';

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -74,8 +74,6 @@ is($died,      1, 'run_all with no tests should catch runalltests dying');
 is($completed, 0, 'run_all with no tests should not complete');
 @sent = [];
 
-`touch autoinst-log.txt`;
-
 loadtest 'start';
 loadtest 'next';
 is(keys %autotest::tests, 2, 'two tests have been scheduled');
@@ -248,7 +246,6 @@ is(autotest::parse_test_path("$sharedir/tests/sle/tests/x11/firefox.pm"),       
 is(autotest::parse_test_path("$sharedir/tests/sle/tests/x11/toolkits/motif.pm"), ('motif',   'x11/toolkits'));
 is(autotest::parse_test_path("$sharedir/factory/other/sysrq.pm"),                ('sysrq',   'other'));
 
-unlink 'autoinst-log.txt';
 done_testing();
 
 # vim: set sw=4 et:


### PR DESCRIPTION
This reverts commit 85a4003cb5c716744a487d92c5b74977ea1973ab and
partially reverts commit fe70160d7134dfa499cae7d47fafd95e5321dcf8 as
problems in the output handling in conjunction with openQA has been
encountered. The general code interface is preserved and should be
overhauled when the implementation is completed.
 
Related ticket: https://progress.opensuse.org/issues/52235

Was: Reverts os-autoinst/os-autoinst#1159 to prevent the problem as described in https://progress.opensuse.org/issues/52235#note-5 until a proper solution has been found.