### PR TITLE
Allow consoles to persist over reset

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -567,7 +567,7 @@ sub reset_consoles {
 
     # we iterate through all consoles
     for my $console (keys %{$testapi::distri->{consoles}}) {
-        #next if ($console eq 'x3270');
+        next if $self->console($console)->{args}->{persistent};
         $self->reset_console({testapi_console => $console});
     }
     return;

--- a/backend/spvm.pm
+++ b/backend/spvm.pm
@@ -46,9 +46,10 @@ sub do_start_vm {
         'novalink-ssh',
         'ssh-xterm',
         {
-            hostname => get_required_var('NOVALINK_HOSTNAME'),
-            password => get_required_var('NOVALINK_PASSWORD'),
-            username => get_var('NOVALINK_USERNAME', 'root')});
+            hostname   => get_required_var('NOVALINK_HOSTNAME'),
+            password   => get_required_var('NOVALINK_PASSWORD'),
+            username   => get_var('NOVALINK_USERNAME', 'root'),
+            persistent => 1});
     $ssh->backend($self);
 
     return {};

--- a/testapi.pm
+++ b/testapi.pm
@@ -1559,7 +1559,8 @@ tests to select
 You need to do this in your distribution and not in tests. It will not trigger
 any action on the system under test, but only store the parameters.
 
-The console parameters are console specific.
+The console parameters are console specific. Parameter C<persistent> skips
+console reset and console is persistent during the test execution.
 
 I<The implementation is distribution specific and not always available.>
 


### PR DESCRIPTION
Fix poo#57329: PowerVM console is connected and disconnected during
test execution, but it means that not all console messages are
captured. Console should be connected all the time and we need to
skip reset for it.

Related PR in distri: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8718
Verification run: http://10.100.12.105/tests/3348