### PR TITLE
Ensure we are also checking coverage in tests themselves

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,5 +1,5 @@
 AM_MAKEFLAGS = \
-	PERL5OPT="-MDevel::Cover=-db,$(abs_builddir)/cover_db,-ignore,^.*\.t|^data\/tests\/|^fake\/tests\/" \
+	PERL5OPT="-MDevel::Cover=-db,$(abs_builddir)/cover_db,-ignore,^data\/tests\/*|^fake\/tests\/*" \
 	PERL5LIB="..:../ppmclibs:../ppmclibs/blib/arch/auto/tinycv:$$PERL5LIB"
 # Prevent error "blank line following trailing backslash" when deleting last
 # line in list in spec file to exclude tests


### PR DESCRIPTION
We also want to know if there is dead code in our tests, e.g. by
accident. This also fixes the warning

```
^* matches null string many times in regex; marked by <-- HERE in m/^*
<-- HERE \.t|^data\/tests\/*|^fake\/tests\/*/ at
/usr/lib/perl5/vendor_perl/5.26.1/x86_64-linux-thread-multi/Devel/Cover.pm
line 379.
```

Related progress issue: https://progress.opensuse.org/issues/42074