### PR TITLE
Fix build after opencv4 submission

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -24,7 +24,7 @@ License:        GPL-2.0-or-later
 Group:          Development/Tools/Other
 Url:            https://github.com/os-autoinst/os-autoinst
 Source0:        %{name}-%{version}.tar.xz
-%define         build_requires autoconf automake gcc-c++ libtool opencv-devel > 3.0, pkg-config perl(Module::CPANfile) perl(Perl::Tidy) perl(Test::Compile) pkgconfig(fftw3) pkgconfig(libpng) pkgconfig(sndfile) pkgconfig(theoraenc) make
+%define         build_requires autoconf automake gcc-c++ libtool pkgconfig(opencv) pkg-config perl(Module::CPANfile) perl(Perl::Tidy) perl(Test::Compile) pkgconfig(fftw3) pkgconfig(libpng) pkgconfig(sndfile) pkgconfig(theoraenc) make
 BuildRequires:  %build_requires
 # just for the test suite
 BuildRequires:  qemu-tools

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -24,6 +24,8 @@ License:        GPL-2.0-or-later
 Group:          Development/Tools/Other
 Url:            https://github.com/os-autoinst/os-autoinst
 Source0:        %{name}-%{version}.tar.xz
+# Force OBS to resolve choices on opencv-devel
+#!BuildIgnore: opencv3-devel
 %define         build_requires autoconf automake gcc-c++ libtool pkgconfig(opencv) pkg-config perl(Module::CPANfile) perl(Perl::Tidy) perl(Test::Compile) pkgconfig(fftw3) pkgconfig(libpng) pkgconfig(sndfile) pkgconfig(theoraenc) make
 BuildRequires:  %build_requires
 # just for the test suite


### PR DESCRIPTION
* spec: Force OBS to resolve choices on opencv-devel
* spec: Fix build for openSUSE Factory and backports after opencv4 submission

Needs the package opencv3 submitted to our backport repos. I can do that after PR approval just before merge.

See https://build.opensuse.org/package/show/home:okurz:branches:devel:openQA:fix:os-autoinst_opencv2/os-autoinst for build results

Related progress issue: https://progress.opensuse.org/issues/54356