### PR TITLE
Fix left-over qemu processes regression due to f9c71d0e

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -29,7 +29,7 @@ use Time::HiRes qw(sleep gettimeofday);
 use IO::Select;
 use IO::Socket::UNIX 'SOCK_STREAM';
 use IO::Handle;
-use POSIX qw(strftime :sys_wait_h mkfifo);
+use POSIX qw(strftime :sys_wait_h);
 use Mojo::JSON;
 use Carp;
 use Fcntl;
@@ -848,9 +848,7 @@ sub start_qemu {
             sp('device', 'virtio-serial');
             for (my $i = 0; $i < ($vars->{VIRTIO_CONSOLE_NUM} // 1); $i++) {
                 my $name = 'virtio_console' . ($i ? $i : '');
-                mkfifo($name . ".in",  0666);
-                mkfifo($name . ".out", 0666);
-                sp('chardev', [qv "pipe id=$name path=$name logfile=$name.log logappend=on"]);
+                sp('chardev', [qv "socket path=$name server nowait id=$name logfile=$name.log logappend=on"]);
                 sp('device',  [qv "virtconsole chardev=$name name=org.openqa.console.$name"]);
             }
         }

--- a/consoles/serial_screen.pm
+++ b/consoles/serial_screen.pm
@@ -26,12 +26,10 @@ use Carp 'croak';
 our $VERSION;
 
 sub new {
-    my ($class, $fd_read, $fd_write) = @_;
+    my ($class, $socket_fd) = @_;
     my $self = bless {class => $class}, $class;
-    $self->{fd_read}      = $fd_read;
-    $self->{fd_write}     = $fd_write // $fd_read;
+    $self->{socket_fd}    = $socket_fd;
     $self->{carry_buffer} = '';
-
     return $self;
 }
 
@@ -91,7 +89,7 @@ and ETX is the same as pressing Ctrl-C on a terminal.
 =cut
 sub type_string {
     my ($self, $nargs) = @_;
-    my $fd = $self->{fd_write};
+    my $fd = $self->{socket_fd};
 
     bmwqemu::log_call(%$nargs);
 
@@ -157,7 +155,7 @@ sub normalise_pattern {
 
   my $num_read = do_read($buffer [, max_size => 2048][,timeout => undef]);
 
-Attempts to read up to max_size bytes from the C<<$self->{fd_read}>> into buffer.
+Attempts to read up to max_size bytes from the C<<$self->{socket_fd}>> into buffer.
 The method returns as soon as some data is available, even if the given size has not been reached.
 Returns number of bytes read or undef on timeout. Note that 0 is a valid return code.
 If an failure occur the method croak.
@@ -170,7 +168,7 @@ sub do_read
     my $buffer = '';
     $args{timeout}  //= undef;    # wait till data is available
     $args{max_size} //= 2048;
-    my $fd = $self->{fd_read};
+    my $fd = $self->{socket_fd};
 
     my $rin = '';
     vec($rin, fileno($fd), 1) = 1;
@@ -225,7 +223,7 @@ and { matched => 0, string => 'text from the terminal' } on failure.
 =cut
 sub read_until {
     my ($self, $pattern, $timeout) = @_[0 .. 2];
-    my $fd       = $self->{fd_read};
+    my $fd       = $self->{socket_fd};
     my %nargs    = @_[3 .. $#_];
     my $buflen   = $nargs{buffer_size} || 4096;
     my $overflow = $nargs{record_output} ? '' : undef;
@@ -313,7 +311,7 @@ sub peak {
 
     bmwqemu::log_call(%nargs);
   LOOP: {
-        $read = sysread($self->{fd_read}, $buf, $buflen);
+        $read = sysread($self->{socket_fd}, $buf, $buflen);
         last LOOP unless defined $read;
 
         $self->{carry_buffer} .= $buf;

--- a/t/10-terminal.t
+++ b/t/10-terminal.t
@@ -15,8 +15,7 @@ use 5.018;
 use warnings;
 use Carp 'confess';
 use English -no_match_vars;
-use POSIX qw( :sys_wait_h sigprocmask sigsuspend mkfifo);
-use Fcntl;
+use POSIX qw( :sys_wait_h sigprocmask sigsuspend );
 use Socket qw( PF_UNIX SOCK_STREAM sockaddr_un );
 use Time::HiRes 'usleep';
 use File::Temp 'tempfile';
@@ -115,7 +114,7 @@ sub try_write_sequence {
 # Once we have read the data, echo it back like a real terminal, unless the
 # message is $next_test which we just use for synchronisation.
 sub try_read {
-    my ($fd, $fd_w, $expected) = @_;
+    my ($fd, $expected) = @_;
     my ($buf, $text);
 
     while (1) {
@@ -140,7 +139,7 @@ sub try_read {
     $text .= $buf;
 
     if ($expected ne $next_test) {
-        try_write($fd_w, $text);
+        try_write($fd, $text);
     }
     elsif ($text ne $next_test) {
         confess 'fake_terminal: Expecting special $next_test message, but got: ' . $text;
@@ -151,7 +150,7 @@ sub try_read {
 
 # A mock terminal which we can communicate with over a UNIX socket
 sub fake_terminal {
-    my ($pipe_in, $pipe_out) = @_;
+    my ($sock_path) = @_;
     my ($fd, $listen_fd);
 
     $SIG{ALRM} = sub {
@@ -162,10 +161,25 @@ sub fake_terminal {
 
     alarm $timeout;
 
-    open(my $fd_r, "<", $pipe_in)
-      or die "Can't open in pipe for writing $!";
-    open(my $fd_w, ">", $pipe_out)
-      or die "Can't open out pipe for reading $!";
+    socket($listen_fd, PF_UNIX, SOCK_STREAM, 0)
+      || confess "fake_terminal: Could not create socket: $ERRNO";
+    unlink($sock_path);
+    bind($listen_fd, sockaddr_un($sock_path))
+      || confess "fake_terminal: Could not bind socket to path $sock_path: $ERRNO";
+    listen($listen_fd, 1)
+      || confess "fake_terminal: Could not list on socket: $ERRNO";
+
+    #Signal to parent that the socket is listening
+    kill 'CONT', getppid;
+
+  ACCEPT: {
+        accept($fd, $listen_fd) || do {
+            if ($ERRNO{EINTR}) {
+                next ACCEPT;
+            }
+            confess "fake_terminal: Failed to accept connection: $ERRNO";
+        };
+    }
 
     $SIG{ALRM} = sub {
         fail('fake_terminal timed out while performing IO');
@@ -179,41 +193,41 @@ sub fake_terminal {
     my $tb = Test::More->builder;
     $tb->reset;
 
-    try_write($fd_w, $login_prompt_data);
-    ok(try_read($fd_r, $fd_w, $user_name_data), 'fake_terminal reads: Entered user name');
+    try_write($fd, $login_prompt_data);
+    ok(try_read($fd, $user_name_data), 'fake_terminal reads: Entered user name');
 
-    try_write($fd_w, $password_prompt_data);
-    ok(try_read($fd_r, $fd_w, $password_data), 'fake_terminal reads: Entered password');
+    try_write($fd, $password_prompt_data);
+    ok(try_read($fd, $password_data), 'fake_terminal reads: Entered password');
 
-    try_write($fd_w, $first_prompt_data);
-    ok(try_read($fd_r, $fd_w, $set_prompt_data), 'fake_terminal reads: Normalised bash prompt');
+    try_write($fd, $first_prompt_data);
+    ok(try_read($fd, $set_prompt_data), 'fake_terminal reads: Normalised bash prompt');
 
-    try_write($fd_w, $normalised_prompt_data);
+    try_write($fd, $normalised_prompt_data);
 
-    ok(try_read($fd_r, $fd_w, $C0_EOT), 'fake_terminal reads: C0 EOT control code');
-    ok(try_read($fd_r, $fd_w, $C0_ETX), 'fake_terminal reads: C0 ETX control code');
-    ok(try_read($fd_r, $fd_w, "\n"),    'fake_terminal reads: ret');
-    try_write($fd_w, $login_prompt_data);
+    ok(try_read($fd, $C0_EOT), 'fake_terminal reads: C0 EOT control code');
+    ok(try_read($fd, $C0_ETX), 'fake_terminal reads: C0 ETX control code');
+    ok(try_read($fd, "\n"),    'fake_terminal reads: ret');
+    try_write($fd, $login_prompt_data);
 
     alarm $timeout;
 
     # This for loop corresponds to the 'large amount of data tests'
     for (1 .. 2) {
-        try_read($fd_r, $fd_w, $next_test);
-        try_write_sequence($fd_w, $US_keyboard_data, $repeat_sequence_count, $stop_code_data);
+        try_read($fd, $next_test);
+        try_write_sequence($fd, $US_keyboard_data, $repeat_sequence_count, $stop_code_data);
     }
 
     # Trailing data/carry buffer tests
     for (1 .. 2) {
-        try_read($fd_r, $fd_w, $next_test);
-        try_write($fd_w, $US_keyboard_data . $stop_code_data . $stop_code_data);
+        try_read($fd, $next_test);
+        try_write($fd, $US_keyboard_data . $stop_code_data . $stop_code_data);
     }
 
     #alarm $timeout * 2;
     #try_write($fd, ($US_keyboard_data x 100_000) . $stop_code_data);
 
-    try_write($fd_w, $first_prompt_data);
-    try_read($fd_r, $fd_w, $next_test);
+    try_write($fd, $first_prompt_data);
+    try_read($fd, $next_test);
 
     alarm $timeout;
     $SIG{ALRM} = sub {
@@ -222,10 +236,10 @@ sub fake_terminal {
         exit(0);
     };
 
-    try_read($fd_r, $fd_w, $next_test);
-    try_write($fd_w, $US_keyboard_data);
+    try_read($fd, $next_test);
+    try_write($fd, $US_keyboard_data);
     # Keep the socket open while we test the timeout
-    try_read($fd_r, $fd_w, $next_test);
+    try_read($fd, $next_test);
 
     alarm 0;
     pass('fake_terminal managed to get all the way to the end without timing out!');
@@ -352,19 +366,16 @@ sub check_child {
 # so wait for fake terminal to create socket and emit SIGCONT. Sigsuspend only
 # returns if a signal is received which has a handler set. We must initially
 # block the signal incase SIGCONT is emitted before we reach sigsuspend.
-my $pipe_in  = $socket_path . ".in";
-my $pipe_out = $socket_path . ".out";
-
-for (($pipe_in, $pipe_out)) {
-    unlink($_) if (-p $_);
-    mkfifo($_, 0666) or die("Cannot create fifo pipe $_");
-}
+$SIG{CONT} = sub { };
+my $blockmask = POSIX::SigSet->new(POSIX::SIGCONT());
+my $oldmask   = POSIX::SigSet->new();
+sigprocmask(POSIX::SIG_BLOCK, $blockmask, $oldmask);
 
 my $fpid = fork || do {
-    fake_terminal($pipe_in, $pipe_out);
+    fake_terminal($socket_path);
     exit 0;
 };
-
+sigsuspend($oldmask);
 my $tpid = fork || do {
     test_terminal_directly;
     exit 0;
@@ -383,6 +394,5 @@ waitpid($tpid2, 0);
 check_child('Direct test with VIRTIO_CONSOLE=0', 255);
 
 done_testing;
-unlink $socket_path . ".in";
-unlink $socket_path . ".out";
+unlink $socket_path;
 say "The IO log file is at $log_path and the error log is $err_path.";


### PR DESCRIPTION
Revert "Fix missing data while reading from virtio_console" to fix
problems on cleanup/migration/post_fail_hook etc.

As can be seen in e.g.
https://openqa.opensuse.org/tests/1006423/file/autoinst-log.txt
the VNC port for a qemu process is blocked. This is due to left-over
qemu processes in previous jobs that did not shut down cleanly.

I could reproduce the problem locally by calling `save_memory_dump` in a
test module with a subsequent early `die` triggering the post_fail_hook.
In these cases like in
http://lord.arch.suse.de/tests/2521/file/autoinst-log.txt
the post_fail_hooks dies with a stack trace similar to:

```
[2019-08-14T15:22:30.204 CEST] [debug] syswrite failed Broken pipe at /local/os-autoinst/myjsonrpc.pm line 40.
>.......myjsonrpc::send_json(GLOB(0x55938dd04b08), HASH(0x55939002f910)) called at /local/os-autoinst/basetest.pm line 682
>.......basetest::get_serial_output_json(welcome=HASH(0x55938f6dee10), 163995) called at /local/os-autoinst/basetest.pm line 691
>.......basetest::parse_serial_output_qemu(welcome=HASH(0x55938f6dee10)) called at /local/os-autoinst/basetest.pm line 674
>.......basetest::search_for_expected_serial_failures(welcome=HASH(0x55938f6dee10)) called at /local/os-autoinst/basetest.pm line 375
```

pointing to problems to get data over the serial output. There seem to be
similar problems as well which point to the same root cause.

http://lord.arch.suse.de/tests/2523/file/autoinst-log.txt shows how the
post_fail_hook can be correctly executed with the faulty commit 
reverted.

This reverts commit f9c71d0e25c50ee9f9acf76560b80791ca3bf6c8.

Related progress issue: https://progress.opensuse.org/issues/55505