### PR TITLE
Increase the read buffer for JSON RPC

### DIFF
--- a/myjsonrpc.pm
+++ b/myjsonrpc.pm
@@ -24,6 +24,7 @@ use Mojo::JSON;    # booleans
 use Cpanel::JSON::XS ();
 
 use constant DEBUG_JSON => $ENV{PERL_MYJSONRPC_DEBUG} || 0;
+use constant READ_BUFFER => $ENV{PERL_MYJSONRPC_BYTES} || 8000000;
 
 sub send_json {
     my ($to_fd, $cmd) = @_;
@@ -120,7 +121,7 @@ sub read_json {
         }
 
         my $qbuffer;
-        my $bytes = sysread($socket, $qbuffer, 8000);
+        my $bytes = sysread($socket, $qbuffer, READ_BUFFER);
         #bmwqemu::diag("sysread $qbuffer");
         if (!$bytes) { bmwqemu::diag("sysread failed: $!"); return; }
         $cjx->incr_parse($qbuffer);


### PR DESCRIPTION
As we learned yesterday the JSON can be easily several megabytes, so reading them by pages doesn't really make sense as we just keep the CPU busy trying to parse JSON. So try to read all of it in one go