### PR TITLE
Fix git hash not being able to compute when no git is available

### DIFF
--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -28,7 +28,7 @@ sub calculate_git_hash {
     my ($git_repo_dir) = @_;
     my $dir = getcwd();
     chdir($git_repo_dir);
-    chomp(my $git_hash = qx{git rev-parse HEAD});
+    chomp(my $git_hash = qx{git rev-parse HEAD ||:});
     $git_hash ||= "UNKNOWN";
     chdir($dir);
     diag "git hash in $git_repo_dir: $git_hash";


### PR DESCRIPTION
This fixes a regression introduced with 87856568 as we try to compute
the git hash of the needle checkout directory also within
t/01-test_needle.t as we moved the functionality to needle::init. As in
before we simply want to ignore any potential problem with the git
executable completely at this point. This also covers the executable not
being existant at all.