### PR TITLE
Add missing 'use' for 'Data::Dumper'

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -33,6 +33,7 @@ parameters which are represented as complex objects.
 package OpenQA::Qemu::Proc;
 use Mojo::Base -base;
 
+use Data::Dumper;
 use File::Basename;
 use File::Which;
 use Mojo::JSON qw(encode_json decode_json);


### PR DESCRIPTION
Dumper is used in a die message hence must be imported in before.