### PR TITLE
Add new status file that worker can read from (because the isotovideo process might already be finished)

### DIFF
--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -22,7 +22,7 @@ use warnings;
 # -> increment on every change of such APIs
 # -> never move that variable to another place (when refactoring)
 #    because it may be accessed by the tests itself
-our $version = 17;
+our $version = 18;
 
 # major version of the (web socket) API relevant to the developer mode
 # -> increment when making non-backward compatible changes to that API

--- a/autotest.pm
+++ b/autotest.pm
@@ -369,10 +369,11 @@ sub runalltests {
             }
 
             eval { $t->runtest; };
+            my $error = $@;    # save $@, it might be overwritten
             $t->save_test_result();
 
-            if ($@) {
-                my $msg = $@;
+            if ($error) {
+                my $msg = $error;
                 if ($msg !~ /^test.*died/) {
                     # avoid duplicating the message
                     bmwqemu::diag $msg;

--- a/dist/rpm/os-autoinst-test.spec
+++ b/dist/rpm/os-autoinst-test.spec
@@ -1,7 +1,7 @@
 %define name_ext -test
 %define         short_name os-autoinst
 Name:           %{short_name}%{?name_ext}
-Version:        4.5.1544111663.31867f0e
+Version:        4.6
 Release:        0
 Summary:        test package for os-autoinst
 License:        GPL-2.0+

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -17,7 +17,7 @@
 
 
 Name:           os-autoinst
-Version:        4.5.1544111663.31867f0e
+Version:        4.6
 Release:        0
 Summary:        OS-level test automation
 License:        GPL-2.0-or-later

--- a/t/19-isotovideo-command-processing.t
+++ b/t/19-isotovideo-command-processing.t
@@ -54,10 +54,10 @@ $rpc_mock->mock(read_json => sub {
 
 # setup a CommandHandler instance using the fake file descriptors
 my $command_handler = OpenQA::Isotovideo::CommandHandler->new(
-    cmd_srv_fd             => $cmd_srv_fd,
-    backend_fd             => $backend_fd,
-    current_test_name      => 'welcome',
-    current_test_full_name => 'installation-welcome',
+    cmd_srv_fd        => $cmd_srv_fd,
+    backend_fd        => $backend_fd,
+    current_test_name => 'welcome',
+    status            => 'initial',
 );
 
 sub reset_state {
@@ -66,6 +66,16 @@ sub reset_state {
     $last_received_msg_by_fd[$answer_fd]  = undef;
     $last_received_msg_by_fd[$cmd_srv_fd] = undef;
 }
+
+subtest set_current_test => sub {
+    $command_handler->process_command($answer_fd, {
+            cmd       => 'set_current_test',
+            name      => 'welcome',
+            full_name => 'installation-welcome',
+    });
+    is($command_handler->status, 'running', 'Status == running');
+};
+
 
 subtest status => sub {
     $command_handler->tags([qw(foo bar)]);
@@ -296,3 +306,7 @@ subtest 'set_assert_screen_timeout' => sub {
 };
 
 done_testing;
+
+END {
+    unlink OpenQA::Isotovideo::CommandHandler::AUTOINST_STATUSFILE;
+}


### PR DESCRIPTION
For a description of the issue see https://github.com/os-autoinst/openQA/pull/2327

See:
* https://github.com/os-autoinst/openQA/pull/2327
* https://progress.opensuse.org/issues/39845