### PR TITLE
VNC: reverse key order when sending key up events

### DIFF
--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -759,7 +759,7 @@ sub map_and_send_key {
     }
     usleep(2_000);
     if (!defined $down_flag || $down_flag == 0) {
-        for my $key (@events) {
+        for my $key (reverse @events) {
             $self->send_key_event_up($key);
         }
     }


### PR DESCRIPTION
When map_and_send_key maps an input to multiple key presses -
e.g. a ':' requires a press of shift and a press of ';', or
when dealing with any input like "ctrl-t" - it gets an array,
sends a 'down' event for each key in the array, then sends an
'up' event for each key in the array. So for our ctrl-t example
it does this:

ctrl down
t down
ctrl up
t up

This is a bit odd and not how humans normally type. Humans
would normally hold the modifier key, press and release any
modified keys they want to press, then release the modifier.
I've run into one issue previously where this caused a problem,
which was ultimately fixed in qemu so that os-autoinst's unusual
key event order worked OK. Now I've run into another:

https://bugzilla.redhat.com/show_bug.cgi?id=1727388

All the details of that bug are still not worked out, but today
I *did* work out that changing this key press order avoids that
bug. By simply reversing the array for the key up events, so we
do this instead:

ctrl down
t down
t up
ctrl up

The bug stops happening. Since it's triggered two bugs now, and
as I said it does not map to how humans type, I think we should
really go ahead and change this.

Signed-off-by: Adam Williamson <awilliam@redhat.com>