### PR TITLE
lockapi: handle 400 which we could get from openQA API

### DIFF
--- a/lockapi.pm
+++ b/lockapi.pm
@@ -39,7 +39,7 @@ sub _try_lock {
         sleep 10;
     }
     bmwqemu::mydie "$type '$name': lock owner already finished" if $res == 410;
-    if ($res != 409) {
+    if ($res != 409 and $res != 400) {
         bmwqemu::fctwarn("Unknown return code $res for lock api");
     }
     return 0;

--- a/mmapi.pm
+++ b/mmapi.pm
@@ -75,12 +75,15 @@ sub api_call {
     $expected_codes //= {
         200 => 1,
         409 => 1,
+        400 => 1,
     };
 
     my $res;
     while ($tries--) {
         $res = $ua->$method($ua_url)->res;
-        last if $expected_codes->{$res->code};
+        my $body = $res->body;
+        bmwqemu::log_call('mmapi call: ' . $body) if defined $body and $res->code != 200;
+        last                                      if $expected_codes->{$res->code};
     }
     return $res;
 }


### PR DESCRIPTION
Currently in case mutex has wrong name you will get 400 error . This situation appear unexpected for os-autoinst 