### PR TITLE
Remove status API call

### DIFF
--- a/commands.pm
+++ b/commands.pm
@@ -232,7 +232,7 @@ sub isotovideo_command {
 
 sub isotovideo_get {
     my ($c) = @_;
-    return isotovideo_command($c, [qw(status version)]);
+    return isotovideo_command($c, [qw(version)]);
 }
 
 sub isotovideo_post {


### PR DESCRIPTION
The status API call is not used anymore since:
https://github.com/os-autoinst/os-autoinst/pull/1212

It is now writing a status file.

The corresponding PR in openQA to use the status file:
https://github.com/os-autoinst/openQA/pull/2327

Issue: https://progress.opensuse.org/issues/39845

Once openQA is deployed this can be merged.