### PR TITLE
Make point in time when a test fails in log more explicit

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -366,7 +366,7 @@ sub runtest {
         # show a text result with the die message unless the die was internally generated
         if (!$internal) {
             my $msg = "# Test died: $@";
-            bmwqemu::diag($@);
+            bmwqemu::fctinfo($msg);
             $self->record_resultfile('Failed', $msg, result => 'fail');
             $died = 1;
         }


### PR DESCRIPTION
An openQA test that fails shows in a thumbnail popup a text like
"# Test died: no candidate needle with tag(s) 'updates_click-install' matched"
but in the autoinst-log.txt it is not really apparent and just an
innocent
"[2020-03-31T15:51:13.134 CEST] [debug] no candidate needle with tag(s) 'updates_click-install' matched"

which is not even easy to distinguish from a check_screen that is
allowed to return no matches. This should be made more prominent.

Example output from log:

```
[2020-04-02T11:45:49.295 CEST] [debug] >>> testapi::_check_backend_response: match=grub2 timed out after 80 (assert_screen)
[2020-04-02T11:45:49.369 CEST] [info] ::: basetest::runtest: # Test died: no candidate needle with tag(s) 'grub2' matched
```

Related progress issue: https://progress.opensuse.org/issues/65106