### PR TITLE
Update doc for default value of VNC_TYPING_LIMIT

### DIFF
--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -23,7 +23,7 @@ SCREENSHOTINTERVAL;float;0.5;The interval in seconds at which screenshots are ta
 SSH_CONNECT_RETRY;integer;5;Maximum retries to connect to SSH based console targets
 SSH_CONNECT_RETRY_INTERVAL;float;10;Interval in seconds between retries to connect to SSH based console targets. Related to SSH_CONNECT_RETRY
 VNC_STALL_THRESHOLD;integer;4;Time after which is VNC considered stalled
-VNC_TYPING_LIMIT;integer;50;Maximum number of keys per second
+VNC_TYPING_LIMIT;integer;30;Maximum number of keys per second
 _CHKSEL_RATE_WAIT_TIME;integer;30;The ammount of time isotovideo is going to wait for the VNC console to become responsive
 _CHKSEL_RATE_HITS;integer;15000;The ammount of times, the select should return the same fileno during the _CHKSEL_RATE_WAIT_TIME seconds, to consider the VNC console unresponsive
 TIMEOUT_SCALE;integer;1;This scale parameter can be used based on performance of workers to prevent false positive timeouts based on differing worker performance.


### PR DESCRIPTION
```bash
$ git grep "VNC_TYPING_LIMIT"
```
```perl
consoles/vnc_base.pm:use constant VNC_TYPING_LIMIT_DEFAULT => 30;
consoles/vnc_base.pm:    my $seconds_per_keypress = 1 / (get_var('VNC_TYPING_LIMIT', VNC_TYPING_LIMIT_DEFAULT) || 1);
consoles/vnc_base.pm:    # send_key rate must be limited to take into account VNC_TYPING_LIMIT- poo#55703
consoles/vnc_base.pm:    my $press_release_delay = 1 / (get_var('VNC_TYPING_LIMIT', VNC_TYPING_LIMIT_DEFAULT) || 1);
consoles/vnc_base.pm:    $self->{vnc}->map_and_send_key($args->{key}, 1, 1 / VNC_TYPING_LIMIT_DEFAULT);
consoles/vnc_base.pm:    $self->{vnc}->map_and_send_key($args->{key}, 0, 1 / VNC_TYPING_LIMIT_DEFAULT);
doc/backend_vars.asciidoc:VNC_TYPING_LIMIT;integer;50;Maximum number of keys per second
```
