### PR TITLE
check_ssh_serial: Fix reading from channel

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -1271,7 +1271,6 @@ sub check_ssh_serial {
         open(my $serial, '>>', $self->{serialfile});
         print $serial $buffer;
         close($serial);
-        $bytes_read = $chan->read($buffer, 4096);
     }
 
     my ($error_code, $error_name, $error_string) = $ssh->error;

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -157,7 +157,7 @@ subtest 'SSH utilities' => sub {
         is($ssh->blocking(),     0,                              'We run SSH in none blocking mode');
 
         $baseclass->truncate_serial_file();
-        my $expect_output       = "FOO$/" x 80;
+        my $expect_output       = "FOO$/" x 4096;
         my $channel_read_string = $expect_output;
         $chan->mock('read', sub {
                 my ($self, undef, $max) = @_;


### PR DESCRIPTION
Commit b2838e23 introduced a error on reading, as it called $chan-read()
twice per loop!

Tickets: https://progress.opensuse.org/issues/60815
VR: http://cfconrad-vm.qa.suse.de/tests/6572