### PR TITLE
Use hda audio instead of deprecated ac97

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -738,7 +738,7 @@ sub start_qemu {
     sp('only-migratable') if $self->can_handle({function => 'snapshots', no_warn => 1});
     sp('chardev', 'ringbuf,id=serial0,logfile=serial0,logappend=on');
     sp('serial',  'chardev:serial0');
-    sp('soundhw', 'ac97');
+    sp('soundhw', 'hda');
     {
         # Remove floppy drive device on architectures
         unless ($arch eq 'aarch64' || $arch eq 'arm' || $vars->{QEMU_NO_FDC_SET}) {


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/55958#change-243110
Verification (on x86_64 - at least it doesn't break that): http://artemis.suse.de/tests/1644#step/aplay/21

As the default volume seems to be different for hda, we need to have some needles updated:

https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1218/diffs
