### PR TITLE
Escape parameters in log calls

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -271,7 +271,7 @@ sub update_line_number {
 # pretty print like Data::Dumper but without the "VAR1 = " prefix
 sub pp {
     # FTR, I actually hate Data::Dumper.
-    my $value_with_trailing_newline = Data::Dumper->new(\@_)->Terse(1)->Dump();
+    my $value_with_trailing_newline = Data::Dumper->new(\@_)->Terse(1)->Useqq(1)->Dump();
     chomp($value_with_trailing_newline);
     return $value_with_trailing_newline;
 }

--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -19,6 +19,7 @@ use 5.018;
 use warnings;
 use Test::More;
 use Test::Exception;
+use Test::Output 'stderr_like';
 use File::Temp 'tempdir';
 use File::Basename;
 use File::Path 'make_path';
@@ -46,6 +47,14 @@ sub read_vars {
     close($varsfh);
     return $ret;
 }
+
+subtest 'log_call' => sub {
+    require bmwqemu;
+    sub log_call_test {
+        bmwqemu::log_call(foo => "bar\tbaz\rboo\n");
+    }
+    stderr_like(\&log_call_test, qr{\Q<<< main::log_call_test(foo="bar\tbaz\rboo\n")}, 'log_call escapes special characters');
+};
 
 subtest 'CASEDIR is mandatory' => sub {
     my $dir = '/var/lib/openqa';


### PR DESCRIPTION
Otherwise the log will have linebreaks like this:

    [Thu Dec 14 04:10:45 2017] [12032:debug] <<< testapi::type_string(string='root
    ', max_interval=250, wait_screen_changes=0, wait_still_screen=0)

Also other unprintable characters can make the log unreadable ("\r", ...)

Issue: https://progress.opensuse.org/issues/29399