### PR TITLE
qemu: Fix MAKETESTSNAPSHOTS with test modules in nested dirs

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -451,7 +451,7 @@ sub save_snapshot {
 
     mkpath(VM_SNAPSHOTS_DIR);
     $self->_migrate_to_file(
-        filename         => VM_SNAPSHOTS_DIR . '/' . $snapshot->name,
+        filename         => File::Spec->catfile(VM_SNAPSHOTS_DIR, $snapshot->name),
         compress_level   => $vars->{QEMU_COMPRESS_LEVEL} || 6,
         compress_threads => $vars->{QEMU_COMPRESS_THREADS} // $vars->{QEMUCPUS},
         max_bandwidth    => $vars->{QEMU_MAX_BANDWIDTH});

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -22,6 +22,7 @@ use autodie ':all';
 
 use base 'backend::virt';
 
+use File::Basename 'dirname';
 use File::Path 'mkpath';
 use File::Spec;
 use File::Which;
@@ -186,6 +187,7 @@ sub open_file_and_send_fd_to_qemu {
     my ($self, $path, $fdname) = @_;
     my $rsp;
 
+    mkpath(dirname($path));
     my $fd = POSIX::open($path, POSIX::O_CREAT() | POSIX::O_RDWR());
     die "Failed to open $path: $!" unless (defined $fd);
 
@@ -449,7 +451,6 @@ sub save_snapshot {
             diag('blockdev-snapshot-sync(' . Dumper($req) . ') -> ' . Dumper($rsp));
     });
 
-    mkpath(VM_SNAPSHOTS_DIR);
     $self->_migrate_to_file(
         filename         => File::Spec->catfile(VM_SNAPSHOTS_DIR, $snapshot->name),
         compress_level   => $vars->{QEMU_COMPRESS_LEVEL} || 6,


### PR DESCRIPTION
When MAKETESTSNAPSHOTS is used with test modules which reside in
multiple layers of directories, e.g. "openqa/tests/install" the
necessary directory structure would not be created and snapshot creation
would fail. By ensuring the prerequisite parent directories on creation
of the snapshot files this can be fixed.

Tested locally with

```
openqa-clone-job https://openqa.opensuse.org/tests/1080059 MAKETESTSNAPSHOTS=1
```

cloning a job from the test scenario
"openqa-Tumbleweed-dev-x86_64-Build:TW.3350-openqa_install+publish@64bit-2G"
based on the test distribution
https://github.com/os-autoinst/os-autoinst-distri-openQA/