### PR TITLE
Prevent incompatible overwriting of source qcow images

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -144,6 +144,19 @@ sub init {
         });
 }
 
+sub _check_publish_vars {
+    return 0 unless my $nd = $vars{NUMDISKS};
+    my @hdds = map { $vars{"HDD_$_"} } 1 .. $nd;
+    for my $i (1 .. $nd) {
+        for my $type (qw(STORE PUBLISH FORCE_PUBLISH)) {
+            my $name = $type . "_HDD_$i";
+            next unless my $out = $vars{$name};
+            die "HDD_$i also specified in $name. This is not supported" if grep { $_ eq $out } @hdds;
+        }
+    }
+    return 1;
+}
+
 sub ensure_valid_vars {
     # defaults
     $vars{QEMUPORT} ||= 15222;
@@ -162,7 +175,7 @@ sub ensure_valid_vars {
 
     die "CASEDIR variable not set, unknown test case directory" if !defined $vars{CASEDIR};
     die "No scripts in $vars{CASEDIR}" if !-e "$vars{CASEDIR}";
-
+    _check_publish_vars();
     save_vars();
 }
 

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -117,7 +117,7 @@ our $scriptdir;
 sub init {
     load_vars();
 
-    $bmwqemu::vars{BACKEND} ||= "qemu";
+    $vars{BACKEND} ||= "qemu";
 
     # remove directories for asset upload
     remove_tree("assets_public");

--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -18,6 +18,7 @@
 use 5.018;
 use warnings;
 use Test::More;
+use Test::Exception;
 use File::Temp 'tempdir';
 use File::Basename;
 use File::Path 'make_path';
@@ -99,6 +100,14 @@ subtest 'save_vars no_secret' => sub {
     my %vars = %{read_vars()};
     ok(!$vars{_SECRET_TEST}, '_SECRET_TEST not written to vars.json');
     is($vars{CASEDIR}, $dir, 'CASEDIR unchanged');
+};
+
+subtest 'HDD variables sanity check' => sub {
+    use bmwqemu ();
+    %bmwqemu::vars = (NUMDISKS => 1, HDD_1 => 'foo.qcow2', PUBLISH_HDD_1 => 'bar.qcow2');
+    ok(bmwqemu::_check_publish_vars, 'one HDD for reading, one for publishing is ok');
+    $bmwqemu::vars{PUBLISH_HDD_1} = 'foo.qcow2';
+    throws_ok { bmwqemu::_check_publish_vars } qr/HDD_1 also specified in PUBLISH/, 'overwriting source HDD is prevented';
 };
 
 done_testing;

--- a/testapi.pm
+++ b/testapi.pm
@@ -747,7 +747,7 @@ sub get_required_var {
   set_var($variable, $value [, reload_needles => 1] );
 
 Set test variable C<$variable> to value C<$value>.
-Variables starting with C<_SECRET_> will not appear in the vars.json file.
+Variables starting with C<_SECRET_> will not appear in the C<vars.json> file.
 
 Specify a true value for the C<reload_needles> flag to trigger a reloading
 of needles in the backend and call the cleanup handler with the new variables


### PR DESCRIPTION
Previously an upload was attempted eventually failing within openQA with
a DB constraint trying to overwrite the source qcow image. This
situation should be caught also to prevent not reproducible tests due to
changed image content.

Related progress issue: https://progress.opensuse.org/issues/20788