### PR TITLE
Remove "use Devel::Cover" from 07-commands.t

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,5 @@ snd2png/test.pnm.md5
 t/*.log
 t/*.trs
 t/pool/*
-t/cover_db/*
 cover_db/*
 .*.swp

--- a/t/07-commands.t
+++ b/t/07-commands.t
@@ -32,7 +32,6 @@ use Test::More;
 use Test::Warnings;
 use Test::Output;
 use Test::Mojo;
-use Devel::Cover;    # needed to collect coverage on spawned processes as well
 use Mojo::File qw(path tempfile tempdir);
 use File::Which;
 use Data::Dumper;


### PR DESCRIPTION
This is probably not needed anymore, as it might have been caused by
Devel::Cover not picking up all module paths by default, and it
was fixed by using the select option in PERL5OPT.

