### PR TITLE
os-autoinst.spec: Fix vanished runtime requires

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -47,6 +47,7 @@ Requires:       qemu >= 2.0.0
 Recommends:       tesseract-ocr
 %define t_requires perl(Carp::Always) perl(Data::Dump) perl(Crypt::DES) perl(JSON) perl(autodie) perl(Class::Accessor::Fast) perl(Exception::Class) perl(File::Touch) perl(File::Which) perl(IPC::Run::Debug) perl(Net::DBus) perl(Net::SNMP) perl(Net::IP) perl(IPC::System::Simple) perl(Net::SSH2) perl(XML::LibXML) perl(XML::SemanticDiff) perl(Test::Exception) perl(Test::Output) perl(Test::Fatal) perl(Test::Warnings) perl(Pod::Coverage) perl(Test::Pod) perl(Test::MockModule) perl(Devel::Cover) perl(JSON::XS) perl(List::MoreUtils) perl(Mojo::IOLoop::ReadWriteProcess) perl(Test::Mock::Time) perl(Socket::MsgHdr) perl(Cpanel::JSON::XS) perl(IO::Scalar)
 BuildRequires:  %t_requires
+Requires:       %t_requires
 BuildRequires:  perl(Mojolicious)
 Requires:       perl(Mojolicious) >= 7.92
 Requires:       perl(Mojo::IOLoop::ReadWriteProcess) >= 0.23


### PR DESCRIPTION
Introduced in c168894d