### PR TITLE
Ensure tianocore boot menu is shown for aarch64 workaround

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -874,6 +874,8 @@ sub start_qemu {
         }
 
         my @boot_args;
+        # Enable boot menu for aarch64 workaround, see bsc#1022064 for details
+        $vars->{BOOT_MENU} //= 1 if ($vars->{BOOTFROM} && ($vars->{ARCH} // '') eq 'aarch64');
         push @boot_args, ('menu=on,splash-time=' . ($vars->{BOOT_MENU_TIMEOUT} // '5000')) if $vars->{BOOT_MENU};
         if ($arch_supports_boot_order) {
             if (($vars->{PXEBOOT} // '') eq 'once') {


### PR DESCRIPTION
https://github.com/os-autoinst/os-autoinst/pull/1275 removed the boot
menu by default to save 5s of boot time when the menu is not really
required. With the variable BOOT_MENU we can always request the menu
when it is necessary. On aarch64 to boot a non-default disk the
tianocore menu is required so for convience we can propose a different
default value to show the boot menu unless requested differently.

Related progress issue: https://progress.opensuse.org/issues/61910