### PR TITLE
Add power function to spvm backend

### DIFF
--- a/backend/spvm.pm
+++ b/backend/spvm.pm
@@ -95,4 +95,17 @@ sub stop_serial_grab {
     return;
 }
 
+sub power {
+    # parameters: on, off, reset
+    my ($self, $args) = @_;
+    my $action  = $args->{action};
+    my $lpar_id = get_required_var('NOVALINK_LPAR_ID');
+
+    my %cmds = (
+        on    => "pvmctl lpar power-on -i id=${lpar_id} --bootmode norm",
+        off   => "pvmctl lpar power-off -i id=${lpar_id} --hard",
+        reset => "pvmctl lpar restart -i id=${lpar_id}");
+    $self->run_cmd($cmds{$action}) if (exists($cmds{$action})) || die "Unknown power action ${action}";
+}
+
 1;


### PR DESCRIPTION
Enhancement poo#64180: Power function was not implemented for spvm
backend. It is possible to use power function for reset, power off/on
operations.

Verification: http://black-bit.suse.cz/tests/4158/file/autoinst-log.txt
```
[2020-03-11T13:45:34.494 CET] [debug] <<< testapi::power(action="reset")
[2020-03-11T13:45:34.494 CET] [debug] <<< backend::baseclass::run_ssh_cmd(cmd="pvmctl lpar restart -i id=3", wantarray=0, username="padmin", password="SECRET", hostname="vugava.arch.suse.de", keep_open=0)
[2020-03-11T13:45:34.494 CET] [debug] <<< backend::baseclass::run_ssh(cmd="pvmctl lpar restart -i id=3", wantarray=0, username="padmin", password="SECRET", hostname="vugava.arch.suse.de", keep_open=0)
[2020-03-11T13:45:34.494 CET] [debug] <<< backend::baseclass::new_ssh_connection(wantarray=0, username="padmin", password="SECRET", keep_open=0, hostname="vugava.arch.suse.de", blocking=1)
[2020-03-11T13:45:34.776 CET] [debug] SSH connection to padmin@vugava.arch.suse.de established
[2020-03-11T13:45:42.897 CET] [debug] [run_ssh_cmd(pvmctl lpar restart -i id=3)] stdout:
Restarting partition vugava-1, this may take a few minutes.
Partition vugava-1 restart successful.

[2020-03-11T13:47:44.167 CET] [debug] <<< testapi::power(action="off")
[2020-03-11T13:47:44.167 CET] [debug] <<< backend::baseclass::run_ssh_cmd(cmd="pvmctl lpar power-off -i id=3 --hard", hostname="vugava.arch.suse.de", keep_open=0, password="SECRET", wantarray=0, username="padmin")
[2020-03-11T13:47:44.167 CET] [debug] <<< backend::baseclass::run_ssh(cmd="pvmctl lpar power-off -i id=3 --hard", hostname="vugava.arch.suse.de", keep_open=0, username="padmin", wantarray=0, password="SECRET")
[2020-03-11T13:47:44.168 CET] [debug] <<< backend::baseclass::new_ssh_connection(keep_open=0, hostname="vugava.arch.suse.de", blocking=1, username="padmin", wantarray=0, password="SECRET")
[2020-03-11T13:47:44.449 CET] [debug] SSH connection to padmin@vugava.arch.suse.de established
[2020-03-11T13:47:52.564 CET] [debug] [run_ssh_cmd(pvmctl lpar power-off -i id=3 --hard)] stdout:
Powering off partition vugava-1, this may take a few minutes.
Partition vugava-1 power-off successful.

[2020-03-11T13:47:52.581 CET] [debug] tests/console/lpar.pm:39 called testapi::power
[2020-03-11T13:47:52.581 CET] [debug] <<< testapi::power(action="on")
[2020-03-11T13:47:52.582 CET] [debug] <<< backend::baseclass::run_ssh_cmd(cmd="pvmctl lpar power-on -i id=3 --bootmode norm", keep_open=0, hostname="vugava.arch.suse.de", wantarray=0, username="padmin", password="SECRET")
[2020-03-11T13:47:52.582 CET] [debug] <<< backend::baseclass::run_ssh(cmd="pvmctl lpar power-on -i id=3 --bootmode norm", wantarray=0, username="padmin", password="SECRET", keep_open=0, hostname="vugava.arch.suse.de")
[2020-03-11T13:47:52.582 CET] [debug] <<< backend::baseclass::new_ssh_connection(blocking=1, keep_open=0, hostname="vugava.arch.suse.de", password="SECRET", username="padmin", wantarray=0)
[2020-03-11T13:47:52.868 CET] [debug] SSH connection to padmin@vugava.arch.suse.de established
[2020-03-11T13:47:57.549 CET] [debug] [run_ssh_cmd(pvmctl lpar power-on -i id=3 --bootmode norm)] stdout:
Powering on partition vugava-1, this may take a few minutes.
Partition vugava-1 power-on successful.

[2020-03-11T13:50:00.892 CET] [debug] <<< testapi::power(action="fuuuuu")
[2020-03-11T13:50:00.893 CET] [debug] Backend process died, backend errors are reported below in the following lines:
Unknown power action fuuuuu at /usr/lib/os-autoinst/backend/spvm.pm line 108.
```
Verification that standard installation is not impacted:
http://black-bit.suse.cz/tests/4157