### PR TITLE
Use default graphics on x86 to circumvent "cirrus" limitations

### DIFF
--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -22,7 +22,7 @@ use warnings;
 # -> increment on every change of such APIs
 # -> never move that variable to another place (when refactoring)
 #    because it may be accessed by the tests itself
-our $version = 15;
+our $version = 16;
 
 # major version of the (web socket) API relevant to the developer mode
 # -> increment when making non-backward compatible changes to that API

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -637,10 +637,6 @@ sub start_qemu {
         sp('g', '1024x768');
         $use_usb_kbd = 1;
     }
-    else {
-        $vars->{QEMUVGA} ||= "cirrus";
-    }
-
     sp('vga', $vars->{QEMUVGA}) if $vars->{QEMUVGA};
 
     my @nicmac;


### PR DESCRIPTION
"cirrus" was the default graphical adapter since 8 years (see e3ac9c27) or
longer, it is time to trust the qemu default option better now :)

This uses "std" on qemu >= 2.2 which we can assume to have on usual
systems nowadays. As we do not detect the qemu version we should simply
rely on the default on all versions.

This was already suggested e.g. in
https://bugzilla.suse.com/show_bug.cgi?id=1064041#c19

What about the alternatives?:

* *qxl*: Might provide better performance but is also more recent.
Still, we have problems with it in drivers, e.g. see
https://bugzilla.opensuse.org/show_bug.cgi?id=1057241 just recently
fixed and only for more recent products
* *virtio*: Demands a more recent qemu without more benefit for now

See https://progress.opensuse.org/issues/53339#note-2 for verification.

Further references:
* https://wiki.archlinux.org/index.php/QEMU#Graphic_card

Related progress issue: https://progress.opensuse.org/issues/53339