### PR TITLE
Fix custom needle dir checkouts by removing check for "working directory"

### DIFF
--- a/needle.pm
+++ b/needle.pm
@@ -59,6 +59,7 @@ sub new {
     # - This code initializes $json->{file} so it contains the path within the needle directory.
     # - $jsonfile is re-assigned to contain the absolute path the the JSON file.
     # - The needle must be within the needle directory.
+    $needledir //= '';
     if (index($jsonfile, $needledir) == 0) {
         $self->{file} = substr($jsonfile, length($needledir) + 1);
     }
@@ -325,10 +326,6 @@ sub init {
     my $user_provided_needles_dir = $bmwqemu::vars{NEEDLES_DIR};
     if (defined $user_provided_needles_dir) {
         $user_provided_needles_dir = File::Spec->rel2abs($user_provided_needles_dir) unless File::Spec->file_name_is_absolute($user_provided_needles_dir);
-        if (index($user_provided_needles_dir, cwd) != 0) {
-            $bmwqemu::vars{NEEDLES_DIR} = $user_provided_needles_dir = undef;
-            bmwqemu::diag('Ignoring needle dir specified via NEEDLES_DIR because it is not within the current working directory.');
-        }
     }
 
     # initialize/re-assign global $needledir

--- a/t/01-test_needle.t
+++ b/t/01-test_needle.t
@@ -388,24 +388,6 @@ subtest 'needle::init accepts custom NEEDLES_DIR within working directory and ot
         Mojo::File->new($misc_needle_dir, "click-point.$extension")->copy_to("$needles_dir/subdir/foo.$extension");
     }
 
-    subtest 'custom NEEDLES_DIR ignored when not within working directory' => sub {
-        $bmwqemu::vars{PRODUCTDIR} = '/does/not/exist';    # set PRODUCTDIR as it is used to deduce the default needle dir
-        combined_like(
-            sub {
-                throws_ok(
-                    sub {
-                        needle::init;
-                    },
-                    qr{needledir not found: /does/not/exist/needles}s,
-                    'attempt to use default needle dir (which does not exist here)'
-                );
-            },
-            qr{Ignoring needle dir specified via NEEDLES_DIR because it is not within the current working directory\.}s,
-            'custom needle dir outside cwd ignored'
-        );
-        is($bmwqemu::vars{NEEDLES_DIR}, undef, 'custom needle directory unset if ignored');
-    };
-
     subtest 'custom NEEDLES_DIR used when within working directory' => sub {
         note("using working directory $temp_working_dir");
         chdir($temp_working_dir);


### PR DESCRIPTION
Verification run: https://openqa.opensuse.org/tests/1083314

Related progress issue: https://progress.opensuse.org/issues/59330