### PR TITLE
qemu: Check expected format for snapshotted image

### DIFF
--- a/OpenQA/Qemu/DriveDevice.pm
+++ b/OpenQA/Qemu/DriveDevice.pm
@@ -26,7 +26,11 @@ use Mojo::Base 'OpenQA::Qemu::MutParams';
 use OpenQA::Qemu::DrivePath;
 use bmwqemu 'diag';
 
-use constant DEVICE_POSTFIX => '-device';
+use constant DEVICE_POSTFIX    => '-device';
+use constant QEMU_IMAGE_FORMAT => 'qcow2';
+
+use Exporter 'import';
+our @EXPORT_OK = qw(QEMU_IMAGE_FORMAT);
 
 =head3 drive
 
@@ -137,7 +141,7 @@ sub gen_qemu_img_cmdlines {
 sub gen_qemu_img_convert {
     my ($self, $img_dir, $name) = @_;
 
-    return ['convert', '-c', '-O', 'qcow2', $self->drive->file, "$img_dir/$name"];
+    return ['convert', '-c', '-O', QEMU_IMAGE_FORMAT, $self->drive->file, "$img_dir/$name"];
 }
 
 sub gen_unlink_list {


### PR DESCRIPTION
after run 'nice ionice qemu-img convert ...'

In theory this should detect wrong snapshot of qcow2 image.
Tested only on x86_64.

See: poo#51743

Verification run
- http://quasar.suse.cz/tests/4408 (opensuse-Tumbleweed-DVD-x86_64-Build20191214-install_ltp+opensuse+DVD@64bit)
- http://quasar.suse.cz/tests/4422 (sle-15-SP1-Server-DVD-Incidents-Kernel-x86_64-Build4.12.14-727.1.g6e36e9f-install_ltp+sle+Server-DVD-Incidents-Kernel@64bit)
- http://quasar.suse.cz/tests/4423 (sle-12-SP1-Server-DVD-Incidents-Kernel-x86_64-Build3.12.74-88.1.gc042dbb-install_ltp+sle+Server-DVD-Incidents-Kernel@64bit)