### PR TITLE
Revert "Add possibility to have a comment text in the script_run"

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -107,7 +107,7 @@ sub become_root {
 
 =head2 script_run
 
-  script_run($cmd [, timeout => $timeout] [, output => $output] [,quiet => $quiet])
+  script_run($cmd [, timeout => $timeout] [,quiet => $quiet])
 
 Deprecated mode
 
@@ -116,8 +116,6 @@ Deprecated mode
 Run I<$cmd> (by assuming the console prompt and typing the command). After that, echo
 hashed command to serial line and wait for it in order to detect execution is finished.
 To avoid waiting, use I<$timeout> 0.
-
-Use C<output> to add a description or a comment of the $cmd.
 
 Use C<quiet> to avoid recording serial_results.
 
@@ -131,7 +129,6 @@ sub script_run {
     my %args = testapi::compat_args(
         {
             timeout => $bmwqemu::default_timeout,
-            output  => '',
             quiet   => undef
         }, ['timeout'], @_);
 
@@ -140,15 +137,15 @@ sub script_run {
     }
     testapi::type_string "$cmd";
     if ($args{timeout} > 0) {
-        my $str    = testapi::hashed_string("SR" . $cmd . $args{timeout});
-        my $marker = ($args{output} ? " ; echo $str-\$?- Comment: $args{output}" : " ; echo $str-\$?-");
+        my $str = testapi::hashed_string("SR" . $cmd . $args{timeout});
         if (testapi::is_serial_terminal) {
+            my $marker = " ; echo $str-\$?-";
             testapi::type_string($marker);
             testapi::wait_serial($cmd . $marker, no_regex => 1, quiet => $args{quiet});
             testapi::type_string("\n");
         }
         else {
-            testapi::type_string " ; echo $marker > /dev/$testapi::serialdev\n";
+            testapi::type_string " ; echo $str-\$?- > /dev/$testapi::serialdev\n";
         }
         my $res = testapi::wait_serial(qr/$str-\d+-/, timeout => $args{timeout}, quiet => $args{quiet});
         return unless $res;

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -48,7 +48,7 @@ sub fake_read_json {
     my $cmd  = $lcmd->{cmd};
     if ($cmd eq 'backend_wait_serial') {
         my $str = $lcmd->{regexp};
-        $str =~ s,\\d\+(\\s\+\\S\+)?,$fake_exit,;
+        $str =~ s,\\d\+,$fake_exit,;
         return {ret => {matched => 1, string => $str}};
     }
     elsif ($cmd eq 'backend_select_console') {
@@ -231,10 +231,8 @@ subtest 'script_run' => sub {
     );
     $fake_exit = 0;
     is(script_run('true'), '0', 'script_run with no check of success, returns exit code');
-    is(script_run('true', output => 'foo'), '0', 'script_run with no check of success and output, returns exit code');
     $fake_exit = 1;
     is(script_run('false'), '1', 'script_run with no check of success, returns exit code');
-    is(script_run('false', output => 'foo'), '1', 'script_run with no check of success and output, returns exit code');
     is(script_run('false', 0), undef, 'script_run with no check of success, returns undef when not waiting');
 };
 
@@ -293,7 +291,7 @@ subtest 'check_assert_screen' => sub {
         is_deeply($autotest::current_test->{details}, [
                 {
                     result     => 'unk',
-                    screenshot => 'basetest-13.png',
+                    screenshot => 'basetest-11.png',
                     frametime  => [qw(1.75 1.79)],
                     tags       => [qw(fake tags)],
                 }

--- a/testapi.pm
+++ b/testapi.pm
@@ -969,7 +969,7 @@ sub assert_script_run {
 
 =head2 script_run
 
-  script_run($cmd [, timeout => $timeout] [, output => ''] [, quiet => $quiet]);
+  script_run($cmd [, timeout => $timeout] [, quiet => $quiet]);
 
 Deprecated mode
 
@@ -980,9 +980,6 @@ the command). If C<$timeout> is greater than 0, wait for that length of time for
 execution to complete (otherwise, returns undef immediately). See C<distri->script_run>
 for default timeout.
 
-C<$output> can be used as an explanatory text that will be displayed with the execution of
-the command.
- 
 <Returns> exit code received from I<$cmd>, or undef if $timeout is 0 or execution
 does not complete within $timeout.
 
@@ -999,7 +996,6 @@ sub script_run {
     my %args = compat_args(
         {
             timeout => undef,
-            output  => '',
             quiet   => testapi::get_var('_QUIET_SCRIPT_CALLS')
         }, ['timeout'], @_);
 


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst#1204 to fix a regression as visible in
https://openqa.opensuse.org/tests/1045173#step/yast2_lan/9
where there is an additional echo with no argument that is
overwriting the exit status of the previous command.