### PR TITLE
Get rid of distracting "last frame" message from videoencoder

### DIFF
--- a/videoencoder.cpp
+++ b/videoencoder.cpp
@@ -375,7 +375,6 @@ int main(int argc, char* argv[])
 
     }
 
-    printf("last frame\n");
     // send last frame
     if (ogg_fp) {
         th_encode_ctl(td, TH_ENCCTL_SET_DUP_COUNT, &repeat, sizeof(repeat));


### PR DESCRIPTION
The string "last frame" is printed without any logging prefix and pretty
much out of context for the unaware reader of autoinst-log.txt in a
usual test run so it is better to remove it.