### PR TITLE
t: Fix warning in tests about wrong regex for Devel::Cover

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,5 +1,5 @@
 AM_MAKEFLAGS = \
-	PERL5OPT="-MDevel::Cover=-db,$(abs_builddir)/cover_db,-ignore,^*\.t|^data\/tests\/*|^fake\/tests\/*" \
+	PERL5OPT="-MDevel::Cover=-db,$(abs_builddir)/cover_db,-ignore,^.*\.t|^data\/tests\/|^fake\/tests\/" \
 	PERL5LIB="..:../ppmclibs:../ppmclibs/blib/arch/auto/tinycv:$$PERL5LIB"
 # Prevent error "blank line following trailing backslash" when deleting last
 # line in list in spec file to exclude tests


### PR DESCRIPTION
```
^* matches null string many times in regex; marked by <-- HERE in m/^*
<-- HERE \.t|^data\/tests\/*|^fake\/tests\/*/ at
/usr/lib/perl5/vendor_perl/5.26.1/x86_64-linux-thread-multi/Devel/Cover.pm
line 379.
```