### PR TITLE
Fix missing 'consoles/serial_screen.pm' in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,6 +32,7 @@ consolesexec_DATA = \
 	consoles/localXvnc.pm \
 	consoles/remoteVnc.pm \
 	consoles/s3270.pm \
+	consoles/serial_screen.pm \
 	consoles/sshX3270.pm \
 	consoles/sshVirtsh.pm \
 	consoles/sshVirtshSUT.pm \


### PR DESCRIPTION
See https://github.com/os-autoinst/os-autoinst/pull/1176#issuecomment-514074158