### PR TITLE
Add automatic lookup for UEFI_PFLASH_CODE/VARS to fix UEFI on Tumbleweed machines

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -64,8 +64,8 @@ our $direct_output;
 # the kraxel.org nightly packages, third is Fedora's edk2-ovmf package,
 # fourth is Debian's ovmf package.
 our @ovmf_locations = (
-    '/usr/share/qemu/ovmf-x86_64-ms.bin', '/usr/share/edk2.git/ovmf-x64/OVMF_CODE-pure-efi.fd',
-    '/usr/share/edk2/ovmf/OVMF_CODE.fd',  '/usr/share/OVMF/OVMF_CODE.fd'
+    '/usr/share/qemu/ovmf-x86_64-ms-code.bin', '/usr/share/edk2.git/ovmf-x64/OVMF_CODE-pure-efi.fd',
+    '/usr/share/edk2/ovmf/OVMF_CODE.fd',       '/usr/share/OVMF/OVMF_CODE.fd'
 );
 
 our %vars;


### PR DESCRIPTION
This allows to simply set UEFI=1 and neither BIOS nor UEFI_PFLASH which will
lookup corresponding "code" and "vars" firmware files instead of failing.

The firmware files used by Fedora and Debian were already referencing "code"
files as single pflash targets so we do the same for the openSUSE package
which by now in openSUSE Factory does not supply the single code+vars image
anymore.

Currently os-autoinst-distri-opensuse sets UEFI_PFLASH which is still
supported from os-autoinst but will not work if the worker is a more recent
openSUSE Tumbleweed. Simply not specifying the variable will fix that problem
as soon as this commit is in.

Tested locally with a vars.json file in three variants, with UEFI_PFLASH
resolving the single code+vars file as well as without UEFI_PFLASH and no
explicit path to neither BIOS nor UEFI_FPLASH_CODE so that the firmware file
is automatically looked up. The third variant is to explicitly specify either
code or vars file which still works.

Related progress issue: https://progress.opensuse.org/issues/55052