### PR TITLE
Improve result display of validate_script_output

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,3 +1,4 @@
+requires 'B::Deparse';
 requires 'Carp';
 requires 'Carp::Always';
 requires 'Class::Accessor::Fast';

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -28,7 +28,7 @@ Source0:        %{name}-%{version}.tar.xz
 #!BuildIgnore: opencv3-devel
 %{perl_requires}
 %define build_requires autoconf automake gcc-c++ libtool pkgconfig(opencv) pkg-config perl(Module::CPANfile) pkgconfig(fftw3) pkgconfig(libpng) pkgconfig(sndfile) pkgconfig(theoraenc) make
-%define requires perl(Mojolicious) >= 7.92, perl(Mojo::IOLoop::ReadWriteProcess) >= 0.23, perl(Carp::Always) perl(Data::Dump) perl(Data::Dumper) perl(Crypt::DES) perl(JSON) perl(autodie) perl(Class::Accessor::Fast) perl(Exception::Class) perl(File::Touch) perl(File::Which) perl(IPC::Run::Debug) perl(Net::DBus) perl(Net::SNMP) perl(Net::IP) perl(IPC::System::Simple) perl(Net::SSH2) perl(XML::LibXML) perl(XML::SemanticDiff) perl(JSON::XS) perl(List::MoreUtils) perl(Mojo::IOLoop::ReadWriteProcess) perl(Socket::MsgHdr) perl(Cpanel::JSON::XS) perl(IO::Scalar) perl(Try::Tiny) perl-base
+%define requires perl(B::Deparse) perl(Mojolicious) >= 7.92, perl(Mojo::IOLoop::ReadWriteProcess) >= 0.23, perl(Carp::Always) perl(Data::Dump) perl(Data::Dumper) perl(Crypt::DES) perl(JSON) perl(autodie) perl(Class::Accessor::Fast) perl(Exception::Class) perl(File::Touch) perl(File::Which) perl(IPC::Run::Debug) perl(Net::DBus) perl(Net::SNMP) perl(Net::IP) perl(IPC::System::Simple) perl(Net::SSH2) perl(XML::LibXML) perl(XML::SemanticDiff) perl(JSON::XS) perl(List::MoreUtils) perl(Mojo::IOLoop::ReadWriteProcess) perl(Socket::MsgHdr) perl(Cpanel::JSON::XS) perl(IO::Scalar) perl(Try::Tiny) perl-base
 %define requires_not_needed_in_tests qemu >= 2.0.0, /usr/bin/qemu-img, git-core optipng
 # all requirements needed by the tests, do not require on this in the package
 # itself or any sub-packages

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -489,12 +489,19 @@ subtest 'validate_script_output' => sub {
     my $mock_testapi = Test::MockModule->new('testapi');
     $mock_testapi->mock(script_output => sub { return 'output'; });
     ok(!validate_script_output('script', sub { m/output/ }), 'validating output with default timeout');
+    ok(!validate_script_output('script', qr/output/),        'validating output with regex and default timeout');
     ok(!validate_script_output('script', sub { m/output/ }, 30), 'specifying timeout');
     like(
         exception {
             validate_script_output('script', sub { m/error/ });
         },
         qr/output not validating/
+    );
+    like(
+        exception {
+            validate_script_output('script', ['Invalid parameter']);
+        },
+        qr/coderef or regexp/
     );
 };
 


### PR DESCRIPTION
See also https://progress.opensuse.org/issues/54548

Example code:

    package your::test::package;
    ...
    sub run {
        validate_script_output 'pwd', sub { m/some.*regex/ };
    }

Before the output showed this:

    # wait_serial expected: (whatever the output was)

    # Result:
    (whatever the output was)

"wait_serial" is wrong here, and it showed the actual output twice.

Now it shows:

    validate_script_output got:
    (whatever the output was)

    Check function (deparsed code):
    {
        package your::test::package;
        /some.*regex/;
    }

Also validate_script_output() can now take a simple regular expression qr/foo/
instead of a coderef.

Suggestions for improvement of the output welcome.
The deparsed code is generated with the B::Deparse module and usually looks a bit different than the original code.