### PR TITLE
sshVirtshSUT use ssh aware serial screen

### DIFF
--- a/consoles/sshVirtshSUT.pm
+++ b/consoles/sshVirtshSUT.pm
@@ -22,7 +22,7 @@ use base 'consoles::console';
 
 use testapi 'get_var';
 use backend::svirt qw(SERIAL_TERMINAL_DEFAULT_PORT SERIAL_TERMINAL_DEFAULT_DEVICE);
-use consoles::serial_screen;
+use consoles::ssh_screen;
 
 sub new {
     my ($class, $testapi_console, $args) = @_;
@@ -64,9 +64,12 @@ sub activate {
     my ($self) = @_;
 
     my $backend = $self->{backend};
+    bmwqemu::diag(sprintf("Activate console on libvirt_domain:%s devname:%s port:%s",
+            $self->{libvirt_domain}, $self->{pty_dev}, $self->{serial_port_no}));
     my ($ssh, $chan) = $backend->open_serial_console_via_ssh($self->{libvirt_domain},
         devname => $self->{pty_dev}, port => $self->{serial_port_no}, is_terminal => 1);
-    $self->{screen} = consoles::serial_screen->new($chan, $ssh->sock);
+    $ssh->blocking(0);
+    $self->{screen} = consoles::ssh_screen->new(ssh_connection => $ssh, ssh_channel => $chan);
     return;
 }
 

--- a/consoles/ssh_screen.pm
+++ b/consoles/ssh_screen.pm
@@ -1,0 +1,58 @@
+# Copyright © 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package consoles::ssh_screen;
+
+use Mojo::Base 'consoles::serial_screen';
+use Carp 'croak';
+
+has ssh_connection => undef;
+has ssh_channel    => undef;
+
+sub new {
+    my $class = shift;
+    my $self  = bless @_ ? @_ > 1 ? {@_} : {%{$_[0]}} : {}, ref $class || $class;
+
+    croak('Missing parameter ssh_connection') unless $self->ssh_connection;
+    croak('Missing parameter ssh_channel')    unless $self->ssh_channel;
+
+    $self->{socket_fd}    = $self->ssh_channel;
+    $self->{carry_buffer} = '';
+
+    return $self;
+}
+
+sub do_read
+{
+    my ($self, undef, %args) = @_;
+    my $buffer = '';
+    $args{timeout}  //= undef;    # wait till data is available
+    $args{max_size} //= 2048;
+
+    croak('We expect to get a none blocking SSH channel') if ($self->ssh_channel->blocking());
+    my $stime = consoles::serial_screen::thetime();
+    while (!$args{timeout} || (consoles::serial_screen::elapsed($stime) < $args{timeout})) {
+        my $read = $self->ssh_channel->read($buffer, $args{max_size});
+        if (defined($read)) {
+            $_[1] = $buffer;
+            return $read;
+        }
+
+        last if ($args{timeout} == 0);
+        select(undef, undef, undef, 0.25);
+    }
+    return undef;
+}
+1;


### PR DESCRIPTION
The method of using NET::SSH2->sock() to do the select and then read
on the NET::SSH2::Channel wasn't reliable.
It got stock from time to time: https://progress.opensuse.org/issues/54260

This approach is to use the polling approach of a none blocking socket.

Make the ssh socked none blocking. <- The code of serial_terminal actually expect it, but somehow it wasn't. This is already fixed in https://github.com/os-autoinst/os-autoinst/pull/1166

Progress Ticket: https://progress.opensuse.org/issues/54260