### PR TITLE
Save virsh output for later handling

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -571,7 +571,7 @@ __END"
         $self->get_cmd_output('echo bios.bootDelay = \"10000\" >> /vmfs/volumes/datastore1/openQA/' . $self->name . '.vmx', {domain => 'sshVMwareServer'});
     }
 
-    $ret = $self->run_cmd("virsh $remote_vmm start " . $self->name);
+    $ret = $self->run_cmd("virsh $remote_vmm start " . $self->name . ' 2> >(tee /tmp/os-autoinst-' . $self->name . '-stderr.log >&2)');
     bmwqemu::diag("Dump actually used libvirt configuration file " . ($ret ? "(broken)" : "(working)"));
     $self->run_cmd("virsh $remote_vmm dumpxml " . $self->name);
     die "virsh start failed" if $ret;


### PR DESCRIPTION
Based on the generated file, an automated decision can be made to restart libvirt.

- Related ticket: https://progress.opensuse.org/issues/45326
- Verification run: http://openqa.slindomansilla-vm.qa.suse.de/tests/1542