### PR TITLE
Fix broken condition introduced by #1213

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -357,8 +357,10 @@ sub add_disk {
             # Avoid qemu-img's failure to get a write lock to be the reason for a job to fail
             while (1) {
                 my ($ret, $stdout, $stderr) = $self->run_cmd("qemu-img create $file $size -f qcow2", wantarray => 1);
-                die "Too many attempts to format HDD" unless ($bucket-- && $ret);
                 if ($stderr =~ /lock/i) {
+                    $bucket--;
+                    die "Too many attempts to format HDD" unless $bucket;
+                    bmwqemu::diag("Resource is still not free, waiting a bit more. $bucket attempts left");
                     sleep 5;
                     next;
                 }


### PR DESCRIPTION
FiBackend should only die when all of the attempts have finished and still
the command is not successful.

* Progress ticket: https://progress.opensuse.org/issues/57377
* Verification Run: [All 5 attempts](http://phobos.suse.de/tests/1748058/file/autoinst-log.txt)
* Verification Run: [Unlocked after the second attempt](http://phobos.suse.de/tests/1748056/file/autoinst-log.txt)
* Verification Run: [SUT boots without need for retrials](http://phobos.suse.de/tests/1748059/file/autoinst-log.txt)

This should solve the broken [xen and zkvm](https://openqa.suse.de/tests/overview?arch=&machine=&modules=bootloader_zkvm%2Cbootloader_svirt&modules_result=failed&distri=sle&version=12-SP5&build=0333#) jobs :)

Tested defining manually the domain using the same resource image, and triggering the jobs. 