### PR TITLE
Fix missing data while reading from virtio_console

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -29,7 +29,7 @@ use Time::HiRes qw(sleep gettimeofday);
 use IO::Select;
 use IO::Socket::UNIX 'SOCK_STREAM';
 use IO::Handle;
-use POSIX qw(strftime :sys_wait_h);
+use POSIX qw(strftime :sys_wait_h mkfifo);
 use Mojo::JSON;
 use Carp;
 use Fcntl;
@@ -846,7 +846,9 @@ sub start_qemu {
             sp('device', 'virtio-serial');
             for (my $i = 0; $i < ($vars->{VIRTIO_CONSOLE_NUM} // 1); $i++) {
                 my $name = 'virtio_console' . ($i ? $i : '');
-                sp('chardev', [qv "socket path=$name server nowait id=$name logfile=$name.log logappend=on"]);
+                mkfifo($name . ".in",  0666);
+                mkfifo($name . ".out", 0666);
+                sp('chardev', [qv "pipe id=$name path=$name logfile=$name.log logappend=on"]);
                 sp('device',  [qv "virtconsole chardev=$name name=org.openqa.console.$name"]);
             }
         }

--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -21,6 +21,7 @@ use autodie;
 
 use base 'consoles::console';
 
+use Mojo::File 'path';
 use Socket qw(SOCK_NONBLOCK PF_UNIX SOCK_STREAM sockaddr_un);
 use Errno qw(EAGAIN EWOULDBLOCK);
 use English -no_match_vars;
@@ -28,7 +29,8 @@ use Carp 'croak';
 use Scalar::Util 'blessed';
 use Cwd;
 use consoles::serial_screen ();
-use testapi 'check_var';
+use testapi qw(check_var get_var);
+use Fcntl;
 
 our $VERSION;
 
@@ -48,8 +50,8 @@ where it can start a tty on the virtual console. By default openSUSE and SLE
 automatically start agetty when the kernel finds the virtio console device, but
 another OS may require some additional configuration.
 
-It may also be possible to use a transport other than virtio. This code just
-requires a UNIX socket which inputs and outputs terminal ASCII/ANSI codes.
+It may also be possible to use a transport other than virtio. This code
+uses two pipes to communicate with virtio_consoles from qemu.
 
 =head1 SUBROUTINES/METHODS
 
@@ -58,8 +60,9 @@ requires a UNIX socket which inputs and outputs terminal ASCII/ANSI codes.
 sub new {
     my ($class, $testapi_console, $args) = @_;
     my $self = $class->SUPER::new($testapi_console, $args);
-    $self->{socket_fd}      = 0;
-    $self->{socket_path}    = $self->{args}->{socked_path} // cwd() . '/virtio_console';
+    $self->{fd_read}        = 0;
+    $self->{fd_write}       = 0;
+    $self->{pipe_prefix}    = $self->{args}->{socked_path} // cwd() . '/virtio_console';
     $self->{snapshots}      = {};
     $self->{preload_buffer} = '';
     return $self;
@@ -72,10 +75,12 @@ sub screen {
 
 sub disable {
     my ($self) = @_;
-    if ($self->{socket_fd} > 0) {
-        close $self->{socket_fd};
-        $self->{socket_fd} = 0;
-        $self->{screen}    = undef;
+    if ($self->{fd_read} > 0) {
+        close $self->{fd_read};
+        close $self->{fd_write};
+        $self->{fd_read}  = 0;
+        $self->{fd_write} = 0;
+        $self->{screen}   = undef;
     }
 }
 
@@ -99,47 +104,60 @@ sub load_snapshot {
     }
 }
 
-=head2 socket_path
-
-The file system path bound to a UNIX socket which will be used to transfer
-terminal data between the host and guest.
-
+=head2 F_GETPIPE_SZ
+This is a helper method for system which do not have F_GETPIPE_SZ in
+there Fcntl bindings. See https://perldoc.perl.org/Fcntl.html
 =cut
-sub socket_path {
-    my ($self) = @_;
-    return $self->{socket_path};
+sub F_GETPIPE_SZ
+{
+    return eval 'no warnings "all"; Fcntl::F_GETPIPE_SZ;' || 1032;
 }
 
-=head2 open_socket
+=head2 F_SETPIPE_SZ
+This is a helper method for system which do not have F_SETPIPE_SZ in
+there Fcntl bindings. See: https://perldoc.perl.org/Fcntl.html
+=cut
+sub F_SETPIPE_SZ
+{
+    return eval 'no warnings "all"; Fcntl::F_SETPIPE_SZ;' || 1031;
+}
 
-  open_socket();
+=head2 open_pipe
 
-Opens a unix socket to the character device located at $socket_path.
+  open_pipe();
 
-Returns the file descriptor for the open socket, otherwise it dies.
+Opens a the read and write pipe based on C<$pipe_prefix>.
+
+Returns the read and write file descriptors for the open sockets,
+otherwise it dies.
 
 =cut
-sub open_socket {
+sub open_pipe {
     my ($self) = @_;
-    my $fd;
-    bmwqemu::log_call(socket_path => $self->socket_path);
+    bmwqemu::log_call(pipe_prefix => $self->{pipe_prefix});
 
-    (-S $self->socket_path) || croak 'Could not find ' . $self->socket_path;
-    socket($fd, PF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0)
-      || croak 'Could not create Unix socket: ' . $ERRNO;
-    connect($fd, sockaddr_un($self->socket_path))
-      || croak 'Could not connect to virtio-console chardev socket: ' . $ERRNO;
+    sysopen(my $fd_w, $self->{pipe_prefix} . '.in', O_WRONLY)
+      or die "Can't open in pipe for writing $!";
+    sysopen(my $fd_r, $self->{pipe_prefix} . '.out', O_NONBLOCK | O_RDONLY)
+      or die "Can't open out pipe for reading $!";
 
-    return $fd;
+    my $newsize = get_var('VIRTIO_CONSOLE_PIPE_SZ', path('/proc/sys/fs/pipe-max-size')->slurp());
+    for my $fd (($fd_w, $fd_r)) {
+        my $old = fcntl($fd, F_GETPIPE_SZ(), 0);
+        my $new = fcntl($fd, F_SETPIPE_SZ(), int($newsize));
+        bmwqemu::fctinfo("Set PIPE_SZ from $old to $new");
+    }
+
+    return ($fd_r, $fd_w);
 }
 
 sub activate {
     my ($self) = @_;
     if (!check_var('VIRTIO_CONSOLE', 0)) {
-        $self->{socket_fd}              = $self->open_socket unless $self->{socket_fd};
-        $self->{screen}                 = consoles::serial_screen::->new($self->{socket_fd});
+        ($self->{fd_read}, $self->{fd_write}) = $self->open_pipe() unless ($self->{fd_read});
+        $self->{screen} = consoles::serial_screen::->new($self->{fd_read}, $self->{fd_write});
         $self->{screen}->{carry_buffer} = $self->{preload_buffer};
-        $self->{preload_buffer}         = '';
+        $self->{preload_buffer} = '';
     }
     else {
         croak 'VIRTIO_CONSOLE is set 0, so no virtio-serial and virtconsole devices will be available to use with this console.';


### PR DESCRIPTION
During some test, we figured out that for unknown reason we miss some
data.
E.g. `cat large_file_140kb.txt` sporadically have some output gap somewhere
in the middle of the output.

Interesting is, that the logfile, which is created from qemu, contains
all data.

I checked `ss -x -a` on host and `cat /sys/kernel/debug/virtio-ports/*`
inside the VM. But I didn't found any hint of discarded packages.