### PR TITLE
All JSON communication goes through myjsonrpc.pm

### DIFF
--- a/myjsonrpc.pm
+++ b/myjsonrpc.pm
@@ -32,7 +32,8 @@ sub send_json {
     my $cjx = Cpanel::JSON::XS->new->convert_blessed();
     # deep copy to add a random string
     my %cmdcopy = %$cmd;
-    $cmdcopy{json_cmd_token} = bmwqemu::random_string(8);
+    # The hash might already contain a json_cmd_token
+    $cmdcopy{json_cmd_token} ||= bmwqemu::random_string(8);
     my $json = $cjx->encode(\%cmdcopy);
 
     #bmwqemu::diag("send_json $json");


### PR DESCRIPTION
If we want to change or debug the JSON communication, we only have
one location: myjsonrpc::send_json/myjsonrpc::read_json

I noticed this when debugging https://progress.opensuse.org/issues/39845

