### PR TITLE
Fix in-package test failure on git

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -82,6 +82,8 @@ This package contains openvswitch support for os-autoinst.
 %prep
 %setup -q
 sed -e 's,/bin/env python,/bin/python,' -i crop.py
+# Replace version number from git to what's reported by the package
+sed  -i 's/ my $thisversion = qx{git.*rev-parse HEAD}.*;/ my $thisversion = "%{version}";/' isotovideo
 
 %build
 mkdir -p m4
@@ -91,8 +93,6 @@ make INSTALLDIRS=vendor %{?_smp_mflags}
 
 %install
 %make_install INSTALLDIRS=vendor
-# Replace version number from git to what's reported by the package
-sed  -i 's/ my $thisversion = qx{git.*rev-parse HEAD}.*;/ my $thisversion = "%{version}";/' %{buildroot}/usr/bin/isotovideo
 # only internal stuff
 rm %{buildroot}/usr/lib/os-autoinst/tools/{tidy,check_coverage,absolutize}
 rm -r %{buildroot}/usr/lib/os-autoinst/tools/lib/perlcritic


### PR DESCRIPTION
8d38d28 introduced a now fatal check if the version can be evaluated or
not. The package tests failed silently in before because git was not
available in the build context when it even should not be available
because we want to use a fixed version from the package within the
isotovideo application.

This commit moves the version replacement from %install to %prep to
adjust the version in the isotovideo source code before installing it
hence having an effect on both the installed file as well as the file
used by the tests in %check.

This fixes the problem observed in OBS with the error message:
"Can't exec "git": No such file or directory at
/home/abuild/rpmbuild/BUILD/os-autoinst-4.5.1565258100.2ea934eb/isotovideo
line 107."