### PR TITLE
Further test optimization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ before_install:
   - docker build --no-cache docker/travis_test -t os-autoinst/travis_test:latest
 script:
   - CI_ENV=`bash <(curl -s https://codecov.io/env)` &&
-    docker run --env "QEMU_QMP_CONNECT_ATTEMPTS=10" $CI_ENV --rm -v $TRAVIS_BUILD_DIR:/opt/repo os-autoinst/travis_test:latest 'make && make check coverage-codecov VERBOSE=1'
+    docker run --env "QEMU_QMP_CONNECT_ATTEMPTS=10" --env "EXPECTED_QEMU_START_S=20" $CI_ENV --rm -v $TRAVIS_BUILD_DIR:/opt/repo os-autoinst/travis_test:latest 'make && make check coverage-codecov VERBOSE=1'

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -963,6 +963,7 @@ sub start_qemu {
 
     $self->create_virtio_console_fifo();
     my $qemu_pipe = $self->{qemupipe} = $self->{proc}->exec_qemu();
+    return bmwqemu::fctinfo('Returning early as requested by QEMU_ONLY_EXEC.') if $vars->{QEMU_ONLY_EXEC};
     $self->{qmpsocket} = $self->{proc}->connect_qmp();
     my $init = myjsonrpc::read_json($self->{qmpsocket});
     my $hash = $self->handle_qmp_command({execute => 'qmp_capabilities'});

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,5 @@
 requires 'B::Deparse';
+requires 'Benchmark';
 requires 'Carp';
 requires 'Carp::Always';
 requires 'Class::Accessor::Fast';

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -80,6 +80,7 @@ NICVLAN;integer;undef;network (vlan) number to which the NIC should be connected
 NUMDISKS;integer;1;Number of disks to be created and attached to VM, can be 0 to disable disks
 OFFLINE_SUT;boolean;0;Disable network for a VM
 OFW;boolean;0;QEMU Open Firmware is in use
+QEMU_ONLY_EXEC;boolean;undef;If set, only execute the qemu process but return early before connecting to the process. This can be helpful for cutting testing time or to connect to the qemu process manually.
 QEMU_OVERRIDE_VIDEO_DEVICE_AARCH64;boolean;undef;If set, for aarch64 systems use VGA as video adapter
 QEMU_DISABLE_SNAPSHOTS;boolean;undef;If set, disable snapshots in case the worker has slow disks to avoid save_vm calls failing due to timeouts (See https://bugzilla.suse.com/show_bug.cgi?id=1035453[bsc#1035453])
 QEMU_QMP_CONNECT_ATTEMPTS;integer;20;The number of attempts to connect to qemu qmp. Usually used for internal testing

--- a/t/18-qemu-options.t
+++ b/t/18-qemu-options.t
@@ -38,6 +38,21 @@ chdir($pool_dir);
 $ENV{OSUTILS_WAIT_ATTEMPT_INTERVAL} //= 1;
 $ENV{QEMU_QMP_CONNECT_ATTEMPTS}     //= 1;
 
+my $common_options = <<EOV;
+   "ARCH" : "i386",
+   "BACKEND" : "qemu",
+   "QEMU" : "i386",
+   "QEMU_NO_KVM" : "1",
+   "QEMU_NO_TABLET" : "1",
+   "QEMU_NO_FDC_SET" : "1",
+   "CASEDIR" : "$data_dir/tests",
+   "ISO" : "$data_dir/Core-7.2.iso",
+   "CDMODEL" : "ide-cd",
+   "HDDMODEL" : "ide-drive",
+   "VERSION" : "1",
+EOV
+
+
 # Test QEMU_APPEND option with:
 # * version: '-version'
 # * list machines: '-M ?'
@@ -50,17 +65,8 @@ subtest qemu_append_option => sub {
     open(my $var, '>', 'vars.json');
     print $var <<EOV;
 {
-   "ARCH" : "i386",
-   "BACKEND" : "qemu",
-   "QEMU" : "i386",
-   "QEMU_NO_KVM" : "1",
-   "QEMU_NO_TABLET" : "1",
-   "QEMU_NO_FDC_SET" : "1",
-   "CASEDIR" : "$data_dir/tests",
-   "ISO" : "$data_dir/Core-7.2.iso",
-   "CDMODEL" : "ide-cd",
-   "HDDMODEL" : "ide-drive",
-   "VERSION" : "1",
+$common_options
+   "QEMU_ONLY_EXEC": "1",
    "QEMU_APPEND" : "version"
 }
 EOV
@@ -70,23 +76,14 @@ EOV
     is(system('grep -q -e "-version" autoinst-log.txt'),                                     0, '-version option added');
     is(system('grep -q "QEMU emulator version" autoinst-log.txt'),                           0, 'QEMU version printed');
     is(system('grep -q "Fabrice Bellard and the QEMU Project developers" autoinst-log.txt'), 0, 'Copyright printed');
+    is(system('grep -q "Returning early as requested by QEMU_ONLY_EXEC" autoinst-log.txt'),  0, 'Copyright printed');
     isnt(system('grep -q -e ": invalid option" autoinst-log.txt'), 0, 'no invalid option detected');
 
     # List machines
     open($var, '>', 'vars.json');
     print $var <<EOV;
 {
-   "ARCH" : "i386",
-   "BACKEND" : "qemu",
-   "QEMU" : "i386",
-   "QEMU_NO_KVM" : "1",
-   "QEMU_NO_TABLET" : "1",
-   "QEMU_NO_FDC_SET" : "1",
-   "CASEDIR" : "$data_dir/tests",
-   "ISO" : "$data_dir/Core-7.2.iso",
-   "CDMODEL" : "ide-cd",
-   "HDDMODEL" : "ide-drive",
-   "VERSION" : "1",
+$common_options
    "QEMU_APPEND" : "M ?"
 }
 EOV
@@ -101,17 +98,7 @@ EOV
     open($var, '>', 'vars.json');
     print $var <<EOV;
 {
-   "ARCH" : "i386",
-   "BACKEND" : "qemu",
-   "QEMU" : "i386",
-   "QEMU_NO_KVM" : "1",
-   "QEMU_NO_TABLET" : "1",
-   "QEMU_NO_FDC_SET" : "1",
-   "CASEDIR" : "$data_dir/tests",
-   "ISO" : "$data_dir/Core-7.2.iso",
-   "CDMODEL" : "ide-cd",
-   "HDDMODEL" : "ide-drive",
-   "VERSION" : "1",
+$common_options
    "QEMU_APPEND" : "M ? -version"
 }
 EOV
@@ -127,17 +114,7 @@ EOV
     open($var, '>', 'vars.json');
     print $var <<EOV;
 {
-   "ARCH" : "i386",
-   "BACKEND" : "qemu",
-   "QEMU" : "i386",
-   "QEMU_NO_KVM" : "1",
-   "QEMU_NO_TABLET" : "1",
-   "QEMU_NO_FDC_SET" : "1",
-   "CASEDIR" : "$data_dir/tests",
-   "ISO" : "$data_dir/Core-7.2.iso",
-   "CDMODEL" : "ide-cd",
-   "HDDMODEL" : "ide-drive",
-   "VERSION" : "1",
+$common_options
    "QEMU_APPEND" : "broken option"
 }
 EOV
@@ -159,17 +136,7 @@ subtest qemu_huge_pages_option => sub {
     open(my $var, '>', 'vars.json');
     print $var <<EOV;
 {
-   "ARCH" : "i386",
-   "BACKEND" : "qemu",
-   "QEMU" : "i386",
-   "QEMU_NO_KVM" : "1",
-   "QEMU_NO_TABLET" : "1",
-   "QEMU_NO_FDC_SET" : "1",
-   "CASEDIR" : "$data_dir/tests",
-   "ISO" : "$data_dir/Core-7.2.iso",
-   "CDMODEL" : "ide-cd",
-   "HDDMODEL" : "ide-drive",
-   "VERSION" : "1",
+$common_options
    "QEMU_HUGE_PAGES_PATH" : "/no/dev/hugepages/"
 }
 EOV


### PR DESCRIPTION
* Add test for shutdown time of complete stack
* t: Cut 18-qemu-options.t runtime from 45s to 27s by allowing to abort qemu start early