### PR TITLE
Fix PXEBOOT once to actually check for 'once' value

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -792,7 +792,7 @@ sub start_qemu {
         }
 
         if ($arch_supports_boot_order) {
-            if ($vars->{PXEBOOT} // '' eq 'once') {
+            if (($vars->{PXEBOOT} // '') eq 'once') {
                 sp("boot", "once=n");
             }
             elsif ($vars->{PXEBOOT}) {


### PR DESCRIPTION
Without parentheses this will return true every time PXEBOOT is set to true.