### PR TITLE
Revert "Check exit code when running qemu-img"

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -138,9 +138,8 @@ sub configure_controllers {
 
 sub get_img_json_field {
     my ($self, $path, $field) = @_;
-    my ($rc, $json) = simple_run($self->qemu_img_bin, 'info', '--output=json', $path);
-    die "qemu-img command failed" if $rc;
-    my $map = decode_json($json);
+    my $json = simple_run($self->qemu_img_bin, 'info', '--output=json', $path);
+    my $map  = decode_json($json);
     die "No $field field in: " . Dumper($map) unless defined $map->{$field};
     return $map->{$field};
 }

--- a/osutils.pm
+++ b/osutils.pm
@@ -111,12 +111,8 @@ sub _run {
     return $p->exit_status, $out;
 }
 
-# Just execute and print/return output. Return exit code on request
-sub simple_run {
-    my ($rc, $o) = _run(@_);
-    diag($o) if $o;
-    return wantarray ? ($rc, $o) : $o;
-}
+# Do not check for anything - just execute and print
+sub simple_run { my $o = (_run(@_))[1]; diag($o) if $o; $o }
 
 # Open a process to run external program and check its return status
 sub runcmd {

--- a/t/18-qemu.t
+++ b/t/18-qemu.t
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 
 use Test::More;
-use Test::Warnings 'warning';
+use Test::Warnings;
 use Mojo::File qw(tempfile path);
 use Carp 'cluck';
 
@@ -338,25 +338,6 @@ $bdc->for_each_drive(sub {
 @gcmdl = $proc->gen_cmdline();
 is_deeply(\@gcmdl, \@cmdl, 'Generate qemu command line after deserialising and reverting a snapshot')
   || diag(explain(\@gcmdl));
-
-subtest 'non-existing-iso' => sub {
-    $vars{ISO} .= 'XXX';
-    my $err;
-    my $warning = warning {
-        eval {
-            $proc = OpenQA::Qemu::Proc->new()
-              ->_static_params(['-static-args'])
-              ->qemu_bin('qemu-kvm')
-              ->qemu_img_bin('qemu-img')
-              ->configure_controllers(\%vars)
-              ->configure_blockdevs('disk', 'raid', \%vars)
-              ->configure_pflash(\%vars);
-        };
-        $err = $@;
-    };
-    like $err,     qr{qemu-img command failed},                        'Got expected eval error';
-    like $warning, qr{qemu-img command failed.*data/Core-7.2.isoXXX}s, 'Got expected warning';
-};
 
 subtest DriveDevice => sub {
 


### PR DESCRIPTION
This reverts commit 7e94f5f7630579159fb9f76dfb2cfd1a9aa672b6.

See issue https://progress.opensuse.org/issues/64854

There seems to be a problem with qemu-img and exit codes on ppc64le