### PR TITLE
spec: Provide a "devel" subpackage pulling in all build+test dependencies

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -24,19 +24,8 @@ License:        GPL-2.0-or-later
 Group:          Development/Tools/Other
 Url:            https://github.com/os-autoinst/os-autoinst
 Source0:        %{name}-%{version}.tar.xz
-BuildRequires:  autoconf
-BuildRequires:  automake
-BuildRequires:  gcc-c++
-BuildRequires:  libtool
-BuildRequires:  opencv-devel > 3.0
-BuildRequires:  pkg-config
-BuildRequires:  perl(Module::CPANfile)
-BuildRequires:  perl(Perl::Tidy)
-BuildRequires:  perl(Test::Compile)
-BuildRequires:  pkgconfig(fftw3)
-BuildRequires:  pkgconfig(libpng)
-BuildRequires:  pkgconfig(sndfile)
-BuildRequires:  pkgconfig(theoraenc)
+%define         build_requires autoconf automake gcc-c++ libtool opencv-devel > 3.0, pkg-config perl(Module::CPANfile) perl(Perl::Tidy) perl(Test::Compile) pkgconfig(fftw3) pkgconfig(libpng) pkgconfig(sndfile) pkgconfig(theoraenc) make
+BuildRequires:  %build_requires
 # just for the test suite
 BuildRequires:  qemu-tools
 Requires:       /usr/bin/qemu-img
@@ -56,6 +45,7 @@ Requires:       perl(Mojo::IOLoop::ReadWriteProcess) >= 0.23
 # and the JSON modules have subtle differences and we only test against XS in production
 Requires:       perl(JSON::XS)
 Recommends:     /usr/bin/xkbcomp /usr/bin/Xvnc dumponlyconsole
+%define         devel_requires %build_requires %t_requires
 Requires(pre):  %{_bindir}/getent
 Requires(pre):  %{_sbindir}/useradd
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -68,6 +58,14 @@ and upgrade, which can not easily and safely be tested with other
 automated testing frameworks. However, it can just as well be used
 to test firefox and openoffice operation on top of a newly
 installed OS.
+
+%package devel
+Summary:        Development package pulling in all build+test dependencies
+Group:          Development/Tools/Other
+Requires:       %devel_requires
+
+%description devel
+Development package pulling in all build+test dependencies.
 
 %package openvswitch
 Summary:        Openvswitch support for os-autoinst
@@ -170,5 +168,7 @@ make check VERBOSE=1
 /usr/lib/systemd/system/os-autoinst-openvswitch.service
 %config /etc/dbus-1/system.d/org.opensuse.os_autoinst.switch.conf
 %{_sbindir}/rcos-autoinst-openvswitch
+
+%files devel
 
 %changelog

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -43,6 +43,7 @@ Requires:       /usr/bin/qemu-img
 Requires:       git-core
 Requires:       optipng
 %{perl_requires}
+Requires:       perl-base
 Requires:       qemu >= 2.0.0
 Recommends:       tesseract-ocr
 %define t_requires perl(Carp::Always) perl(Data::Dump) perl(Crypt::DES) perl(JSON) perl(autodie) perl(Class::Accessor::Fast) perl(Exception::Class) perl(File::Touch) perl(File::Which) perl(IPC::Run::Debug) perl(Net::DBus) perl(Net::SNMP) perl(Net::IP) perl(IPC::System::Simple) perl(Net::SSH2) perl(XML::LibXML) perl(XML::SemanticDiff) perl(Test::Exception) perl(Test::Output) perl(Test::Fatal) perl(Test::Warnings) perl(Pod::Coverage) perl(Test::Pod) perl(Test::MockModule) perl(Devel::Cover) perl(JSON::XS) perl(List::MoreUtils) perl(Mojo::IOLoop::ReadWriteProcess) perl(Test::Mock::Time) perl(Socket::MsgHdr) perl(Cpanel::JSON::XS) perl(IO::Scalar)


### PR DESCRIPTION
This "devel" package can be used instead of explicit repetition in our
containers.

Tested in the following way:
* Building package locally using the spec file
* Checking runtime dependencies with `rpm -qpR $rpm_file`
* Building a container with Dockerfile:

```
FROM registry.opensuse.org/opensuse/leap:42.3
ARG minor=42.3
RUN zypper -n ar -f http://download.opensuse.org/repositories/devel:/openQA/openSUSE_Leap_${minor}/devel:openQA.repo && \
    zypper -n ar -f http://download.opensuse.org/repositories/devel:/openQA:/Leap:/${minor}/openSUSE_Leap_${minor}/devel:openQA:Leap:${minor}.repo && \
    zypper -n --no-gpg-checks ref
COPY os-autoinst-devel*.rpm /tmp/
RUN zypper --no-refresh -n --no-gpg-checks in /tmp/*.rpm
```

* Tagging as "os-autoinst/dev:latest" locally
* Running that container with

```
docker run -it --rm -v $(pwd):/opt/repo -v $(pwd)/docker/dev/os-autoinst-devel*.rpm:/tmp/os-autoinst-devel.x86_64.rpm os-autoinst/dev:latest sh -c 'cd /opt/repo && ./autogen && make && make check'
```

to install the package delta – if any – and check if we have all
dependencies for build.

The intention is to simplify
https://github.com/os-autoinst/openQA/blob/master/docker/travis_test/Dockerfile#L10
by not explicitly repeat the build dependencies but rely on the
dependencies generated by the spec file that already use it.