### PR TITLE
myjsonrpc - Allow read_json() to return multiple results

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -24,6 +24,7 @@ use autodie ':all';
 
 use Carp qw(cluck carp confess);
 use Mojo::JSON;    # booleans
+use Cpanel::JSON::XS ();
 use File::Copy 'cp';
 use File::Basename;
 use Time::HiRes qw(gettimeofday time tv_interval);

--- a/commands.pm
+++ b/commands.pm
@@ -325,14 +325,16 @@ sub run_daemon {
     Mojo::IOLoop->singleton->reactor->io($isotovideo => sub {
             my ($reactor, $writable) = @_;
 
-            my $isotovideo_response = myjsonrpc::read_json($isotovideo);
-            my $clients             = app->defaults('clients');
-            _handle_isotovideo_response(app, $isotovideo_response);
-            delete $isotovideo_response->{json_cmd_token};
+            my @isotovideo_responses = myjsonrpc::read_json($isotovideo, undef, 1);
+            my $clients              = app->defaults('clients');
+            for my $response (@isotovideo_responses) {
+                _handle_isotovideo_response(app, $response);
+                delete $response->{json_cmd_token};
 
-            app->log->debug('cmdsrv: broadcasting message from os-autoinst to all ws clients: ' . to_json($isotovideo_response));
-            for (keys %$clients) {
-                $clients->{$_}->send({json => $isotovideo_response});
+                app->log->debug('cmdsrv: broadcasting message from os-autoinst to all ws clients: ' . to_json($response));
+                for (keys %$clients) {
+                    $clients->{$_}->send({json => $response});
+                }
             }
     })->watch($isotovideo, 1, 0);    # watch only readable (and not writable)
 

--- a/myjsonrpc.pm
+++ b/myjsonrpc.pm
@@ -23,20 +23,33 @@ use Errno;
 use Mojo::JSON;    # booleans
 use Cpanel::JSON::XS ();
 
+use constant DEBUG_JSON => $ENV{PERL_MYJSONRPC_DEBUG} || 0;
+
 sub send_json {
     my ($to_fd, $cmd) = @_;
 
     # allow regular expressions to be automatically converted into
     # strings, using the Regex::TO_JSON function as defined at the end
     # of this file.
-    my $cjx = Cpanel::JSON::XS->new->convert_blessed();
+    # The resulting JSON should be in a single line, otherwise
+    # read_json won't work
+    my $cjx = Cpanel::JSON::XS->new->canonical->utf8->convert_blessed();
+
     # deep copy to add a random string
     my %cmdcopy = %$cmd;
     # The hash might already contain a json_cmd_token
     $cmdcopy{json_cmd_token} ||= bmwqemu::random_string(8);
-    my $json = $cjx->encode(\%cmdcopy);
 
-    #bmwqemu::diag("send_json $json");
+    my $json = $cjx->encode(\%cmdcopy);
+    if (DEBUG_JSON) {
+        my $copy = $json;
+        # shorten long content
+        $copy =~ s/"([^"]{30})[^"]+"/"$1"/g;
+        my $fd = fileno($to_fd);
+        bmwqemu::diag("($$) send_json($fd) JSON=$copy");
+    }
+    $json .= "\n";
+
     my $wb = syswrite($to_fd, "$json");
     confess "syswrite failed $!" unless ($wb && $wb == length($json));
     return $cmdcopy{json_cmd_token};
@@ -47,38 +60,48 @@ our $sockets;
 
 # utility function
 sub read_json {
-    my ($socket, $cmd_token) = @_;
+    my ($socket, $cmd_token, $multi) = @_;
 
-    my $cjx = Cpanel::JSON::XS->new;
 
     my $fd = fileno($socket);
+    if (DEBUG_JSON) {
+        bmwqemu::diag("($$) read_json($fd)");
+    }
+    my $buffer = '';
     if (exists $sockets->{$fd}) {
         # start with the trailing text from previous call
-        $cjx->incr_parse($sockets->{$fd});
-        delete $sockets->{$fd};
+        $buffer = delete $sockets->{$fd};
     }
 
     my $s = IO::Select->new();
     $s->add($socket);
 
-    my $hash;
+    my @results;
 
     # the goal here is to find the end of the next valid JSON - and don't
     # add more data to it. As the backend sends things unasked, we might
     # run into the next message otherwise
     while (1) {
-        $hash = $cjx->incr_parse();
+        my $hash = _parse_json(\$buffer);
+        # remember the trailing text
+        $sockets->{$fd} = $buffer;
         if ($hash) {
-            # remember the trailing text
-            $sockets->{$fd} = $cjx->incr_text();
             if ($hash->{QUIT}) {
                 bmwqemu::diag("received magic close");
-                return;
+                push @results, undef;
+                last;
             }
             if ($cmd_token && ($hash->{json_cmd_token} || '') ne $cmd_token) {
                 confess "ERROR: the token does not match - questions and answers not in the right order";
             }
-            return $hash;
+            push @results, $hash;
+            # parse all lines from buffer
+            next if $multi;
+            last;
+        }
+        elsif ($multi and @results) {
+            # read at least one item in list context
+            last;
         }
 
         # wait for next read
@@ -99,10 +122,28 @@ sub read_json {
         my $bytes = sysread($socket, $qbuffer, 8000);
         #bmwqemu::diag("sysread $qbuffer");
         if (!$bytes) { bmwqemu::diag("sysread failed: $!"); return; }
-        $cjx->incr_parse($qbuffer);
+        $buffer .= $qbuffer;
     }
 
-    return $hash;
+    return $multi ? @results : $results[0];
+}
+
+sub _parse_json {
+    my ($buffer) = @_;
+    if ($$buffer =~ s/^([^\r\n]*)\r?\n//) {
+        my $json = $1;
+        if ($json) {
+            my $cjx  = Cpanel::JSON::XS->new->utf8;
+            my $hash = $cjx->decode($json);
+            if (DEBUG_JSON) {
+                # shorten long content
+                $json =~ s/"([^"]{30})[^"]+"/"$1"/g;
+                bmwqemu::diag("($$) _parse_json() JSON=$json");
+            }
+            return $hash;
+        }
+    }
+    return undef;
 }
 
 ###################################################################

--- a/myjsonrpc.pm
+++ b/myjsonrpc.pm
@@ -32,7 +32,8 @@ sub send_json {
     my $cjx = Cpanel::JSON::XS->new->convert_blessed();
     # deep copy to add a random string
     my %cmdcopy = %$cmd;
-    $cmdcopy{json_cmd_token} = bmwqemu::random_string(8);
+    # The hash might already contain a json_cmd_token
+    $cmdcopy{json_cmd_token} ||= bmwqemu::random_string(8);
     my $json = $cjx->encode(\%cmdcopy);
 
     #bmwqemu::diag("send_json $json");

--- a/t/24-myjsonrpc-debug.t
+++ b/t/24-myjsonrpc-debug.t
@@ -1,0 +1,64 @@
+#!/usr/bin/perl
+#
+# Copyright (c) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+
+use strict;
+use warnings;
+use Socket;
+BEGIN {
+    $ENV{PERL_MYJSONRPC_DEBUG} = 1;
+}
+use myjsonrpc;
+
+use Test::More;
+use Test::Warnings 'warnings';
+
+no warnings 'redefine';
+sub bmwqemu::diag {
+    warn $_[0];
+}
+
+
+my ($child, $isotovideo);
+socketpair($child, $isotovideo, AF_UNIX, SOCK_STREAM, PF_UNSPEC);
+
+$child->autoflush(1);
+$isotovideo->autoflush(1);
+
+my $send1 = {a => 1};
+my $send2 = {b => 12, json_cmd_token => 'dummy'};
+
+$send1->{json_cmd_token} = 'dummy';
+
+sub debug {
+    myjsonrpc::send_json($child, $send1);
+    my $read = myjsonrpc::read_json($isotovideo);
+    is_deeply($read, $send1, "read_json returns what send_json sent");
+}
+subtest debug_json => sub {
+    local $myjsonrpc::DEBUG_JSON = 1;
+
+    my @warnings = warnings { debug() };
+    like($warnings[0], qr{send_json});
+    like($warnings[1], qr{read_json});
+    like($warnings[2], qr{_parse_json});
+};
+
+close $isotovideo;
+close $child;
+
+done_testing;

--- a/t/24-myjsonrpc.t
+++ b/t/24-myjsonrpc.t
@@ -1,0 +1,79 @@
+#!/usr/bin/perl
+#
+# Copyright (c) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+
+use strict;
+use warnings;
+use Socket;
+use myjsonrpc;
+
+use Test::More;
+use Test::Warnings 'warnings';
+
+no warnings 'redefine';
+sub bmwqemu::diag {
+    warn $_[0];
+}
+
+my ($child, $isotovideo);
+socketpair($child, $isotovideo, AF_UNIX, SOCK_STREAM, PF_UNSPEC);
+
+$child->autoflush(1);
+$isotovideo->autoflush(1);
+
+my $send1 = {a => 1};
+my $send2 = {b => 12, json_cmd_token => 'dummy'};
+
+subtest single_json => sub {
+    myjsonrpc::send_json($child, $send1);
+    my $read = myjsonrpc::read_json($isotovideo);
+    ok(exists $read->{json_cmd_token}, "send_json/read_json json_cmd_token exists");
+    delete $read->{json_cmd_token};
+
+    is_deeply($read, $send1, "read_json returns what send_json sent");
+    $send1->{json_cmd_token} = 'dummy';
+
+    myjsonrpc::send_json($child, $send1);
+    myjsonrpc::send_json($child, $send2);
+    my $read1 = myjsonrpc::read_json($isotovideo, undef, 0);
+    my $read2 = myjsonrpc::read_json($isotovideo, undef, 0);
+    is_deeply([$read1, $read2], [$send1, $send2], "read_json twice works");
+};
+
+subtest multi_json => sub {
+
+    myjsonrpc::send_json($child, $send1);
+    myjsonrpc::send_json($child, $send2);
+    my @read = myjsonrpc::read_json($isotovideo, undef, 1);
+    is_deeply(\@read, [$send1, $send2], "read_json in list context works");
+
+};
+
+sub magic_close {
+    myjsonrpc::send_json($child, {QUIT => 1});
+    my $quit = myjsonrpc::read_json($isotovideo);
+    is($quit, undef, "received magic close");
+}
+subtest magic_close => sub {
+    my @warnings = warnings { magic_close() };
+    like($warnings[0], qr{received magic close});
+};
+
+close $isotovideo;
+close $child;
+
+done_testing;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,6 +1,6 @@
 AM_MAKEFLAGS = \
 	PERL5OPT="-MDevel::Cover=-db,$(abs_builddir)/cover_db,-ignore,^*\.t|^data\/tests\/*|^fake\/tests\/*" \
 	PERL5LIB="..:../ppmclibs:../ppmclibs/blib/arch/auto/tinycv:$$PERL5LIB"
-TESTS = 00-compile-check-all.t 01-test_needle.t 02-test_ocr.t 03-testapi.t 04-check_vars_docu.t 05-pod.t 06-pod-coverage.t 07-commands.t 08-autotest.t 09-lockapi.t 10-terminal.t 10-test-image-conversion-benchmark.t 11-image-ppm.t 12-bmwqemu.t 13-osutils.t 14-isotovideo.t 15-logging.t 16-send_with_fd.t 17-basetest.t 18-qemu.t 18-backend-qemu.t 18-qemu-options.t 19-isotovideo-command-processing.t 20-openqa-benchmark-stopwatch-utils.t 21-needle-downloader.t 22-svirt.t 23-baseclass.t 99-full-stack.t
+TESTS = 00-compile-check-all.t 01-test_needle.t 02-test_ocr.t 03-testapi.t 04-check_vars_docu.t 05-pod.t 06-pod-coverage.t 07-commands.t 08-autotest.t 09-lockapi.t 10-terminal.t 10-test-image-conversion-benchmark.t 11-image-ppm.t 12-bmwqemu.t 13-osutils.t 14-isotovideo.t 15-logging.t 16-send_with_fd.t 17-basetest.t 18-qemu.t 18-backend-qemu.t 18-qemu-options.t 19-isotovideo-command-processing.t 20-openqa-benchmark-stopwatch-utils.t 21-needle-downloader.t 22-svirt.t 23-baseclass.t 24-myjsonrpc.t 24-myjsonrpc-debug.t 99-full-stack.t
 
 EXTRA_DIST = $(TESTS)


### PR DESCRIPTION
* All JSON communication goes through myjsonrpc.pm
* Allow read_json() to return multiple results

The `read_json` in `commands.pm`

    Mojo::IOLoop->singleton->reactor->io

is triggered only once if there is something to read, but the buffer might contain more than one JSON at that time.

Before the result was that the JSON items were delayed to the next read, which caused bugs.

I changed the incremental parsing from `Cpanel::JSON::XS` to our own because it was difficult to debug. Therefor every JSON sent must end with a newline.

Also I added `$DEBUG_JSON`, so it can more easily debugged if necessary.

Background:

I noticed occasional errors while working on my PR for https://progress.opensuse.org/issues/39845
Debugging showed that when the error happened, a socket in myjsonrpc had two or more JSON messages in the buffer, and I didn't see that when the test succeeded.
I noticed that the leftover messages where never read, so never reached the webui.