### PR TITLE
Allow relative "productdir" and "needledir" relative to "casedir"

### DIFF
--- a/isotovideo
+++ b/isotovideo
@@ -281,12 +281,17 @@ if ($bmwqemu::vars{SCHEDULE}) {
     autotest::loadtest($_ . '.pm') foreach split(',', $bmwqemu::vars{SCHEDULE});
     $bmwqemu::vars{INCLUDE_MODULES} = 'none';
 }
-unshift @INC, '.' unless File::Spec->file_name_is_absolute($bmwqemu::vars{PRODUCTDIR});
-if (-e $bmwqemu::vars{PRODUCTDIR} . '/main.pm') {
-    require $bmwqemu::vars{PRODUCTDIR} . '/main.pm';
+my $productdir = $bmwqemu::vars{PRODUCTDIR};
+my $main_path  = File::Spec->catfile($productdir, 'main.pm');
+if (-e $main_path) {
+    unshift @INC, '.';
+    require $main_path;
+}
+elsif (!File::Spec->file_name_is_absolute($productdir) && -e File::Spec->catfile($bmwqemu::vars{CASEDIR}, $main_path)) {
+    require File::Spec->catfile($bmwqemu::vars{CASEDIR}, $main_path);
 }
 elsif (!$bmwqemu::vars{SCHEDULE}) {
-    die '\'SCHEDULE\' not set and ' . $bmwqemu::vars{PRODUCTDIR} . '/main.pm not found, need one of both';
+    die '\'SCHEDULE\' not set and ' . $productdir . '/main.pm not found, need one of both';
 }
 @INC = @oldINC;
 

--- a/needle.pm
+++ b/needle.pm
@@ -323,14 +323,7 @@ sub default_needles_dir {
 }
 
 sub init {
-    # validate that possibly user-provided NEEDLES_DIR is a path within the current working directory (usually the openQA worker's pool directory)
-    my $user_provided_needles_dir = $bmwqemu::vars{NEEDLES_DIR};
-    if (defined $user_provided_needles_dir) {
-        $user_provided_needles_dir = File::Spec->rel2abs($user_provided_needles_dir) unless File::Spec->file_name_is_absolute($user_provided_needles_dir);
-    }
-
-    # initialize/re-assign global $needledir
-    $needledir = ($user_provided_needles_dir // default_needles_dir);
+    $needledir = ($bmwqemu::vars{NEEDLES_DIR} // default_needles_dir);
     die "needledir not found: $needledir (check vars.json?)" unless -d $needledir;
 
     %needles = ();

--- a/needle.pm
+++ b/needle.pm
@@ -324,6 +324,7 @@ sub default_needles_dir {
 
 sub init {
     $needledir = ($bmwqemu::vars{NEEDLES_DIR} // default_needles_dir);
+    $needledir = File::Spec->catdir($bmwqemu::vars{CASEDIR}, $needledir) unless -d $needledir;
     die "needledir not found: $needledir (check vars.json?)" unless -d $needledir;
 
     %needles = ();

--- a/t/01-test_needle.t
+++ b/t/01-test_needle.t
@@ -375,17 +375,6 @@ is($other_needle->get_image, $img2, 'cleaning cache to keep 1 image kept $img2')
 ok($needle->get_image != $img1, 'cleaning cache to keep 1 image deleted $img1');
 is($needle->{file}, 'other-desktop-dvd-20140904.json', 'needle json path is relative to needles dir');
 
-TODO: {
-    local $TODO = 'loading needles outside the needle dir not prevented yet';
-    throws_ok(
-        sub {
-            $needle = needle->new('../misc_needles/click-point.json');
-        },
-        qr{Needle ../misc_needles/click-point.json is not under needle directory}s,
-        'died when accessing needle outside of needledir'
-    );
-}
-
 subtest 'needle::init accepts custom NEEDLES_DIR within working directory and otherwise falls back to "$bmwqemu::vars{PRODUCTDIR}/needles"' => sub {
     # create temporary working directory and a needle directory within it
     my $temp_working_dir = tempdir(CLEANUP => 1);

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -72,6 +72,11 @@ subtest 'productdir variable relative/absolute' => sub {
     symlink("$data_dir/tests/main.pm", "$pool_dir/product/foo/main.pm") unless -e "$pool_dir/product/foo/main.pm";
     isotovideo(opts => "casedir=$data_dir/tests _exit_after_schedule=1 productdir=product/foo");
     is_in_log('\d* scheduling.*shutdown', 'schedule can still be found');
+    unlink("$pool_dir/product/foo/main.pm");
+    mkdir("$data_dir/tests/product") unless -e "$data_dir/tests/product";
+    symlink("$data_dir/tests/main.pm", "$data_dir/tests/product/main.pm") unless -e "$data_dir/tests/product/main.pm";
+    isotovideo(opts => "casedir=$data_dir/tests _exit_after_schedule=1 productdir=product");
+    is_in_log('\d* scheduling.*shutdown', 'schedule can still be found for productdir relative to casedir');
 };
 
 subtest 'upload assets on demand even in failed jobs' => sub {


### PR DESCRIPTION
This might help with being more flexible regarding also custom git
checkouts in openQA as well as in the case of manual calls to isotovideo
not needing the user to provide productdir and/or needledir as absolute
paths when the general expectation is that they reside within casedir
anyway although this is not necessarily required.

Related progress issue: https://progress.opensuse.org/issues/56789