### PR TITLE
crop.py: tweak imports to work with Python 3

### DIFF
--- a/crop.py
+++ b/crop.py
@@ -19,7 +19,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from Tkinter import Tk, Canvas, NW
+try:
+    # Python 2
+    from Tkinter import Tk, Canvas, NW
+except ImportError:
+    # Python 3
+    from tkinter import Tk, Canvas, NW
 from PIL import Image, ImageTk
 import json
 import optparse


### PR DESCRIPTION
In Python 3 it's tkinter, not Tkinter. This works both ways.

Signed-off-by: Adam Williamson <awilliam@redhat.com>