### PR TITLE
Test enhancements

### DIFF
--- a/osutils.pm
+++ b/osutils.pm
@@ -123,13 +123,17 @@ sub runcmd {
 
 ## use critic
 
+sub wait_attempt {
+    sleep 1;
+}
+
 sub attempt {
     my $attempts = 0;
     my ($total_attempts, $condition, $cb, $or) = ref $_[0] eq 'HASH' ? (@{$_[0]}{qw(attempts condition cb or)}) : @_;
     until ($condition->() || $attempts >= $total_attempts) {
         warn "Attempt $attempts";
         $cb->();
-        sleep 1;
+        wait_attempt;
         $attempts++;
     }
     $or->() if $or && !$condition->();

--- a/osutils.pm
+++ b/osutils.pm
@@ -131,13 +131,13 @@ sub attempt {
     my $attempts = 0;
     my ($total_attempts, $condition, $cb, $or) = ref $_[0] eq 'HASH' ? (@{$_[0]}{qw(attempts condition cb or)}) : @_;
     until ($condition->() || $attempts >= $total_attempts) {
-        warn "Attempt $attempts";
+        diag "Waiting for $attempts attempts";
         $cb->();
         wait_attempt;
         $attempts++;
     }
     $or->() if $or && !$condition->();
-    warn "Attempts terminated!";
+    diag "Finished after $attempts attempts";
 }
 
 1;

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -18,7 +18,7 @@ use bmwqemu;
 use OpenQA::Test::RunArgs;
 
 $bmwqemu::vars{CASEDIR} = File::Basename::dirname($0) . '/fake';
-$bmwqemu::vars{PRJDIR} = File::Basename::dirname($0);
+$bmwqemu::vars{PRJDIR}  = File::Basename::dirname($0);
 # array of messages sent with the fake json_send
 my @sent;
 

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -18,6 +18,7 @@ use bmwqemu;
 use OpenQA::Test::RunArgs;
 
 $bmwqemu::vars{CASEDIR} = File::Basename::dirname($0) . '/fake';
+$bmwqemu::vars{PRJDIR} = File::Basename::dirname($0);
 # array of messages sent with the fake json_send
 my @sent;
 
@@ -98,7 +99,7 @@ subtest 'test always_rollback flag' => sub {
     my $reverts_done = 0;
     $mock_autotest->mock(load_snapshot => sub { $reverts_done++; });
 
-    autotest::run_all;
+    stderr_like(sub { autotest::run_all }, qr/finished/, 'run_all outputs status on stderr');
     ($died, $completed) = get_tests_done;
     is($died,         0, 'start+next+start should not die when always_rollback flag is set');
     is($completed,    1, 'start+next+start should complete when always_rollback flag is set');
@@ -109,10 +110,10 @@ subtest 'test always_rollback flag' => sub {
     # Test that no rollback is triggered if snapshots are not supported
     $mock_basetest->mock(test_flags       => sub { return {always_rollback => 1, milestone => 1}; });
     $mock_autotest->mock(query_isotovideo => sub { return 0; });
-    my $reverts_done = 0;
+    $reverts_done = 0;
     $mock_autotest->mock(load_snapshot => sub { $reverts_done++; });
 
-    autotest::run_all;
+    stderr_like(sub { autotest::run_all }, qr/finished/, 'run_all outputs status on stderr');
     ($died, $completed) = get_tests_done;
     is($died,         0, 'start+next+start should not die when always_rollback flag is set');
     is($completed,    1, 'start+next+start should complete when always_rollback flag is set');
@@ -125,7 +126,7 @@ subtest 'test always_rollback flag' => sub {
     $mock_autotest->mock(query_isotovideo => sub { return 1; });
     $reverts_done = 0;
 
-    autotest::run_all;
+    stderr_like(sub { autotest::run_all }, qr/finished/, 'run_all outputs status on stderr');
     ($died, $completed) = get_tests_done;
     is($died,         0, 'start+next+start should not die when always_rollback flag is set');
     is($completed,    1, 'start+next+start should complete when always_rollback flag is set');
@@ -135,7 +136,7 @@ subtest 'test always_rollback flag' => sub {
 
     # Test with snapshot available
     $mock_basetest->mock(test_flags => sub { return {always_rollback => 1, milestone => 1}; });
-    autotest::run_all;
+    stderr_like(sub { autotest::run_all }, qr/finished/, 'run_all outputs status on stderr');
     ($died, $completed) = get_tests_done;
     is($died,         0, 'start+next+start should not die when always_rollback flag is set');
     is($completed,    1, 'start+next+start should complete when always_rollback flag is set');
@@ -167,14 +168,14 @@ stderr_like(
     },
     qr@scheduling alt_name tests/run_args.pm@
 );
-autotest::run_all;
+stderr_like(sub { autotest::run_all }, qr/Snapshots are not supported/, 'run_all outputs status on stderr');
 ($died, $completed) = get_tests_done;
 is($died,      0, 'run_args test should not die if there is no run_args');
 is($completed, 0, 'run_args test should not complete if there is no run_args');
 @sent = [];
 
 eval { autotest::loadtest("tests/run_args.pm", name => 'alt_name', run_args => {foo => 'bar'}); };
-like($@, qr/The run_args must be a sub-class of OpenQA::Test::RunArgs/);
+like($@, qr/The run_args must be a sub-class of OpenQA::Test::RunArgs/, 'error message mentions RunArgs');
 
 # now let's make the tests fail...but so far none is fatal. We also
 # have to mock query_isotovideo so we think snapshots are supported.
@@ -206,7 +207,7 @@ $mock_basetest->mock(search_for_expected_serial_failures => sub {
         $self->{fatal_failure} = 1;
         die "Got serial hard failure";
 });
-autotest::run_all;
+stderr_like(sub { autotest::run_all }, qr/Snapshots are supported/, 'run_all outputs status on stderr');
 ($died, $completed) = get_tests_done;
 is($died,      0, 'fatal serial failure test should not die');
 is($completed, 0, 'fatal serial failure test should not complete');
@@ -217,7 +218,7 @@ $mock_basetest->mock(search_for_expected_serial_failures => sub {
         $self->{fatal_failure} = 0;
         die "Got serial hard failure";
 });
-autotest::run_all;
+stderr_like(sub { autotest::run_all }, qr/Snapshots are supported/, 'run_all outputs status on stderr');
 ($died, $completed) = get_tests_done;
 is($died,      0, 'non-fatal serial failure test should not die');
 is($completed, 1, 'non-fatal serial failure test should complete');
@@ -242,9 +243,9 @@ is(@{$autotest::tests{'tests-fatal'}}{@opts}, @{$autotest::tests{'tests-fatal' .
   for 1 .. 10;
 
 my $sharedir = '/home/tux/.local/lib/openqa/share';
-is(autotest::parse_test_path("$sharedir/tests/sle/tests/x11/firefox.pm"),        ('firefox', 'x11'));
-is(autotest::parse_test_path("$sharedir/tests/sle/tests/x11/toolkits/motif.pm"), ('motif',   'x11/toolkits'));
-is(autotest::parse_test_path("$sharedir/factory/other/sysrq.pm"),                ('sysrq',   'other'));
+is(autotest::parse_test_path("$sharedir/tests/sle/tests/x11/firefox.pm"),        'x11');
+is(autotest::parse_test_path("$sharedir/tests/sle/tests/x11/toolkits/motif.pm"), 'x11/toolkits');
+is(autotest::parse_test_path("$sharedir/factory/other/sysrq.pm"),                'other');
 
 done_testing();
 

--- a/t/13-osutils.t
+++ b/t/13-osutils.t
@@ -18,6 +18,7 @@
 use 5.018;
 use warnings;
 use Test::More;
+use Test::MockModule;
 
 BEGIN {
     unshift @INC, '..';
@@ -169,6 +170,9 @@ subtest runcmd => sub {
 
 subtest attempt => sub {
     use osutils 'attempt';
+    my $module = Test::MockModule->new('osutils');
+    # just save ourselves some time during testing
+    $module->mock(wait_attempt => sub { sleep 0; });
 
     my $var = 0;
     attempt(5, sub { $var == 5 }, sub { $var++ });

--- a/t/13-osutils.t
+++ b/t/13-osutils.t
@@ -19,6 +19,8 @@ use 5.018;
 use warnings;
 use Test::More;
 use Test::MockModule;
+use Test::Warnings ':all';
+use Test::Output;
 
 BEGIN {
     unshift @INC, '..';
@@ -164,7 +166,7 @@ subtest runcmd => sub {
     is runcmd(@cmd), 0, "qemu-image creation and get its return code";
     is runcmd('rm', 'image.qcow2'), 0, "delete image and get its return code";
     local $@;
-    eval { runcmd('ls', 'image.qcow2') };
+    stderr_like(sub { eval { runcmd('ls', 'image.qcow2') } }, qr/No such file or directory/, 'no image found as expected');
     like $@, qr/runcmd failed with exit code \d+/, "command failed and calls die";
 };
 

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -156,7 +156,7 @@ subtest record_screenmatch => sub {
     my $image    = bless({} => __PACKAGE__);
     my %match    = (
         area => [
-            {x => 1, y => 2, w => 3, h => 4, result => 'ok'},
+            {x => 1, y => 2, w => 3, h => 4, similarity => 0, result => 'ok'},
         ],
         error  => 0.128,
         needle => {
@@ -169,7 +169,7 @@ subtest record_screenmatch => sub {
         {
             error => 1,
             area  => [
-                {x => 4, y => 3, w => 2, h => 1, result => 'fail'},
+                {x => 4, y => 3, w => 2, h => 1, similarity => 0, result => 'fail'},
             ],
             needle => {
                 name => 'failure',


### PR DESCRIPTION
* t: Catch output of failing runcmd to potentially even adress sporadic failures
* osutils: Let the "attempts" sound less harmful
* t: Do not waste time waiting in test 13-osutils.t
* t: Fix all uncaught output and warnings in 08-autotest.t
* t: Fix warning about undefined variable in 17-basetest.t