### PR TITLE
Implement shutdown check for spvm backend

### DIFF
--- a/backend/spvm.pm
+++ b/backend/spvm.pm
@@ -74,7 +74,7 @@ sub run_cmd {
         username => get_var('NOVALINK_USERNAME', 'root'));
     my $chan = $ssh->channel() || $ssh->die_with_error();
     $chan->exec($cmd) || $ssh->die_with_error();
-    get_ssh_output($chan);
+    backend::svirt::get_ssh_output($chan);
     $chan->send_eof();
     my $ret = $chan->exit_status();
     bmwqemu::diag "Command executed: $cmd, ret=$ret";
@@ -89,8 +89,8 @@ sub can_handle {
 
 sub is_shutdown {
     my ($self) = @_;
-    # TODO
-    return 0;
+    my $lpar_id = get_required_var('NOVALINK_LPAR_ID');
+    return $self->run_cmd("! pvmctl  lpar list -i id=${lpar_id} | grep  'not a'");
 }
 
 sub check_socket {


### PR DESCRIPTION
Enhancement poo#58871: Function is_shutdown contained only TODO
placeholder. Status check for lpar on PowerVM is implemented now.

Progress: https://progress.opensuse.org/issues/58871

Verification run: http://10.100.12.105/tests/3467

Verification logs:
```
[2019-10-31T17:34:27.884 CET] [debug] <<< testapi::type_string(string='poweroff
', max_interval=250, wait_screen_changes=0, wait_still_screen=0, timeout=30, similarity_level=47)
[2019-10-31T17:34:28.107 CET] [debug] /var/lib/openqa/share/tests/sle/tests/kernel/shutdown_ltp.pm:47 called power_action_utils::power_action
[2019-10-31T17:34:28.107 CET] [debug] <<< testapi::check_shutdown(timeout=60)
[2019-10-31T17:34:28.427 CET] [debug] Connection to padmin@vugava.arch.suse.de established
[2019-10-31T17:34:30.125 CET] [debug] Command's stderr:
tput: No value for $TERM and no -T specified
[2019-10-31T17:34:30.125 CET] [debug] Command executed: ! pvmctl  lpar list -i id=3 | grep  'not a', ret=0
[2019-10-31T17:34:31.959 CET] [debug] Connection to padmin@vugava.arch.suse.de established
[2019-10-31T17:34:33.635 CET] [debug] Command's stderr:
tput: No value for $TERM and no -T specified
[2019-10-31T17:34:33.635 CET] [debug] Command executed: ! pvmctl  lpar list -i id=3 | grep  'not a', ret=0
[2019-10-31T17:34:34.955 CET] [debug] Connection to padmin@vugava.arch.suse.de established
[2019-10-31T17:34:36.652 CET] [debug] Command's stdout:
| vugav> | 3  | not a> | inact> | AIX/L> |  00000>  | 125952 |  1  |     |
[2019-10-31T17:34:36.653 CET] [debug] Command's stderr:
tput: No value for $TERM and no -T specified
[2019-10-31T17:34:36.653 CET] [debug] Command executed: ! pvmctl  lpar list -i id=3 | grep  'not a', ret=1
[2019-10-31T17:34:36.722 CET] [debug] ||| finished shutdown_ltp kernel at 2019-10-31 16:34:36 (97 s)
```