### PR TITLE
Improve bwmqemu::log_call

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -283,11 +283,22 @@ sub pp {
 sub log_call {
     my $fname = (caller(1))[3];
     update_line_number();
-    my @result;
-    while (my ($key, $value) = splice(@_, 0, 2)) {
-        push @result, join("=", $key, pp($value));
+    my $params;
+    if (@_ == 1) {
+        $params = pp($_[0]);
     }
-    my $params = join(", ", @result);
+    else {
+        # key/value pairs
+        my @result;
+        while (my ($key, $value) = splice(@_, 0, 2)) {
+            if ($key =~ tr/0-9a-zA-Z_//c) {
+                # only quote if needed
+                $key = pp($key);
+            }
+            push @result, join("=", $key, pp($value));
+        }
+        $params = join(", ", @result);
+    }
     $logger = Mojo::Log->new(level => 'debug', format => \&log_format_callback) unless $logger;
     $logger->debug('<<< ' . $fname . "($params)");
     return;

--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -54,6 +54,16 @@ subtest 'log_call' => sub {
         bmwqemu::log_call(foo => "bar\tbaz\rboo\n");
     }
     stderr_like(\&log_call_test, qr{\Q<<< main::log_call_test(foo="bar\tbaz\rboo\n")}, 'log_call escapes special characters');
+
+    sub log_call_test_escape_key {
+        bmwqemu::log_call("foo\nbar" => "bar\tbaz\rboo\n");
+    }
+    stderr_like(\&log_call_test_escape_key, qr{\Q<<< main::log_call_test_escape_key("foo\nbar"="bar\tbaz\rboo\n")}, 'log_call escapes special characters');
+
+    sub log_call_test_single {
+        bmwqemu::log_call("bar\tbaz\rboo\n");
+    }
+    stderr_like(\&log_call_test_single, qr{\Q<<< main::log_call_test_single("bar\tbaz\rboo\n")}, 'log_call escapes special characters');
 };
 
 subtest 'update_line_number' => sub {


### PR DESCRIPTION
If called with only one parameter, don't try to log like key/vale pairs

Issue: https://progress.opensuse.org/issues/63808

