### PR TITLE
Remove import of Devel::Cover in commands test

### DIFF
--- a/t/07-commands.t
+++ b/t/07-commands.t
@@ -35,7 +35,6 @@ use Time::HiRes 'sleep';
 use Test::More;
 use Test::Warnings;
 use Test::Mojo;
-use Devel::Cover;
 use Mojo::File qw(path tempfile tempdir);
 use File::Which;
 use Data::Dumper;


### PR DESCRIPTION
Since the coverage target invokes tests with `make PERL5OPT="-MDevel::Cover=...` this should not be necessary.