### PR TITLE
Reduce overly long waiting time on shutdown waiting on processes

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -279,7 +279,7 @@ sub start_process {
             bmwqemu::load_vars();
 
             run_all;
-    })->blocking_stop(1)->separate_err(0)->set_pipes(0)->internal_pipes(0)->start;
+    }, sleeptime_during_kill => .1)->blocking_stop(1)->separate_err(0)->set_pipes(0)->internal_pipes(0)->start;
     $process->on(collected => sub { bmwqemu::diag "[" . __PACKAGE__ . "] process exited: " . shift->exit_status; });
 
     close $isotovideo;

--- a/commands.pm
+++ b/commands.pm
@@ -369,7 +369,7 @@ sub start_server {
             run_daemon($port, $isotovideo);
             Devel::Cover::report() if Devel::Cover->can('report');
             _exit(0);
-    })->blocking_stop(1)->internal_pipes(0)->set_pipes(0)->start;
+    }, sleeptime_during_kill => .1)->blocking_stop(1)->internal_pipes(0)->set_pipes(0)->start;
 
     close($isotovideo);
     $process->on(collected => sub { diag("commands process exited: " . shift->exit_status); });


### PR DESCRIPTION
This is following the perl best practice to use the most important features
from upstream dependencies which are of course undocumented ;)
The parameter "sleeptime_during_kill" from Mojo::IOLoop::ReadWriteProcess
allows to signficantly reduce the shutdown time of an isotovideo process
from about 5s to 1s. The actual actions by Mojo::IOLoop::ReadWriteProcess
can be followed by enabling the environment variable MOJO_PROCESS_DEBUG=1.
The "commands" server seems to be very slow to shut down so it might
actually receive the KILL signal after it does not react to TERM in time.
This is not changed by this commit only that we wait less until we come to
this step.

There is also a proposal for an upstream change to reduce
the initial wait time before sending termination signals, see
https://github.com/mudler/Mojo-IOLoop-ReadWriteProcess/pull/6

Related progress issue: https://progress.opensuse.org/issues/58379