### PR TITLE
Revert "Allow loading needles from pool directory" to fix loading time regression

### DIFF
--- a/needle.pm
+++ b/needle.pm
@@ -20,7 +20,6 @@ use strict;
 use warnings;
 use autodie ':all';
 
-use Cwd 'cwd';
 use File::Find;
 use File::Spec;
 use Mojo::JSON 'decode_json';
@@ -52,33 +51,20 @@ sub new {
     }
 
     my $self = {};
-
-    # locate the needle file in one of the lookup directories
-    # - This code initializes $json->{file} so it contains the path relative to the lookup
-    #   directory and re-assigns $jsonfile to contain the absolute path.
-    # - A custom needle repo checkout referenced by the $bmwqemu::vars{NEEDLES_DIR} variable
-    #   is considered to support loading custom needles (e.g. with the openqa-clone-custom-git-refspec
-    #   script). The custom needle repo must be within the current working directory (usually the
-    #   openQA worker's pool directory).
-    # - Otherwise, the needle will be looked up under $bmwqemu::vars{PRJDIR}.
-    my @lookup_dirs;
-    my $needles_dir = $bmwqemu::vars{NEEDLES_DIR};
-    push(@lookup_dirs, $needles_dir) if (defined $needles_dir && index($needles_dir, cwd) == 0);
-    push(@lookup_dirs, $bmwqemu::vars{PRJDIR});
-    for my $lookup_dir (@lookup_dirs) {
-        if (index($jsonfile, $lookup_dir) == 0) {
-            $self->{file} = substr($jsonfile, length($lookup_dir) + 1);
-            last;
-        }
-        elsif (-f File::Spec->catfile($lookup_dir, $jsonfile)) {
-            # json file path already relative
-            $self->{file} = $jsonfile;
-            $jsonfile = File::Spec->catfile($lookup_dir, $jsonfile);
-            last;
-        }
+    if (index($jsonfile, $bmwqemu::vars{PRJDIR}) == 0) {
+        $self->{file} = substr($jsonfile, length($bmwqemu::vars{PRJDIR}) + 1);
     }
-    die "Needle $jsonfile is not under any of the following directories: " . join(', ', @lookup_dirs)
-      unless exists $self->{file};
+    elsif (-f File::Spec->catfile($bmwqemu::vars{PRJDIR}, $jsonfile)) {
+        # json file path already relative
+        $self->{file} = $jsonfile;
+        $jsonfile = File::Spec->catfile($bmwqemu::vars{PRJDIR}, $jsonfile);
+    }
+    else {
+        die "Needle $jsonfile is not under project directory $bmwqemu::vars{PRJDIR}";
+    }
+
+    # $json->{file} contains path relative to $bmwqemu::vars{PRJDIR}
+    # $jsonfile contains absolute path within $bmwqemu::vars{PRJDIR}
 
     if (!$json) {
         local $/;

--- a/t/01-test_needle.t
+++ b/t/01-test_needle.t
@@ -30,7 +30,7 @@ require tinycv;
 my ($res, $needle, $img1, $cand);
 
 my $data_dir        = dirname(__FILE__) . '/data/';
-my $misc_needle_dir = abs_path(dirname(__FILE__)) . '/misc_needles/';
+my $misc_needle_dir = dirname(__FILE__) . '/misc_needles/';
 
 $img1 = tinycv::read($data_dir . "bootmenu.test.png");
 
@@ -379,7 +379,6 @@ ok($needle->get_image != $img1, 'cleaning cache to keep 1 image deleted $img1');
 
 # test needle->file is relative to default prjdir
 is($needle->{file}, 'data/other-desktop-dvd-20140904.json', 'needle json path is relative to prjdir');
-
 # test needle dir is symlinked from different location
 $bmwqemu::vars{PRJDIR} = tempdir(CLEANUP => 1);
 my $new_data_dir = $bmwqemu::vars{PRJDIR} . '/out-of-def-prj/test/data';
@@ -398,21 +397,6 @@ is($needle->{file}, 'out-of-def-prj/test/data/other-desktop-dvd-20140904.json', 
 
 eval { $needle = needle->new('out-of-prj/test/data/some-needle.json') };
 ok($@, 'died when accessing needle outside of prjdir');
-
-subtest 'needle->new accepts path relative to working directory' => sub {
-    my $temp_working_dir = tempdir(CLEANUP => 1);
-    note("using working directory $temp_working_dir");
-    chdir($temp_working_dir);
-    my $needles_dir = $bmwqemu::vars{NEEDLES_DIR} = "$temp_working_dir/some-needle-repo";
-    make_path("$needles_dir/subdir");
-    for my $extension (qw(json png)) {
-        Mojo::File->new($misc_needle_dir, "click-point.$extension")->copy_to("$needles_dir/subdir/foo.$extension");
-    }
-
-    ok($needle = needle->new('subdir/foo.json'), 'needle object created with needle from working directory');
-    is($needle->{file}, 'subdir/foo.json',             'relative file path assigned');
-    is($needle->{png},  "$needles_dir/subdir/foo.png", 'absolute image path assigned');
-};
 
 subtest 'click point' => sub {
     $bmwqemu::vars{PRJDIR} = $misc_needle_dir;


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst#1217 to fix https://progress.opensuse.org/issues/57962