### PR TITLE
Get rid of unhelpful log about "unknown process"

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -361,13 +361,6 @@ sub exec_qemu {
     my $self   = shift;
     my @params = $self->gen_cmdline();
     session->enable;
-
-    session->on(
-        collected_orphan => sub {
-            my ($session, $p) = @_;
-            bmwqemu::diag("Collected unknown process with pid " . $p->pid . " and exit status: " . $p->exit_status);
-        });
-
     bmwqemu::diag("starting: " . join(" ", @params));
     session->enable_subreaper;
     $self->_process->code(sub {


### PR DESCRIPTION
I assume the log message had been added for temporary debugging but is probably
not that helpful in the long run as only the PID of an already terminated
subprocess of process is printed which can happen multiple times during a test
run even between single test API call messages like in the following example:

```
[2019-11-09T15:04:55.051 CET] [debug] <<< testapi::wait_serial(timeout=300, quiet=undef, record_output=undef, expect_not_found=0, buffer_size=undef, regexp=qr/WnO8K-\d+-/, no_regex=0)
[2019-11-09T15:05:01.0829 CET] [debug] [pid:5140] Collected unknown process with pid 26762 and exit status: 0
[2019-11-09T15:05:12.0046 CET] [debug] [pid:5140] Collected unknown process with pid 26765 and exit status: 0
[2019-11-09T15:05:22.0161 CET] [debug] [pid:5140] Collected unknown process with pid 26778 and exit status: 0
[2019-11-09T15:05:32.0303 CET] [debug] [pid:5140] Collected unknown process with pid 26780 and exit status: 0
[2019-11-09T15:05:42.0420 CET] [debug] [pid:5140] Collected unknown process with pid 26786 and exit status: 0
[2019-11-09T15:05:52.0638 CET] [debug] [pid:5140] Collected unknown process with pid 26859 and exit status: 0
[2019-11-09T15:06:02.0777 CET] [debug] [pid:5140] Collected unknown process with pid 26878 and exit status: 0
[2019-11-09T15:06:12.0912 CET] [debug] [pid:5140] Collected unknown process with pid 26891 and exit status: 0
[2019-11-09T15:06:23.0035 CET] [debug] [pid:5140] Collected unknown process with pid 26897 and exit status: 0
[2019-11-09T15:06:33.0134 CET] [debug] [pid:5140] Collected unknown process with pid 26935 and exit status: 0
[2019-11-09T15:06:43.0293 CET] [debug] [pid:5140] Collected unknown process with pid 26955 and exit status: 0
[2019-11-09T15:06:53.0436 CET] [debug] [pid:5140] Collected unknown process with pid 26990 and exit status: 0
[2019-11-09T15:07:03.0551 CET] [debug] [pid:5140] Collected unknown process with pid 26992 and exit status: 0
[2019-11-09T15:07:13.0710 CET] [debug] [pid:5140] Collected unknown process with pid 26995 and exit status: 0
[2019-11-09T15:07:23.0850 CET] [debug] [pid:5140] Collected unknown process with pid 26997 and exit status: 0
[2019-11-09T15:07:30.629 CET] [debug] >>> testapi::wait_serial: (?^:WnO8K-\d+-): ok
```