### PR TITLE
Prevent confusing call stack-trace from send_json on shutdown

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -1011,7 +1011,7 @@ sub handle_qmp_command {
     else {
         $wb = syswrite($sk, $line);
     }
-    die "syswrite failed $!" unless ($wb == length($line));
+    die "handle_qmp_command: syswrite failed $!" unless ($wb == length($line));
 
     my $hash;
     while (!$hash) {

--- a/myjsonrpc.pm
+++ b/myjsonrpc.pm
@@ -52,7 +52,11 @@ sub send_json {
     $json .= "\n";
 
     my $wb = syswrite($to_fd, "$json");
-    confess "syswrite failed $!" unless ($wb && $wb == length($json));
+    if (!$wb || !$wb == length($json)) {
+        confess "syswrite failed: $!" if DEBUG_JSON;
+        # remote end most likely terminated on request, silently ignore
+        return undef;
+    }
     return $cmdcopy{json_cmd_token};
 }
 
@@ -126,7 +130,6 @@ sub read_json {
 
         my $qbuffer;
         my $bytes = sysread($socket, $qbuffer, READ_BUFFER);
-        #bmwqemu::diag("sysread $qbuffer");
         if (!$bytes) { bmwqemu::diag("sysread failed: $!"); return; }
         $cjx->incr_parse($qbuffer);
     }


### PR DESCRIPTION
E.g. see https://openqa.opensuse.org/tests/1083172/file/autoinst-log.txt
with

```
[2019-11-12T09:04:09.879 CET] [debug] no match: 245.3s, best candidate: bootloader-grub2-leap150-20180427 (0.29)
[2019-11-12T09:04:09.889 CET] [debug] no change: 240.0s
[2019-11-12T09:04:10.884 CET] [debug] no change: 239.0s
[2019-11-12T09:04:19.091 CET] [debug] backend process exited: 0
[2019-11-12T09:04:19.139 CET] [debug] Driver backend collected unknown process with pid 4420 and exit status: 0
[2019-11-12T09:04:19.152 CET] [debug] sysread failed:
[2019-11-12T09:04:19.232 CET] [debug] killing command server 4234 because test execution ended
[2019-11-12T09:04:19.263 CET] [debug] isotovideo: informing websocket clients before stopping command server: http://127.0.0.1:20043/pVXii4EhoNO6YvWO/broadcast
[2019-11-12T09:04:22.497 CET] [debug] commands process exited: 0
[2019-11-12T09:04:23.521 CET] [debug] done with command server
[2019-11-12T09:04:23.535 CET] [debug] killing autotest process 4381
[2019-11-12T09:04:23.544 CET] [debug] sysread failed:
[2019-11-12T09:04:23.979 CET] [debug] syswrite failed Broken pipe at /usr/lib/os-autoinst/myjsonrpc.pm line 54.
	myjsonrpc::send_json(GLOB(0xaaaae81358c8), HASH(0xaaaae5ea79c8)) called at /usr/lib/os-autoinst/autotest.pm line 327
	autotest::query_isotovideo("backend_last_screenshot_data") called at /usr/lib/os-autoinst/basetest.pm line 532
	basetest::_result_add_screenshot(boot_to_desktop=HASH(0xaaaae7846150), HASH(0xaaaae7882de8)) called at /usr/lib/os-autoinst/basetest.pm line 559
	basetest::take_screenshot(boot_to_desktop=HASH(0xaaaae7846150)) called at /usr/lib/os-autoinst/basetest.pm line 363
	basetest::runtest(boot_to_desktop=HASH(0xaaaae7846150)) called at /usr/lib/os-autoinst/autotest.pm line 371
	eval {...} called at /usr/lib/os-autoinst/autotest.pm line 371
	autotest::runalltests() called at /usr/lib/os-autoinst/autotest.pm line 228
	eval {...} called at /usr/lib/os-autoinst/autotest.pm line 228
	autotest::run_all() called at /usr/lib/os-autoinst/autotest.pm line 281
	autotest::__ANON__(Mojo::IOLoop::ReadWriteProcess=HASH(0xaaaae8200a80)) called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 325
	eval {...} called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 325
	Mojo::IOLoop::ReadWriteProcess::_fork(Mojo::IOLoop::ReadWriteProcess=HASH(0xaaaae8200a80), CODE(0xaaaae7846a68)) called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 476
	Mojo::IOLoop::ReadWriteProcess::start(Mojo::IOLoop::ReadWriteProcess=HASH(0xaaaae8200a80)) called at /usr/lib/os-autoinst/autotest.pm line 282
	autotest::start_process() called at /usr/bin/isotovideo line 306
```

While there is a problem, e.g. that there is simply no message after
"09:04:10.884" for 9 seconds the syswrite stack trace most likely never helps.
As we have a debug switch which we can control from runtime we can still enable
it when needed.