### PR TITLE
Fix svirt backend's 100 % CPU usage

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -115,8 +115,10 @@ sub run {
 
     bmwqemu::diag "started mgmt loop with pid $$";
 
-    $self->{select} = IO::Select->new();
-    $self->{select}->add($self->{cmdpipe});
+    my $select_read  = $self->{select_read}  = IO::Select->new;
+    my $select_write = $self->{select_write} = IO::Select->new;
+    $select_read->add($self->{cmdpipe});
+    $select_write->add($self->{cmdpipe});
 
     $self->last_update_request("-Inf" + 0);
     $self->last_screenshot(undef);
@@ -199,7 +201,7 @@ sub run_capture_loop {
             }
 
             my $time_to_next = min($time_to_screenshot, $time_to_update_request, $time_to_timeout);
-            my ($read_set, $write_set) = IO::Select->select($self->{select}, $self->{select}, undef, $time_to_next);
+            my ($read_set, $write_set) = IO::Select->select($self->{select_read}, $self->{select_write}, undef, $time_to_next);
 
             # We need to check the video encoder and the serial socket
             my ($video_encoder, $other) = (0, 0);
@@ -207,14 +209,15 @@ sub run_capture_loop {
                 if ($fh == $self->{encoder_pipe}) {
                     # check the video encoder pipe, it has the most traffic
                     my $fdata        = shift @{$self->{video_frame_data}};
-                    my $data_written = $self->{encoder_pipe}->syswrite($fdata);
+                    my $data_written = $fh->syswrite($fdata);
                     die "Encoder not accepting data" unless defined $data_written;
                     if ($data_written != length($fdata)) {
                         # put it back into the queue
                         unshift @{$self->{video_frame_data}}, substr($fdata, $data_written);
                     }
                     if (!@{$self->{video_frame_data}}) {
-                        $self->{select}->remove($self->{encoder_pipe});
+                        $self->{select_read}->remove($fh);
+                        $self->{select_write}->remove($fh);
                     }
                     $video_encoder = 1;
                 }
@@ -233,7 +236,7 @@ sub run_capture_loop {
                 # There are three ways to solve this problem:
                 # + Send a message either to the application protocol (null message) or to the application protocol framing (an empty message)
                 #   Disadvantages: Requires changes on both ends of the communication. (for example: on SSH connection i realized that after a
-                #   while i start getting "bad packet length" errors)
+                #   while I start getting "bad packet length" errors)
                 # + Polling the connections (Note: This is how HTTP servers work when dealing with persistent connections)
                 #    Disadvantages: False positives
                 # + Change the keepalive packet settings
@@ -473,7 +476,9 @@ sub enqueue_screenshot {
         push(@{$self->{video_frame_data}}, $imgdata);
         $self->{min_video_similarity} = 10000;
     }
-    $self->{select}->add($self->{encoder_pipe});
+    my $encoder_pipe = $self->{encoder_pipe};
+    $self->{select_read}->add($encoder_pipe);
+    $self->{select_write}->add($encoder_pipe);
     $self->{video_frame_number} += 1;
 
     $watch->stop();
@@ -1211,7 +1216,8 @@ sub start_ssh_serial {
     }
     $chan->blocking(0);
     $chan->pty(1);
-    $self->{select}->add($self->{serial}->sock);
+    $chan->ext_data('merge');
+    $self->{select_read}->add($ssh->sock);
     return ($ssh, $chan);
 }
 
@@ -1235,13 +1241,12 @@ sub check_ssh_serial {
 sub stop_ssh_serial {
     my ($self) = @_;
 
-    if (!$self->{serial}) {
-        return;
-    }
-    $self->{select}->remove($self->{serial}->sock);
-    $self->{serial}->disconnect;
-    $self->{serial} = undef;
-    return;
+    my $ssh = $self->{serial};
+    return undef unless $ssh;
+
+    $self->{select_read}->remove($ssh->sock);
+    $ssh->disconnect;
+    return $self->{serial} = undef;
 }
 
 # Send TERM signal to any child process

--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -314,9 +314,13 @@ sub start_serial_grab {
     else {
         $cmd = 'virsh console ' . $name;
     }
+
+    bmwqemu::diag('svirt: grabbing serial console');
+    $ssh->blocking(1);
     if (!$chan->exec($cmd)) {
-        bmwqemu::diag('Unable to grab serial console at this point: ' . ($ssh->error // 'unknown SSH error'));
+        bmwqemu::diag('svirt: unable to grab serial console at this point: ' . ($ssh->error // 'unknown SSH error'));
     }
+    $ssh->blocking(0);
 }
 
 =head2 ($ssh, $chan) = $self->backend->start_serial_grab($name, %args)

--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -395,7 +395,7 @@ sub serial_terminal_log_file {
 sub check_socket {
     my ($self, $fh, $write) = @_;
 
-    if ($self->check_ssh_serial($fh)) {
+    if ($self->check_ssh_serial($fh, $write)) {
         return 1;
     }
     return $self->SUPER::check_socket($fh, $write);

--- a/consoles/sshIucvconn.pm
+++ b/consoles/sshIucvconn.pm
@@ -49,9 +49,12 @@ sub connect_remote {
     # ssh connection to SUT for iucvconn
     my ($ssh, $serialchan) = $self->backend->start_ssh_serial(hostname => $args->{hostname}, password => $args->{password}, username => 'root');
     # start iucvconn
+    bmwqemu::diag('ssh iucvconn: grabbing serial console');
+    $ssh->blocking(1);
     if (!$serialchan->exec("iucvconn $zvmguest lnxhvc0")) {
-        bmwqemu::diag('Unable to grab serial console at this point: ' . ($ssh->error // 'unknown SSH error'));
+        bmwqemu::diag('ssh iucvconn: unable to grab serial console at this point: ' . ($ssh->error // 'unknown SSH error'));
     }
+    $ssh->blocking(0);
 }
 
 # to be called on reconnect

--- a/consoles/sshXtermVt.pm
+++ b/consoles/sshXtermVt.pm
@@ -53,9 +53,12 @@ sub activate {
         );
 
         # start iucvconn
+        bmwqemu::diag('ssh xterm vt: grabbing serial console');
+        $ssh->blocking(1);
         if (!$serialchan->exec($serial)) {
-            bmwqemu::diag('Unable to grab serial console at this point: ' . ($ssh->error // 'unknown SSH error'));
+            bmwqemu::diag('ssh xterm vt: unable to grab serial console at this point: ' . ($ssh->error // 'unknown SSH error'));
         }
+        $ssh->blocking(0);
     }
 }
 

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -39,8 +39,7 @@ $distri->mock(add_console => sub {
 });
 $backend_mock->mock(select_console => undef);
 $testapi::distri = distribution->new;
-$backend->{select} = Test::MockObject->new();
-$backend->{select}->set_true('add');
+($backend->{"select_$_"} = Test::MockObject->new)->set_true('add') for qw(read write);
 ok($backend->start_qemu(),      'qemu can be started');
 ok(exists $called{add_console}, 'a console has been added');
 is($called{add_console}, 1, 'one console has been added');


### PR DESCRIPTION
See the particular commit messages and https://progress.opensuse.org/issues/33529.

---

So far I tested this only locally using svirt/QEMU (see https://github.com/Martchus/openQA-helper#testrun-svirt-backend-locally). I started a job and paused it when the SUT was running using the developer mode. Without this change isotovideo's backend process fully occupies one CPU core. With this change it drops to 1 % when idling. The warning about using `readline()` in async mode is gone, too.