### PR TITLE
Add optional fatal handling for qemu dbus calls for easier error analysis

### DIFF
--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -108,6 +108,7 @@ QEMU_SMBIOS;see qemu -smbios ?;undef;pass this value to qemu -smbios
 QEMU_SOUNDHW;see qemu -soundhw ?;hda;pass this value to qemu -soundhw
 QEMU_COMPRESS_LEVEL;integer;6;Sets the compression level used for memory dumps and snapshots. Zero turns compression off and 9 is the maximum level. Generally there is little improvement in compression ratio by increasing the level, but the CPU time can be high on some platforms.
 QEMU_COMPRESS_THREADS;integer;QEMUCPUS;Number of threads used for compressing memory dumps and snapshots.
+QEMU_FATAL_DBUS_CALL;boolean;0;Yield fatal error on failed dbus calls instead of just recording the error and continuing
 QEMU_MAX_BANDWIDTH;integer;INT_MAX;Limits the transfer rate during a snapshot.
 QEMU_DUMP_COMPRESS_METHOD;string;xz;The compression to use during a memory dump. Can be set to xz, bzip2 or internal (QEMU's internal compression, not compatible with crash or gdb). If xz is set, but not available, it will fallback to bzip2. Also see QEMU_COMPRESSION_LEVEL.
 QEMU_APPEND;string;;Append parameters on qemu command line. The first item will have '-' prepended to it.


### PR DESCRIPTION
MM tests fail to access other machines in the network if tap device is
not present, there is a diag message reported but the test does not fail
at this point.

For example a test can show "Failed to connect to 10.0.2.2 port 20243:
No route to host" and fails. What is hidden in autoinst-log.txt:

```
[2020-05-04T08:30:16.586 CEST] [debug] Failed to run dbus command 'set_vlan' with arguments 'tap23 13' : 'tap23' is not connected to bridge 'br1'
```

Multi-machine tests relying on a tap device should fail hard if the tap
device is not present or can not be configured. With the added feature
switch QEMU_FATAL_DBUS_CALL this can be enabled. The original behaviour
had been introduced in 82fe22e2 . The reason for continuing despite the
error is unknown to me hence for now I am just adding a feature switch
for changed behaviour which we eventually might want to use as the only
new supported behaviour.

Related progress issue: https://progress.opensuse.org/issues/66376