### PR TITLE
t: Enable 00-compile-check-all.t to be run with prove

### DIFF
--- a/t/00-compile-check-all.t
+++ b/t/00-compile-check-all.t
@@ -17,7 +17,10 @@
 use strict;
 use warnings;
 use Test::Compile;
-use Test::Warnings;
+# We need :no_end_test here because otherwise it would output a no warnings
+# test for each of the modules, but with the same test number
+use Test::Warnings ':no_end_test';
+
 use Cwd;
 
 use FindBin '$Bin';


### PR DESCRIPTION
Currently, prove -v 00-compile-check-all.t will output wrong test numbers:

    ok 1 - Compile test for lockapi.pm
    ok 2 - no (unexpected) warnings (via END block)
    ok 2 - Compile test for commands.pm
    ok 3 - no (unexpected) warnings (via END block)
    ok 3 - Compile test for bmwqemu.pm
    ...

I can only reproduce that on travis-ci, though. Locally I don't see the
additonal tests.

    use Test::Warnings ':no_end_test'

fixes it

See https://travis-ci.org/perlpunk/os-autoinst/builds/621081860#L885 for how
it looks like without the fix.

