### PR TITLE
spec: Remove tools/docker_run_ci from installed tools

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -112,7 +112,7 @@ make INSTALLDIRS=vendor %{?_smp_mflags}
 %install
 %make_install INSTALLDIRS=vendor
 # only internal stuff
-rm %{buildroot}/usr/lib/os-autoinst/tools/{tidy,check_coverage,absolutize}
+rm %{buildroot}/usr/lib/os-autoinst/tools/{tidy,check_coverage,absolutize,docker_run_ci}
 rm -r %{buildroot}/usr/lib/os-autoinst/tools/lib/perlcritic
 #
 ls -lR %buildroot


### PR DESCRIPTION
https://build.opensuse.org/package/live_build_log/devel:openQA/os-autoinst/openSUSE_Factory/x86_64
```
[  213s] error: Installed (but unpackaged) file(s) found:
[  213s]    /usr/lib/os-autoinst/tools/docker_run_ci
```