### PR TITLE
API bump; fix typo and warning

### DIFF
--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -22,7 +22,7 @@ use warnings;
 # -> increment on every change of such APIs
 # -> never move that variable to another place (when refactoring)
 #    because it may be accessed by the tests itself
-our $version = 14;
+our $version = 15;
 
 # major version of the (web socket) API relevant to the developer mode
 # -> increment when making non-backward compatible changes to that API

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -596,7 +596,7 @@ sub start_qemu {
     }
 
     if ($vars->{HDDFORMAT}) {
-        die 'HDDFORMAT has been removed. If you are using existing images in some other format then qcow2 overalys will be created on top of them';
+        die 'HDDFORMAT has been removed. If you are using existing images in some other format then qcow2 overlays will be created on top of them';
     }
 
     # disk settings

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -509,7 +509,7 @@ sub start_qemu {
 
     local *sp = sub { $self->{proc}->static_param(@_); };
 
-    if ($vars->{VIRTIO_CONSOLE} ne 0) {
+    if (($vars->{VIRTIO_CONSOLE} // '') ne 0) {
         $vars->{VIRTIO_CONSOLE} = 1;
     }
 


### PR DESCRIPTION
* Increment API version after  'Always log to autoinst-log.txt'
* Fix perl warning about undefined VIRTIO_CONSOLE
* Fix typo in HDDFORMAT die handler