### PR TITLE
[WIP]Adding a slow type parameter to assert_script_run

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -107,7 +107,7 @@ sub become_root {
 
 =head2 script_run
 
-  script_run($cmd [, timeout => $timeout] [, output => $output] [,quiet => $quiet])
+  script_run($cmd [, timeout => $timeout] [, output => $output] [,quiet => $quiet] [,max_interval => $max_interval])
 
 Deprecated mode
 
@@ -116,6 +116,7 @@ Deprecated mode
 Run I<$cmd> (by assuming the console prompt and typing the command). After that, echo
 hashed command to serial line and wait for it in order to detect execution is finished.
 To avoid waiting, use I<$timeout> 0.
+In case you have mistyping problems lower I<$max_interval> which sets I<max_interval> in C<type_string>
 
 Use C<output> to add a description or a comment of the $cmd.
 
@@ -130,15 +131,16 @@ sub script_run {
     my ($self, $cmd) = splice(@_, 0, 2);
     my %args = testapi::compat_args(
         {
-            timeout => $bmwqemu::default_timeout,
-            output  => '',
-            quiet   => undef
+            timeout      => $bmwqemu::default_timeout,
+            output       => '',
+            quiet        => undef,
+            max_interval => undef
         }, ['timeout'], @_);
 
     if (testapi::is_serial_terminal) {
         testapi::wait_serial($self->{serial_term_prompt}, no_regex => 1, quiet => $args{quiet});
     }
-    testapi::type_string "$cmd";
+    testapi::type_string("$cmd", max_interval => $args{max_interval});
     if ($args{timeout} > 0) {
         my $str    = testapi::hashed_string("SR" . $cmd . $args{timeout});
         my $marker = "; echo $str-\$?-" . ($args{output} ? "Comment: $args{output}" : '');

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -249,7 +249,16 @@ subtest 'script_run' => sub {
         'using two named arguments; fail message does not apply on timeout'
     );
     $fake_exit = 0;
-    $cmds      = [];
+
+    $cmds = [];    #resetting cmds for easier handling
+
+    # running assert_script_run with a non default max_interval, then checking if it passed
+    #  correctly to the underlying functions
+    is(assert_script_run('true', timeout => 2, max_interval => 1000), '1', 'assert_script_run timed out as expected');
+    like($cmds->[0]->{max_interval}, qr/1000/);
+
+    $cmds = [];
+
     is(script_run('true'), '0', 'script_run with no check of success, returns exit code');
     like($cmds->[1]->{text}, qr/; echo /);
     $cmds = [];

--- a/testapi.pm
+++ b/testapi.pm
@@ -943,7 +943,7 @@ sub _handle_script_run_ret {
 
 =head2 assert_script_run
 
-  assert_script_run($cmd [, timeout => $timeout] [, fail_message => $fail_message] [,quiet => $quiet]);
+  assert_script_run($cmd [, timeout => $timeout] [, fail_message => $fail_message] [,quiet => $quiet] [,max_interval => $max_interval ]);
 
 Deprecated mode
 
@@ -960,6 +960,8 @@ For this to work correctly, it must return 0 if and only if C<$command> complete
 successfully. It must NOT return 0 if C<$command> times out. The default implementation
 should work on *nix operating systems with a configured serial device.>
 
+C<$max_interval> is mapped to C<max_interval> of C<type_string>
+
 =cut
 
 sub assert_script_run {
@@ -971,11 +973,12 @@ sub assert_script_run {
             # not change default timeout.
             timeout      => 90,
             fail_message => '',
-            quiet        => testapi::get_var('_QUIET_SCRIPT_CALLS')
+            quiet        => testapi::get_var('_QUIET_SCRIPT_CALLS'),
+            max_interval => undef
         }, ['timeout', 'fail_message'], @_);
 
     bmwqemu::log_call(cmd => $cmd, %args);
-    my $ret = $distri->script_run($cmd, timeout => $args{timeout}, quiet => $args{quiet});
+    my $ret = $distri->script_run($cmd, imeout => $args{timeout}, quiet => $args{quiet}, max_interval => $args{max_interval});
     _handle_script_run_ret($ret, $cmd, %args);
     return;
 }
@@ -1011,9 +1014,10 @@ sub script_run {
     my $cmd  = shift;
     my %args = compat_args(
         {
-            timeout => undef,
-            output  => '',
-            quiet   => testapi::get_var('_QUIET_SCRIPT_CALLS')
+            timeout      => undef,
+            output       => '',
+            quiet        => testapi::get_var('_QUIET_SCRIPT_CALLS'),
+            max_interval => undef
         }, ['timeout'], @_);
 
     bmwqemu::log_call(cmd => $cmd, %args);


### PR DESCRIPTION
We have the issue that commands are typed wrongly and want to avoid
tests failing because of this. The easiest workaround is to take some
time typing

This still needs documentation