### PR TITLE
virtio_terminal: Don't force max PIPE_SZ

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -230,6 +230,7 @@ TEST_FILES = \
 	08-autotest.t \
 	09-lockapi.t \
 	10-terminal.t \
+	10-virtio_terminal.t \
 	10-test-image-conversion-benchmark.t \
 	11-image-ppm.t \
 	12-bmwqemu.t \

--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -122,6 +122,18 @@ sub F_SETPIPE_SZ
     return eval 'no warnings "all"; Fcntl::F_SETPIPE_SZ;' || 1031;
 }
 
+sub set_pipe_sz
+{
+    my ($self, $fd, $newsize) = @_;
+    return fcntl($fd, F_SETPIPE_SZ(), int($newsize));
+}
+
+sub get_pipe_sz
+{
+    my ($self, $fd) = @_;
+    return fcntl($fd, F_GETPIPE_SZ(), 0);
+}
+
 =head2 open_pipe
 
   open_pipe();
@@ -143,12 +155,12 @@ sub open_pipe {
 
     my $newsize = get_var('VIRTIO_CONSOLE_PIPE_SZ', path('/proc/sys/fs/pipe-max-size')->slurp());
     for my $fd (($fd_w, $fd_r)) {
-        my $old = fcntl($fd, F_GETPIPE_SZ(), 0) or die("Unable to read PIPE_SZ");
+        my $old = $self->get_pipe_sz($fd) or die("Unable to read PIPE_SZ");
         {
             no autodie;
             my $new;
             while ($newsize > $old) {
-                $new = fcntl($fd, F_SETPIPE_SZ(), int($newsize));
+                $new = $self->set_pipe_sz($fd, $newsize);
                 last if ($new);
                 $newsize /= 2;
             }

--- a/t/10-virtio_terminal.t
+++ b/t/10-virtio_terminal.t
@@ -1,0 +1,115 @@
+#!/usr/bin/perl
+# Copyright © 2020 SUSE LLC
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+use Test::MockModule;
+use Test::Output;
+use POSIX 'mkfifo';
+
+use consoles::virtio_terminal;
+use testapi;
+use bmwqemu;
+
+
+sub prepare_pipes
+{
+    my ($socket_path) = @_;
+    my $pipe_in       = $socket_path . ".in";
+    my $pipe_out      = $socket_path . ".out";
+
+    for (($pipe_in, $pipe_out)) {
+        unlink $_ if (-e $_);
+        mkfifo($_, 0666) or die("Cannot create fifo pipe $_");
+    }
+
+    my $pid = fork || do {
+        my $running = 1;
+        $SIG{USR1} = sub { $running = 0; };
+        $SIG{ALRM} = sub {
+            die('Timeout for pipe other side helper');
+        };
+        alarm 60;
+
+        open(my $fd_r, "<", $pipe_in)
+          or die "Can't open in pipe for writing $!";
+        open(my $fd_w, ">", $pipe_out)
+          or die "Can't open out pipe for reading $!";
+
+        sysread($fd_r, my $buf, 1024) while ($running);
+        exit 0;
+    };
+
+    return {pid => $pid, files => [$pipe_in, $pipe_out]};
+}
+
+sub cleanup_pipes
+{
+    my $obj = shift;
+    kill 'USR1', $obj->{pid};
+    waitpid(-1, 0);
+    unlink for (@{$obj->{files}});
+}
+
+subtest "Test open_pipe() error condition" => sub {
+
+    my $socket_path    = './virtio_console_open_test';
+    my $file_mock      = Test::MockModule->new('Mojo::File');
+    my $vterminal_mock = Test::MockModule->new('consoles::virtio_terminal');
+    $vterminal_mock->mock("get_pipe_sz", sub { return; });
+
+    my $helper = prepare_pipes($socket_path);
+    my $term   = consoles::virtio_terminal->new('unit-test-console', {socked_path => $socket_path});
+    dies_ok { $term->open_pipe(); } 'Expect die if pipe_sz fail';
+    cleanup_pipes($helper);
+
+    my $size = 1024;
+    $file_mock->mock('slurp', sub { return 65536; });
+    $vterminal_mock->mock("get_pipe_sz", sub { return 1024; });
+    $vterminal_mock->mock("set_pipe_sz", sub {
+            my ($self, $fd, $newsize) = @_;
+            return if ($newsize > 2048);
+            return $size = $newsize;
+    });
+    $helper = prepare_pipes($socket_path);
+    $term   = consoles::virtio_terminal->new('unit-test-console', {socked_path => $socket_path});
+    stderr_like { $term->open_pipe() } qr/Set PIPE_SZ from 1024 to 2048/, 'Log mention size';
+    cleanup_pipes($helper);
+    is($size, 2048, "PIPE_SZ is 2048");
+
+    $size = 1024;
+    $vterminal_mock->mock("set_pipe_sz", undef);
+    $helper = prepare_pipes($socket_path);
+    $term   = consoles::virtio_terminal->new('unit-test-console', {socked_path => $socket_path});
+    stderr_like { $term->open_pipe() } qr/Set PIPE_SZ from 1024 to 1024/, 'Log mention new size';
+    cleanup_pipes($helper);
+    is($size, 1024, "Size didn't changed");
+
+    $size = 1024;
+    $vterminal_mock->mock("set_pipe_sz", sub {
+            my ($self, $fd, $newsize) = @_;
+            return $size = $newsize;
+    });
+
+    $helper = prepare_pipes($socket_path);
+    $term   = consoles::virtio_terminal->new('unit-test-console', {socked_path => $socket_path});
+    combined_like { $term->open_pipe() } qr/Set PIPE_SZ from 1024 to 65536/, 'Log mention new size';
+    cleanup_pipes($helper);
+    is($size, 65536, "PIPE_SZ is 65536");
+
+    testapi::set_var('VIRTIO_CONSOLE_PIPE_SZ', 5555);
+    $helper = prepare_pipes($socket_path);
+    $term   = consoles::virtio_terminal->new('unit-test-console', {socked_path => $socket_path});
+    stderr_like { $term->open_pipe() } qr/Set PIPE_SZ from 1024 to 5555/, 'Log mention new size';
+    cleanup_pipes($helper);
+    is($size, 5555, "PIPE_SZ is 5555 from VIRTIO_CONSOLE_PIPE_SZ");
+
+    $term = consoles::virtio_terminal->new('unit-test-console', {socked_path => $socket_path});
+    throws_ok { $term->open_pipe() } qr/No such file or directory/, "Throw exception if pipe doesn't exists";
+};
+
+done_testing;
+


### PR DESCRIPTION
Sometime (the reason why isn't known) the PIPE_SZ syscall fail.

[2020-01-14T03:06:11.813 CET] [debug] Backend process died, backend errors are reported below in the following lines:
Can't fcntl($fh, '1031', '1048576'): Operation not permitted at /usr/lib/os-autoinst/consoles/virtio_terminal.pm line 147

So we can be more gentle on setting new PIPE_SZ and retry with lower
values.

Ticket: https://progress.opensuse.org/issues/62108