### PR TITLE
t: Improve scope of cleanup 'chdir' call

### DIFF
--- a/t/00-compile-check-all.t
+++ b/t/00-compile-check-all.t
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-# Copyright (C) 2015-2019 SUSE LLC
+# Copyright (C) 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,6 +23,7 @@ use Test::Strict;
 
 use FindBin '$Bin';
 chdir "$Bin/..";
+END { chdir $Bin }
 
 $Test::Strict::TEST_SYNTAX   = 1;
 $Test::Strict::TEST_STRICT   = 1;

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -16,6 +16,7 @@ my $toplevel_dir = abs_path(dirname(__FILE__) . '/..');
 my $data_dir     = "$toplevel_dir/t/data";
 my $pool_dir     = "$dir/pool";
 chdir $dir;
+END { chdir $Bin }
 mkdir $pool_dir;
 
 sub isotovideo {
@@ -107,7 +108,6 @@ subtest 'upload assets on demand even in failed jobs' => sub {
 
 done_testing();
 
-chdir $Bin;
 END {
     rmtree "$Bin/data/tests/product";
 }

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -11,6 +11,7 @@ use Mojo::File 'tempdir';
 
 my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
 chdir $dir;
+END { chdir $Bin }
 mkdir 'testresults';
 
 use basetest;
@@ -326,5 +327,3 @@ subtest 'execute_time' => sub {
 };
 
 done_testing;
-
-chdir $Bin;

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -16,6 +16,7 @@ use backend::qemu;
 
 my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
 chdir $dir;
+END { chdir $Bin }
 
 my $proc = Test::MockModule->new('OpenQA::Qemu::Proc');
 $proc->mock(exec_qemu            => undef);
@@ -46,5 +47,3 @@ ok(exists $called{add_console}, 'a console has been added');
 is($called{add_console}, 1, 'one console has been added');
 
 done_testing();
-
-chdir $Bin;

--- a/t/18-qemu-options.t
+++ b/t/18-qemu-options.t
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-# Copyright (C) 2018 SUSE LLC
+# Copyright (C) 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -37,6 +37,7 @@ my $pool_dir     = "$dir/pool";
 mkdir $pool_dir;
 
 chdir($pool_dir);
+END { chdir $Bin }
 
 # just save ourselves some time during testing
 $ENV{OSUTILS_WAIT_ATTEMPT_INTERVAL} //= 1;
@@ -157,5 +158,3 @@ EOV
 };
 
 done_testing();
-
-chdir $Bin;

--- a/t/18-qemu.t
+++ b/t/18-qemu.t
@@ -17,6 +17,7 @@ use constant TMPPATH => '/tmp/18-qemu.t/';
 
 my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
 chdir $dir;
+END { chdir $Bin }
 mkdir "$dir/testresults";
 
 $SIG{__DIE__} = sub { cluck(shift); };
@@ -377,5 +378,3 @@ subtest DriveDevice => sub {
 };
 
 done_testing();
-chdir $Bin;
-

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-# Copyright © 2018-2019 SUSE LLC
+# Copyright © 2018-2020 SUSE LLC
 
 use strict;
 use warnings;
@@ -22,6 +22,7 @@ use Mojo::File 'tempdir';
 
 my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
 chdir $dir;
+END { chdir $Bin }
 mkdir 'testresults';
 
 bmwqemu::init_logger;
@@ -280,5 +281,3 @@ subtest 'Method backend::svirt::open_serial_console_via_ssh()' => sub {
 };
 
 done_testing;
-
-chdir $Bin;

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -17,6 +17,7 @@ use Mojo::File 'tempdir';
 
 my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
 chdir $dir;
+END { chdir $Bin }
 mkdir 'testresults';
 
 # make the test time-zone neutral
@@ -196,5 +197,3 @@ subtest 'SSH utilities' => sub {
 };
 
 done_testing;
-
-chdir $Bin;

--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-# Copyright (C) 2017-2019 SUSE LLC
+# Copyright (C) 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -41,6 +41,7 @@ note("data dir: $data_dir");
 note("pool dir: $pool_dir");
 
 chdir($pool_dir);
+END { chdir $Bin }
 open(my $var, '>', 'vars.json');
 print $var <<EOV;
 {
@@ -126,5 +127,3 @@ is(system('grep -q "isotovideo done" autoinst-log.txt'),                 0, 'iso
 is(system('grep -q "EXIT 0" autoinst-log.txt'),                          0, 'Test finished as expected');
 
 done_testing();
-
-chdir $Bin;


### PR DESCRIPTION
The call "chdir $Bin" at the end of tests is done to revert the earlier
"chdir $dir" at the beginning of tests. By doing that in an "END" block
we ensure the call to be done regardless of which way the test exists as
well have both calls together so that it should be more obvious what
corresponding calls go together.