### PR TITLE
Fix unexpected error on xz in save_memory_dump()

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -338,7 +338,7 @@ sub save_memory_dump {
 
     if ($compress_method eq 'xz') {
         if (defined which('xz')) {
-            system(('xz', '-T', $compress_threads, "-v$compress_level", "ulogs/$filename"));
+            runcmd('xz', '--no-warn', '-T', $compress_threads, "-v$compress_level", "ulogs/$filename");
         }
         else {
             bmwqemu::fctwarn('xz not found; falling back to bzip2');
@@ -347,7 +347,7 @@ sub save_memory_dump {
     }
 
     if ($compress_method eq 'bzip2') {
-        system(('bzip2', "-v$compress_level", "ulogs/$filename"));
+        runcmd('bzip2', "-v$compress_level", "ulogs/$filename");
     }
 
     return;


### PR DESCRIPTION
save_memory_dump() failed sporadically. This happen due to the call of
`system('xz ...')` and `autodie :all` is enabled.
Cause `xz` also return `!= 0` when warnings appear, which actually isn't an
error!

Adding `--no-warn` avoid this exit code and just return != 0 on error.

Also used `runcmd()` instead of `system()` which makes error hunting more
easy.

Tickets
 * https://progress.opensuse.org/issues/48671
 * https://progress.opensuse.org/issues/55595

Maybe related:
 * https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8202

