### PR TITLE
Improve log output of test module as well as lib function lines

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -260,15 +260,15 @@ sub current_test {
 sub update_line_number {
     return unless current_test;
     return unless current_test->{script};
-    my $out    = "";
-    my $ending = quotemeta(current_test->{script});
-    for my $i (1 .. 10) {
-        my ($package, $filename, $line, $subroutine, $hasargs, $wantarray, $evaltext, $is_require, $hints, $bitmask, $hinthash) = caller($i);
-        last unless $filename;
-        next unless $filename =~ m/$ending$/;
-        $logger->debug("$filename:$line called $subroutine");
-        last;
+    my @out;
+    my $casedir = $vars{CASEDIR} // '';
+    for (my $i = 10; $i > 0; $i--) {
+        my ($package, $filename, $line, $subroutine) = caller($i);
+        next unless $filename && $filename =~ /\Q$casedir/;
+        $filename =~ s@$casedir/?@@;
+        push @out, "$filename:$line called $subroutine";
     }
+    $logger->debug(join(' -> ', @out));
     return;
 }
 

--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -56,6 +56,14 @@ subtest 'log_call' => sub {
     stderr_like(\&log_call_test, qr{\Q<<< main::log_call_test(foo="bar\tbaz\rboo\n")}, 'log_call escapes special characters');
 };
 
+subtest 'update_line_number' => sub {
+    $bmwqemu::direct_output = 1;
+    bmwqemu::init_logger();
+    ok !bmwqemu::update_line_number(), 'update_line_number needs current_test defined';
+    $autotest::current_test = {script => 'my/module.pm'};
+    stderr_like(sub { bmwqemu::update_line_number() }, qr{bmwqemu.t.*called.*subtest}, 'update_line_number identifies caller scope');
+};
+
 subtest 'CASEDIR is mandatory' => sub {
     my $dir = '/var/lib/openqa';
     create_vars({DISTRI => 'test'});


### PR DESCRIPTION
Previously there was a log line called for every call of a test API function
but limiting the debug output line to the filename and line number within a
test module with both a very verbose file path that is often not helpful
internal information. For example the file path in case of a caching openQA
worker would be an internally computed one not interested to test reviewers.
Also, for test modules using any kind of internal library functions not the
file location and line location within that library module file would be
reported but instead a repeated output of the same file location and line
number of the calling test module would be shown.

This commit changes the behaviour by stripping the path prefix of "CASEDIR"
which is rewritten by the openQA caching feature to relate relative to paths
that test reviewer can know from the used test distribution. The second
change is that additional to the test module location any other referenced
file within "CASEDIR" is correctly reported with filename and file number.

So for example instead of

```
[2020-02-12T14:55:11.800 CET] [debug] /home/okurz/local/os-autoinst/os-autoinst/t/data//tests/tests/boot.pm:36 called testapi::check_screen
[2020-02-12T14:55:11.801 CET] [debug] <<< testapi::check_screen(mustmatch="core", timeout=15, no_wait=1)
…
[2020-02-12T14:55:13.441 CET] [debug] /home/okurz/local/os-autoinst/os-autoinst/t/data//tests/tests/boot.pm:37 called helper::my_helper
[2020-02-12T14:55:13.441 CET] [debug] <<< testapi::assert_screen(mustmatch="core", timeout=42)
…
[2020-02-12T14:55:14.432 CET] [debug] /home/okurz/local/os-autoinst/os-autoinst/t/data//tests/tests/boot.pm:37 called helper::my_helper
```

we now get

```
[2020-02-12T15:47:57.979 CET] [debug] tests/boot.pm:36 called testapi::check_screen
[2020-02-12T15:47:57.980 CET] [debug] <<< testapi::check_screen(mustmatch="core", no_wait=1, timeout=15)
…
[2020-02-12T15:47:59.623 CET] [debug] tests/boot.pm:37 called helper::my_helper -> lib/helper.pm:24 called testapi::assert_screen
[2020-02-12T15:47:59.623 CET] [debug] <<< testapi::assert_screen(mustmatch="core", timeout=42)
…
[2020-02-12T15:48:00.621 CET] [debug] tests/boot.pm:37 called helper::my_helper -> lib/helper.pm:25 called testapi::assert_screen
```

with no redundant repetition but additional information.