### PR TITLE
Allow special value 'once' for PXEBOOT, to PXE boot...once

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -792,7 +792,10 @@ sub start_qemu {
         }
 
         if ($arch_supports_boot_order) {
-            if ($vars->{PXEBOOT}) {
+            if ($vars->{PXEBOOT} // '' eq 'once') {
+                sp("boot", "once=n");
+            }
+            elsif ($vars->{PXEBOOT}) {
                 sp("boot", "n");
             }
             elsif ($vars->{BOOTFROM}) {

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -78,7 +78,7 @@ OFW;boolean;0;QEMU Open Firmware is in use
 QEMU_OVERRIDE_VIDEO_DEVICE_AARCH64;boolean;undef;If set, for aarch64 systems use VGA as video adapter
 QEMU_DISABLE_SNAPSHOTS;boolean;undef;If set, disable snapshots in case the worker has slow disks to avoid save_vm calls failing due to timeouts (See https://bugzilla.suse.com/show_bug.cgi?id=1035453[bsc#1035453])
 PATHCNT;integer;2;Number of paths in MULTIPATH scenario
-PXEBOOT;boolean;0;Boot VM from network
+PXEBOOT;boolean or 'once';0;Boot VM from network, on every boot or only once if set to 'once'
 QEMU;QEMU binary filename;undef;Filename of QEMU binary to use
 QEMUCPU;see qemu -cpu ?;undef;CPU to emulate
 QEMUCPUS;integer;1;Number of CPUs to assign to VM


### PR DESCRIPTION
For a PXE install test, we want to boot PXE just the *first*
time, then revert to default boot order (much like we boot
once=d by default for optical media installs). This allows the
special value 'once' for the PXEBOOT var to request this.

Signed-off-by: Adam Williamson <awilliam@redhat.com>