### PR TITLE
Enhance logs

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -1356,11 +1356,11 @@ sub hide_password {
 }
 
 # Send TERM signal to any child process
-sub _kill_children_processes {
+sub _stop_children_processes {
     my ($self) = @_;
     my $ret;
     for my $pid (@{$self->{children}}) {
-        bmwqemu::diag("killing child $pid");
+        bmwqemu::diag("terminating child $pid");
         kill('TERM', $pid);
         for my $i (1 .. 5) {
             $ret = waitpid($pid, WNOHANG);

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -123,10 +123,10 @@ sub do_start_vm {
     return {};
 }
 
-sub kill_qemu {
+sub stop_qemu {
     my ($self) = (@_);
     $self->{proc}->_process->stop;
-    $self->_kill_children_processes;
+    $self->_stop_children_processes;
 }
 
 sub _dbus_call {
@@ -157,7 +157,7 @@ sub _dbus_call {
 sub do_stop_vm {
     my $self = shift;
     $self->{proc}->save_state();
-    $self->kill_qemu;
+    $self->stop_qemu;
 }
 
 sub can_handle {

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -767,10 +767,6 @@ sub start_qemu {
 
     my $keephdds = $vars->{KEEPHDDS} || $vars->{SKIPTO};
 
-    if ($vars->{AUTO_INST}) {
-        die 'Ironically AUTO_INST has been removed from os-autoinst';
-    }
-
     if ($keephdds) {
         $self->{proc}->load_state();
     } else {

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -1044,7 +1044,7 @@ sub read_qemupipe {
 
 sub close_pipes {
     my ($self) = @_;
-    $self->do_stop_vm();
+    $self->do_stop_vm() if $self->{started};
 
     if (my $qemu_pipe = $self->{qemupipe}) {
         # one last word?
@@ -1069,7 +1069,7 @@ sub is_shutdown {
     my $ret = $self->handle_qmp_command({execute => 'query-status'})->{return}->{status}
       || 'unknown';
 
-    diag("QEMU status is not shutdown it is $ret") if $ret ne 'shutdown';
+    diag("QEMU status is not 'shutdown', it is '$ret'") if $ret ne 'shutdown';
 
     return $ret eq 'shutdown';
 }

--- a/consoles/amtSol.pm
+++ b/consoles/amtSol.pm
@@ -95,7 +95,7 @@ sub disable {
     return unless $self->{serialpid};
     $self->{serial_pipe}->print("GO!\n");
     $self->{serial_pipe}->close;
-    bmwqemu::diag "killing amtterm $self->{serialpid}";
+    bmwqemu::diag "waiting for termination of amtterm $self->{serialpid}";
     my $ret = waitpid($self->{serialpid}, 0);
     $self->{serialpid} = undef;
     return $ret;

--- a/consoles/ipmiSol.pm
+++ b/consoles/ipmiSol.pm
@@ -100,7 +100,7 @@ sub disable {
     return unless $self->{serialpid};
     $self->{serial_pipe}->print("GO!\n");
     $self->{serial_pipe}->close;
-    bmwqemu::diag "killing ipmiconsole $self->{serialpid}";
+    bmwqemu::diag "waiting for termination of ipmiconsole $self->{serialpid}";
     my $ret = waitpid($self->{serialpid}, 0);
     $self->{serialpid} = undef;
     return $ret;

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -48,7 +48,6 @@ IPMI_BACKEND_MC_RESET;boolean;undef;Reset ipmi main board before test for sol co
 |====================
 Variable;Values allowed;Default value;Explanation
 ARCH;x86_64|i686|aarch64|...;depends on tested medium;Architecture of VM.
-AUTO_INST;;;
 ATACONTROLLER;see qemu -device ?, e. g. for SATA: ich9-ahci;;Controller for ATA devices, needed for connecting disks as SATA.
 BIOS;;;
 BOOT_HDD_IMAGE;boolean;;enables boot from HDD_1 (BOOTFROM has higher priority)

--- a/isotovideo
+++ b/isotovideo
@@ -147,17 +147,17 @@ my $cmd_srv_port;
 my $backend_process;
 my $loop = 1;
 
-# note: The subsequently defined kill_* functions are used to tear down the process tree.
+# note: The subsequently defined stop_* functions are used to tear down the process tree.
 #       However, the worker also ensures that all processes are being terminated (and
 #       eventually killed).
 
-sub kill_commands {
+sub stop_commands {
     my ($reason) = @_;
     return unless defined $cmd_srv_process;
     return unless $cmd_srv_process->is_running;
 
     my $pid = $cmd_srv_process->pid;
-    diag("killing command server $pid because $reason");
+    diag("terminating command server $pid because $reason");
 
     # inform websocket clients
     # note: If the job is stopped by the worker because it has been aborted, the worker will send this command
@@ -180,7 +180,7 @@ sub kill_commands {
                     diag("isotovideo: The command server could be under heavy load and the timeout of $timeout seconds has been exceeded. This message is most likely not be related to the MAX_JOB_TIME of the current job possibly being exceeded.");
                 }
                 else {
-                    diag('The command server might have already been killed by the worker after the user has aborted the job or the job timeout has been exceeded.');
+                    diag('The command server might have already been stopped by the worker after the user has aborted the job or the job timeout has been exceeded.');
                 }
             }
         }
@@ -195,19 +195,19 @@ sub kill_commands {
     diag('done with command server');
 }
 
-sub kill_autotest {
+sub stop_autotest {
     return unless defined $testprocess;
 
-    diag('killing autotest process ' . $testprocess->pid);
+    diag('stopping autotest process ' . $testprocess->pid);
     $testprocess->stop() if $testprocess->is_running;
     $testprocess = undef;
     diag('done with autotest process');
 }
 
-sub kill_backend {
+sub stop_backend {
     return unless defined $bmwqemu::backend && $backend_process;
 
-    diag('killing backend process ' . $backend_process->pid);
+    diag('stopping backend process ' . $backend_process->pid);
     $backend_process->stop if $backend_process->is_running;
     $backend_process = undef;
     diag('done with backend process');
@@ -220,9 +220,9 @@ sub signalhandler {
         $loop = 0;
         return;
     }
-    kill_backend;
-    kill_commands("received signal $sig");
-    kill_autotest;
+    stop_backend;
+    stop_commands("received signal $sig");
+    stop_autotest;
     _exit(1);
 }
 
@@ -351,7 +351,7 @@ $command_handler = OpenQA::Isotovideo::CommandHandler->new(
 $command_handler->on(tests_done => sub {
         CORE::close($testfd);
         $testfd = undef;
-        kill_autotest;
+        stop_autotest;
         $loop = 0;
 });
 
@@ -423,12 +423,12 @@ while ($loop) {
 $command_handler->stop_command_processing;
 
 # terminate/kill the command server and let it inform its websocket clients before
-kill_commands('test execution ended');
+stop_commands('test execution ended');
 
 if ($testfd) {
     $return_code = 1;    # unusual shutdown
     CORE::close $testfd;
-    kill_autotest;
+    stop_autotest;
 }
 
 diag 'isotovideo ' . ($return_code ? 'failed' : 'done');
@@ -440,7 +440,7 @@ if (!$return_code) {
         diag "BACKEND SHUTDOWN $clean_shutdown";
     };
 
-    # don't rely on the backend in a sane state if we failed - just kill it later
+    # don't rely on the backend in a sane state if we failed - just stop it later
     eval { bmwqemu::stop_vm(); };
     if ($@) {
         diag "Error during stop_vm: $@";
@@ -503,9 +503,9 @@ sub handle_generated_assets {
 handle_generated_assets;
 
 END {
-    kill_backend;
-    kill_commands('test execution ended through exception');
-    kill_autotest;
+    stop_backend;
+    stop_commands('test execution ended through exception');
+    stop_autotest;
 
     # in case of early exit, e.g. help display
     $return_code //= 0;

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -7,6 +7,7 @@ use warnings;
 use Test::More;
 use Test::MockModule;
 use Test::MockObject;
+use Test::Output qw(combined_like stderr_like);
 use Test::Warnings;
 
 BEGIN {
@@ -40,7 +41,7 @@ $distri->mock(add_console => sub {
 $backend_mock->mock(select_console => undef);
 $testapi::distri = distribution->new;
 ($backend->{"select_$_"} = Test::MockObject->new)->set_true('add') for qw(read write);
-ok($backend->start_qemu(),      'qemu can be started');
+stderr_like(sub { ok($backend->start_qemu(), 'qemu can be started'); }, qr/running .*chattr/, 'preparing local files');
 ok(exists $called{add_console}, 'a console has been added');
 is($called{add_console}, 1, 'one console has been added');
 


### PR DESCRIPTION
* t: Catch output in 18-backend-qemu.t
* Remove obsolete AUTO_INST after more than a year past c670720d
* Prevent duplicate "Saving QEMU state to qemu_state.json"
* Avoid the word "killing" to have nicer wording and discern it from POSIX "kill"