### PR TITLE
Use :report_warnings feature of Test::Warnings

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -85,7 +85,7 @@ on 'test' => sub {
     requires 'Test::Output';
     requires 'Test::Pod';
     requires 'Test::Strict';
-    requires 'Test::Warnings';
+    requires 'Test::Warnings', '>= 0.029';
 
 };
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -70,7 +70,7 @@ test_requires:
   perl(Test::Output):
   perl(Test::Pod):
   perl(Test::Strict):
-  perl(Test::Warnings):
+  perl(Test::Warnings): '>= 0.029'
   qemu:
   qemu-kvm:
   qemu-tools:

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -53,7 +53,7 @@ Source0:        %{name}-%{version}.tar.xz
 %define make_check_args CHECK_DOC=0
 %endif
 # The following line is generated from dependencies.yaml
-%define test_requires %build_requires %requires %spellcheck_requires perl(Benchmark) perl(Devel::Cover) perl(FindBin) perl(Perl::Critic) perl(Perl::Critic::Freenode) perl(Pod::Coverage) perl(Test::Exception) perl(Test::Fatal) perl(Test::Mock::Time) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::More) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) qemu qemu-kvm qemu-tools qemu-x86
+%define test_requires %build_requires %requires %spellcheck_requires perl(Benchmark) perl(Devel::Cover) perl(FindBin) perl(Perl::Critic) perl(Perl::Critic::Freenode) perl(Pod::Coverage) perl(Test::Exception) perl(Test::Fatal) perl(Test::Mock::Time) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::More) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 qemu qemu-kvm qemu-tools qemu-x86
 # The following line is generated from dependencies.yaml
 %define devel_requires %requires_not_needed_in_tests %test_requires perl(Devel::Cover) perl(Devel::Cover::Report::Codecov) perl(Perl::Tidy) perl(YAML::PP)
 BuildRequires:  %test_requires

--- a/t/00-compile-check-all.t
+++ b/t/00-compile-check-all.t
@@ -18,7 +18,7 @@ use strict;
 use warnings;
 # We need :no_end_test here because otherwise it would output a no warnings
 # test for each of the modules, but with the same test number
-use Test::Warnings ':no_end_test';
+use Test::Warnings qw(:no_end_test :report_warnings);
 use Test::Strict;
 
 use FindBin '$Bin';

--- a/t/01-test_needle.t
+++ b/t/01-test_needle.t
@@ -6,7 +6,7 @@ use Cwd 'abs_path';
 use Test::Exception;
 use Test::Output qw(combined_like stderr_like);
 use Test::More;
-use Test::Warnings 'warning';
+use Test::Warnings qw(warning :report_warnings);
 use File::Basename;
 use File::Path 'make_path';
 use File::Temp qw(tempdir);

--- a/t/02-test_ocr.t
+++ b/t/02-test_ocr.t
@@ -5,7 +5,7 @@ use warnings;
 
 use Test::More;
 use Test::Output;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use File::Which 'which';
 use File::Basename;
 

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -8,7 +8,7 @@ use File::Temp;
 use Test::More;
 use Test::Output;
 use Test::Fatal;
-use Test::Warnings ':all';
+use Test::Warnings qw(:all :report_warnings);
 use Test::Exception;
 use Scalar::Util 'looks_like_number';
 

--- a/t/04-check_vars_docu.t
+++ b/t/04-check_vars_docu.t
@@ -19,7 +19,7 @@
 use strict;
 use warnings;
 
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Test::More;
 use FindBin;
 use File::Find;

--- a/t/06-pod-coverage.t
+++ b/t/06-pod-coverage.t
@@ -8,7 +8,7 @@ BEGIN {
 }
 
 use Test::More;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Pod::Coverage;
 use File::Basename;
 

--- a/t/07-commands.t
+++ b/t/07-commands.t
@@ -29,7 +29,7 @@ use commands;
 use Mojo::IOLoop::Server;
 use Time::HiRes 'sleep';
 use Test::More;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Test::Output;
 use Test::Mojo;
 use Mojo::File qw(path tempfile tempdir);

--- a/t/09-lockapi.t
+++ b/t/09-lockapi.t
@@ -5,7 +5,7 @@ use warnings;
 
 use Test::More;
 use Test::MockModule;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 
 use lockapi;
 

--- a/t/10-terminal.t
+++ b/t/10-terminal.t
@@ -24,7 +24,7 @@ use Mojo::Log;
 use Mojo::JSON qw( encode_json decode_json );
 
 use Test::More;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use FindBin '$Bin';
 my $main_pid = $$;
 

--- a/t/10-test-image-conversion-benchmark.t
+++ b/t/10-test-image-conversion-benchmark.t
@@ -4,7 +4,7 @@
 use strict;
 use warnings;
 use Test::More;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 
 use Try::Tiny;
 use File::Basename;

--- a/t/11-image-ppm.t
+++ b/t/11-image-ppm.t
@@ -4,7 +4,7 @@
 use strict;
 use warnings;
 use Test::More;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 
 use Try::Tiny;
 use File::Basename;

--- a/t/13-osutils.t
+++ b/t/13-osutils.t
@@ -19,7 +19,7 @@ use 5.018;
 use warnings;
 use Test::More;
 use Test::MockModule;
-use Test::Warnings ':all';
+use Test::Warnings qw(:all :report_warnings);
 use Test::Output;
 
 subtest qv => sub {

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -8,7 +8,7 @@ use Test::More;
 use Test::MockModule;
 use Test::MockObject;
 use Test::Output qw(combined_like stderr_like);
-use Test::Warnings ':all';
+use Test::Warnings qw(:all :report_warnings);
 use Test::Fatal;
 use FindBin '$Bin';
 use Mojo::File 'tempdir';

--- a/t/18-qemu-options.t
+++ b/t/18-qemu-options.t
@@ -17,7 +17,7 @@
 use strict;
 use warnings;
 use Test::More;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Try::Tiny;
 use File::Basename;
 use Cwd 'abs_path';

--- a/t/18-qemu.t
+++ b/t/18-qemu.t
@@ -6,7 +6,7 @@ use warnings;
 
 use Test::More;
 use Test::Fatal;
-use Test::Warnings 'warnings';
+use Test::Warnings qw(warnings :report_warnings);
 use Mojo::File qw(tempfile tempdir path);
 use Carp 'cluck';
 use FindBin '$Bin';

--- a/t/19-isotovideo-command-processing.t
+++ b/t/19-isotovideo-command-processing.t
@@ -5,7 +5,7 @@ use warnings;
 
 use Test::More;
 use Test::MockModule;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Mojo::JSON;
 use OpenQA::Isotovideo::CommandHandler;
 use OpenQA::Isotovideo::Interface;

--- a/t/20-openqa-benchmark-stopwatch-utils.t
+++ b/t/20-openqa-benchmark-stopwatch-utils.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 use Test::More;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Time::HiRes 'sleep';
 
 

--- a/t/21-needle-downloader.t
+++ b/t/21-needle-downloader.t
@@ -7,7 +7,7 @@ use File::Touch;
 use File::Path qw(make_path remove_tree);
 use Test::More;
 use Test::MockModule;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Test::Output 'stderr_like';
 use Mojo::File qw(path tempdir);
 use OpenQA::Isotovideo::NeedleDownloader;

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -6,7 +6,7 @@ use warnings;
 use Test::More;
 use Test::MockModule;
 use Test::MockObject;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Test::Exception;
 use Test::Output;
 use Mojo::Log;

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -7,7 +7,7 @@ use Test::More;
 use Test::MockModule;
 use Test::MockObject;
 use Test::Output 'stdout_is';
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Net::SSH2 'LIBSSH2_ERROR_EAGAIN';
 use Mojo::File 'path';
 use Mojo::JSON 'decode_json';

--- a/t/24-myjsonrpc-debug.t
+++ b/t/24-myjsonrpc-debug.t
@@ -25,7 +25,7 @@ BEGIN {
 use myjsonrpc;
 
 use Test::More;
-use Test::Warnings 'warnings';
+use Test::Warnings qw(warnings :report_warnings);
 
 no warnings 'redefine';
 sub bmwqemu::diag { warn $_[0] }

--- a/t/24-myjsonrpc.t
+++ b/t/24-myjsonrpc.t
@@ -22,7 +22,7 @@ use Socket;
 use myjsonrpc;
 
 use Test::More;
-use Test::Warnings 'warnings';
+use Test::Warnings qw(warnings :report_warnings);
 
 no warnings 'redefine';
 sub bmwqemu::diag { warn $_[0] }

--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -19,7 +19,7 @@ use strict;
 use warnings;
 
 use Test::More;
-use Test::Warnings;
+use Test::Warnings ':report_warnings';
 use Try::Tiny;
 use File::Basename;
 use Cwd 'abs_path';


### PR DESCRIPTION
It will report all unexpected warnings at the end, to avoid having to search
through the whole output.
