### PR TITLE
Ensure 'rundcmd' output is shown with error

### DIFF
--- a/osutils.pm
+++ b/osutils.pm
@@ -118,7 +118,7 @@ sub runcmd {
     my (@cmd) = @_;
     my ($e, $out) = run(@cmd);
     diag $out if $out && length($out) > 0;
-    die "runcmd '" . join(' ', @cmd) . "' failed with exit code $e" unless $e == 0;
+    die "runcmd '" . join(' ', @cmd) . "' failed with exit code $e" . ($out ? ": '$out'" : '') unless $e == 0;
     return $e;
 }
 

--- a/t/18-qemu.t
+++ b/t/18-qemu.t
@@ -5,6 +5,7 @@ use strict;
 use warnings;
 
 use Test::More;
+use Test::Fatal;
 use Test::Warnings 'warnings';
 use Mojo::File qw(tempfile tempdir path);
 use Carp 'cluck';
@@ -148,6 +149,13 @@ $proc = OpenQA::Qemu::Proc->new()
 $proc->deserialise_state(path($path)->slurp());
 @gcmdl = $proc->gen_cmdline();
 is_deeply(\@gcmdl, \@cmdl, 'Multipath Command line after serialisation and deserialisation');
+
+my @warnings = warnings {
+    like exception { $proc->init_blockdev_images() }, qr/No such.*directory/, 'init_blockdev_images can report error';
+};
+like $warnings[0], qr/No such.*directory/, 'failure message for no directory';
+mkdir 'raid';
+ok $proc->init_blockdev_images(), 'init_blockdev_images passes';
 
 @cmdl = ('qemu-kvm', '-static-args',
     '-device', 'virtio-scsi-device,id=scsi0',


### PR DESCRIPTION
I have the feeling runcmd fails, e.g. on qemu-img but we never see the
error output. Showing the actual command output together with the error
message sounds like a good idea in general and might help with this
problem.

Related progress issue: https://progress.opensuse.org/issues/64917