### PR TITLE
virtio_console: Fix `no autodie` placement for fcntl(PIPE_SZ)

### DIFF
--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -124,6 +124,7 @@ sub F_SETPIPE_SZ
 
 sub set_pipe_sz
 {
+    no autodie;
     my ($self, $fd, $newsize) = @_;
     return fcntl($fd, F_SETPIPE_SZ(), int($newsize));
 }
@@ -157,7 +158,6 @@ sub open_pipe {
     for my $fd (($fd_w, $fd_r)) {
         my $old = $self->get_pipe_sz($fd) or die("Unable to read PIPE_SZ");
         {
-            no autodie;
             my $new;
             while ($newsize > $old) {
                 $new = $self->set_pipe_sz($fd, $newsize);


### PR DESCRIPTION
Fix commit edb3cfdd.

The autodie pragma has lexical scope, meaning that functions and subroutines
altered with autodie will only change their behaviour until the end of
the enclosing block, file, or eval.

I still don't have a glue why it doesn't work. But at least we don't die anymore.

VR:  https://openqa.suse.de/t3861653 (autoinst-log.txt +34669)