### PR TITLE
qemu: allow to use different soundhw option with QEMU_SOUNDHW

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -818,7 +818,8 @@ sub start_qemu {
     sp('only-migratable') if $self->can_handle({function => 'snapshots', no_warn => 1});
     sp('chardev', 'ringbuf,id=serial0,logfile=serial0,logappend=on');
     sp('serial',  'chardev:serial0');
-    sp('soundhw', 'hda');
+    my $soundhw = $vars->{QEMU_SOUNDHW} // 'hda';
+    sp('soundhw', $soundhw);
     {
         # Remove floppy drive device on architectures
         unless ($arch eq 'aarch64' || $arch eq 'arm' || $vars->{QEMU_NO_FDC_SET}) {

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -100,6 +100,7 @@ QEMU_NO_TABLET;boolean;0;Don't use USB tablet.
 QEMU_VIRTIO_RNG;boolean;0;Enable virtio random number generator
 QEMU_NUMA;boolean;0;Enable NUMA simulation, requires QEMUCPUS to be greater than one
 QEMU_SMBIOS;see qemu -smbios ?;undef;pass this value to qemu -smbios
+QEMU_SOUNDHW;see qemu -soundhw ?;hda;pass this value to qemu -soundhw
 QEMU_COMPRESS_LEVEL;integer;6;Sets the compression level used for memory dumps and snapshots. Zero turns compression off and 9 is the maximum level. Generally there is little improvement in compression ratio by increasing the level, but the CPU time can be high on some platforms.
 QEMU_COMPRESS_THREADS;integer;QEMUCPUS;Number of threads used for compressing memory dumps and snapshots.
 QEMU_MAX_BANDWIDTH;integer;INT_MAX;Limits the transfer rate during a snapshot.


### PR DESCRIPTION
Tested locally on aarch64:
* without option (default to `hda`)
* with `QEMU_SOUNDHW=ac97`