### PR TITLE
sshVirtsh: Remove procedure add_serial_console()

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -280,17 +280,6 @@ sub add_vnc {
     return;
 }
 
-# adds a further serial port
-# (in addition to the serial console on port 0 which added in add_pty, so don't use port 0 here)
-# As it's used over virsh console, use <console>.
-sub add_serial_console {
-    my ($self, $args) = @_;
-
-    my $port    = $args->{port}    // backend::svirt::SERIAL_TERMINAL_DEFAULT_PORT;
-    my $pty_dev = $args->{pty_dev} // backend::svirt::SERIAL_TERMINAL_DEFAULT_DEVICE;
-    $self->add_pty({pty_dev => $pty_dev, pty_dev_type => 'pty', target_port => $port});
-}
-
 sub add_input {
     my ($self, $args) = @_;
 

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -62,9 +62,7 @@ subtest 'XML config for VNC and serial console' => sub {
     $svirt_console->_init_xml();
     $svirt_console->add_vnc({port => 5901});
     $svirt_console->add_pty({target_port => SERIAL_CONSOLE_DEFAULT_PORT});
-    $svirt_console->add_serial_console({
-            pty_dev     => SERIAL_TERMINAL_DEFAULT_DEVICE,
-            target_port => SERIAL_TERMINAL_DEFAULT_PORT});
+    $svirt_console->add_pty({pty_dev     => SERIAL_TERMINAL_DEFAULT_DEVICE, pty_dev_type => 'pty', target_port => SERIAL_TERMINAL_DEFAULT_PORT});
 
     my $produced_xml = $svirt_console->{domainxml}->toString(2);
     my $expected_xml = '22-svirth-virsh-config.xml';


### PR DESCRIPTION
Reasons for removing:

* not used any more
The only use of add_serial_console() was in os-autoinst-distri-opensuse.git
and removed in 71d855917 ("Revert "svirt: Add root-sut-serial console")
when svirt serial backend was reverted. On re-enablement of svirt serial
backend in efc9a8afb ("svirt: Add (again) root-sut-serial console") generic
procedure add_pty() was used.

* confusing name
1) It's meant to be used for adding a further serial port, but name
suggest adding serial console (which is added by add_pty().
2) There already was a procedure add_serial_console() in
lib/serial_terminal.pm.

* questionable use
For being really helpful it should pass target_type => 'virtio' to
add_pty(), i.e.:

```
 sub add_serial_console {
    my ($self, $args) = @_;

    my $port    = $args->{port}    // backend::svirt::SERIAL_TERMINAL_DEFAULT_PORT;
    my $pty_dev = $args->{pty_dev} // backend::svirt::SERIAL_TERMINAL_DEFAULT_DEVICE;
    $self->add_pty({pty_dev => $pty_dev, pty_dev_type => 'pty', target_type => 'virtio', target_port => $port});
 }
```

But IMHO it's better to explicitly specify all parameters, thus use add_pty().