### PR TITLE
Add support to checkout git refspec in existing working copies

### DIFF
--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -6,7 +6,7 @@ Supported variables per backend
 [options="header",cols="^m,^m,^m,v",separator=";"]
 |====================
 Variable;Values allowed;Default value;Explanation
-CASEDIR;string;;Path to test distribution. Can be a git repository URL of a test distribution to checkout with an optional refspec into the current directory. It tries to follow the definition of https://docs.npmjs.com/files/package.json#git-urls-as-dependencies (e.g. `https://github.com/os-autoinst/os-autoinst-distri-opensuse.git#feature/test` or `git@github.com:os-autoinst/os-autoinst-distri-opensuse.git`). Note that cloning via SSH is only possible if git is configured accordingly on the host where isotovideo is executed.
+CASEDIR;string;;Path to test distribution. Can be a git repository URL of a test distribution to checkout with an optional refspec into the current directory. It tries to follow the definition of https://docs.npmjs.com/files/package.json#git-urls-as-dependencies (e.g. `https://github.com/os-autoinst/os-autoinst-distri-opensuse.git#feature/test` or `git@github.com:os-autoinst/os-autoinst-distri-opensuse.git`). Note that cloning via SSH is only possible if git is configured accordingly on the host where isotovideo is executed. Can be combined with `TEST_GIT_REFSPEC` and `NEEDLES_GIT_REFSPEC`.
 PRODUCTDIR;string;;Path to optional "product directory" which includes the test schedule entry point "main.pm" as well as a "needles" subdirectory with the needles to load. Can be relative path.
 NEEDLES_DIR;string;;Path to needles subdirectory to use, defaults to "needles" within `PRODUCTDIR`. Can be a git repository URL, comparable to `CASEDIR`
 INCLUDE_MODULES;string;;comma separated names or fullnames of test modules to be included while excluding all that do not match, e.g. "boot,mod1"
@@ -14,6 +14,8 @@ EXCLUDE_MODULES;string;;comma separated names or fullnames of test modules to ex
 SCHEDULE;string;;comma separated list of relative paths to test modules within CASEDIR without the implicit file extension '.pm' to be scheduled instead of evaluating a schedule from the test distributions main.pm file, e.g. "boot,console/mod1"
 _EXIT_AFTER_SCHEDULE;boolean;0;Exit test execution immediately after evaluation of the test schedule, e.g. to check only which test modules would be executed
 _SKIP_POST_FAIL_HOOKS;boolean;0;Skip the execution of post_fail_hook methods if set. This can be useful to save test execution time during test development when the post_fail_hook is not expected to provide any value as most likely the test developer already knows what needs to be done as a next step on a test fail. Note that this also skips the test module result evaluation, for example a failing fatal test module does not abort the isotovideo run.
+TEST_GIT_REFSPEC;string;;git refspec to checkout within `CASEDIR` when `CASEDIR` is a git working copy. By default, does not change the content of `CASEDIR`. Overrides the optional git refspec in `CASEDIR`. Can be used to explicitly select a git commit within an existing git working copy and also to skip unnecessary git network transfers when `CASEDIR` is already providing the right git working copy.
+NEEDLES_GIT_REFSPEC;string;;git refspec to checkout within `NEEDLES_DIR`. See `TEST_GIT_REFSPEC` for details.
 NOVIDEO;boolean;0;Do not encode video if set
 NO_DEBUG_IO;boolean;0;Disable the I/O debug output in case of needle comparison times longer than expected
 OSUTILS_WAIT_ATTEMPT_INTERVAL;float;1;The interval in seconds between "attempts" in osutils, e.g. used for connections to qemu qmp backend

--- a/isotovideo
+++ b/isotovideo
@@ -84,7 +84,7 @@ use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 Getopt::Long::Configure("no_ignore_case");
 use OpenQA::Isotovideo::CommandHandler;
 use OpenQA::Isotovideo::Interface;
-use OpenQA::Isotovideo::Utils;
+use OpenQA::Isotovideo::Utils qw(checkout_git_repo_and_branch checkout_git_refspec);
 
 session->enable;
 session->enable_subreaper;
@@ -244,7 +244,7 @@ $SIG{HUP}  = \&signalhandler;
 $ENV{LC_ALL} = 'en_US.UTF-8';
 $ENV{LANG}   = 'en_US.UTF-8';
 
-OpenQA::Isotovideo::Utils::checkout_git_repo_and_branch('CASEDIR');
+checkout_git_repo_and_branch('CASEDIR');
 
 # Try to load the main.pm from one of the following in this order:
 #  - product dir
@@ -255,14 +255,15 @@ OpenQA::Isotovideo::Utils::checkout_git_repo_and_branch('CASEDIR');
 $bmwqemu::vars{PRODUCTDIR} ||= $bmwqemu::vars{CASEDIR};
 
 # checkout Git repo NEEDLES_DIR refers to (if it is a URL) and re-assign NEEDLES_DIR to contain the checkout path
-OpenQA::Isotovideo::Utils::checkout_git_repo_and_branch('NEEDLES_DIR');
+checkout_git_repo_and_branch('NEEDLES_DIR');
 
 bmwqemu::ensure_valid_vars();
 
-# as we are about to load the test modules store the git hash that has been
-# used. If it is not a git repo fail silently, i.e. store an empty variable
+# as we are about to load the test modules checkout the specified git refspec,
+# if specified, or simply store the git hash that has been used. If it is not a
+# git repo fail silently, i.e. store an empty variable
 
-$bmwqemu::vars{TEST_GIT_HASH} = OpenQA::Isotovideo::Utils::calculate_git_hash($bmwqemu::vars{CASEDIR});
+$bmwqemu::vars{TEST_GIT_HASH} = checkout_git_refspec($bmwqemu::vars{CASEDIR} => 'TEST_GIT_REFSPEC');
 
 # start the command fork before we get into the backend, the command child
 # is not supposed to talk to the backend directly
@@ -300,11 +301,7 @@ if ($bmwqemu::vars{_EXIT_AFTER_SCHEDULE}) {
     exit 0;
 }
 testapi::init();
-
-# make sure the needles are initialized
-$bmwqemu::vars{NEEDLES_GIT_HASH} = OpenQA::Isotovideo::Utils::calculate_git_hash(needle::init);
-
-# init part
+needle::init();
 bmwqemu::save_vars();
 
 my $testfd;

--- a/needle.pm
+++ b/needle.pm
@@ -30,6 +30,7 @@ use File::Basename;
 use Try::Tiny;
 require IPC::System::Simple;
 use OpenQA::Benchmark::Stopwatch;
+use OpenQA::Isotovideo::Utils 'checkout_git_refspec';
 
 our %needles;
 our %tags;
@@ -327,6 +328,7 @@ sub init {
     $needles_dir = ($bmwqemu::vars{NEEDLES_DIR} // default_needles_dir);
     $needles_dir = File::Spec->catdir($bmwqemu::vars{CASEDIR}, $needles_dir) unless -d $needles_dir;
     die "needles_dir not found: $needles_dir (check vars.json?)" unless -d $needles_dir;
+    $bmwqemu::vars{NEEDLES_GIT_HASH} = checkout_git_refspec($needles_dir => 'NEEDLES_GIT_REFSPEC');
 
     %needles = ();
     %tags    = ();

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -22,6 +22,8 @@ sub isotovideo {
 
 sub is_in_log {
     my ($regex, $msg) = @_;
+    # adjust file location report on error to one level up
+    local $Test::Builder::Level = $Test::Builder::Level + 2;
     is(system("grep -q \"$regex\" autoinst-log.txt"), 0, $msg);
 }
 
@@ -60,6 +62,13 @@ subtest 'isotovideo with custom git repo parameters specified' => sub {
     is_in_log('git URL.*\<repo\>', 'git repository would be cloned');
     is_in_log('branch.*foo',       'branch in git repository would be checked out');
     is_in_log('No scripts',        'the repo actually has no test definitions');
+};
+
+subtest 'isotovideo with git refspec specified' => sub {
+    chdir($pool_dir);
+    unlink('vars.json') if -e 'vars.json';
+    isotovideo(opts => "casedir=$data_dir/tests test_git_refspec=deadbeef _exit_after_schedule=1");
+    is_in_log("Checking.*local.*deadbeef", 'refspec in local git repository would be checked out');
 };
 
 subtest 'productdir variable relative/absolute' => sub {


### PR DESCRIPTION
The test variable CASEDIR already provides the possibility to clone a
git repository and checkout a git repository. However this can be a
costly operation. When the provided CASEDIR is already a git working
copy we can instead simply checkout a commit within that working copy.

Related progress issue: https://progress.opensuse.org/issues/60272