### PR TITLE
Create and remove tempfiles in every test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,5 @@ snd2png/test.pnm
 snd2png/test.pnm.md5
 t/*.log
 t/*.trs
-t/vars.json
-t/pool/*
 cover_db/*
 .*.swp

--- a/t/.gitignore
+++ b/t/.gitignore
@@ -1,8 +1,0 @@
-data/tests/product/
-fork-share.txt
-raid/hd0
-serial0
-tesseract_opencl_profile_devices.dat
-testresults/autoinst-log.txt
-testresults/ulogs
-vars.json

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -8,6 +8,8 @@ use Test::Output qw(stderr_like combined_from);
 use Test::Fatal;
 use Test::MockModule;
 use File::Basename ();
+use FindBin '$Bin';
+use File::Path 'rmtree';
 
 use autotest;
 use bmwqemu;
@@ -316,3 +318,8 @@ is(autotest::parse_test_path("$sharedir/tests/sle/tests/x11/toolkits/motif.pm"),
 is(autotest::parse_test_path("$sharedir/factory/other/sysrq.pm"),                'other');
 
 done_testing();
+
+END {
+    unlink "$Bin/vars.json";
+    rmtree "$Bin/testresults";
+}

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -7,10 +7,16 @@ use Test::More;
 use File::Basename;
 use File::Path 'remove_tree';
 use Cwd 'abs_path';
+use FindBin '$Bin';
+use File::Path 'rmtree';
+use Mojo::File 'tempdir';
 
+my $dir          = tempdir("/tmp/$FindBin::Script-XXXX");
 my $toplevel_dir = abs_path(dirname(__FILE__) . '/..');
 my $data_dir     = "$toplevel_dir/t/data";
-my $pool_dir     = "$toplevel_dir/t/pool";
+my $pool_dir     = "$dir/pool";
+chdir $dir;
+mkdir $pool_dir;
 
 sub isotovideo {
     my (%args) = @_;
@@ -100,3 +106,8 @@ subtest 'upload assets on demand even in failed jobs' => sub {
 };
 
 done_testing();
+
+chdir $Bin;
+END {
+    rmtree "$Bin/data/tests/product";
+}

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -6,6 +6,12 @@ use Test::MockModule;
 use Test::More;
 use Test::Fatal;
 use File::Basename;
+use FindBin '$Bin';
+use Mojo::File 'tempdir';
+
+my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
+chdir $dir;
+mkdir 'testresults';
 
 use basetest;
 use needle;
@@ -320,3 +326,5 @@ subtest 'execute_time' => sub {
 };
 
 done_testing;
+
+chdir $Bin;

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -9,9 +9,13 @@ use Test::MockModule;
 use Test::MockObject;
 use Test::Output qw(combined_like stderr_like);
 use Test::Warnings;
+use FindBin '$Bin';
+use Mojo::File 'tempdir';
 
 use backend::qemu;
 
+my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
+chdir $dir;
 
 my $proc = Test::MockModule->new('OpenQA::Qemu::Proc');
 $proc->mock(exec_qemu            => undef);
@@ -42,3 +46,5 @@ ok(exists $called{add_console}, 'a console has been added');
 is($called{add_console}, 1, 'one console has been added');
 
 done_testing();
+
+chdir $Bin;

--- a/t/18-qemu-options.t
+++ b/t/18-qemu-options.t
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-
 use strict;
 use warnings;
 use Test::More;
@@ -24,14 +23,18 @@ use File::Basename;
 use Cwd 'abs_path';
 use Mojo::File;
 use Benchmark ':hireswallclock';
+use FindBin '$Bin';
+use Mojo::File 'tempdir';
 
 # optional but very useful
 eval 'use Test::More::Color';
 eval 'use Test::More::Color "foreground"';
 
-my $toplevel_dir = abs_path(dirname(__FILE__) . '/..');
-my $data_dir     = "$toplevel_dir/t/data/";
-my $pool_dir     = "$toplevel_dir/t/pool/";
+my $dir          = tempdir("/tmp/$FindBin::Script-XXXX");
+my $toplevel_dir = "$Bin/..";
+my $data_dir     = "$Bin/data";
+my $pool_dir     = "$dir/pool";
+mkdir $pool_dir;
 
 chdir($pool_dir);
 
@@ -154,3 +157,5 @@ EOV
 };
 
 done_testing();
+
+chdir $Bin;

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -17,6 +17,12 @@ use distribution;
 use Net::SSH2;
 use testapi qw(get_var get_required_var check_var set_var);
 use backend::svirt qw(SERIAL_CONSOLE_DEFAULT_PORT SERIAL_TERMINAL_DEFAULT_DEVICE SERIAL_TERMINAL_DEFAULT_PORT);
+use FindBin '$Bin';
+use Mojo::File 'tempdir';
+
+my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
+chdir $dir;
+mkdir 'testresults';
 
 bmwqemu::init_logger;
 
@@ -68,8 +74,7 @@ subtest 'XML config for VNC and serial console' => sub {
     $svirt_console->add_pty({pty_dev     => SERIAL_TERMINAL_DEFAULT_DEVICE, pty_dev_type => 'pty', target_port => SERIAL_TERMINAL_DEFAULT_PORT});
 
     my $produced_xml = $svirt_console->{domainxml}->toString(2);
-    my $expected_xml = '22-svirth-virsh-config.xml';
-    $expected_xml = 't/' . $expected_xml unless (-f $expected_xml);
+    my $expected_xml = "$Bin/22-svirth-virsh-config.xml";
 
     my $diff = XML::SemanticDiff->new(keeplinenums => 1);
     if (my @changes = $diff->compare($produced_xml, $expected_xml)) {
@@ -275,3 +280,5 @@ subtest 'Method backend::svirt::open_serial_console_via_ssh()' => sub {
 };
 
 done_testing;
+
+chdir $Bin;

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -12,6 +12,12 @@ use Mojo::File 'path';
 use Scalar::Util 'refaddr';
 use backend::baseclass;
 use POSIX 'tzset';
+use FindBin '$Bin';
+use Mojo::File 'tempdir';
+
+my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
+chdir $dir;
+mkdir 'testresults';
 
 # make the test time-zone neutral
 $ENV{TZ} = 'UTC';
@@ -190,3 +196,5 @@ subtest 'SSH utilities' => sub {
 };
 
 done_testing;
+
+chdir $Bin;

--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -23,16 +23,19 @@ use Test::Warnings;
 use Try::Tiny;
 use File::Basename;
 use Cwd 'abs_path';
-use Mojo::File;
 use Mojo::JSON 'decode_json';
+use FindBin '$Bin';
+use Mojo::File 'tempdir';
 
 # optional but very useful
 eval 'use Test::More::Color';
 eval 'use Test::More::Color "foreground"';
 
-my $toplevel_dir = abs_path(dirname(__FILE__) . '/..');
-my $data_dir     = "$toplevel_dir/t/data/";
-my $pool_dir     = "$toplevel_dir/t/pool/";
+my $dir          = tempdir("/tmp/$FindBin::Script-XXXX");
+my $toplevel_dir = "$Bin/..";
+my $data_dir     = "$Bin/data/";
+my $pool_dir     = "$dir/pool/";
+mkdir $pool_dir;
 
 note("data dir: $data_dir");
 note("pool dir: $pool_dir");
@@ -123,3 +126,5 @@ is(system('grep -q "isotovideo done" autoinst-log.txt'),                 0, 'iso
 is(system('grep -q "EXIT 0" autoinst-log.txt'),                          0, 'Test finished as expected');
 
 done_testing();
+
+chdir $Bin;


### PR DESCRIPTION
and get rid of some gitignores.

Now every test can be run without relying on a previous test creating
a certain directory.

Issue: https://progress.opensuse.org/issues/64926

