### PR TITLE
Fix warning on failed load_snapshot command

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -214,11 +214,10 @@ sub load_snapshot {
     my $command = query_isotovideo('backend_load_snapshot', {name => $sname});
     # On VMware VNC console needs to be re-selected after snapshot revert,
     # so the screen is refreshed. Same with serial console.
-    if ($command eq 'vmware_fixup') {
-        testapi::select_console('sut');
-        query_isotovideo('backend_stop_serial_grab');
-        query_isotovideo('backend_start_serial_grab');
-    }
+    return unless ($command // '') eq 'vmware_fixup';
+    testapi::select_console('sut');
+    query_isotovideo('backend_stop_serial_grab');
+    query_isotovideo('backend_start_serial_grab');
 }
 
 sub run_all {


### PR DESCRIPTION
As observed in https://openqa.suse.de/tests/3677612/file/autoinst-log.txt