### PR TITLE
Prevent "malformed JSON" on qemu-img failure also with custom die handler

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -38,7 +38,7 @@ use Net::DBus;
 use bmwqemu qw(fileContent diag save_vars);
 require IPC::System::Simple;
 use Try::Tiny;
-use osutils qw(find_bin gen_params qv simple_run runcmd);
+use osutils qw(find_bin gen_params qv run_diag runcmd);
 use List::Util 'max';
 use Data::Dumper;
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
@@ -803,7 +803,7 @@ sub start_qemu {
     mkpath($basedir);
 
     # do not use autodie here, it can fail on tmpfs, xfs, ...
-    simple_run('/usr/bin/chattr', '-f', '+C', $basedir);
+    run_diag('/usr/bin/chattr', '-f', '+C', $basedir);
 
     my $keephdds = $vars->{KEEPHDDS} || $vars->{SKIPTO};
 

--- a/osutils.pm
+++ b/osutils.pm
@@ -33,7 +33,8 @@ our @EXPORT_OK = qw(
   qv
   quote
   runcmd
-  simple_run
+  run
+  run_diag
   attempt
 );
 
@@ -90,7 +91,7 @@ sub quote {
     "\'" . $_[0] . "\'";
 }
 
-sub _run {
+sub run {
     diag "running " . join(' ', @_);
     my @args = @_;
     my $out;
@@ -112,11 +113,11 @@ sub _run {
 }
 
 # Do not check for anything - just execute and print
-sub simple_run { my $o = (_run(@_))[1]; diag($o) if $o; $o }
+sub run_diag { my $o = (run(@_))[1]; diag($o) if $o; $o }
 
 # Open a process to run external program and check its return status
 sub runcmd {
-    my ($e, $out) = _run(@_);
+    my ($e, $out) = run(@_);
     diag $out if $out && length($out) > 0;
     die join(" ", RUNCMD_FAILURE_MESS, $e) unless $e == 0;
     return $e;

--- a/t/18-qemu.t
+++ b/t/18-qemu.t
@@ -354,9 +354,11 @@ subtest 'non-existing-iso' => sub {
         };
         $err = $@;
     };
-    like $err, qr{qemu-img command failed}, 'Got expected eval error';
-    like $warnings[0], qr{malformed JSON},                                 'Got expected warning';
-    like $warnings[1], qr{qemu-img command failed.*data/Core-7.2.isoXXX}s, 'Got expected warning';
+    my $expected = qr{qemu-img: Could not open.*data/Core-7.2.isoXXX.*No such file};
+    like $err, $expected, 'Got expected eval error';
+    is @warnings, 1, 'only a single-line failure message';
+    like $warnings[0], $expected, 'Got expected warning';
+    unlike $warnings[0], qr{malformed JSON}, 'No confusing JSON parsing error';
 };
 
 subtest DriveDevice => sub {


### PR DESCRIPTION
https://github.com/os-autoinst/os-autoinst/pull/1370 was the original approach
which we reverted after encountering problems relying on the exit code of
qemu-img, especially on ppc64le. Instead we went with
https://github.com/os-autoinst/os-autoinst/pull/1372 which ended up not really
addressing the original problem of preventing the confusing JSON parsing error
when we erroneously try to parse an error string as JSON. This commit addresses
all the following:

* Replace a question in the comment by a statement as we should not ask the
  reader a question from source code
* Delete unused variable "$err"
* Prevent any error output from "decode_json"
* Ensure to output the error message from qemu-img once and only after "Backend
  process died", this addresses
https://github.com/os-autoinst/os-autoinst/pull/1370#issuecomment-604496720

Also verified manually with

```
isotovideo -d iso=/dev/shm/ flavor=DVD casedir=/var/lib/openqa/tests/opensuse
```

Old output:

```
[2020-03-30T16:40:31.535 CEST] [debug] running /usr/bin/qemu-img info --output=json /dev/shm/
[2020-03-30T16:40:31.609 CEST] [debug] qemu-img: Could not open '/dev/shm/': A regular file was expected by the 'file' driver, but something else was given
[2020-03-30T16:40:31.609 CEST] [debug] Backend process died, backend errors are reported below in the following lines:
malformed JSON string, neither tag, array, object, number, string or atom, at character offset 0 (before "qemu-img: Could not ...") at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/JSON.pm line 39.

```

Example output:

```
[2020-03-30T16:39:20.498 CEST] [debug] running /usr/bin/qemu-img info --output=json /dev/shm/
[2020-03-30T16:39:20.508 CEST] [debug] Backend process died, backend errors are reported below in the following lines:
qemu-img: Could not open '/dev/shm/': A regular file was expected by the 'file' driver, but something else was given

```

OBS build test at https://build.opensuse.org/package/show/home:okurz:branches:devel:openQA:pr1376/os-autoinst

Related progress issue: https://progress.opensuse.org/issues/64854