### PR TITLE
Make qemu boot menu optional to save 5s in every qemu test run

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -838,20 +838,23 @@ sub start_qemu {
             sp('append', "dhcp && sanhook iscsi:$vars->{WORKER_HOSTNAME}::3260:1:$vars->{NBF}", no_quotes => 1);
         }
 
+        my @boot_args;
+        push @boot_args, ('menu=on,splash-time=' . $vars->{BOOT_MENU_TIMEOUT} // '5000') if $vars->{BOOT_MENU};
         if ($arch_supports_boot_order) {
             if (($vars->{PXEBOOT} // '') eq 'once') {
-                sp("boot", "once=n");
+                push @boot_args, 'once=n';
             }
             elsif ($vars->{PXEBOOT}) {
-                sp("boot", "n");
+                push @boot_args, 'n';
             }
             elsif ($vars->{BOOTFROM}) {
-                sp("boot", [qv "order=$vars->{BOOTFROM} menu=on splash-time=5000"]);
+                push @boot_args, "order=$vars->{BOOTFROM}";
             }
             else {
-                sp("boot", [qw(once=d menu=on splash-time=5000)]);
+                push @boot_args, 'once=d';
             }
         }
+        sp('boot', join(',', @boot_args)) if @boot_args;
 
         if (!$vars->{UEFI} && $vars->{BIOS}) {
             sp("bios", $vars->{BIOS});

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -52,6 +52,8 @@ AUTO_INST;;;
 ATACONTROLLER;see qemu -device ?, e. g. for SATA: ich9-ahci;;Controller for ATA devices, needed for connecting disks as SATA.
 BIOS;;;
 BOOT_HDD_IMAGE;boolean;;enables boot from HDD_1 (BOOTFROM has higher priority)
+BOOT_MENU;boolean;enables boot menu for selection of boot device
+BOOT_MENU_TIMEOUT;integer;5000;boot menu timeout in ms. Needs BOOT_MENU
 BOOTFROM;chars;undef;Influences order of boot devices. See qemu -boot option
 CDMODEL;see qemu -device ?;undef;Storage device for virtualized CD
 DELAYED_START;boolean;;delay vm cpu start until resume_vm() is called


### PR DESCRIPTION
See https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8972
for the removal of the unused boot menu handling code.