### PR TITLE
Improve OCR test to avoid default-initialization of needles dir

### DIFF
--- a/needle.pm
+++ b/needle.pm
@@ -47,6 +47,8 @@ sub is_click_point_valid {
 sub new {
     my ($classname, $jsonfile) = @_;
 
+    die 'needles not initialized via needle::init() before needle constructor called' unless defined $needledir;
+
     my $json;
     if (ref $jsonfile eq 'HASH') {
         $json     = $jsonfile;
@@ -59,7 +61,6 @@ sub new {
     # - This code initializes $json->{file} so it contains the path within the needle directory.
     # - $jsonfile is re-assigned to contain the absolute path the the JSON file.
     # - The needle must be within the needle directory.
-    $needledir //= '';
     if (index($jsonfile, $needledir) == 0) {
         $self->{file} = substr($jsonfile, length($needledir) + 1);
     }

--- a/t/01-test_needle.t
+++ b/t/01-test_needle.t
@@ -24,6 +24,14 @@ BEGIN {
 use needle;
 use cv;
 
+throws_ok(
+    sub {
+        needle->new('foo.json');
+    },
+    qr{needles not initialized}s,
+    'died when constructing needle without prior call to needle::init()'
+);
+
 cv::init();
 require tinycv;
 

--- a/t/02-test_ocr.t
+++ b/t/02-test_ocr.t
@@ -10,8 +10,9 @@ use File::Basename;
 
 BEGIN {
     unshift @INC, '..';
-    $bmwqemu::vars{DISTRI}  = "unicorn";
-    $bmwqemu::vars{CASEDIR} = "/var/lib/empty";
+    $bmwqemu::vars{DISTRI}      = 'unicorn';
+    $bmwqemu::vars{CASEDIR}     = '/var/lib/empty';
+    $bmwqemu::vars{NEEDLES_DIR} = dirname(__FILE__) . '/data';
 }
 
 use needle;
@@ -26,14 +27,12 @@ unless (which('tesseract')) {
     exit(0);
 }
 
-my ($res, $needle, $img1);
+needle::init;
 
-my $data_dir = dirname(__FILE__) . '/data/';
-$img1 = tinycv::read($data_dir . "bootmenu.test.png");
-
-$needle = needle->new($data_dir . "bootmenu-ocr.ref.json");
-$res    = $img1->search($needle);
-ok(defined $res, "ocr match 1");
+my $img1   = tinycv::read("$needle::needledir/bootmenu.test.png");
+my $needle = needle->new('bootmenu-ocr.ref.json');
+my $res    = $img1->search($needle);
+ok(defined $res, 'ocr match 1');
 
 my $ocr;
 for my $area (@{$res->{needle}->{area}}) {


### PR DESCRIPTION
This way it is clear that needle::init() must be called before constructing needle objects and we don't silently ignore if that didn't happen.