### PR TITLE
Fix condition for using pkgconfig(opencv4)

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -25,10 +25,11 @@ Group:          Development/Tools/Other
 Url:            https://github.com/os-autoinst/os-autoinst
 Source0:        %{name}-%{version}.tar.xz
 %{perl_requires}
-%if 0%{?sle_version} <= 150100
-%define opencv_require pkgconfig(opencv)
-%else
+%if 0%{?suse_version} > 1500
+# openSUSE Tumbleweed
 %define opencv_require pkgconfig(opencv4)
+%else
+%define opencv_require pkgconfig(opencv)
 %endif
 %define build_requires autoconf automake gcc-c++ libtool pkg-config perl(Module::CPANfile) pkgconfig(fftw3) pkgconfig(libpng) pkgconfig(sndfile) pkgconfig(theoraenc) make %opencv_require
 %define requires perl(B::Deparse) perl(Mojolicious) >= 7.92, perl(Mojo::IOLoop::ReadWriteProcess) >= 0.23, perl(Carp::Always) perl(Data::Dump) perl(Data::Dumper) perl(Crypt::DES) perl(JSON) perl(autodie) perl(Class::Accessor::Fast) perl(Exception::Class) perl(File::Touch) perl(File::Which) perl(IO::Socket::INET) perl(IPC::Run::Debug) perl(Net::DBus) perl(Net::SNMP) perl(Net::IP) perl(IPC::System::Simple) perl(Net::SSH2) perl(XML::LibXML) perl(XML::SemanticDiff) perl(JSON::XS) perl(List::MoreUtils) perl(Mojo::IOLoop::ReadWriteProcess) perl(Socket::MsgHdr) perl(Cpanel::JSON::XS) perl(IO::Scalar) perl(Try::Tiny) perl-base


### PR DESCRIPTION
Fixup of https://github.com/os-autoinst/os-autoinst/pull/1315

---

* Condition for Tumbleweed is according to https://en.opensuse.org/openSUSE:Build_Service_cross_distribution_howto
* Apparently OpenCV is still at [version 3 in Leap 15.2](https://build.opensuse.org/package/show/openSUSE:Leap:15.2/opencv) so we really only want to enable Tumbleweed here
* It now really depends on OpenCV 4: https://build.opensuse.org/package/binary/home:mkittler:branches:devel:openQA/os-autoinst/openSUSE_Tumbleweed/x86_64/os-autoinst-devel-4.6.1578664894.cfbf352f-317.1.x86_64.rpm
* And otherwise it builds as well: https://build.opensuse.org/package/show/home:mkittler:branches:devel:openQA/os-autoinst