### PR TITLE
Remove abs path from content of ASSET_1

### DIFF
--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -681,4 +681,20 @@ subtest 'autoinst_url' => sub {
     is(autoinst_url('foo'), 'http://localhost:1/foo', 'we can configure the hostname that autoinst_url returns');
 };
 
+subtest 'data_url' => sub {
+    $bmwqemu::vars{QEMUPORT}              = 9998;
+    $bmwqemu::vars{JOBTOKEN}              = 'test-token';
+    $bmwqemu::vars{ASSET_0}               = 'file1';
+    $bmwqemu::vars{ASSET_9}               = '/var/what/ever/else/file1';
+    $bmwqemu::vars{ASSET_10}              = '/var/what/ever/else/file1.keep_my_prefix';
+    $bmwqemu::vars{ASSET_9000}            = '/var/what/ever/else//empty/file1.keep_my_prefix2';
+    $bmwqemu::vars{AUTOINST_URL_HOSTNAME} = 'localhost';
+
+    is(data_url('ASSET_0'),    'http://localhost:9999/test-token/assets/other/file1',                 'Retrieved path is correct');
+    is(data_url('ASSET_9'),    'http://localhost:9999/test-token/assets/other/file1',                 'Retrieved path is correct');
+    is(data_url('ASSET_10'),   'http://localhost:9999/test-token/assets/other/file1.keep_my_prefix',  'Retrieved path is correct');
+    is(data_url('ASSET_9000'), 'http://localhost:9999/test-token/assets/other/file1.keep_my_prefix2', 'Retrieved fake_pause_on_timeouth is correct');
+
+};
+
 done_testing;

--- a/testapi.pm
+++ b/testapi.pm
@@ -2063,11 +2063,11 @@ in the corresponding variable
 
 sub data_url($) {
     my ($name) = @_;
-    if ($name =~ /^REPO_\d$/) {
+    if ($name =~ /^REPO_\d+$/) {
         return autoinst_url("/assets/repo/" . get_var($name));
     }
-    if ($name =~ /^ASSET_\d$/) {
-        return autoinst_url("/assets/other/" . get_var($name));
+    if ($name =~ /^ASSET_\d+$/) {
+        return autoinst_url("/assets/other/" . basename(get_var($name)));
     }
     else {
         return autoinst_url("/data/$name");


### PR DESCRIPTION
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9963

```
[2020-04-09T14:25:43.049 CEST] [debug] <<< testapi::assert_script_run(cmd="true", quiet=1, timeout=90, fail_message="")
[2020-04-09T14:25:43.049 CEST] [debug] <<< distribution::script_output("Content of /tmp/scriptXXX.sh :\n \"cat > /tmp/scriptXXX.sh << 'EOT_XXX'; echo XXX-\$?-\" \n")
[2020-04-09T14:25:43.049 CEST] [debug] <<< testapi::script_run(cmd="true", output="", timeout=undef, quiet=0)
[2020-04-09T14:25:43.049 CEST] [debug] <<< testapi::assert_script_run(cmd="true", fail_message="", timeout=90, quiet=0)
03-testapi.t .. ok    
All tests successful.
Files=1, Tests=36,  1 wallclock secs ( 0.04 usr  0.01 sys +  0.87 cusr  0.28 csys =  1.20 CPU)
Result: PASS
```