### PR TITLE
ssh_screen: Fix initialize of base class

### DIFF
--- a/consoles/serial_screen.pm
+++ b/consoles/serial_screen.pm
@@ -27,7 +27,13 @@ our $VERSION;
 
 sub new {
     my ($class, $fd_read, $fd_write) = @_;
-    my $self = bless {class => $class}, $class;
+    my $self;
+    if (ref($class) ne '' && $class->isa('consoles::serial_screen')) {
+        $self = $class;
+    } else {
+        $self = bless {class => $class}, $class;
+    }
+
     $self->{fd_read}      = $fd_read;
     $self->{fd_write}     = $fd_write // $fd_read;
     $self->{carry_buffer} = '';

--- a/consoles/ssh_screen.pm
+++ b/consoles/ssh_screen.pm
@@ -28,10 +28,7 @@ sub new {
     croak('Missing parameter ssh_connection') unless $self->ssh_connection;
     croak('Missing parameter ssh_channel')    unless $self->ssh_channel;
 
-    $self->{socket_fd}    = $self->ssh_channel;
-    $self->{carry_buffer} = '';
-
-    return $self;
+    return $self->SUPER::new($self->ssh_channel);
 }
 
 sub do_read

--- a/t/26-serial_screen.t
+++ b/t/26-serial_screen.t
@@ -1,0 +1,18 @@
+#!/usr/bin/perl
+# Copyright © 2019 SUSE LLC
+
+use strict;
+use warnings;
+use Test::More;
+use consoles::serial_screen;
+
+my $screen = consoles::serial_screen->new('read', 'write');
+is($screen->{fd_write},     'write', 'Check if channel was set for write fd');
+is($screen->{fd_read},      'read',  'Check if channel was set for read fd');
+is($screen->{carry_buffer}, '',      'Check if channel was set for read fd');
+
+$screen = consoles::serial_screen->new('same', 'same');
+is($screen->{fd_read}, 'same', 'Fd read member was set.');
+is($screen->{fd_read}, $screen->{fd_write}, 'If only one fd give, read and write are equal');
+
+done_testing;

--- a/t/26-ssh_screen.t
+++ b/t/26-ssh_screen.t
@@ -1,0 +1,13 @@
+#!/usr/bin/perl
+# Copyright © 2019 SUSE LLC
+
+use strict;
+use warnings;
+use Test::More;
+use consoles::ssh_screen;
+
+my $screen = consoles::ssh_screen->new(ssh_connection => 'My_Con', ssh_channel => 'My_Chan');
+is($screen->{fd_read},  'My_Chan', 'SSH channel is used for reading');
+is($screen->{fd_write}, 'My_Chan', 'SSH channel is used for writing');
+
+done_testing;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -39,6 +39,7 @@ TESTS = \
 	24-myjsonrpc.t \
 	24-myjsonrpc-debug.t \
 	25-spvm.t \
+	26-ssh_screen.t \
 	99-full-stack.t \
 	$(EMPTY)
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -40,6 +40,7 @@ TESTS = \
 	24-myjsonrpc-debug.t \
 	25-spvm.t \
 	26-ssh_screen.t \
+	26-serial_screen.t \
 	99-full-stack.t \
 	$(EMPTY)
 


### PR DESCRIPTION
The base class consoles::serial_screen changed in commit f9c71d0e. But this
class wasn't updated.

Ticket: https://progress.opensuse.org/issues/60725

I had this good run: http://cfconrad-vm.qa.suse.de/tests/6553

But currently I'm running in this error: http://cfconrad-vm.qa.suse.de/tests/6556#step/update_kernel/34
I'm not sure where it comes from.