### PR TITLE
Try to catch failures in "reset_consoles" like we do for activate

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -586,7 +586,13 @@ sub reset_consoles {
     # we iterate through all consoles
     for my $console (keys %{$testapi::distri->{consoles}}) {
         next if $self->console($console)->{args}->{persistent};
-        $self->reset_console({testapi_console => $console});
+        try {
+            local $SIG{__DIE__} = 'DEFAULT';
+            $self->reset_console({testapi_console => $console});
+        }
+        catch {
+            return {error => $_};
+        }
     }
     return;
 }

--- a/basetest.pm
+++ b/basetest.pm
@@ -652,20 +652,21 @@ sub standstill_detected {
 # state
 sub rollback_activated_consoles {
     my ($self) = @_;
+    my $ret;
     for my $console (@{$self->{activated_consoles}}) {
         # the backend will only reset its state, and call activate
         # the next time - the console itself might actually not be
         # able to activate a 2nd time, but that's up to the console class
-        autotest::query_isotovideo('backend_reset_console', {testapi_console => $console});
+        $ret = autotest::query_isotovideo('backend_reset_console', {testapi_console => $console});
+        last if $ret->{error};
     }
     $self->{activated_consoles} = [];
 
     if (defined($autotest::last_milestone_console)) {
-        my $ret = autotest::query_isotovideo('backend_select_console',
+        $ret = autotest::query_isotovideo('backend_select_console',
             {testapi_console => $autotest::last_milestone_console});
-        die $ret->{error} if $ret->{error};
     }
-
+    die $ret->{error} if $ret->{error};
     return;
 }
 


### PR DESCRIPTION
Resetting a console might fail as well as activating or selecting one
depending on the backend implementation. For example the IPMI backend
needs to detach from a SOL session which might have terminated already
in before which we can catch and forward to the test scope.

This is untested.

Related progress issue: https://progress.opensuse.org/issues/60437