### PR TITLE
Add configuration option for number of NVMe queues

### DIFF
--- a/OpenQA/Qemu/BlockDevConf.pm
+++ b/OpenQA/Qemu/BlockDevConf.pm
@@ -96,7 +96,7 @@ sub del_overlay {
 }
 
 sub _push_new_drive_dev {
-    my ($self, $id, $drive, $model) = @_;
+    my ($self, $id, $drive, $model, $num_queues) = @_;
 
     die 'PFlash drives are not supported by DriveDevice, use PFlashDevice'
       if $model eq 'pflash';
@@ -104,7 +104,8 @@ sub _push_new_drive_dev {
     my $dd = OpenQA::Qemu::DriveDevice->new()
       ->id($id)
       ->drive($drive)
-      ->model($model);
+      ->model($model)
+      ->num_queues($num_queues);
     push(@{$self->_drives}, $dd);
 
     return $dd;
@@ -116,11 +117,11 @@ Create a new drive device and qcow2 image.
 
 =cut
 sub add_new_drive {
-    my ($self, $id, $model, $size) = @_;
+    my ($self, $id, $model, $size, $num_queues) = @_;
 
     my $base_drive = $self->add_new_base($id, $id, $size);
 
-    return $self->_push_new_drive_dev($id, $base_drive, $model);
+    return $self->_push_new_drive_dev($id, $base_drive, $model, $num_queues);
 }
 
 =head3 add_existing_drive
@@ -130,12 +131,12 @@ new overlay is created so that the existing qcow2 image is not modified.
 
 =cut
 sub add_existing_drive {
-    my ($self, $id, $file_name, $model, $size) = @_;
+    my ($self, $id, $file_name, $model, $size, $num_queues) = @_;
 
     my $base_drive = $self->add_existing_base($id, $file_name, $size)->implicit(1);
     my $overlay    = $self->add_new_overlay($id . OVERLAY_POSTFIX . '0', $base_drive);
 
-    return $self->_push_new_drive_dev($id, $overlay, $model);
+    return $self->_push_new_drive_dev($id, $overlay, $model, $num_queues);
 }
 
 

--- a/OpenQA/Qemu/DriveDevice.pm
+++ b/OpenQA/Qemu/DriveDevice.pm
@@ -69,6 +69,13 @@ has 'serial';
 has 'id';
 has last_overlay_id => 0;
 
+=head3 num_queues
+
+The number of I/O queues of the drive, esp. for NVMe devices
+
+=cut
+has 'num_queues';
+
 sub new_overlay_id {
     my $self = shift;
 
@@ -112,8 +119,9 @@ sub gen_cmdline {
             push(@params, 'bus=' . $path->controller->id . '.0');
         }
         # Configure bootindex only for first path
-        $self->_push_ifdef(\@params, 'bootindex=', $self->bootindex) if (!$path->id || $path->id eq 'path0');
-        $self->_push_ifdef(\@params, 'serial=',    $self->serial);
+        $self->_push_ifdef(\@params, 'bootindex=',  $self->bootindex) if (!$path->id || $path->id eq 'path0');
+        $self->_push_ifdef(\@params, 'serial=',     $self->serial);
+        $self->_push_ifdef(\@params, 'num_queues=', $self->num_queues) if ($self->num_queues != -1);
         push(@cmdln, ('-device', join(',', @params)));
     }
 
@@ -160,11 +168,12 @@ sub _to_map {
     });
 
     return {drives => \@overlays,
-        model     => $self->model,
-        paths     => \@paths,
-        bootindex => $self->bootindex,
-        serial    => $self->serial,
-        id        => $self->id};
+        model      => $self->model,
+        paths      => \@paths,
+        bootindex  => $self->bootindex,
+        serial     => $self->serial,
+        id         => $self->id,
+        num_queues => $self->num_queues};
 }
 
 sub _from_map {
@@ -179,7 +188,8 @@ sub _from_map {
       ->paths(\@paths)
       ->bootindex($map->{bootindex})
       ->serial($map->{serial})
-      ->id($map->{id});
+      ->id($map->{id})
+      ->num_queues($map->{num_queues});
 }
 
 sub CARP_TRACE {

--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -163,6 +163,7 @@ sub configure_blockdevs {
         my $node_id      = 'hd' . ($i - 1);
         my $hdd_serial   = $vars->{"HDDSERIAL_$i"} || $node_id;
         my $size         = $vars->{"HDDSIZEGB_$i"};
+        my $num_queues   = $vars->{"HDDNUMQUEUES_$i"} || -1;
         my $drive;
 
         $size .= 'G' if defined($size);
@@ -177,10 +178,10 @@ sub configure_blockdevs {
                 $backing_file = $path . $name;
             }
             $size //= $self->get_img_size($backing_file);
-            $drive = $bdc->add_existing_drive($node_id, $backing_file, $hdd_model, $size);
+            $drive = $bdc->add_existing_drive($node_id, $backing_file, $hdd_model, $size, $num_queues);
         } else {
             $size //= $vars->{HDDSIZEGB} . 'G';
-            $drive = $bdc->add_new_drive($node_id, $hdd_model, $size);
+            $drive = $bdc->add_new_drive($node_id, $hdd_model, $size, $num_queues);
         }
 
         if ($i == 1 && $bootfrom eq 'disk') {

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -60,6 +60,7 @@ HDDMODEL;see qemu -device ?;virtio-blk;Storage device for virtualized HDD.
 HDDMODEL_$i;see qemu -device ?;virtio-blk;Storage device for virtualized HDD. Overrides global HDDMODEL for HDD_$i
 HDDSIZEGB;integer;10;Creates HDD with specified size in GiB
 HDD_$i;filename;;Filename of HDD image to be used for VM. Up to 9
+HDDNUMQUEUES_$i:see qemu-system-x86_64 -device nvme,help - set the number of queues for HDD_$i
 ISO;filename;;Filename of ISO file to be attached to VM
 ISO_$i;filename;;Aditional ISO to be attached to VM. Up to 9
 KEEPHDDS;boolean;;Leave created HDD after test finishes. Useful for debugging tests


### PR DESCRIPTION
There are scenarios, where we should have control over the number of
queues a NVMe device has. The number of queues varies, and recent
versions of Qemu emulate 32 queues, for example.
In some scenarios, like the one depicted in [1], we need to set the
number of queues to a value smaller than the number of NUMA-nodes in the
system.
In order to allow to test this with reasonable ressource requirements,
instead of running a machine wit 40+ NUMA-nodes, it is more reasonable
to run a test with four nodes and two NVMe queues instead.
With these changes, it is possible to configure the NVMe queues by
setting the HDDNUMQUEUES_n parameter for the disk number n.

[1] https://progress.opensuse.org/issues/55502

A proof run can be found here: http://mmoese-vm.qa.suse.de/tests/28#