### PR TITLE
[WIP] Increase calculated test coverage with "use Devel::Cover" in all tests

### DIFF
--- a/t/00-compile-check-all.t
+++ b/t/00-compile-check-all.t
@@ -16,6 +16,7 @@
 
 use strict;
 use warnings;
+use Devel::Cover;
 use Test::Compile;
 use Test::Warnings;
 use Cwd;

--- a/t/01-test_needle.t
+++ b/t/01-test_needle.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use Devel::Cover;
 use Cwd 'abs_path';
 use Test::Exception;
 use Test::Output qw(combined_like stderr_like);

--- a/t/02-test_ocr.t
+++ b/t/02-test_ocr.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use Devel::Cover;
 
 use Test::More;
 use Test::Warnings;

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use Devel::Cover;
 
 use Test::Mock::Time;
 use File::Temp;

--- a/t/04-check_vars_docu.t
+++ b/t/04-check_vars_docu.t
@@ -18,6 +18,7 @@
 
 use strict;
 use warnings;
+use Devel::Cover;
 
 use Test::Warnings;
 use FindBin;

--- a/t/05-pod.t
+++ b/t/05-pod.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use Devel::Cover;
 
 use Test::More;
 use Test::Pod;

--- a/t/06-pod-coverage.t
+++ b/t/06-pod-coverage.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use Devel::Cover;
 
 BEGIN {
     push @INC, '.';

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use Devel::Cover;
 
 use Test::More;
 use Test::Output qw(stderr_like combined_from);

--- a/t/09-lockapi.t
+++ b/t/09-lockapi.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use Devel::Cover;
 
 use Test::More;
 use Test::MockModule;

--- a/t/10-terminal.t
+++ b/t/10-terminal.t
@@ -14,6 +14,7 @@
 use 5.018;
 use warnings;
 use Carp 'confess';
+use Devel::Cover;
 use English -no_match_vars;
 use POSIX qw( :sys_wait_h sigprocmask sigsuspend mkfifo);
 use Fcntl;

--- a/t/10-test-image-conversion-benchmark.t
+++ b/t/10-test-image-conversion-benchmark.t
@@ -3,6 +3,7 @@
 
 use strict;
 use warnings;
+use Devel::Cover;
 use Test::More;
 use Test::Warnings;
 

--- a/t/11-image-ppm.t
+++ b/t/11-image-ppm.t
@@ -3,6 +3,7 @@
 
 use strict;
 use warnings;
+use Devel::Cover;
 use Test::More;
 use Test::Warnings;
 

--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -17,6 +17,7 @@
 
 use 5.018;
 use warnings;
+use Devel::Cover;
 use Test::More;
 use Test::Exception;
 use File::Temp 'tempdir';

--- a/t/13-osutils.t
+++ b/t/13-osutils.t
@@ -17,6 +17,7 @@
 
 use 5.018;
 use warnings;
+use Devel::Cover;
 use Test::More;
 use Test::MockModule;
 use Test::Warnings ':all';

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use Devel::Cover;
 use autodie ':all';
 use Test::More;
 use File::Basename;

--- a/t/15-logging.t
+++ b/t/15-logging.t
@@ -19,6 +19,7 @@
 
 use strict;
 use warnings;
+use Devel::Cover;
 use Test::More;
 use bmwqemu;
 use Mojo::File 'tempfile';

--- a/t/16-send_with_fd.t
+++ b/t/16-send_with_fd.t
@@ -3,6 +3,7 @@
 use 5.018;
 use strict;
 use warnings;
+use Devel::Cover;
 
 use Test::More;
 use Socket;

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use Devel::Cover;
 use Test::MockModule;
 use Test::More;
 use Test::Fatal;

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -3,6 +3,7 @@
 use 5.018;
 use strict;
 use warnings;
+use Devel::Cover;
 
 use Test::More;
 use Test::MockModule;

--- a/t/18-qemu-options.t
+++ b/t/18-qemu-options.t
@@ -17,6 +17,7 @@
 
 use strict;
 use warnings;
+use Devel::Cover;
 use Test::More;
 use Test::Warnings;
 use Try::Tiny;

--- a/t/18-qemu.t
+++ b/t/18-qemu.t
@@ -3,6 +3,7 @@
 use 5.018;
 use strict;
 use warnings;
+use Devel::Cover;
 
 use Test::More;
 use Mojo::JSON 'encode_json';

--- a/t/19-isotovideo-command-processing.t
+++ b/t/19-isotovideo-command-processing.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use Devel::Cover;
 
 use Test::More;
 use Test::MockModule;

--- a/t/20-openqa-benchmark-stopwatch-utils.t
+++ b/t/20-openqa-benchmark-stopwatch-utils.t
@@ -3,6 +3,7 @@
 
 use strict;
 use warnings;
+use Devel::Cover;
 use Test::More;
 use Test::Warnings;
 use Time::HiRes 'sleep';

--- a/t/21-needle-downloader.t
+++ b/t/21-needle-downloader.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use Devel::Cover;
 
 use File::Touch;
 use File::Path qw(make_path remove_tree);

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -3,6 +3,7 @@
 
 use strict;
 use warnings;
+use Devel::Cover;
 use Test::More;
 use Test::MockModule;
 use Test::MockObject;

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use Devel::Cover;
 use Test::More;
 use Test::MockModule;
 use Test::MockObject;

--- a/t/24-myjsonrpc-debug.t
+++ b/t/24-myjsonrpc-debug.t
@@ -18,6 +18,7 @@
 
 use strict;
 use warnings;
+use Devel::Cover;
 use Socket;
 BEGIN {
     $ENV{PERL_MYJSONRPC_DEBUG} = 1;

--- a/t/24-myjsonrpc.t
+++ b/t/24-myjsonrpc.t
@@ -18,6 +18,7 @@
 
 use strict;
 use warnings;
+use Devel::Cover;
 use Socket;
 use myjsonrpc;
 

--- a/t/25-spvm.t
+++ b/t/25-spvm.t
@@ -3,6 +3,7 @@
 use 5.018;
 use strict;
 use warnings;
+use Devel::Cover;
 
 use Test::More;
 use Test::MockModule;

--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -17,6 +17,7 @@
 
 use strict;
 use warnings;
+use Devel::Cover;
 
 use Test::More;
 use Test::Warnings;


### PR DESCRIPTION
It does not really make sense to me yet but including "use Devel::Cover"
in more tests raises coverage.

Tested with

```
mv t/cover_db{/,_before/} && ./configure && make && make coverage && mv t/cover_db{/,_all_devel_cover/} && firefox t/cover_db_{before,all_devel_cover}/coverage.html
```

I could see an overall coverage increase from 55.5 to 67.9

Certainly not all test files would really add to the coverage increase,
e.g. "00-compile-check-all.t" sounds unlikely to cause this but to be
sure unless we know better we might just as well add everywhere.

Related progress issue: https://progress.opensuse.org/issues/42074