### PR TITLE
Allow unsetting 'fatal' test flag without snapshot support

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -381,7 +381,7 @@ sub runalltests {
                 if ($bmwqemu::vars{DUMP_MEMORY_ON_FAIL}) {
                     query_isotovideo('backend_save_memory_dump', {filename => $fullname});
                 }
-                if ($flags->{fatal} || $t->{fatal_failure} || !$snapshots_supported || $bmwqemu::vars{TESTDEBUG}) {
+                if ($t->{fatal_failure} || $flags->{fatal} || (!exists $flags->{fatal} && !$snapshots_supported) || $bmwqemu::vars{TESTDEBUG}) {
                     bmwqemu::stop_vm();
                     return 0;
                 }

--- a/t/fake/tests/ignore_failure.pm
+++ b/t/fake/tests/ignore_failure.pm
@@ -5,7 +5,7 @@ use base 'basetest';
 sub run { }
 
 sub test_flags {
-    return {ignore_failure => 1};
+    return {ignore_failure => 1, fatal => 0};
 }
 
 1;


### PR DESCRIPTION
This enables the workflow described in the following ticket:
https://progress.opensuse.org/issues/58166

However, it does *not* change the default behavior. So when tests
without snapshot support fail they are still stopped by default. Only
when `fatal => 0` is set via `test_flags` the job will continue. Of
course no rollback to previous snapshots is done.

Note that this also affects the QEMU backend when snapshots are not
available (e.g. `QEMU_DISABLE_SNAPSHOTS` has been set).