### PR TITLE
Port away from the deprecated OpenCV 1 C API

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,20 @@ PERL_CFLAGS=`perl -MExtUtils::Embed -e ccopts`
 AC_MSG_RESULT([$PERL_CFLAGS])
 AC_SUBST([PERL_CFLAGS])
 
-PKG_CHECK_MODULES([OPENCV], [opencv >= 2.4])
+# ================================
+# Find dependencies via pkg-config
+# ================================
+# Use preferably the "opencv4", otherwise fall back to "opencv"
+PKG_CHECK_MODULES(
+	[OPENCV],
+	[opencv4 >= 4.0],
+	[AC_DEFINE([HAVE_OPENCV_4], [1], [Using opencv4 package])],
+	[PKG_CHECK_MODULES(
+		[OPENCV],
+		[opencv >= 2.4],
+		[AC_DEFINE([HAVE_OPENCV], [1], [Using opencv package])]
+	)]
+)
 PKG_CHECK_MODULES([THEORAENC], [theoraenc >= 1.1])
 PKG_CHECK_MODULES([FFTW], [fftw3])
 PKG_CHECK_MODULES([SNDFILE], [sndfile])

--- a/debugviewer/debugviewer.cpp
+++ b/debugviewer/debugviewer.cpp
@@ -18,7 +18,7 @@ int main(int argc, char** argv)
 
     Mat image(768, 1024, CV_8UC3, Scalar(0, 0, 0));
     while (1) {
-        Mat last = imread(argv[1], CV_LOAD_IMAGE_COLOR); // Read the file
+        Mat last = imread(argv[1], cv::IMREAD_COLOR); // Read the file
         if (last.data)
             image = last;
 

--- a/ppmclibs/Makefile.PL
+++ b/ppmclibs/Makefile.PL
@@ -12,8 +12,8 @@ WriteMakefile(
   LIBS => [$opencv_libs],
   DEFINE => '-Wall',
   INC => `pkg-config --cflags opencv4 || pkg-config --cflags opencv`,
-  CC => 'g++',
-  LD => 'g++',
+  CC => $ENV{CXX} // 'g++',
+  LD => $ENV{CXX} // 'g++',
   XSOPT => '-C++',
   OBJECT => '$(O_FILES)',
 );

--- a/ppmclibs/Makefile.PL
+++ b/ppmclibs/Makefile.PL
@@ -11,7 +11,7 @@ WriteMakefile(
   VERSION_FROM => 'tinycv.pm',
   LIBS => [$opencv_libs],
   DEFINE => '-Wall',
-  INC => `pkg-config --cflags opencv`,
+  INC => `pkg-config --cflags opencv4 || pkg-config --cflags opencv`,
   CC => 'g++',
   LD => 'g++',
   XSOPT => '-C++',

--- a/ppmclibs/tinycv_impl.cc
+++ b/ppmclibs/tinycv_impl.cc
@@ -53,7 +53,7 @@ struct Image {
         // Union of earlier requests and current
         _prep_roi |= roi;
 
-        cvtColor(img, _preped, CV_BGR2GRAY);
+        cvtColor(img, _preped, cv::COLOR_BGR2GRAY);
 
         if (img.total() * 0.5 <= _prep_roi.area())
             _prep_roi = Rect(Point(0, 0), img.size());
@@ -228,7 +228,7 @@ std::vector<int> search_TEMPLATE(const Image* scene, const Image* object,
     // http://docs.opencv.org/trunk/doc/tutorials/imgproc/histograms/template_matching/template_matching.html
     // http://docs.opencv.org/modules/imgproc/doc/object_detection.html
     // Used metric is (sum of) squared differences
-    matchTemplate(scene_roi, object_roi, result, CV_TM_SQDIFF);
+    matchTemplate(scene_roi, object_roi, result, cv::TM_SQDIFF);
 
     // Use error at original location as upper bound
     Point center = Point(x - scene_x, y - scene_y);
@@ -322,7 +322,7 @@ Image* image_new(long width, long height)
 Image* image_read(const char* filename)
 {
     Image* image = new Image;
-    image->img = imread(filename, CV_LOAD_IMAGE_COLOR);
+    image->img = imread(filename, cv::IMREAD_COLOR);
     if (!image->img.data) {
         std::cerr << "Could not open image " << filename << std::endl;
         delete image;
@@ -335,7 +335,7 @@ Image* image_from_ppm(const unsigned char* data, size_t len)
 {
     std::vector<uchar> buf(data, data + len);
     Image* image = new Image;
-    image->img = imdecode(buf, CV_LOAD_IMAGE_COLOR);
+    image->img = imdecode(buf, cv::IMREAD_COLOR);
     return image;
 }
 
@@ -375,7 +375,7 @@ void image_replacerect(Image* s, long x, long y, long width, long height)
         return;
     }
 
-    rectangle(s->img, Rect(x, y, width, height), CV_RGB(0, 255, 0), CV_FILLED);
+    rectangle(s->img, Rect(x, y, width, height), CV_RGB(0, 255, 0), cv::FILLED);
 }
 
 /* copies the given range into a new image */

--- a/videoencoder.cpp
+++ b/videoencoder.cpp
@@ -344,7 +344,7 @@ int main(int argc, char* argv[])
             repeat = 0;
 
             if (output_video || need_last_png()) {
-                last_frame_image = imdecode(buf, CV_LOAD_IMAGE_COLOR, &last_frame_image);
+                last_frame_image = imdecode(buf, cv::IMREAD_COLOR, &last_frame_image);
 
                 if (!last_frame_image.data) {
                     cout << "Could not open or find the image" << endl;


### PR DESCRIPTION
These changes would be required to compile the video encoder against OpenCV 4. <s>Not sure about the pkg-config change because the pkg-config file is currently missing in the Tumbleweed package.</s> It works with the [opencv package from my home repo](https://build.opensuse.org/package/show/home:mkittler:branches:science/opencv) which I'm going to submit to Tumbleweed.