### PR TITLE
Add possibility to have a comment text in script_run (fixed)

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -107,7 +107,7 @@ sub become_root {
 
 =head2 script_run
 
-  script_run($cmd [, timeout => $timeout] [,quiet => $quiet])
+  script_run($cmd [, timeout => $timeout] [, output => $output] [,quiet => $quiet])
 
 Deprecated mode
 
@@ -116,6 +116,8 @@ Deprecated mode
 Run I<$cmd> (by assuming the console prompt and typing the command). After that, echo
 hashed command to serial line and wait for it in order to detect execution is finished.
 To avoid waiting, use I<$timeout> 0.
+
+Use C<output> to add a description or a comment of the $cmd.
 
 Use C<quiet> to avoid recording serial_results.
 
@@ -129,6 +131,7 @@ sub script_run {
     my %args = testapi::compat_args(
         {
             timeout => $bmwqemu::default_timeout,
+            output  => '',
             quiet   => undef
         }, ['timeout'], @_);
 
@@ -137,15 +140,15 @@ sub script_run {
     }
     testapi::type_string "$cmd";
     if ($args{timeout} > 0) {
-        my $str = testapi::hashed_string("SR" . $cmd . $args{timeout});
+        my $str    = testapi::hashed_string("SR" . $cmd . $args{timeout});
+        my $marker = "; echo $str-\$?-" . ($args{output} ? "Comment: $args{output}" : '');
         if (testapi::is_serial_terminal) {
-            my $marker = " ; echo $str-\$?-";
             testapi::type_string($marker);
             testapi::wait_serial($cmd . $marker, no_regex => 1, quiet => $args{quiet});
             testapi::type_string("\n");
         }
         else {
-            testapi::type_string " ; echo $str-\$?- > /dev/$testapi::serialdev\n";
+            testapi::type_string "$marker > /dev/$testapi::serialdev\n";
         }
         my $res = testapi::wait_serial(qr/$str-\d+-/, timeout => $args{timeout}, quiet => $args{quiet});
         return unless $res;

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -48,7 +48,7 @@ sub fake_read_json {
     my $cmd  = $lcmd->{cmd};
     if ($cmd eq 'backend_wait_serial') {
         my $str = $lcmd->{regexp};
-        $str =~ s,\\d\+,$fake_exit,;
+        $str =~ s,\\d\+(\\s\+\\S\+)?,$fake_exit,;
         return {ret => {matched => 1, string => $str}};
     }
     elsif ($cmd eq 'backend_select_console') {
@@ -230,9 +230,15 @@ subtest 'script_run' => sub {
         'using two named arguments; fail message does not apply on timeout'
     );
     $fake_exit = 0;
+    $cmds      = [];
     is(script_run('true'), '0', 'script_run with no check of success, returns exit code');
+    like($cmds->[1]->{text}, qr/; echo /);
+    $cmds = [];
+    is(script_run('true', output => 'foo'), '0', 'script_run with no check of success and output, returns exit code');
+    like($cmds->[1]->{text}, qr/; echo .*Comment: foo/);
     $fake_exit = 1;
     is(script_run('false'), '1', 'script_run with no check of success, returns exit code');
+    is(script_run('false', output => 'foo'), '1', 'script_run with no check of success and output, returns exit code');
     is(script_run('false', 0), undef, 'script_run with no check of success, returns undef when not waiting');
 };
 
@@ -291,7 +297,7 @@ subtest 'check_assert_screen' => sub {
         is_deeply($autotest::current_test->{details}, [
                 {
                     result     => 'unk',
-                    screenshot => 'basetest-11.png',
+                    screenshot => 'basetest-13.png',
                     frametime  => [qw(1.75 1.79)],
                     tags       => [qw(fake tags)],
                 }

--- a/testapi.pm
+++ b/testapi.pm
@@ -969,7 +969,7 @@ sub assert_script_run {
 
 =head2 script_run
 
-  script_run($cmd [, timeout => $timeout] [, quiet => $quiet]);
+  script_run($cmd [, timeout => $timeout] [, output => ''] [, quiet => $quiet]);
 
 Deprecated mode
 
@@ -979,6 +979,9 @@ Run C<$cmd> (in the default implementation, by assuming the console prompt and t
 the command). If C<$timeout> is greater than 0, wait for that length of time for
 execution to complete (otherwise, returns undef immediately). See C<distri->script_run>
 for default timeout.
+
+C<$output> can be used as an explanatory text that will be displayed with the execution of
+the command.
 
 <Returns> exit code received from I<$cmd>, or undef if $timeout is 0 or execution
 does not complete within $timeout.
@@ -996,6 +999,7 @@ sub script_run {
     my %args = compat_args(
         {
             timeout => undef,
+            output  => '',
             quiet   => testapi::get_var('_QUIET_SCRIPT_CALLS')
         }, ['timeout'], @_);
 


### PR DESCRIPTION
Re-added functionality reverted in 54352a1c with a fix for the
regression and a test covering the expected string appended to the
executed command.

Related progress issue: https://progress.opensuse.org/issues/55151