### PR TITLE
Handle Failed to get "write" lock on svirt-xen

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -615,8 +615,8 @@ sub stop_serial_grab {
 #   my $ret = $svirt->run_cmd("virsh snapshot-create-as snap1");
 #   die "snapshot creation failed" unless $ret == 0;
 sub run_cmd {
-    my ($self, $cmd) = @_;
-    return backend::svirt::run_cmd($self->{ssh}, $cmd);
+    my ($self, $cmd, %args) = @_;
+    return backend::svirt::run_cmd($self->{ssh}, $cmd, %args);
 }
 
 # Executes command and in list context returns pair of standard output and standard error

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -105,7 +105,8 @@ sub _init_xml {
     $root->appendChild($elem);
 
     $elem = $doc->createElement('description');
-    $elem->appendTextNode("openQA Instance $instance");
+    $elem->appendTextNode("openQA Instance $instance: ");
+    $elem->appendTextNode(get_required_var('NAME'));
     $root->appendChild($elem);
 
     $elem = $doc->createElement('memory');

--- a/t/22-svirth-virsh-config.xml
+++ b/t/22-svirth-virsh-config.xml
@@ -2,7 +2,7 @@
 <!-- basic virsh config for KVM with VNC serial console and additional serial console -->
 <domain type="kvm">
   <name>openQA-SUT-1</name>
-  <description>openQA Instance 1</description>
+  <description>openQA Instance 1: 0-no-scenario</description>
   <memory unit="MiB">1024</memory>
   <vcpu>1</vcpu>
   <os>


### PR DESCRIPTION
More or less often we see that some svirt jobs fail on XEN with a very
clear message: 'Failed to get "write" lock' which could be result of a
domain not releasing the file handles when the domain is destroyed,
waiting a bit solves the problem, so retrying up to a maximum of 5 times
and sleeping in between, gives enough room for the Xen backend to
release everything

Related progress ticket: https://progress.opensuse.org/issues/54173

Since #1109 there's wantarray parameter supported (and possibly earlier)
but that change was not applied to consoles::sshVirtsh therefore if one
needs the return values or wants to inspect standard output or error,
it's merely impossible. Passing properly the argument fixes the problem

To facilitate the identification of jobs that happen to fail, or further
investigation of obscure libvirt problems, like poo#54863 or poo#54173