### PR TITLE
Improve svirt backend

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -1,5 +1,5 @@
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,16 +22,13 @@ use warnings;
 use feature 'say';
 use autodie ':all';
 
-use Carp qw(cluck carp confess);
+use Carp qw(carp confess);
 use Mojo::JSON;    # booleans
 use Cpanel::JSON::XS ();
-use File::Copy 'cp';
-use File::Basename;
-use Time::HiRes qw(gettimeofday time tv_interval);
+use Time::HiRes qw(gettimeofday time);
 use POSIX qw(_exit :sys_wait_h);
 use bmwqemu;
 use IO::Select;
-require IPC::System::Simple;
 use myjsonrpc;
 use Net::SSH2;
 use OpenQA::Benchmark::Stopwatch;

--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -21,9 +21,7 @@ use warnings;
 
 use base 'backend::virt';
 
-use File::Basename;
 use IO::Scalar;
-use IO::Select;
 use testapi qw(get_var get_required_var check_var);
 
 use constant SERIAL_CONSOLE_DEFAULT_PORT   => 0;

--- a/backend/virt.pm
+++ b/backend/virt.pm
@@ -1,4 +1,4 @@
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,7 +20,6 @@ use warnings;
 
 use base 'backend::baseclass';
 
-use testapi 'get_var';
 use bmwqemu;
 
 sub new {


### PR DESCRIPTION
## Tasks
- [ ] Remove unused imports
- [ ] Extract common svirt functionality from **bootloader_svirt**, **bootloader_zkvm**

## Further information

- Related ticket: https://progress.opensuse.org/issues/45326
- Verification runs:
  - xen-pv (coming soon)
  - xen-hvm (coming soon)
  - zKVM (coming soon)
  - KVM (coming soon)