### PR TITLE
 Add script_output_with_status() 

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -50,7 +50,7 @@ our @EXPORT = qw($realname $username $password $serialdev %cmd %vars
   mouse_dclick mouse_tclick match_has_tag
 
   assert_script_run script_run assert_script_sudo script_sudo
-  script_output validate_script_output
+  script_output validate_script_output script_output_with_status
 
   start_audiocapture assert_recorded_sound check_recorded_sound
 
@@ -1026,26 +1026,14 @@ sub script_sudo {
 
 =head2 script_output
 
-  script_output($script [, $wait, type_command => 1, proceed_on_failure => 1] [,quiet => $quiet])
+  my $out = script_output($script [, timeout => ?] [, type_command => ?] [, proceed_on_failure => ?] [, quiet => ?])
 
-Executing script inside SUT with C<bash -eox> (in case of serial console with C<bash -eo>)
-and directs C<stdout> (I<not> C<stderr>!) to the serial console and returns
-the output I<if> the script exits with 0. Otherwise the test is set to failed.
-NOTE: execution result may include extra serial output which was on serial console
-since command was triggered in case serial console is not dedicated for
-the script output only.
+Deprecated mode
 
-The script content is based on the variable content of C<current_test_script>
-and is typed or fetched through HTTP depending on various parameters. Typing
-can be forced by passing C<type_command => 1> for example when the SUT does
-not provide a usable network connection.
+  script_output($script [, $wait, type_command => 1, proceed_on_failure => 1])
 
-C<proceed_on_failure> - allows to proceed with validation when C<$script> is
-failing (return non-zero exit code)
-
-The default timeout for the script is based on the default in C<wait_serial>
-and can be tweaked by setting the C<$wait> positional parameter.
-
+Wrap C<script_output_with_status()> and only return the trimmed output.
+Returns empty string, unless start- and end-markers were found.
 =cut
 
 sub script_output {
@@ -1059,6 +1047,37 @@ sub script_output {
         }, ['timeout'], @_);
 
     return $distri->script_output($script, %args);
+}
+
+=head2 script_output_with_status
+
+  my ($out, $retval) = script_output_with_status($script [, timeout => ?] [, type_command => ?] [, proceed_on_failure => ?] [, quiet => ?])
+
+Executes a script inside SUT with C<bash -eox> (in case of serial console with C<bash -eo>)
+and directs C<stdout> (I<not> C<stderr>!) to the serial console. Returns an array
+with the data written to C<stdout> and the exit code of the script.
+I<If> the script exits with != 0, the test is set to failed. Use
+C<proceed_on_failure> to proceed with validation.
+If retrieved C<$out> is I<undef>, this function wasn't able to find the start
+and end marker to identify the script output.
+NOTE: execution result may include extra serial output which was on serial console
+since command was triggered in case serial console is not dedicated for
+the script output only.
+
+The given script is typed or fetched through HTTP depending on various parameters.
+Typing can be forced by passing C<<type_command => 1>> for example when the SUT does
+not provide a usable network connection.
+
+The default timeout for the script is based on the default in C<wait_serial>
+and can be tweaked by setting the C<$timeout> parameter.
+
+Use C<quiet> to avoid recording serial_results or test variable C<_QUIET_SCRIPT_CALLS>.
+=cut
+
+sub script_output_with_status {
+    my ($script, %args) = @_;
+    $args{quiet} //= testapi::get_var('_QUIET_SCRIPT_CALLS');
+    return $distri->script_output_with_status($script, %args);
 }
 
 


### PR DESCRIPTION
This function is like script_output(). But it always return a array
wich contains the output and the exit code of the script.

This is useful, when calling this function with `proceed_on_failure=>1`.
