### PR TITLE
myjsonrpc: Go back to incremental parsing

### DIFF
--- a/t/24-myjsonrpc-debug.t
+++ b/t/24-myjsonrpc-debug.t
@@ -55,7 +55,6 @@ subtest debug_json => sub {
     my @warnings = warnings { debug() };
     like($warnings[0], qr{send_json});
     like($warnings[1], qr{read_json});
-    like($warnings[2], qr{_parse_json});
 };
 
 close $isotovideo;


### PR DESCRIPTION
The strategy to look for the next newline was too slow.

The time for `read_json()` increased to about 4-5 times with the changes introduced in #1230

https://progress.opensuse.org/issues/58823 "os-autoinst is too slow pressing F2 causing ARM tests to fail in "boot_to_desktop"

The `write_json` seemed to fail sometimes because the read took too long, resulting in test failures.