### PR TITLE
send_key: limit rate with VNC_TYPING_LIMIT

### DIFF
--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -20,6 +20,8 @@ use Try::Tiny;
 use Scalar::Util 'blessed';
 use OpenQA::Exceptions;
 
+use constant DEFAULT_KEY_PRESS_RELEASE_DELAY_US => 20_000; # default to 20 ms
+
 __PACKAGE__->mk_accessors(
     qw(hostname port username password socket name width height depth
       no_endian_conversion  _pixinfo _colourmap _framebuffer _rfb_version screen_on
@@ -723,7 +725,7 @@ sub init_ikvm_keymap {
 sub map_and_send_key {
     my ($self, $keys, $down_flag, $press_release_delay_us) = @_;
 
-    $press_release_delay_us //= 2_000;    # default to 2 ms
+    $press_release_delay_us //= DEFAULT_KEY_PRESS_RELEASE_DELAY_US;
 
     if ($self->ikvm) {
         $self->init_ikvm_keymap;

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -721,7 +721,9 @@ sub init_ikvm_keymap {
 
 
 sub map_and_send_key {
-    my ($self, $keys, $down_flag) = @_;
+    my ($self, $keys, $down_flag, $press_release_delay_us) = @_;
+
+    $press_release_delay_us //= 2_000;    # default to 2 ms
 
     if ($self->ikvm) {
         $self->init_ikvm_keymap;
@@ -755,15 +757,17 @@ sub map_and_send_key {
     if (!defined $down_flag || $down_flag == 1) {
         for my $key (@events) {
             $self->send_key_event_down($key);
+            usleep($press_release_delay_us);
         }
     }
-    usleep(2_000);
+    usleep($press_release_delay_us);
     if (!defined $down_flag || $down_flag == 0) {
         for my $key (reverse @events) {
             $self->send_key_event_up($key);
+            usleep($press_release_delay_us);
         }
     }
-    usleep(2_000);
+    usleep($press_release_delay_us);
 }
 
 sub send_pointer_event {

--- a/consoles/vnc_base.pm
+++ b/consoles/vnc_base.pm
@@ -141,8 +141,8 @@ sub send_key {
     my ($self, $args) = @_;
 
     # send_key rate must be limited to take into account VNC_TYPING_LIMIT- poo#55703
-    # map_and_send_key default value is 2 ms, so do not be faster.
-    my $press_release_delay_us = max(2_000, 1_000_000 / (get_var('VNC_TYPING_LIMIT', 50) || 1));
+    # map_and_send_key: do not be faster than default
+    my $press_release_delay_us = max(consoles::VNC->DEFAULT_KEY_PRESS_RELEASE_DELAY_US, 1_000_000 / (get_var('VNC_TYPING_LIMIT', 50) || 1));
 
     $self->{vnc}->map_and_send_key($args->{key}, undef, $press_release_delay_us);
     $self->backend->run_capture_loop(.2);


### PR DESCRIPTION
- ticket: https://progress.opensuse.org/issues/55703

Update `send_key` to respect `VNC_TYPING_LIMIT`, which required update on `map_and_send_key`.