### PR TITLE
Simplify automatic coverage analysis with just statement coverage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -257,7 +257,7 @@ TEST_FILES = \
 
 PATHRE = ^|$(PWD)/|\.\./
 COVER_OPTS = \
-	PERL5OPT="-MDevel::Cover=-db,$(abs_builddir)/cover_db,-select,($(PATHRE))(OpenQA|backend|consoles|ppmclibs)/|($(PATHRE))isotovideo|($(PATHRE))[^/]+\.pm,-ignore,\.t|data/tests/|fake/tests/|/usr/bin/prove"
+	PERL5OPT="-MDevel::Cover=-db,$(abs_builddir)/cover_db,-select,($(PATHRE))(OpenQA|backend|consoles|ppmclibs)/|($(PATHRE))isotovideo|($(PATHRE))[^/]+\.pm,-ignore,\.t|data/tests/|fake/tests/|/usr/bin/prove,-coverage,statement"
 TEST_OPTS = \
 	PERL5LIB="$(PWD):$(PWD)/ppmclibs:$(PWD)/ppmclibs/blib/arch/auto/tinycv:$$PERL5LIB"
 


### PR DESCRIPTION
Just collect statement coverage by default, same as done for openQA for
better stability in coverage check.

Related progress issue: https://progress.opensuse.org/issues/55364