### PR TITLE
Improve here tag handling in script_output()

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -239,6 +239,7 @@ sub script_output {
         bmwqemu::log_call("Content of $script_path :\n \"$cat\" \n");
         testapi::type_string($cat . "\n");
         testapi::wait_serial("$cat", no_regex => 1, quiet => $args{quiet});
+        testapi::wait_serial('> ',   no_regex => 1, quiet => $args{quiet});
         testapi::type_string("$script\n$heretag\n");
         testapi::wait_serial("> $heretag", no_regex => 1, quiet => $args{quiet});
         testapi::wait_serial("$marker-0-", quiet => $args{quiet});


### PR DESCRIPTION
We observed from time to time that script_output() return wrong
or none output from executed script.
A reason is, that script_output() struggles to identify
script-start and script-end markers.
When the error happens, we see that the final wait_serial("> $heretag")
fail. With this, I'm not sure what's the reason. But what also happen is,
that the $script appear twice, which seems to be a cause of typing to
early. So hopefully waiting for the input prompt '> ' will solve it.

Example output:
```
 # cat > /tmp/scriptfY1mJ.sh << 'EOT_fY1mJ'; echo fY1mJ-$?-
 grep -c 'menuentry .SLES \?12-SP5.*(ima_policy=tcb)' /boot/grub2/grub.cfg
 EOT_fY1mJ
 echo fY1mJ; bash -oe pipefail /tmp/scriptfY1mJ.sh ; echo
 SCRIPT_FINISHEDfY1mJ-$?-
 > grep -c 'menuentry .SLES \?12-SP5.*(ima_policy=tcb)' /boot/grub2/grub.cfg
 > EOT_fY1mJ
 fY1mJ-0-
 # echo fY1mJ; bash -oe pipefail /tmp/scriptfY1mJ.sh ; echo
 SCRIPT_FINISHEDfY1mJ-$?-
 fY1mJ
 3
 SCRIPT_FINISHEDfY1mJ-0-
```

ticket: https://progress.opensuse.org/issues/58697
VR: http://cfconrad-vm.qa.suse.de/tests/6130#