### PR TITLE
Fix default boot menu timeout in qemu backend

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -874,7 +874,7 @@ sub start_qemu {
         }
 
         my @boot_args;
-        push @boot_args, ('menu=on,splash-time=' . $vars->{BOOT_MENU_TIMEOUT} // '5000') if $vars->{BOOT_MENU};
+        push @boot_args, ('menu=on,splash-time=' . ($vars->{BOOT_MENU_TIMEOUT} // '5000')) if $vars->{BOOT_MENU};
         if ($arch_supports_boot_order) {
             if (($vars->{PXEBOOT} // '') eq 'once') {
                 push @boot_args, 'once=n';


### PR DESCRIPTION
'5000' default should apply to the timeout only, not to the whole qemu option.