### PR TITLE
Generalize Net::SSH2 usage in svirt backend

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -65,6 +65,7 @@ sub new {
     $self->{min_image_similarity} = 10000;
     $self->{min_video_similarity} = 10000;
     $self->{children}             = [];
+    $self->{ssh_connections}      = {};
 
     return $self;
 }
@@ -348,6 +349,7 @@ sub stop_vm {
         $self->{encoder_pipe} = undef;
         $self->{started}      = 0;
     }
+    $self->close_ssh_connections();
     $self->close_pipes();    # does not return
     return;
 }
@@ -1179,7 +1181,20 @@ sub retry_assert_screen {
 # shared between svirt and s390 backend
 sub new_ssh_connection {
     my ($self, %args) = @_;
+    bmwqemu::log_call(%args);
+    my %credentials = $self->get_ssh_credentials;
+    $args{$_} //= $credentials{$_} foreach (keys(%credentials));
     $args{username} ||= 'root';
+    $args{keep_open} //= 0;
+    my $connection_key;
+
+    # e.g. using hyperv_intermediate host which is running Windows need to keep the connection.
+    # Otherwise a mount point doesn't exists within the next command.
+    if ($args{keep_open}) {
+        $connection_key = join(',', map { $_ . "=" . $args{$_} } qw(hostname username password));
+        my $con = $self->{ssh_connections}->{$connection_key};
+        return $con if (defined($con));
+    }
 
     my $ssh = Net::SSH2->new;
 
@@ -1195,7 +1210,7 @@ sub new_ssh_connection {
                 # this relies on agent to be set up correctly
                 $ssh->auth_agent($args{username});
             }
-            bmwqemu::diag "Connection to $args{username}\@$args{hostname} established" if $ssh->auth_ok;
+            bmwqemu::diag "SSH connection to $args{username}\@$args{hostname} established" if $ssh->auth_ok;
             last;
         }
         else {
@@ -1207,13 +1222,21 @@ sub new_ssh_connection {
     }
     OpenQA::Exception::SSHConnectionError->throw(error => "Error connecting to <$args{username}\@$args{hostname}>: $@") unless $ssh->auth_ok;
 
+    $self->{ssh_connections}->{$connection_key} = $ssh if ($args{keep_open});
     return $ssh;
+}
+
+=head2 get_ssh_credentials
+Should return a hash with the keys: C<host, username, password>
+=cut
+sub get_ssh_credentials {
+    return;
 }
 
 # open another ssh connection to grab the serial console
 sub start_ssh_serial {
     my ($self, %args) = @_;
-
+    bmwqemu::log_call(%args);
     $self->stop_ssh_serial;
 
     my $ssh  = $self->{serial}      = $self->new_ssh_connection(%args);
@@ -1260,6 +1283,59 @@ sub check_ssh_serial {
 
     bmwqemu::diag("svirt serial: unable to read: $error_string (error code: $error_code)");
     return 1;
+}
+
+=head2 run_ssh_cmd
+
+   $ret = run_ssh_cmd($cmd [, username => ?][, password => ?][,host => ?]);
+   ($ret, $stdout, $stderr) = run_ssh_cmd($cmd [, username => ?][, password => ?][,host => ?], wantarray => 1);
+
+=cut
+sub run_ssh_cmd {
+    my ($self, $cmd, %args) = @_;
+    my ($stdout, $stderr) = ('', '');
+    $args{wantarray} //= 0;
+    $args{keep_open} //= 1;
+
+    bmwqemu::log_call(cmd => $cmd, %args);
+    my ($ssh, $chan) = $self->run_ssh($cmd, %args);
+    $chan->send_eof;
+
+    while (!$chan->eof) {
+        if (my ($o, $e) = $chan->read2) {
+            $stdout .= $o;
+            $stderr .= $e;
+        }
+    }
+
+    bmwqemu::diag("[run_ssh_cmd($cmd)] stdout:$/$stdout") if length($stdout);
+    bmwqemu::diag("[run_ssh_cmd($cmd)] stderr:$/$stderr") if length($stderr);
+    my $ret = $chan->exit_status();
+    bmwqemu::diag("[run_ssh_cmd($cmd)] exit-code: $ret");
+    $ssh->disconnect() unless ($args{keep_open});
+
+    return $args{wantarray} ? ($ret, $stdout, $stderr) : $ret;
+}
+
+sub run_ssh {
+    my ($self, $cmd, %args) = @_;
+    bmwqemu::log_call(cmd => $cmd, %args);
+    $args{blocking} //= 1;
+    my $ssh  = $self->new_ssh_connection(%args);
+    my $chan = $ssh->channel() || $ssh->die_with_error("Unable to create SSH channel for executing \"$cmd\"");
+    $chan->exec($cmd) || $ssh->die_with_error("Unable to execute \"$cmd\"");
+    $ssh->blocking($args{blocking});
+    return ($ssh, $chan);
+}
+
+sub close_ssh_connections {
+    my $self = shift;
+    my $cons = $self->{ssh_connections} // {};
+    for my $key (keys(%{$cons})) {
+        bmwqemu::diag("SSH disconnect $key");
+        $cons->{$key}->disconnect();
+        delete($cons->{$key});
+    }
 }
 
 sub stop_ssh_serial {

--- a/backend/spvm.pm
+++ b/backend/spvm.pm
@@ -67,19 +67,9 @@ sub run_cmd {
     my ($self, $cmd, $hostname, $password) = @_;
     $hostname ||= get_required_var('NOVALINK_HOSTNAME');
     $password ||= get_required_var('NOVALINK_PASSWORD');
+    my $username = get_var('NOVALINK_USERNAME', 'root');
 
-    my $ssh = $self->{ssh} = $self->new_ssh_connection(
-        hostname => $hostname,
-        password => $password,
-        username => get_var('NOVALINK_USERNAME', 'root'));
-    my $chan = $ssh->channel() || $ssh->die_with_error();
-    $chan->exec($cmd) || $ssh->die_with_error();
-    backend::svirt::get_ssh_output($chan);
-    $chan->send_eof();
-    my $ret = $chan->exit_status();
-    bmwqemu::diag "Command executed: $cmd, ret=$ret";
-    $chan->close();
-    return $ret;
+    return $self->run_ssh_cmd($cmd, username => $username, password => $password, hostname => $hostname, keep_open => 0);
 }
 
 sub can_handle {

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -54,8 +54,7 @@ sub activate {
     my $args = $self->{args};
 
     # initialize SSH console(s)
-    $self->_init_ssh(ssh             => $args);
-    $self->_init_ssh(sshVMwareServer => $args) if ($self->vmm_family eq 'vmware');
+    $self->_init_ssh($args);
 
     # start Xvnc
     $self->SUPER::activate;
@@ -63,27 +62,33 @@ sub activate {
     $self->_init_xml();
 }
 
-# initializes the SSH console(s), $domain is used to distinguish between the regular SSH console and the one to the VMware server
+# initializes the SSH credentials, $domain is used to distinguish between the
+# regular SSH and the one to the VMware server
 sub _init_ssh {
-    my ($self, $domain, $args) = @_;
+    my ($self, $args) = @_;
 
-    my %connection_settings;
-    if ($domain eq 'ssh') {
-        %connection_settings = (
-            hostname => ($args->{hostname} || die('we need a hostname to ssh to')),
+    $self->{ssh_credentials} = {
+        default => {
+            hostname => $args->{hostname} || die('we need a hostname to ssh to'),
             username => $args->{username},
             password => $args->{password},
-        );
-    } elsif ($domain eq 'sshVMwareServer') {
-        %connection_settings = (
+        }
+    };
+    if ($self->vmm_family eq 'vmware') {
+        $self->{ssh_credentials}->{sshVMwareServer} =
+          {
             hostname => get_required_var('VMWARE_HOST'),
             password => get_required_var('VMWARE_PASSWORD'),
-        );
-    } else {
-        die "can not initialize SSH console for domain \"$domain\"";
+            username => 'root',
+          };
     }
+}
 
-    return $self->{$domain} = $self->backend->new_ssh_connection(%connection_settings);
+sub get_ssh_credentials {
+    my ($self, $domain) = @_;
+    $domain //= 'default';
+    die("Unknown ssh credentials domain $domain") unless (exists($self->{ssh_credentials}->{$domain}));
+    return %{$self->{ssh_credentials}->{$domain}};
 }
 
 # creates an XML document to configure the libvirt domain
@@ -335,21 +340,16 @@ sub add_disk {
             my $vmware_disk_path = $vmware_openqa_datastore . $file;
             # Power VM off, delete it's disk image, and create it again.
             # Than wait for some time for the VM to *really* turn off.
-            my $ssh         = $self->{sshVMwareServer};
-            my $vmware_chan = $ssh->channel() || $ssh->die_with_error("Unable to create SSH channel for adding disk");
-            $vmware_chan->exec(
-                "( set -x; vmid=\$(vim-cmd vmsvc/getallvms | awk \'/$name/ { print \$1 }\');" .
-                  'if [ $vmid ]; then ' .
-                  'vim-cmd vmsvc/power.off $vmid;' .
-                  'vim-cmd vmsvc/destroy $vmid;' .
-                  'fi;' .
-                  "vmkfstools -v1 -U $vmware_disk_path;" .
-                  "vmkfstools -v1 -c $size --diskformat thin $vmware_disk_path; sleep 10 ) 2>&1"
-            ) || $ssh->die_with_error("Unable to execute command for adding disk");
-            $vmware_chan->send_eof;
-            backend::svirt::get_ssh_output($vmware_chan);
-            $vmware_chan->close();
-            die "Can't create VMware image $vmware_disk_path" if $vmware_chan->exit_status();
+            my $cmd =
+              "( set -x; vmid=\$(vim-cmd vmsvc/getallvms | awk \'/$name/ { print \$1 }\');" .
+              'if [ $vmid ]; then ' .
+              'vim-cmd vmsvc/power.off $vmid;' .
+              'vim-cmd vmsvc/destroy $vmid;' .
+              'fi;' .
+              "vmkfstools -v1 -U $vmware_disk_path;" .
+              "vmkfstools -v1 -c $size --diskformat thin $vmware_disk_path; sleep 10 ) 2>&1";
+            my $retval = $self->run_cmd($cmd, domain => 'ssh_VMwareServer');
+            die "Can't create VMware image $vmware_disk_path" if $retval;
         }
         else {
             $file = $basedir . $file;
@@ -379,37 +379,28 @@ sub add_disk {
                 # otherwise copy image from NFS datastore.
                 my $nfs_dir              = $backingfile ? 'hdd' : 'iso';
                 my $vmware_nfs_datastore = get_required_var('VMWARE_NFS_DATASTORE');
-                my $ssh                  = $self->{sshVMwareServer};
-                my $vmware_chan          = $ssh->channel() || $ssh->die_with_error("Unable to create SSH channel for adding disk");
-                $vmware_chan->exec(
-                    "if test -e $vmware_openqa_datastore$file_basename; then " .
-                      "while lsof | grep 'cp.*$file_basename'; do " .
-                      "echo File $file_basename is being copied by other process, sleeping for 60 seconds; sleep 60;" .
-                      'done;' .
-                      'else ' .
-                      "cp /vmfs/volumes/$vmware_nfs_datastore/$nfs_dir/$file_basename $vmware_openqa_datastore;" .
-                      'fi;'
-                ) || $ssh->die_with_error("Unable to execute command to copy VMware image $file_basename");
-                $vmware_chan->send_eof;
-                backend::svirt::get_ssh_output($vmware_chan);
-                $vmware_chan->close();
-                die "Can't copy VMware image $file_basename" if $vmware_chan->exit_status();
+                my $cmd =
+                  "if test -e $vmware_openqa_datastore$file_basename; then " .
+                  "while lsof | grep 'cp.*$file_basename'; do " .
+                  "echo File $file_basename is being copied by other process, sleeping for 60 seconds; sleep 60;" .
+                  'done;' .
+                  'else ' .
+                  "cp /vmfs/volumes/$vmware_nfs_datastore/$nfs_dir/$file_basename $vmware_openqa_datastore;" .
+                  'fi;';
+                my $retval = $self->run_cmd($cmd, domain => 'sshVMwareServer');
+                die "Can't copy VMware image $file_basename" if $retval;
                 if ($backingfile) {
                     # Power VM off, delete it's disk image, and create it again.
                     # Than wait for some time for the VM to *really* turn off.
-                    $vmware_chan = $ssh->channel() || $ssh->die_with_error("Unable to create SSH channel for adding disk");
-                    $vmware_chan->exec(
-                        "( set -x; vmid=\$(vim-cmd vmsvc/getallvms | awk \'/$name/ { print \$1 }\');" .
-                          'if [ $vmid ]; then ' .
-                          'vim-cmd vmsvc/power.off $vmid;' .
-                          'fi;' .
-                          "vmkfstools -v1 -U $vmware_disk_path_thinfile;" .
-                          "vmkfstools -v1 -i $vmware_disk_path --diskformat thin $vmware_disk_path_thinfile; sleep 10 ) 2>&1"
-                    ) || $ssh->die_with_error("Unable to execute command to create thin VMware image");
-                    $vmware_chan->send_eof;
-                    backend::svirt::get_ssh_output($vmware_chan);
-                    $vmware_chan->close();
-                    die "Can't create thin VMware image" if $vmware_chan->exit_status();
+                    my $cmd =
+                      "( set -x; vmid=\$(vim-cmd vmsvc/getallvms | awk \'/$name/ { print \$1 }\');" .
+                      'if [ $vmid ]; then ' .
+                      'vim-cmd vmsvc/power.off $vmid;' .
+                      'fi;' .
+                      "vmkfstools -v1 -U $vmware_disk_path_thinfile;" .
+                      "vmkfstools -v1 -i $vmware_disk_path --diskformat thin $vmware_disk_path_thinfile; sleep 10 ) 2>&1";
+                    my $retval = $self->run_cmd($cmd, domain => 'sshVMwareServer');
+                    die "Can't create thin VMware image" if $retval;
                 }
             }
             else {
@@ -561,15 +552,12 @@ __END"
     my $instance    = $self->instance;
     my $xmldata     = $self->{domainxml}->toString(2);
     my $xmlfilename = "/var/lib/libvirt/images/" . $self->name . ".xml";
-    my $ssh         = $self->{ssh};
-    my $chan        = $ssh->channel() || $ssh->die_with_error("Unable to create SSH channel for writing virsh config");
     my $ret;
-
     bmwqemu::diag("Creating libvirt configuration file $xmlfilename:\n$xmldata");
-
+    my ($ssh, $chan) = $self->backend->run_ssh("cat > $xmlfilename", $self->get_ssh_credentials(), keep_open => 1);
     # scp_put is unfortunately unreliable (RT#61771)
-    $chan->exec("cat > $xmlfilename") || $ssh->die_with_error();
     $chan->write($xmldata) || $ssh->die_with_error();
+    $chan->send_eof();
     $chan->close();
 
     # shut down possibly running previous test (just to be sure) - ignore errors
@@ -581,7 +569,7 @@ __END"
     # define the new domain
     $self->run_cmd("virsh $remote_vmm define $xmlfilename") && die "virsh define failed";
     if ($self->vmm_family eq 'vmware') {
-        $self->get_cmd_output('echo bios.bootDelay = \"10000\" >> /vmfs/volumes/datastore1/openQA/' . $self->name . '.vmx', {domain => 'sshVMwareServer'});
+        $self->run_cmd('echo bios.bootDelay = \"10000\" >> /vmfs/volumes/datastore1/openQA/' . $self->name . '.vmx', domain => 'sshVMwareServer');
     }
 
     $ret = $self->run_cmd("virsh $remote_vmm start " . $self->name . ' 2> >(tee /tmp/os-autoinst-' . $self->name . '-stderr.log >&2)');
@@ -620,47 +608,41 @@ sub stop_serial_grab {
     $self->backend->stop_serial_grab($self->name);
 }
 
-# Sends command to libvirt host, logs stdout and stderr of the command,
-# returns exit status.
-#
-# Example:
-#   my $ret = $svirt->run_cmd("virsh snapshot-create-as snap1");
-#   die "snapshot creation failed" unless $ret == 0;
+
+=head2 run_cmd
+
+    $ret = $svirt->run_cmd($cmd [, domain => 'default'] [, wantarray => 0 ]);
+
+With C<<wantarray => 1 >> you will receive a list containing I<exitcode>,
+I<stdout> and I<stderr>.
+
+    ($ret, $stdout, $stderr) = $svirt->run_cmd($cmd, wantarray => 1);
+
+
+Execute the command via SSH on given C<domain> by default it is the host given
+on C<activate()>, normally the libvirt host defined via C<VIRSH_HOSTNAME>,
+C<VIRSH_USERNAME> and C<VIRSH_PASSWORD>.
+The second domain B<sshVMwareServer> is available if C<VIRSH_VMM_FAMILY> is
+B<vmware> and defined via C<VMWARE_HOST>, C<VMWARE_PASSWORD> and 'root' as
+username.
+=cut
 sub run_cmd {
     my ($self, $cmd, %args) = @_;
-    return backend::svirt::run_cmd($self->{ssh}, $cmd, %args);
+    return $self->backend->run_ssh_cmd($cmd, $self->get_ssh_credentials($args{domain}), wantarray => $args{wantarray} // 0);
 }
 
-# Executes command and in list context returns pair of standard output and standard error
-# of the command. In void (and scalar) context returns just standard the standard output.
+=head2 get_cmd_output
+
+    $stdout = $svirt->get_cmd_output($cmd , $args = {domain => 'default', wantarray => 0});
+
+With C<<wantarray => 1>> the function will return a reference to a list which
+contains I<stdout> and I<stderr>.
+This function is B<deprecated>, you should use C<<$svirt->run_cmd()>> instead.
+=cut
 sub get_cmd_output {
     my ($self, $cmd, $args) = @_;
-
-    my $wantarray = $args->{wantarray};
-    my $domain    = $args->{domain} // 'ssh';
-    my $ssh       = $self->{$domain};
-    if (!$ssh) {
-        die "get_cmd_output has been called with domain \"$domain\" but no such SSH console has been activated";
-    }
-
-    # create a new channel; try to re-establish the SSH connection on failure
-    my $chan = $ssh->channel();
-    if (!$chan) {
-        $ssh  = $self->_init_ssh($domain);
-        $chan = $ssh->channel() || $ssh->die_with_error("unable to create channel for SSH console \"$domain\"");
-    }
-
-    # execute command
-    if (!$chan->exec($cmd)) {
-        $ssh->die_with_error("unable to execute command \"$cmd\" via SSH console \"$domain\"");
-    }
-
-    # read output and close channel
-    bmwqemu::diag "Command executed: $cmd";
-    my @cmd_output = backend::svirt::get_ssh_output($chan);
-    $chan->send_eof();
-    $chan->close();
-    return $wantarray ? \@cmd_output : $cmd_output[0];
+    my (undef, $stdout, $stderr) = $self->backend->run_ssh_cmd($cmd, $self->get_ssh_credentials($args->{domain}), wantarray => 1);
+    return $args->{wantarray} ? [$stdout, $stderr] : $stdout;
 }
 
 1;

--- a/consoles/sshVirtshSUT.pm
+++ b/consoles/sshVirtshSUT.pm
@@ -66,10 +66,10 @@ sub activate {
     my $backend = $self->{backend};
     bmwqemu::diag(sprintf("Activate console on libvirt_domain:%s devname:%s port:%s",
             $self->{libvirt_domain}, $self->{pty_dev}, $self->{serial_port_no}));
-    my ($ssh, $chan) = $backend->open_serial_console_via_ssh($self->{libvirt_domain},
-        devname => $self->{pty_dev}, port => $self->{serial_port_no}, is_terminal => 1);
-    $ssh->blocking(0);
+    my ($ssh, $chan) = $backend->open_serial_console_via_ssh(
+        $self->{libvirt_domain}, devname => $self->{pty_dev}, port => $self->{serial_port_no}, blocking => 0);
     $self->{screen} = consoles::ssh_screen->new(ssh_connection => $ssh, ssh_channel => $chan);
+    $self->{ssh}    = $ssh;
     return;
 }
 

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -5,11 +5,15 @@ use strict;
 use warnings;
 use Test::More;
 use Test::MockModule;
+use Test::MockObject;
 use Test::Warnings;
+use Test::Exception;
 use Test::Output 'stderr_like';
+use Scalar::Util 'refaddr';
 use XML::SemanticDiff;
 use backend::svirt;
 use distribution;
+use Net::SSH2;
 use testapi qw(get_var get_required_var check_var set_var);
 use backend::svirt qw(SERIAL_CONSOLE_DEFAULT_PORT SERIAL_TERMINAL_DEFAULT_DEVICE SERIAL_TERMINAL_DEFAULT_PORT);
 
@@ -24,7 +28,7 @@ set_var(VIRSH_PASSWORD  => 'password');
 my $distri = $testapi::distri = distribution->new();
 my $svirt  = backend::svirt->new();
 
-is_deeply($svirt->read_credentials_from_virsh_variables, {
+is_deeply({$svirt->get_ssh_credentials()}, {
         hostname => 'bar',
         username => 'root',
         password => 'password',
@@ -79,6 +83,124 @@ subtest 'XML config for VNC and serial console' => sub {
     else {
         ok('XML looks as expected');
     }
+};
+
+
+subtest 'SSH credentials' => sub {
+
+    set_var('VIRSH_GUEST',          'foo321');
+    set_var('VIRSH_GUEST_PASSWORD', 'password321');
+    set_var('VIRSH_VMM_FAMILY',     'hyperv');
+    my $svirt = backend::svirt->new();
+
+    my %creds = $svirt->get_ssh_credentials();
+    is_deeply(\%creds, {hostname => 'bar', password => 'password', username => 'root'}, 'Check SSH credentials');
+
+    %creds = $svirt->get_ssh_credentials('hyperv');
+    is_deeply(\%creds, {hostname => 'foo321', password => 'password321', username => 'root'}, 'Check SSH credentials for hyperv');
+};
+
+subtest 'SSH usage in svirt' => sub {
+    my $ssh_expect_credentials = {username => 'root', password => 'password'};
+    my $ssh_obj_data           = {};                                             # used to store Net::SSH2 fake data per object
+    my $net_ssh2               = Test::MockModule->new('Net::SSH2');
+    $net_ssh2->mock('connect', sub {
+            my $self = shift;
+            $ssh_obj_data->{refaddr($self)}->{connected} = 1;
+            $ssh_obj_data->{refaddr($self)}->{blocking}  = 0;
+            return 1;
+    });
+    $net_ssh2->mock('auth', sub {
+            my ($self, %args) = @_;
+            is($args{username}, $ssh_expect_credentials->{username}, 'Correct username for ssh connection');
+            is($args{password}, $ssh_expect_credentials->{password}, 'Correct password for ssh connection');
+            return 1;
+    });
+    $net_ssh2->mock('auth_ok', sub { return 1; });
+    $net_ssh2->mock('blocking', sub {
+            my ($self, $v);
+            $ssh_obj_data->{refaddr($self)}->{blocking} = $v if defined($v);
+            return $self->{blocking};
+    });
+    $net_ssh2->mock('disconnect', sub {
+            $ssh_obj_data->{refaddr(shift)}->{connected} = 0;
+            return 1;
+    });
+    $net_ssh2->mock('channel', sub {
+            my $self = shift;
+            die("Not connected") unless ($ssh_obj_data->{refaddr($self)}->{connected});
+            my $mock_channel = Test::MockObject->new();
+            $mock_channel->{ssh} = $self;
+            $mock_channel->mock('exec', sub {
+                    my ($self, $cmd) = @_;
+                    $self->{cmd} = $cmd;
+                    $self->{eof} = 0;
+                    if ($cmd =~ /^(echo|test)/) {
+                        $self->{stdout}      = `$cmd`;
+                        $self->{exit_status} = $?;
+                        $self->{stderr}      = '';
+                    }
+                    return 1;
+            });
+            $mock_channel->mock('read2', sub {
+                    my ($self) = @_;
+                    $self->{eof} = 1;
+                    return ($self->{stdout}, $self->{stderr});
+            });
+            $mock_channel->mock('eof',         sub { return shift->{eof}; });
+            $mock_channel->mock('blocking',    sub { return shift->{ssh}->blocking(shift) });
+            $mock_channel->mock('pty',         sub { return 1; });
+            $mock_channel->mock('send_eof',    sub { return 1; });
+            $mock_channel->mock('exit_status', sub { shift->{exit_status}; });
+    });
+
+    # check connection handling
+    my $ssh1 = $svirt->new_ssh_connection();
+    my $ssh2 = $svirt->new_ssh_connection();
+    my $ssh3 = $svirt->new_ssh_connection(keep_open => 1);
+    my $ssh4 = $svirt->new_ssh_connection(keep_open => 1);
+    $ssh_expect_credentials->{username} = 'foo911';
+    my $ssh5 = $svirt->new_ssh_connection(keep_open => 1, username => 'foo911');
+    $ssh_expect_credentials->{username} = 'root';
+    isnt(refaddr($ssh1), refaddr($ssh2), "Got new connection each call");
+    is(refaddr($ssh3), refaddr($ssh4), "Got same connection with keep_open");
+    isnt(refaddr($ssh4), refaddr($ssh5), "Got new connection with different credentials");
+
+    $net_ssh2->mock('auth_ok', sub { return 0; });
+    throws_ok(sub                  { $svirt->new_ssh_connection() }, qr/Error connecting to/, 'Got exception on connection error');
+    $net_ssh2->mock('auth_ok', sub { return 1; });
+
+    # check run_ssh_cmd() usage
+    is($svirt->run_ssh_cmd('echo -n "foo"'), 0, 'Command successful exit');
+    isnt($svirt->run_ssh_cmd('test 23 -eq 42'), 0, 'Command failed exit');
+    my @output = $svirt->run_ssh_cmd('echo -n "foo"', wantarray => 1);
+    is_deeply(\@output, [0, 'foo', ''], 'Command successful exit with output');
+
+    $ssh_expect_credentials->{password} = '2+3=5';
+    is($svirt->run_ssh_cmd('echo -n "foo"', password => '2+3=5'), 0, 'Allow SSH credentials per run_ssh_cmd() call');
+
+    my $num_ssh_connect = scalar(keys(%{$ssh_obj_data}));
+    $svirt->run_ssh_cmd('echo -n "foo"', password => '2+3=5', keep_open => 0);
+    is($num_ssh_connect + 1, scalar(keys(%{$ssh_obj_data})), 'Ensure run_ssh_cmd(keep_open => 0) uses a new SSH connection');
+
+    # cleanup kept ssh connections
+    for my $ssh_ref ((refaddr($ssh3), refaddr($ssh4), refaddr($ssh5))) {
+        is($ssh_obj_data->{$ssh_ref}->{connected}, 1, "SSH connection $ssh_ref connected");
+    }
+    $svirt->close_ssh_connections();
+    is(scalar(keys(%{$svirt->{ssh_connections}})), 0, "Cleanup ssh connections");
+    for my $ssh_ref ((refaddr($ssh3), refaddr($ssh4), refaddr($ssh5))) {
+        is($ssh_obj_data->{$ssh_ref}->{connected}, 0, "SSH connection $ssh_ref is disconnected");
+    }
+
+    # Check console::sshVirtsh
+    my $ssh_creds_svirt = {hostname => 'hostname_svirt', password => 'password_svirt'};
+    # W/A cause $svirt_console->activate() didn't worked so far
+    $svirt_console->_init_ssh($ssh_creds_svirt);
+    %{$ssh_expect_credentials} = (%{$ssh_expect_credentials}, %{$ssh_creds_svirt});
+    is($svirt_console->run_cmd('echo "BLAFAFU"'),           0,         "sshVirtsh::run_cmd() test return value ");
+    is($svirt_console->get_cmd_output('echo -n "BLAFAFU"'), 'BLAFAFU', "sshVirtsh::get_cmd_output()");
+    is_deeply($svirt_console->get_cmd_output('echo -n "BLAFAFU"', {wantarray => 1}), ['BLAFAFU', ''], "sshVirtsh::get_cmd_output(wantarray => 1) ");
 };
 
 done_testing;

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -4,7 +4,10 @@ use strict;
 use warnings;
 use Test::More;
 use Test::MockModule;
+use Test::MockObject;
 use Test::Warnings;
+use Net::SSH2;
+use Scalar::Util 'refaddr';
 use backend::baseclass;
 use POSIX 'tzset';
 
@@ -32,6 +35,96 @@ subtest 'format_vtt_timestamp' => sub {
         "\n1\n00:00:00.041 --> 00:00:00.083\n[2018-12-04T09:50:24.000]\n",
         'frame number 1'
     );
+};
+
+subtest 'SSH utilities' => sub {
+    my $ssh_expect_credentials = {username => 'root', password => 'password'};
+    my $ssh_obj_data           = {};                                             # used to store Net::SSH2 fake data per object
+    my $net_ssh2               = Test::MockModule->new('Net::SSH2');
+    $net_ssh2->mock('connect', sub {
+            my $self = shift;
+            $ssh_obj_data->{refaddr($self)}->{connected} = 1;
+            $ssh_obj_data->{refaddr($self)}->{blocking}  = 0;
+            return 1;
+    });
+    $net_ssh2->mock('auth', sub {
+            my ($self, %args) = @_;
+            is($args{username}, $ssh_expect_credentials->{username}, 'Correct username for ssh connection');
+            is($args{password}, $ssh_expect_credentials->{password}, 'Correct password for ssh connection');
+            return 1;
+    });
+    $net_ssh2->mock('auth_ok', sub { return 1; });
+    $net_ssh2->mock('blocking', sub {
+            my ($self, $v);
+            $ssh_obj_data->{refaddr($self)}->{blocking} = $v if defined($v);
+            return $self->{blocking};
+    });
+    $net_ssh2->mock('disconnect', sub {
+            $ssh_obj_data->{refaddr(shift)}->{connected} = 0;
+            return 1;
+    });
+    $net_ssh2->mock('channel', sub {
+            my $self = shift;
+            die("Not connected") unless ($ssh_obj_data->{refaddr($self)}->{connected});
+            my $mock_channel = Test::MockObject->new();
+            $mock_channel->{ssh} = $self;
+            $mock_channel->mock('exec', sub {
+                    my ($self, $cmd) = @_;
+                    $self->{cmd} = $cmd;
+                    $self->{eof} = 0;
+                    if ($cmd =~ /^(echo|test)/) {
+                        $self->{stdout}      = `$cmd`;
+                        $self->{exit_status} = $?;
+                        $self->{stderr}      = '';
+                    }
+                    return 1;
+            });
+            $mock_channel->mock('read2', sub {
+                    my ($self) = @_;
+                    $self->{eof} = 1;
+                    return ($self->{stdout}, $self->{stderr});
+            });
+            $mock_channel->mock('eof',         sub { return shift->{eof}; });
+            $mock_channel->mock('blocking',    sub { return shift->{ssh}->blocking(shift) });
+            $mock_channel->mock('pty',         sub { return 1; });
+            $mock_channel->mock('send_eof',    sub { return 1; });
+            $mock_channel->mock('exit_status', sub { shift->{exit_status}; });
+    });
+
+    my %ssh_creds = (username => 'root', password => 'password', hostname => 'foo.bla');
+    my $ssh1      = $baseclass->new_ssh_connection(%ssh_creds);
+    my $ssh2      = $baseclass->new_ssh_connection(%ssh_creds);
+    my $ssh3      = $baseclass->new_ssh_connection(keep_open => 1, %ssh_creds);
+    my $ssh4      = $baseclass->new_ssh_connection(keep_open => 1, %ssh_creds);
+    $ssh_expect_credentials->{username} = 'foo911';
+    my $ssh5 = $baseclass->new_ssh_connection(keep_open => 1, %ssh_creds, username => 'foo911');
+    $ssh_expect_credentials->{username} = 'root';
+    isnt(refaddr($ssh1), refaddr($ssh2), "Got new connection each call");
+    is(refaddr($ssh3), refaddr($ssh4), "Got same connection with keep_open");
+    isnt(refaddr($ssh4), refaddr($ssh5), "Got new connection with different credentials");
+
+    # check run_ssh_cmd() usage
+    is($baseclass->run_ssh_cmd('echo -n "foo"', %ssh_creds), 0, 'Command successful exit');
+    isnt($baseclass->run_ssh_cmd('test 23 -eq 42', %ssh_creds), 0, 'Command failed exit');
+    my @output = $baseclass->run_ssh_cmd('echo -n "foo"', wantarray => 1, %ssh_creds);
+    is_deeply(\@output, [0, 'foo', ''], 'Command successful exit with output');
+
+    $ssh_expect_credentials->{password} = '2+3=5';
+    is($baseclass->run_ssh_cmd('echo -n "foo"', %ssh_creds, password => '2+3=5'), 0, 'Allow SSH credentials per run_ssh_cmd() call');
+
+    my $num_ssh_connect = scalar(keys(%{$ssh_obj_data}));
+    $baseclass->run_ssh_cmd('echo -n "foo"', %ssh_creds, password => '2+3=5', keep_open => 0);
+    is($num_ssh_connect + 1, scalar(keys(%{$ssh_obj_data})), 'Ensure run_ssh_cmd(keep_open => 0) uses a new SSH connection');
+
+    # cleanup kept ssh connections
+    for my $ssh_ref ((refaddr($ssh3), refaddr($ssh4), refaddr($ssh5))) {
+        is($ssh_obj_data->{$ssh_ref}->{connected}, 1, "SSH connection $ssh_ref connected");
+    }
+    $baseclass->close_ssh_connections();
+    is(scalar(keys(%{$baseclass->{ssh_connections}})), 0, "Cleanup ssh connections");
+    for my $ssh_ref ((refaddr($ssh3), refaddr($ssh4), refaddr($ssh5))) {
+        is($ssh_obj_data->{$ssh_ref}->{connected}, 0, "SSH connection $ssh_ref is disconnected");
+    }
 };
 
 done_testing;

--- a/t/25-spvm.t
+++ b/t/25-spvm.t
@@ -1,0 +1,43 @@
+#!/usr/bin/perl
+
+use 5.018;
+use strict;
+use warnings;
+
+use Test::More;
+use Test::MockModule;
+use backend::spvm;
+use testapi 'set_var';
+
+BEGIN {
+    unshift @INC, '..';
+}
+
+subtest 'SSH credentials in spvm' => sub {
+    my $expected_credentials = {username => 'root', password => 'foo', hostname => 'my_foo_hostname'};
+    my $mock_spvm            = Test::MockModule->new('backend::spvm');
+    $mock_spvm->mock('run_ssh_cmd', sub {
+            my ($self, $cmd, %args) = @_;
+            for my $k (keys(%{$expected_credentials})) {
+                is($args{$k}, $expected_credentials->{$k}, "Correct $k parameter");
+            }
+            return $cmd =~ m/true/ ? 0 : 1;
+    });
+
+    set_var(WORKER_HOSTNAME => 'foo');
+    my $spvm = backend::spvm->new();
+
+    set_var('NOVALINK_HOSTNAME', 'my_foo_hostname');
+    set_var('NOVALINK_PASSWORD', 'foo');
+    is($spvm->run_cmd('true'), 0, "Test default credentials - without user");
+
+    set_var('NOVALINK_USERNAME', 'tony');
+    $expected_credentials->{username} = 'tony';
+    is($spvm->run_cmd('true'),  0, "Test default credentials - with user");
+    is($spvm->run_cmd('false'), 1, "Test different return code");
+
+    $expected_credentials = {hostname => 'specific_hostname', username => 'tony', password => 'specific_password'};
+    is($spvm->run_cmd('true', $expected_credentials->{hostname}, $expected_credentials->{password}), 0, "Test specific credentials");
+};
+
+done_testing;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,6 +1,6 @@
 AM_MAKEFLAGS = \
 	PERL5OPT="-MDevel::Cover=-db,$(abs_builddir)/cover_db,-ignore,^*\.t|^data\/tests\/*|^fake\/tests\/*" \
 	PERL5LIB="..:../ppmclibs:../ppmclibs/blib/arch/auto/tinycv:$$PERL5LIB"
-TESTS = 00-compile-check-all.t 01-test_needle.t 02-test_ocr.t 03-testapi.t 04-check_vars_docu.t 05-pod.t 06-pod-coverage.t 07-commands.t 08-autotest.t 09-lockapi.t 10-terminal.t 10-test-image-conversion-benchmark.t 11-image-ppm.t 12-bmwqemu.t 13-osutils.t 14-isotovideo.t 15-logging.t 16-send_with_fd.t 17-basetest.t 18-qemu.t 18-backend-qemu.t 18-qemu-options.t 19-isotovideo-command-processing.t 20-openqa-benchmark-stopwatch-utils.t 21-needle-downloader.t 22-svirt.t 23-baseclass.t 24-myjsonrpc.t 24-myjsonrpc-debug.t 99-full-stack.t
+TESTS = 00-compile-check-all.t 01-test_needle.t 02-test_ocr.t 03-testapi.t 04-check_vars_docu.t 05-pod.t 06-pod-coverage.t 07-commands.t 08-autotest.t 09-lockapi.t 10-terminal.t 10-test-image-conversion-benchmark.t 11-image-ppm.t 12-bmwqemu.t 13-osutils.t 14-isotovideo.t 15-logging.t 16-send_with_fd.t 17-basetest.t 18-qemu.t 18-backend-qemu.t 18-qemu-options.t 19-isotovideo-command-processing.t 20-openqa-benchmark-stopwatch-utils.t 21-needle-downloader.t 22-svirt.t 23-baseclass.t 24-myjsonrpc.t 24-myjsonrpc-debug.t 25-spvm.t 99-full-stack.t
 
 EXTRA_DIST = $(TESTS)


### PR DESCRIPTION
Moved methods like run_ssh_cmd() to backend::baseclass(). So each
backend can use it in the same way.

All other run_cmd() functions, which use Net::SSH2 in the background, are
based on run_ssh() and run_ssh_cmd().

By default each call to run_ssh_cmd() with equal credentials, will use
the same SSH Connection. A caller can force a new connection with
`keep_open => 0`.
Each ssh connection is stored in `$self->{ssh_connection}->{$key}`

Ensure none-blocking for permanent connections, which use select() in the
read/write loop.

Hyperv really use 2 different host. One host for running
powershell commands and the other as an intermediate host for serial
connection.
Also there are sequential calls on the hyperv-intermediate host which
must use the same ssh-connection.
Commands like:
  `if not exist N: ( mount \\openqa.suse.de\var\lib\openqa\share\factory N: )`
and
  `if not exist C:\cache\SLE-12-SP5-Server-DVD-x86_64-Build0201-Media1.iso \
       copy /Z /Y N:\iso\SLE-12-SP5-Server-DVD-x86_64-Build0201-Media1.iso \
       :\cache\ )`
And if we disconnect after the first command, the windows usersession-clean
umount the device and the later command fail.

Progress Ticked: https://progress.opensuse.org/issues/45863

The PR is set to WIP as I wont to make further testings. @pevik can you help me with that?