### PR TITLE
Replace all uses of mock with redefine

### DIFF
--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -51,15 +51,15 @@ sub get_tests_done {
 }
 
 my $mock_jsonrpc = Test::MockModule->new('myjsonrpc');
-$mock_jsonrpc->mock(send_json => \&fake_send);
-$mock_jsonrpc->mock(read_json => sub { });
+$mock_jsonrpc->redefine(send_json => \&fake_send);
+$mock_jsonrpc->redefine(read_json => sub { });
 my $mock_bmwqemu = Test::MockModule->new('bmwqemu');
-$mock_bmwqemu->mock(save_json_file => sub { });
+$mock_bmwqemu->redefine(save_json_file => sub { });
 my $mock_basetest = Test::MockModule->new('basetest');
-$mock_basetest->mock(_result_add_screenshot => sub { });
+$mock_basetest->redefine(_result_add_screenshot => sub { });
 # stop run_all from quitting at the end
 my $mock_autotest = Test::MockModule->new('autotest', no_auto => 1);
-$mock_autotest->mock(_exit => sub { });
+$mock_autotest->redefine(_exit => sub { });
 
 my $died;
 my $completed;
@@ -91,10 +91,10 @@ is($completed, 1, 'start+next+start should complete');
 # runargs test module, as it fails.
 subtest 'test always_rollback flag' => sub {
     # Test that no rollback is triggered when flag is not explicitly set to true
-    $mock_basetest->mock(test_flags       => sub { return {milestone => 1}; });
-    $mock_autotest->mock(query_isotovideo => sub { return 0; });
+    $mock_basetest->redefine(test_flags       => sub { return {milestone => 1}; });
+    $mock_autotest->redefine(query_isotovideo => sub { return 0; });
     my $reverts_done = 0;
-    $mock_autotest->mock(load_snapshot => sub { $reverts_done++; });
+    $mock_autotest->redefine(load_snapshot => sub { $reverts_done++; });
 
     stderr_like(sub { autotest::run_all }, qr/finished/, 'run_all outputs status on stderr');
     ($died, $completed) = get_tests_done;
@@ -105,10 +105,10 @@ subtest 'test always_rollback flag' => sub {
     @sent         = [];
 
     # Test that no rollback is triggered if snapshots are not supported
-    $mock_basetest->mock(test_flags       => sub { return {always_rollback => 1, milestone => 1}; });
-    $mock_autotest->mock(query_isotovideo => sub { return 0; });
+    $mock_basetest->redefine(test_flags       => sub { return {always_rollback => 1, milestone => 1}; });
+    $mock_autotest->redefine(query_isotovideo => sub { return 0; });
     $reverts_done = 0;
-    $mock_autotest->mock(load_snapshot => sub { $reverts_done++; });
+    $mock_autotest->redefine(load_snapshot => sub { $reverts_done++; });
 
     stderr_like(sub { autotest::run_all }, qr/finished/, 'run_all outputs status on stderr');
     ($died, $completed) = get_tests_done;
@@ -119,8 +119,8 @@ subtest 'test always_rollback flag' => sub {
     @sent         = [];
 
     # Test that snapshot loading is triggered even when tests are successful
-    $mock_basetest->mock(test_flags       => sub { return {always_rollback => 1}; });
-    $mock_autotest->mock(query_isotovideo => sub { return 1; });
+    $mock_basetest->redefine(test_flags       => sub { return {always_rollback => 1}; });
+    $mock_autotest->redefine(query_isotovideo => sub { return 1; });
     $reverts_done = 0;
 
     stderr_like(sub { autotest::run_all }, qr/finished/, 'run_all outputs status on stderr');
@@ -132,7 +132,7 @@ subtest 'test always_rollback flag' => sub {
     @sent         = [];
 
     # Test with snapshot available
-    $mock_basetest->mock(test_flags => sub { return {always_rollback => 1, milestone => 1}; });
+    $mock_basetest->redefine(test_flags => sub { return {always_rollback => 1, milestone => 1}; });
     stderr_like(sub { autotest::run_all }, qr/finished/, 'run_all outputs status on stderr');
     ($died, $completed) = get_tests_done;
     is($died,         0, 'start+next+start should not die when always_rollback flag is set');
@@ -179,9 +179,9 @@ like($@, qr/The run_args must be a sub-class of OpenQA::Test::RunArgs/, 'error m
 # we cause the failure by mocking runtest rather than using a test
 # which dies, as runtest does a whole bunch of stuff when the test
 # dies that we may not want to run into here
-$mock_basetest->mock(runtest => sub { die 'oh noes!'; });
+$mock_basetest->redefine(runtest => sub { die 'oh noes!'; });
 my $enable_snapshots = 1;
-$mock_autotest->mock(query_isotovideo => sub {
+$mock_autotest->redefine(query_isotovideo => sub {
         my ($command, $arguments) = @_;
         return $enable_snapshots if $command eq 'backend_can_handle' && $arguments->{function} eq 'snapshots';
         return 1;
@@ -204,7 +204,7 @@ is($completed, 1, 'unimportant test failure should complete');
 # unmock runtest, to fail in search_for_expected_serial_failures
 $mock_basetest->unmock('runtest');
 # mock reading of the serial output
-$mock_basetest->mock(search_for_expected_serial_failures => sub {
+$mock_basetest->redefine(search_for_expected_serial_failures => sub {
         my ($self) = @_;
         $self->{fatal_failure} = 1;
         die "Got serial hard failure";
@@ -218,7 +218,7 @@ is($completed, 0, 'fatal serial failure test should not complete');
 
 # make the serial failure non-fatal
 $mock_basetest->unmock('search_for_expected_serial_failures');
-$mock_basetest->mock(search_for_expected_serial_failures => sub {
+$mock_basetest->redefine(search_for_expected_serial_failures => sub {
         my ($self) = @_;
         $self->{fatal_failure} = 0;
         die "Got serial hard failure";
@@ -242,7 +242,7 @@ is($died,      0, 'non-fatal serial failure test should not die');
 is($completed, 0, 'non-fatal serial failure test should not complete by default without snapshot support');
 @sent = [];
 
-$mock_basetest->mock(test_flags => sub { return {fatal => 0}; });
+$mock_basetest->redefine(test_flags => sub { return {fatal => 0}; });
 $output = combined_from(sub { autotest::run_all });
 like($output, qr/Snapshots are not supported/, 'snapshots actually disabled');
 unlike($output, qr/Loading a VM snapshot/, 'no attempt to load VM snapshot');
@@ -254,7 +254,7 @@ is($completed, 1, 'non-fatal serial failure test should complete with {fatal => 
 # Revert mock for runtest and remove mock for search_for_expected_serial_failures
 $mock_basetest->unmock('search_for_expected_serial_failures');
 $mock_basetest->unmock('test_flags');
-$mock_basetest->mock(runtest => sub { die "oh noes!\n"; });
+$mock_basetest->redefine(runtest => sub { die "oh noes!\n"; });
 
 # now let's add a fatal test
 loadtest 'fatal';
@@ -294,7 +294,7 @@ subtest 'test scheduling test modules at test runtime' => sub {
     ];
 
     $mock_basetest->unmock('runtest');
-    $mock_bmwqemu->mock(save_json_file => sub {
+    $mock_bmwqemu->redefine(save_json_file => sub {
             my ($data, $filename) = @_;
             $json_data{$filename} = $data;
     });
@@ -309,7 +309,7 @@ subtest 'test scheduling test modules at test runtime' => sub {
     is_deeply($json_data{$json_filename}, $testorder,
         "loadtest updates test_order.json at test runtime");
 
-    $mock_bmwqemu->mock(save_json_file => sub { });
+    $mock_bmwqemu->redefine(save_json_file => sub { });
 };
 
 my $sharedir = '/home/tux/.local/lib/openqa/share';

--- a/t/09-lockapi.t
+++ b/t/09-lockapi.t
@@ -38,13 +38,13 @@ sub fake_api_call {
 
 # monkey-patch mmap::api_call
 my $mod = Test::MockModule->new('lockapi');
-$mod->mock(api_call => \&fake_api_call);
+$mod->redefine(api_call => \&fake_api_call);
 
 # So barriers can call record_info
 use basetest;
 $autotest::current_test = basetest->new();
 my $mock_bmwqemu = Test::MockModule->new('bmwqemu');
-$mock_bmwqemu->mock(result_dir => File::Temp->newdir());
+$mock_bmwqemu->redefine(result_dir => File::Temp->newdir());
 
 sub check_action {
     my ($method, $action, $params) = @_;

--- a/t/10-virtio_terminal.t
+++ b/t/10-virtio_terminal.t
@@ -59,7 +59,7 @@ subtest "Test open_pipe() error condition" => sub {
     my $socket_path    = './virtio_console_open_test';
     my $file_mock      = Test::MockModule->new('Mojo::File');
     my $vterminal_mock = Test::MockModule->new('consoles::virtio_terminal');
-    $vterminal_mock->mock("get_pipe_sz", sub { return; });
+    $vterminal_mock->redefine("get_pipe_sz", sub { return; });
 
     my $helper = prepare_pipes($socket_path);
     my $term   = consoles::virtio_terminal->new('unit-test-console', {socked_path => $socket_path});
@@ -67,9 +67,9 @@ subtest "Test open_pipe() error condition" => sub {
     cleanup_pipes($helper);
 
     my $size = 1024;
-    $file_mock->mock('slurp', sub { return 65536; });
-    $vterminal_mock->mock("get_pipe_sz", sub { return 1024; });
-    $vterminal_mock->mock("set_pipe_sz", sub {
+    $file_mock->redefine(slurp => sub { return 65536; });
+    $vterminal_mock->redefine("get_pipe_sz", sub { return 1024; });
+    $vterminal_mock->redefine("set_pipe_sz", sub {
             my ($self, $fd, $newsize) = @_;
             return if ($newsize > 2048);
             return $size = $newsize;
@@ -81,7 +81,7 @@ subtest "Test open_pipe() error condition" => sub {
     is($size, 2048, "PIPE_SZ is 2048");
 
     $size = 1024;
-    $vterminal_mock->mock("set_pipe_sz", undef);
+    $vterminal_mock->redefine("set_pipe_sz", undef);
     $helper = prepare_pipes($socket_path);
     $term   = consoles::virtio_terminal->new('unit-test-console', {socked_path => $socket_path});
     stderr_like { $term->open_pipe() } qr/Set PIPE_SZ from 1024 to 1024/, 'Log mention new size';
@@ -89,7 +89,7 @@ subtest "Test open_pipe() error condition" => sub {
     is($size, 1024, "Size didn't changed");
 
     $size = 1024;
-    $vterminal_mock->mock("set_pipe_sz", sub {
+    $vterminal_mock->redefine("set_pipe_sz", sub {
             my ($self, $fd, $newsize) = @_;
             return $size = $newsize;
     });

--- a/t/13-osutils.t
+++ b/t/13-osutils.t
@@ -170,7 +170,7 @@ subtest attempt => sub {
     use osutils 'attempt';
     my $module = Test::MockModule->new('osutils');
     # just save ourselves some time during testing
-    $module->mock(wait_attempt => sub { sleep 0; });
+    $module->redefine(wait_attempt => sub { sleep 0; });
 
     my $var = 0;
     attempt(5, sub { $var == 5 }, sub { $var++ });

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -39,7 +39,7 @@ subtest modules_test => sub {
 subtest parse_serial_output => sub {
     my $mock_basetest = Test::MockModule->new('basetest');
     # Mock reading of the serial output
-    $mock_basetest->mock(get_serial_output_json => sub {
+    $mock_basetest->redefine(get_serial_output_json => sub {
             return {
                 serial   => "Serial to match\n1q2w333\nMore text",
                 position => '100'
@@ -47,7 +47,7 @@ subtest parse_serial_output => sub {
     });
     my $basetest = basetest->new('installation');
     my $message;
-    $mock_basetest->mock(record_resultfile => sub {
+    $mock_basetest->redefine(record_resultfile => sub {
             my ($self, $title, $output, %nargs) = @_;
             $message = $output;
     });
@@ -110,7 +110,7 @@ subtest parse_serial_output => sub {
 subtest record_testresult => sub {
     my $basetest_class = 'basetest';
     my $mock_basetest  = Test::MockModule->new($basetest_class);
-    $mock_basetest->mock(_result_add_screenshot => sub { });
+    $mock_basetest->redefine(_result_add_screenshot => sub { });
 
     my $basetest = bless({
             result     => undef,
@@ -319,8 +319,8 @@ subtest 'execute_time' => sub {
     my $mock_basetest  = Test::MockModule->new($basetest_class);
     my $test           = basetest->new('foo');
     is($test->{execution_time}, 0, 'the execution time is initiated correctly');
-    $mock_basetest->mock(run  => sub { sleep 2; });
-    $mock_basetest->mock(done => sub { });
+    $mock_basetest->mock(run => sub { sleep 2; });
+    $mock_basetest->redefine(done => sub { });
     $test->runtest;
     is($test->{execution_time}, 2, 'the execution time is correct');
 };

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -19,8 +19,9 @@ my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
 chdir $dir;
 
 my $proc = Test::MockModule->new('OpenQA::Qemu::Proc');
-$proc->redefine(exec_qemu   => undef);
-$proc->redefine(connect_qmp => undef);
+$proc->redefine(exec_qemu            => undef);
+$proc->redefine(connect_qmp          => undef);
+$proc->redefine(init_blockdev_images => undef);
 ok(my $backend = backend::qemu->new(), 'backend can be created');
 # disable any graphics display in tests
 $bmwqemu::vars{QEMU_APPEND} = '-nographic';

--- a/t/19-isotovideo-command-processing.t
+++ b/t/19-isotovideo-command-processing.t
@@ -18,7 +18,7 @@ my @last_received_msg_by_fd = (undef, undef, undef);
 
 # mock the json rpc
 my $rpc_mock = Test::MockModule->new('myjsonrpc');
-$rpc_mock->mock(send_json => sub {
+$rpc_mock->redefine(send_json => sub {
         my ($fd, $cmd) = @_;
         if (!defined($fd) || ($fd != $cmd_srv_fd && $fd != $backend_fd && $fd != $answer_fd)) {
             fail('invalid file descriptor passed to send_json: ' . ($fd ? $fd : 'undef'));
@@ -26,7 +26,7 @@ $rpc_mock->mock(send_json => sub {
         }
         $last_received_msg_by_fd[$fd] = $cmd;
 });
-$rpc_mock->mock(read_json => sub {
+$rpc_mock->redefine(read_json => sub {
         fail('we do not expect anything to be read here');
 });
 

--- a/t/21-needle-downloader.t
+++ b/t/21-needle-downloader.t
@@ -16,7 +16,7 @@ use needle;
 # mock user agent and file
 my $user_agent_mock = Test::MockModule->new('Mojo::UserAgent');
 my @queried_urls;
-$user_agent_mock->mock(get => sub {
+$user_agent_mock->redefine(get => sub {
         my ($self, $url) = @_;
         push(@queried_urls, $url);
         return $user_agent_mock->original('get')->(@_);

--- a/t/25-spvm.t
+++ b/t/25-spvm.t
@@ -13,7 +13,7 @@ use Test::Exception;
 subtest 'SSH credentials in spvm' => sub {
     my $expected_credentials = {username => 'root', password => 'foo', hostname => 'my_foo_hostname'};
     my $mock_spvm            = Test::MockModule->new('backend::spvm');
-    $mock_spvm->mock('run_ssh_cmd', sub {
+    $mock_spvm->mock(run_ssh_cmd => sub {
             my ($self, $cmd, %args) = @_;
             for my $k (keys(%{$expected_credentials})) {
                 is($args{$k}, $expected_credentials->{$k}, "Correct $k parameter");
@@ -39,7 +39,7 @@ subtest 'SSH credentials in spvm' => sub {
 
 subtest 'PowerVM power actions' => sub {
     my $mock_spvm = Test::MockModule->new('backend::spvm');
-    $mock_spvm->mock('run_cmd', sub {
+    $mock_spvm->redefine('run_cmd', sub {
             my ($self, $cmd) = @_;
             return $cmd;
     });


### PR DESCRIPTION
Redefine fails early if a sub is not found in the mocked module.

    ag -l -- '->mock' | xargs sed -i 's@->mock@->redefine@'

Whilst looking at #1394  I remembered I still had this lying around (tho this is a fresh version). This is analoguous to os-autoinst/OpenQA#2916

Specific bugs found:
  - OpenQA::Qemu::Proc::init_blockdef_images does not exist! at 18-backend-qemu.t line 24.