### PR TITLE
Include command in error message of osutils::runcmd

### DIFF
--- a/osutils.pm
+++ b/osutils.pm
@@ -24,8 +24,6 @@ use Mojo::File 'path';
 use bmwqemu 'diag';
 use Mojo::IOLoop::ReadWriteProcess 'process';
 
-use constant RUNCMD_FAILURE_MESS => 'runcmd failed with exit code';
-
 our @EXPORT_OK = qw(
   dd_gen_params
   find_bin
@@ -117,9 +115,10 @@ sub run_diag { my $o = (run(@_))[1]; diag($o) if $o; $o }
 
 # Open a process to run external program and check its return status
 sub runcmd {
-    my ($e, $out) = run(@_);
+    my (@cmd) = @_;
+    my ($e, $out) = run(@cmd);
     diag $out if $out && length($out) > 0;
-    die join(" ", RUNCMD_FAILURE_MESS, $e) unless $e == 0;
+    die "runcmd '" . join(' ', @cmd) . "' failed with exit code $e" unless $e == 0;
     return $e;
 }
 

--- a/t/13-osutils.t
+++ b/t/13-osutils.t
@@ -163,7 +163,7 @@ subtest runcmd => sub {
     is runcmd('rm', 'image.qcow2'), 0, "delete image and get its return code";
     local $@;
     stderr_like(sub { eval { runcmd('ls', 'image.qcow2') } }, qr/No such file or directory/, 'no image found as expected');
-    like $@, qr/runcmd failed with exit code \d+/, "command failed and calls die";
+    like $@, qr/runcmd 'ls image.qcow2' failed with exit code \d+/, "command failed and calls die";
 };
 
 subtest attempt => sub {


### PR DESCRIPTION
It is a best practice for log messages to be complete by themselves so
we should not rely on any log messages that came in before.

Related progress issue: https://progress.opensuse.org/issues/64917