### PR TITLE
Allow TESTS variable to be specified with make test

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -218,7 +218,7 @@ clean-local:
 # Prevent error "blank line following trailing backslash" when deleting last
 # line in list in spec file to exclude tests
 EMPTY =
-TEST_FILES = \
+TESTS ?= \
 	00-compile-check-all.t \
 	01-test_needle.t \
 	02-test_ocr.t \
@@ -263,15 +263,15 @@ TEST_OPTS = \
 
 .PHONY: test
 test:
-	( cd t && $(TEST_OPTS) prove $(TEST_FILES) )
+	( cd t && $(TEST_OPTS) prove $(TESTS) )
 
 .PHONY: testv
 testv:
-	( cd t && $(TEST_OPTS) prove -v $(TEST_FILES) )
+	( cd t && $(TEST_OPTS) prove -v $(TESTS) )
 
 .PHONY: test-cover
 test-cover:
-	( cd t && $(TEST_OPTS) $(COVER_OPTS) prove $(TEST_FILES) )
+	( cd t && $(TEST_OPTS) $(COVER_OPTS) prove $(TESTS) )
 
 .PHONY: test-cover-summary
 test-cover-summary:

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -90,8 +90,10 @@ once to setup your workspace and before every commit
 make check
 ----
 
-* You *may* also run local tests on your machine or in your own development
-environment to verify everything works as expected.
+* You can also run individual tests by specifying them explicitly:
+----
+make check TESTS=23-baseclass.t
+----
 
 * For git commit messages use the rules stated on
 http://chris.beams.io/posts/git-commit/[How to Write a Git Commit Message] as


### PR DESCRIPTION
So individual tests can be run like so:

    make test TESTS=23-baseclass.t

This works similarly to OpenQA which picks up TESTS as well,
although the base folder us always t with os-autoinst.

An example is added to the README (by replacing rather than updating the
    existing phrase because it already explains running local tests just
    before the autotools commands).