### PR TITLE
Update test_order.json if test schedule changes at runtime

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -37,8 +37,7 @@ our %tests;        # scheduled or run tests
 our @testorder;    # for keeping them in order
 our $isotovideo;
 our $process;
-
-my $tests_running = 0;
+our $tests_running = 0;
 =head1 Introduction
 
 OS Autoinst decides which test modules to run based on a distribution specific

--- a/autotest.pm
+++ b/autotest.pm
@@ -37,6 +37,8 @@ our %tests;        # scheduled or run tests
 our @testorder;    # for keeping them in order
 our $isotovideo;
 our $process;
+
+my $tests_running = 0;
 =head1 Introduction
 
 OS Autoinst decides which test modules to run based on a distribution specific
@@ -145,6 +147,10 @@ sub loadtest {
 
     return unless $test->is_applicable;
     push @testorder, $test;
+
+    # Test schedule may change at runtime. Update test_order.json to notify
+    # the OpenQA server of the change.
+    write_test_order() if $tests_running;
     bmwqemu::diag("scheduling $test->{name} $script");
 }
 
@@ -219,6 +225,7 @@ sub load_snapshot {
 sub run_all {
     my $died      = 0;
     my $completed = 0;
+    $tests_running = 1;
     eval { $completed = autotest::runalltests(); };
     if ($@) {
         warn $@;

--- a/t/fake/tests/scheduler.pm
+++ b/t/fake/tests/scheduler.pm
@@ -1,0 +1,9 @@
+use strict;
+use warnings;
+use base 'basetest';
+use autotest 'loadtest';
+
+sub run {
+    loadtest 'tests/next.pm';
+}
+1;


### PR DESCRIPTION
This pull request is part of os-autoinst/openQA#2302

After talking to @asmorodskyi via IRC, I've decided that the proper way to notify OpenQA server of test schedule change is by calling `write_test_order()` in `autotest::loadtest()`. The original idea was to call `write_test_order()` from the testcase that scheduled additional tests but that would expose internal implementation details to third-party code and os-autoinst developers might not notice that test schedule may change at runtime.

Both this PR and os-autoinst/openQA#2302 can be safely used with an unpatched version of the other package. The test modules scheduled at runtime won't show up in test results (just like now) but there'll be no errors or crashes.