### PR TITLE
t: Adjust PERL5LIB and Devel::Cover options

### DIFF
--- a/t/00-compile-check-all.t
+++ b/t/00-compile-check-all.t
@@ -20,16 +20,12 @@ use Test::Compile;
 use Test::Warnings;
 use Cwd;
 
-BEGIN {
-    if (getcwd =~ /\/t$/) {
-        # not really using it, but we need the init to be called before the chdir
-        use FindBin;
-        chdir("..");
-    }
-    unshift @INC, ".";
-}
+use FindBin '$Bin';
+use lib "$Bin/..";
 
 use cv;
+
+chdir "$Bin/..";
 cv::init;
 
 my $test = Test::Compile->new();

--- a/t/01-test_needle.t
+++ b/t/01-test_needle.t
@@ -16,7 +16,6 @@ eval 'use Test::More::Color';
 eval 'use Test::More::Color "foreground"';
 
 BEGIN {
-    unshift @INC, '..';
     $bmwqemu::vars{DISTRI}  = "unicorn";
     $bmwqemu::vars{CASEDIR} = "/var/lib/empty";
 }

--- a/t/02-test_ocr.t
+++ b/t/02-test_ocr.t
@@ -9,7 +9,6 @@ use File::Which 'which';
 use File::Basename;
 
 BEGIN {
-    unshift @INC, '..';
     $bmwqemu::vars{DISTRI}      = 'unicorn';
     $bmwqemu::vars{CASEDIR}     = '/var/lib/empty';
     $bmwqemu::vars{NEEDLES_DIR} = dirname(__FILE__) . '/data';

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -15,10 +15,6 @@ use Scalar::Util 'looks_like_number';
 use OpenQA::Isotovideo::Interface;
 use consoles::console;
 
-BEGIN {
-    unshift @INC, '..';
-}
-
 require bmwqemu;
 
 ok(looks_like_number($OpenQA::Isotovideo::Interface::version), 'isotovideo version set (variable is considered part of test API)');

--- a/t/07-commands.t
+++ b/t/07-commands.t
@@ -25,10 +25,6 @@ require IPC::System::Simple;
 use autodie ':all';
 
 
-BEGIN {
-    unshift @INC, '..';
-}
-
 use commands;
 use Mojo::IOLoop::Server;
 use Time::HiRes 'sleep';

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -9,10 +9,6 @@ use Test::Fatal;
 use Test::MockModule;
 use File::Basename ();
 
-BEGIN {
-    unshift @INC, '..';
-}
-
 use autotest;
 use bmwqemu;
 use OpenQA::Test::RunArgs;

--- a/t/09-lockapi.t
+++ b/t/09-lockapi.t
@@ -7,10 +7,6 @@ use Test::More;
 use Test::MockModule;
 use Test::Warnings;
 
-BEGIN {
-    unshift @INC, '..';
-}
-
 use lockapi;
 
 # mock api_call return value

--- a/t/10-terminal.t
+++ b/t/10-terminal.t
@@ -25,10 +25,6 @@ use Mojo::Log;
 use Test::More;
 use Test::Warnings;
 
-BEGIN {
-    unshift @INC, '..';
-}
-
 use consoles::virtio_terminal;
 use testapi ();
 use bmwqemu ();

--- a/t/10-test-image-conversion-benchmark.t
+++ b/t/10-test-image-conversion-benchmark.t
@@ -13,10 +13,6 @@ use File::Temp 'tempfile';
 use Cwd;
 
 
-BEGIN {
-    unshift @INC, '..';
-}
-
 use OpenQA::Benchmark::Stopwatch;
 
 

--- a/t/11-image-ppm.t
+++ b/t/11-image-ppm.t
@@ -12,10 +12,6 @@ use File::Path qw(make_path remove_tree);
 use Cwd;
 
 
-BEGIN {
-    unshift @INC, '..';
-}
-
 use OpenQA::Benchmark::Stopwatch;
 
 

--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -26,10 +26,6 @@ use Cwd 'abs_path';
 use Mojo::JSON;    # booleans
 use Cpanel::JSON::XS ();
 
-BEGIN {
-    unshift @INC, '..';
-}
-
 my $toplevel_dir = abs_path(dirname(__FILE__) . '/..');
 my $data_dir     = "$toplevel_dir/t/data";
 

--- a/t/13-osutils.t
+++ b/t/13-osutils.t
@@ -22,10 +22,6 @@ use Test::MockModule;
 use Test::Warnings ':all';
 use Test::Output;
 
-BEGIN {
-    unshift @INC, '..';
-}
-
 subtest qv => sub {
     use osutils 'qv';
 

--- a/t/16-send_with_fd.t
+++ b/t/16-send_with_fd.t
@@ -10,10 +10,6 @@ use Socket;
 use Socket::MsgHdr;
 use POSIX;
 
-BEGIN {
-    unshift @INC, '..';
-}
-
 use cv;
 
 cv::init();

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -7,10 +7,6 @@ use Test::More;
 use Test::Fatal;
 use File::Basename;
 
-BEGIN {
-    unshift @INC, '..';
-}
-
 use basetest;
 use needle;
 

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -10,10 +10,6 @@ use Test::MockObject;
 use Test::Output qw(combined_like stderr_like);
 use Test::Warnings;
 
-BEGIN {
-    unshift @INC, '..';
-}
-
 use backend::qemu;
 
 

--- a/t/18-qemu.t
+++ b/t/18-qemu.t
@@ -9,10 +9,6 @@ use Mojo::JSON 'encode_json';
 use Mojo::File qw(tempfile path);
 use Carp 'cluck';
 
-BEGIN {
-    unshift @INC, '..';
-}
-
 use OpenQA::Qemu::BlockDevConf;
 use OpenQA::Qemu::Proc;
 

--- a/t/19-isotovideo-command-processing.t
+++ b/t/19-isotovideo-command-processing.t
@@ -10,10 +10,6 @@ use Mojo::JSON;
 use OpenQA::Isotovideo::CommandHandler;
 use OpenQA::Isotovideo::Interface;
 
-BEGIN {
-    unshift @INC, '..';
-}
-
 # declare fake file descriptors
 my $cmd_srv_fd              = 0;
 my $backend_fd              = 1;

--- a/t/20-openqa-benchmark-stopwatch-utils.t
+++ b/t/20-openqa-benchmark-stopwatch-utils.t
@@ -8,10 +8,6 @@ use Test::Warnings;
 use Time::HiRes 'sleep';
 
 
-BEGIN {
-    unshift @INC, '..';
-}
-
 use OpenQA::Benchmark::Stopwatch;
 
 my $watch = OpenQA::Benchmark::Stopwatch->new();

--- a/t/21-needle-downloader.t
+++ b/t/21-needle-downloader.t
@@ -13,10 +13,6 @@ use Mojo::File qw(path tempdir);
 use OpenQA::Isotovideo::NeedleDownloader;
 use needle;
 
-BEGIN {
-    unshift @INC, '..';
-}
-
 # mock user agent and file
 my $user_agent_mock = Test::MockModule->new('Mojo::UserAgent');
 my @queried_urls;

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -17,10 +17,6 @@ use Net::SSH2;
 use testapi qw(get_var get_required_var check_var set_var);
 use backend::svirt qw(SERIAL_CONSOLE_DEFAULT_PORT SERIAL_TERMINAL_DEFAULT_DEVICE SERIAL_TERMINAL_DEFAULT_PORT);
 
-BEGIN {
-    unshift @INC, '..';
-}
-
 set_var(WORKER_HOSTNAME => 'foo');
 set_var(VIRSH_HOSTNAME  => 'bar');
 set_var(VIRSH_PASSWORD  => 'password');

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -11,10 +11,6 @@ use Scalar::Util 'refaddr';
 use backend::baseclass;
 use POSIX 'tzset';
 
-BEGIN {
-    unshift @INC, '..';
-}
-
 # make the test time-zone neutral
 $ENV{TZ} = 'UTC';
 tzset;

--- a/t/25-spvm.t
+++ b/t/25-spvm.t
@@ -9,10 +9,6 @@ use Test::MockModule;
 use backend::spvm;
 use testapi 'set_var';
 
-BEGIN {
-    unshift @INC, '..';
-}
-
 subtest 'SSH credentials in spvm' => sub {
     my $expected_credentials = {username => 'root', password => 'foo', hostname => 'my_foo_hostname'};
     my $mock_spvm            = Test::MockModule->new('backend::spvm');

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,6 +1,10 @@
+UPDIR = $(dir $(PWD))
+
+PATHRE = ^|$(UPDIR)|\.\./
+
 AM_MAKEFLAGS = \
-	PERL5OPT="-MDevel::Cover=-db,$(abs_builddir)/cover_db,-ignore,^.*\.t|^data\/tests\/|^fake\/tests\/" \
-	PERL5LIB="..:../ppmclibs:../ppmclibs/blib/arch/auto/tinycv:$$PERL5LIB"
+	PERL5OPT="-MDevel::Cover=-db,$(abs_builddir)/cover_db,-select,($(PATHRE))(OpenQA|backend|consoles|ppmclibs)/|($(PATHRE))isotovideo|($(PATHRE))[^/]+\.pm,-ignore,\.t|.*data/tests/|.*fake/tests/" \
+	PERL5LIB="$(PWD)/..:$(PWD)/../ppmclibs:$(PWD)/../ppmclibs/blib/arch/auto/tinycv:$$PERL5LIB"
 # Prevent error "blank line following trailing backslash" when deleting last
 # line in list in spec file to exclude tests
 EMPTY =


### PR DESCRIPTION
This removes the modifications of `@INC` from the test files.
Also it adjusts PERL5LIB to use absolute paths, and adds a select option for Devel::Cover.

This is a part of a refactoring regarding this issue:
https://progress.opensuse.org/issues/42074

Explanation:
Tests should not modify `@INC` themselves (and if it must, then via FindBin to
use absolute paths).
The paths should be provided via env vars or `prove -l` or `prove -I.....`
This makes it more flexible.

Also the paths were relative, so it was only possible to call the tests
from the t/ directory.

Usually code coverage is for unit tests.
You call the tests with `-Ilib` or `-Mblib` and unit tests run and a report gets created. Done.

We are calling tests from the `t/` directory, using `..` explicitly in tests, then in the tests we fork, and in the forked processes we do a `chdir` and another `use lib` with a relative path, and then we use other modules.
As far as I can see Devel::Cover is not able to collect all those modules with all those different paths unless we use the select option.


