### PR TITLE
Add optional args to GENERAL_HW_POWERON_CMD and GENERAL_HW_POWEROFF_CMD

### DIFF
--- a/backend/generalhw.pm
+++ b/backend/generalhw.pm
@@ -45,10 +45,8 @@ sub get_cmd {
         die "GENERAL_HW_CMD_DIR is not pointing to a directory";
     }
 
-    my $args = get_var('GENERAL_HW_FLASH_ARGS') if ($cmd eq 'GENERAL_HW_FLASH_CMD' and get_var('GENERAL_HW_FLASH_ARGS'));
-    $args = get_var('GENERAL_HW_SOL_ARGS')      if ($cmd eq 'GENERAL_HW_SOL_CMD'      and get_var('GENERAL_HW_SOL_ARGS'));
-    $args = get_var('GENERAL_HW_POWERON_ARGS')  if ($cmd eq 'GENERAL_HW_POWERON_CMD'  and get_var('GENERAL_HW_POWERON_ARGS'));
-    $args = get_var('GENERAL_HW_POWEROFF_ARGS') if ($cmd eq 'GENERAL_HW_POWEROFF_CMD' and get_var('GENERAL_HW_POWEROFF_ARGS'));
+    my %GENERAL_HW_ARG_VARIABLES_BY_CMD = ('GENERAL_HW_FLASH_CMD' => 'GENERAL_HW_FLASH_ARGS', 'GENERAL_HW_SOL_CMD' => 'GENERAL_HW_SOL_ARGS', 'GENERAL_HW_POWERON_CMD' => 'GENERAL_HW_POWERON_ARGS', 'GENERAL_HW_POWEROFF_CMD' => 'GENERAL_HW_POWEROFF_ARGS');
+    my $args = get_var($GENERAL_HW_ARG_VARIABLES_BY_CMD{$cmd}) if get_var($GENERAL_HW_ARG_VARIABLES_BY_CMD{$cmd});
 
     # Append HDD infos to flash script
     if ($cmd eq 'GENERAL_HW_FLASH_CMD' and get_var('HDD_1')) {

--- a/backend/generalhw.pm
+++ b/backend/generalhw.pm
@@ -46,7 +46,9 @@ sub get_cmd {
     }
 
     my $args = get_var('GENERAL_HW_FLASH_ARGS') if ($cmd eq 'GENERAL_HW_FLASH_CMD' and get_var('GENERAL_HW_FLASH_ARGS'));
-    $args = get_var('GENERAL_HW_SOL_ARGS') if ($cmd eq 'GENERAL_HW_SOL_CMD' and get_var('GENERAL_HW_SOL_ARGS'));
+    $args = get_var('GENERAL_HW_SOL_ARGS')      if ($cmd eq 'GENERAL_HW_SOL_CMD'      and get_var('GENERAL_HW_SOL_ARGS'));
+    $args = get_var('GENERAL_HW_POWERON_ARGS')  if ($cmd eq 'GENERAL_HW_POWERON_CMD'  and get_var('GENERAL_HW_POWERON_ARGS'));
+    $args = get_var('GENERAL_HW_POWEROFF_ARGS') if ($cmd eq 'GENERAL_HW_POWEROFF_CMD' and get_var('GENERAL_HW_POWEROFF_ARGS'));
 
     # Append HDD infos to flash script
     if ($cmd eq 'GENERAL_HW_FLASH_CMD' and get_var('HDD_1')) {

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -185,7 +185,9 @@ GENERAL_HW_CMD_DIR;string;;Directory with allowed CMD scripts
 GENERAL_HW_SOL_CMD;string;;Shell Script to output serial output (in CMD_DIR)
 GENERAL_HW_SOL_ARGS;string;;Arguments to pass GENERAL_HW_SOL_CMD Shell script
 GENERAL_HW_POWERON_CMD;string;;Shell Command to power on the SUT (in CMD_DIR)
+GENERAL_HW_POWERON_ARGS;string;;Arguments to pass GENERAL_HW_POWERON_CMD Shell script
 GENERAL_HW_POWEROFF_CMD;string;;Shell Command to power off the SUT (in CMD_DIR)
+GENERAL_HW_POWEROFF_ARGS;string;;Arguments to pass GENERAL_HW_POWEROFF_CMD Shell script
 GENERAL_HW_FLASH_CMD;string;;Shell Command to flash a disk image on SUT (in CMD_DIR), optionnal
 GENERAL_HW_FLASH_ARGS;string;;Arguments to pass GENERAL_HW_FLASH_CMD Shell script
 |====================


### PR DESCRIPTION
This is required for some power systems, such as those reachable by network where you need to pass IP/hostname.