### PR TITLE
Further speedup isotovideo shutdown by 1-2s

### DIFF
--- a/backend/driver.pm
+++ b/backend/driver.pm
@@ -98,7 +98,7 @@ sub start {
 
             $self->{backend}->run(fileno($process->channel_in), fileno($process->channel_out));
             _exit(0);
-    })->blocking_stop(1)->separate_err(0)->subreaper(1)->start;
+    }, sleeptime_during_kill => .1)->blocking_stop(1)->separate_err(0)->subreaper(1)->start;
 
     $backend_process->on(collected => sub { bmwqemu::diag("backend process exited: " . shift->exit_status) });
 

--- a/backend/null.pm
+++ b/backend/null.pm
@@ -1,0 +1,42 @@
+# Copyright © 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package backend::null;
+
+use strict;
+use warnings;
+
+use base 'backend::baseclass';
+
+sub new { shift->SUPER::new }
+
+sub do_start_vm { {} }
+
+sub do_stop_vm { }
+
+sub run_cmd { }
+
+sub can_handle { }
+
+sub is_shutdown { 1 }
+
+sub check_socket {
+    my ($self, $fh, $write) = @_;
+    $self->SUPER::check_socket($fh, $write);
+}
+
+sub stop_serial_grab { }
+
+1;

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -155,7 +155,7 @@ sub _check_publish_vars {
         for my $type (qw(STORE PUBLISH FORCE_PUBLISH)) {
             my $name = $type . "_HDD_$i";
             next unless my $out = $vars{$name};
-            die "HDD_$i also specified in $name. This is not supported" if grep { $_ eq $out } @hdds;
+            die "HDD_$i also specified in $name. This is not supported" if grep { $_ && $_ eq $out } @hdds;
         }
     }
     return 1;

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -14,9 +14,12 @@ my $pool_dir     = "$toplevel_dir/t/pool";
 
 sub isotovideo {
     my (%args) = @_;
-    $args{opts}      //= '';
-    $args{exit_code} //= 1;
-    system("perl $toplevel_dir/isotovideo -d $args{opts} 2>&1 | tee autoinst-log.txt");
+    $args{default_opts} //= 'backend=null';
+    $args{opts}         //= '';
+    $args{exit_code}    //= 1;
+    my $cmd = "perl $toplevel_dir/isotovideo -d $args{default_opts} $args{opts} 2>&1 | tee autoinst-log.txt";
+    note("Starting isotovideo with: $cmd");
+    system($cmd);
     is(system('grep -q "\d*: EXIT ' . $args{exit_code} . '" autoinst-log.txt'), 0, $args{end_test_str} ? $args{end_test_str} : 'isotovideo run exited as expected');
 }
 


### PR DESCRIPTION
As a followup to 454c5dc0, same as for other subprocesses that we spawn we can
also use a flag to reduce the sleeptime during the shutdown of the "driver"
process, i.e. "backend".

I profiled with `(cd t/pool && perl -d:NYTProf ../../isotovideo -d)` to find
out the biggest time consumer during a short "start+stop" cycle of isotovideo.
This brought me back to the backend process which I thought I had covered in
454c5dc0, maybe forgot, maybe reverted for a good reason that we will learn
about later ;)

For a statistical proof I conducted runtime measurements.
Using '(cd t/pool && avgtime -r=5 -p ../../isotovideo -d)' without any
modifications I get:

Median time    : 6657.16
Avg time       : 6824.06
Std dev.       : 402.794
Minimum        : 6587.82
Maximum        : 7627.35

with `, sleeptime_during_kill => .1` on the process in driver::start:

Median time    : 5591.99
Avg time       : 5592.33
Std dev.       : 8.85996
Minimum        : 5580.75
Maximum        : 5605.03

so a significant improvement of 1.3+-0.4s which should be proof enough for the
change within this pull request.

Further I took the chance to test further combinations and alternatives, e.g.
just https://github.com/mudler/Mojo-IOLoop-ReadWriteProcess/pull/6 :

Median time    : 5203.46
Avg time       : 5353.43
Std dev.       : 212.99
Minimum        : 5141.65
Maximum        : 5639.83

showing another, independant improvement.

with https://github.com/mudler/Mojo-IOLoop-ReadWriteProcess/pull/6 and
additionally `, sleeptime_during_kill => .1`:

Median time    : 4272.04
Avg time       : 4430.27
Std dev.       : 251.437
Minimum        : 4190.39
Maximum        : 4829.96

We see that the positive effects accumulate.

with …pull/6 and `, sleeptime_during_kill => .01`:

Median time    : 4102.76
Avg time       : 4355.76
Std dev.       : 400.075
Minimum        : 4028.73
Maximum        : 5065.25

showing that no significant further improvement is visible.

with …pull/6 and `, sleeptime_during_kill => .01` and `, kill_sleeptime => .01`:

Median time    : 4538.72
Avg time       : 4446.54
Std dev.       : 187.31
Minimum        : 4072.02
Maximum        : 4546.59

also no significant further improvement.

For the "null" backend, n=50, with …pull/6 and `, sleeptime_during_kill => .01`
and `, kill_sleeptime => .01`:

Median time    : 1529.18
Avg time       : 1366.56
Std dev.       : 551.558
Minimum        : 626.798
Maximum        : 2773.82

"null" backend, n=50, with …pull/6 and `, sleeptime_during_kill => .01`:

Median time    : 1534.52
Avg time       : 1378.34
Std dev.       : 599.227
Minimum        : 687.546
Maximum        : 2901.23

"null" backend, n=50, with …pull/6 and `, sleeptime_during_kill => .1`:

Median time    : 1530.83
Avg time       : 1326.06
Std dev.       : 569.442
Minimum        : 689.181
Maximum        : 2558.02

"null" backend, n=50, with …pull/6:

Median time    : 2426.69
Avg time       : 2195.34
Std dev.       : 602.505
Minimum        : 700.167
Maximum        : 3625.74

"null" backend, n=50:

Median time    : 2518.98
Avg time       : 2411.55
Std dev.       : 568.33
Minimum        : 1519.95
Maximum        : 3631.11

Related progress issue: https://progress.opensuse.org/issues/58379