### PR TITLE
Speedup "integration" full stack tests

### DIFF
--- a/t/data/tests/main.pm
+++ b/t/data/tests/main.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2017 SUSE LLC
+# Copyright (C) 2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -34,14 +34,16 @@ sub cleanup_needles {
 
 $needle::cleanuphandler = \&cleanup_needles;
 
+# openQA tests set INTEGRATION_TESTS to 1 when reusing the os-autoinst tests
+#
+autotest::loadtest "tests/freeze.pm" unless get_var('INTEGRATION_TESTS');
 autotest::loadtest "tests/boot.pm";
-
-# openQA tests set this to 0 when reusing the os-autoinst tests
 unless (get_var('INTEGRATION_TESTS')) {
+    autotest::loadtest "tests/assert_screen.pm";
+    autotest::loadtest "tests/typing.pm";
     autotest::loadtest "tests/select_console_fail_test.pm";
     autotest::loadtest "tests/select_ssh_console_fail_test.pm";
     autotest::loadtest "tests/assert_screen_fail_test.pm";
-    autotest::loadtest "tests/typing.pm";
     autotest::loadtest "tests/reload_needles.pm";
     autotest::loadtest "tests/modify_and_upload_file.pm";
 }

--- a/t/data/tests/tests/assert_screen.pm
+++ b/t/data/tests/tests/assert_screen.pm
@@ -16,22 +16,15 @@
 use strict;
 use warnings;
 
-use base "basetest";
+use base 'basetest';
 
 use testapi;
 
 sub run {
-    # just assume the first screen has a timeout so we should make sure not to miss it
-    assert_screen 'core', 15, no_wait => 1;
-    send_key 'ret';
-
-    # set timeout to 10 minutes so we can't miss the situation when we're waiting for the assert_screen to timeout
-    # (test uses 'Skip timeout' so this won't actually delay the test execution)
-    assert_screen 'on_prompt', timeout => get_var('TESTING_ASSERT_SCREEN_TIMEOUT') ? 600 : 90;
-}
-
-sub test_flags {
-    return {};
+    # different variants of parameter selection
+    assert_screen 'on_prompt', timeout => 60;
+    assert_screen 'on_prompt', no_wait => 1;
 }
 
 1;
+

--- a/t/data/tests/tests/boot.pm
+++ b/t/data/tests/tests/boot.pm
@@ -33,14 +33,9 @@ sub run {
     assert_screen 'core', no_wait => 1;
     send_key 'ret';
 
-    if (get_var('TESTING_ASSERT_SCREEN_TIMEOUT')) {
-        # set timeout to 10 minutes so we can't miss the situation when we're waiting for the assert_screen to timeout
-        # (test uses 'Skip timeout' so this won't actually delay the test execution)
-        assert_screen 'on_prompt', timeout => 600;
-    }
-    else {
-        assert_screen 'on_prompt', 90;
-    }
+    # set timeout to 10 minutes so we can't miss the situation when we're waiting for the assert_screen to timeout
+    # (test uses 'Skip timeout' so this won't actually delay the test execution)
+    assert_screen 'on_prompt', timeout => get_var('TESTING_ASSERT_SCREEN_TIMEOUT') ? 600 : 90;
 
     assert_script_run 'cat /proc/cpuinfo';
     type_string "cat > text <<EOF\n";

--- a/t/data/tests/tests/freeze.pm
+++ b/t/data/tests/tests/freeze.pm
@@ -16,22 +16,14 @@
 use strict;
 use warnings;
 
-use base "basetest";
+use base 'basetest';
 
 use testapi;
 
 sub run {
-    # just assume the first screen has a timeout so we should make sure not to miss it
-    assert_screen 'core', 15, no_wait => 1;
-    send_key 'ret';
-
-    # set timeout to 10 minutes so we can't miss the situation when we're waiting for the assert_screen to timeout
-    # (test uses 'Skip timeout' so this won't actually delay the test execution)
-    assert_screen 'on_prompt', timeout => get_var('TESTING_ASSERT_SCREEN_TIMEOUT') ? 600 : 90;
-}
-
-sub test_flags {
-    return {};
+    freeze_vm();
+    diag "Simply freeze the vm and resume right before the first assert screen is done";
+    resume_vm();
 }
 
 1;

--- a/t/data/tests/tests/typing.pm
+++ b/t/data/tests/tests/typing.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2019 SUSE LLC
+# Copyright (C) 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,6 +21,35 @@ use base "basetest";
 use testapi;
 
 sub run {
+    assert_script_run 'cat /proc/cpuinfo';
+    type_string "cat > text <<EOF\n";
+
+    my $text = <<END;
+==Description==
+By default, a viewer/client uses TCP port 5900 to connect to a server (or 5800 for browser access), but can also be set to use any other port. Alternatively, a server can connect to a viewer in "listening mode" (by default on port 5500). One advantage of listening mode is that the server site does not have to configure its firewall/NAT to allow access on the specified ports; the burden is on the viewer, which is useful if the server site has no computer expertise, while the viewer user would be expected to be more knowledgeable.
+
+Although RFB started as a relatively simple protocol, it has been enhanced with additional features (such as file transfers) and more sophisticated [[Data compression|compression]] and security techniques as it has developed. To maintain seamless cross-compatibility between the many different VNC client and server implementations, the clients and servers negotiate a connection using the best RFB version, and the most appropriate compression and security options that they can both support.
+
+== History ==
+
+RFB was originally developed at [[Olivetti Research Laboratory]] (ORL) as a remote display technology to be used by a simple [[thin client]] with [[Asynchronous Transfer Mode|ATM]] connectivity called a Videotile. In order to keep the device as simple as possible, RFB was developed and used in preference to any of the existing remote display technologies.
+
+RFB found a second and more enduring use when VNC was developed. VNC was released as [[open source]] software and the RFB specification published on the web. Since then RFB has been a free protocol which anybody can use.
+
+When ORL was closed in 2002 some of the key people behind VNC and RFB formed [[RealVNC]], Ltd., in order to continue development of VNC and to maintain the RFB protocol. The current RFB protocol is published on the RealVNC website.
+END
+
+    type_string $text;
+    type_string "\nEOF\n";
+    script_run "echo '924095f2cb4d622a8796de66a5e0a44a  text' > text.md5";
+    assert_script_run 'md5sum -c text.md5';
+
+    # TinyCore busybox sh acts as bash but does not provide it so we do here
+    script_run 'alias bash=sh', 0;
+    my $out = script_output('mount');
+    die "mount does not show any mount points? output: $out" unless $out =~ /.*\/.*on/;
+    die "^rootfs not found. output: $out"                    unless $out =~ qr{^rootfs};
+    die "tmpfs on /dev/shm not found. output: $out"          unless $out =~ qr{tmpfs on /dev/shm};
 
     type_string("echo do not wait_still_screen\n", max_interval => 50, wait_still_screen => 0);
     type_string("echo type string and wait for .2 seconds\n",              wait_still_screen => .2);


### PR DESCRIPTION
The os-autoinst full stack test as well as openQA uses the full stack
test with the variable INTEGRATION_TESTS set to 1 to skip some
long-running test steps that are testing os-autoinst but are not
relevant to ensure the full stack of openQA and os-autoinst working
together. Over time the test module "boot" has grown to conduct much
more than what is relevant for booting the tested system. By moving out
all but the boot-relevant test code to dedicated test modules we can
save a lot of time in openQA full stack tests.

In my local environment this reduces the runtime of t/99-full-stack.t
from 4m57s to 3m27s without loosing any coverage as every test module is
still executed once.

The current openQA full stack test has multiple more runs of the full
stack test which can be significantly improved with this commit.