### PR TITLE
Add back colors to log output if available

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -69,6 +69,11 @@ our @ovmf_locations = (
 
 our %vars;
 
+sub logger {
+    $logger //= Mojo::Log->new(level => 'debug', format => \&log_format_callback);
+    return $logger;
+}
+
 sub load_vars {
     my $fn  = "vars.json";
     my $ret = {};
@@ -114,13 +119,8 @@ our $gocrbin = "/usr/bin/gocr";
 our $scriptdir;
 
 sub init_logger {
-    if ($direct_output) {
-        $logger = Mojo::Log->new(level => 'debug');
-    }
-    else {
-        $logger = Mojo::Log->new(level => 'debug', path => catfile(result_dir, 'autoinst-log.txt'));
-    }
-
+    my $log = Mojo::Log->new(level => 'debug');
+    $logger = $log->path(catfile(result_dir, 'autoinst-log.txt')) unless $direct_output;
     $logger->format(
         sub {
             my ($time, $level, @lines) = @_;
@@ -212,9 +212,8 @@ sub log_format_callback {
 
 sub diag {
     my ($args) = @_;
-    $logger = Mojo::Log->new(level => 'debug', format => \&log_format_callback) unless $logger;
     confess "missing input" unless $_[0];
-    $logger->debug("@_");
+    logger->debug("@_");
     return;
 }
 
@@ -222,8 +221,7 @@ sub fctres {
     my ($text, $fname) = @_;
 
     $fname //= (caller(1))[3];
-    $logger = Mojo::Log->new(level => 'debug', format => \&log_format_callback) unless $logger;
-    $logger->debug(">>> $fname: $text");
+    logger->debug(">>> $fname: $text");
     return;
 }
 
@@ -231,8 +229,7 @@ sub fctinfo {
     my ($text, $fname) = @_;
 
     $fname //= (caller(1))[3];
-    $logger = Mojo::Log->new(level => 'debug', format => \&log_format_callback) unless $logger;
-    $logger->info("::: $fname: $text");
+    logger->info("::: $fname: $text");
     return;
 }
 
@@ -240,14 +237,12 @@ sub fctwarn {
     my ($text, $fname) = @_;
 
     $fname //= (caller(1))[3];
-    $logger = Mojo::Log->new(level => 'debug', format => \&log_format_callback) unless $logger;
-    $logger->warn("!!! $fname: $text");
+    logger->warn("!!! $fname: $text");
     return;
 }
 
 sub modstart {
-    $logger = Mojo::Log->new(level => 'debug', format => \&log_format_callback) unless $logger;
-    $logger->debug("||| @{[join(' ', @_)]}");
+    logger->debug("||| @{[join(' ', @_)]}");
     return;
 }
 
@@ -298,8 +293,7 @@ sub log_call {
         }
         $params = join(", ", @result);
     }
-    $logger = Mojo::Log->new(level => 'debug', format => \&log_format_callback) unless $logger;
-    $logger->debug('<<< ' . $fname . "($params)");
+    logger->debug('<<< ' . $fname . "($params)");
     return;
 }
 

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -33,6 +33,7 @@ use Mojo::Log;
 use File::Spec::Functions;
 use Exporter 'import';
 use POSIX 'strftime';
+use Term::ANSIColor;
 
 our $VERSION;
 our @EXPORT    = qw(fileContent save_vars);
@@ -197,7 +198,8 @@ sub log_format_callback {
 sub diag {
     my ($args) = @_;
     confess "missing input" unless $_[0];
-    logger->debug("@_");
+    logger->append(color('white'));
+    logger->debug(@_)->append(color('reset'));
     return;
 }
 
@@ -205,7 +207,8 @@ sub fctres {
     my ($text, $fname) = @_;
 
     $fname //= (caller(1))[3];
-    logger->debug(">>> $fname: $text");
+    logger->append(color('green'));
+    logger->debug(">>> $fname: $text")->append(color('reset'));
     return;
 }
 
@@ -213,7 +216,8 @@ sub fctinfo {
     my ($text, $fname) = @_;
 
     $fname //= (caller(1))[3];
-    logger->info("::: $fname: $text");
+    logger->append(color('yellow'));
+    logger->info("::: $fname: $text")->append(color('reset'));
     return;
 }
 
@@ -221,12 +225,14 @@ sub fctwarn {
     my ($text, $fname) = @_;
 
     $fname //= (caller(1))[3];
-    logger->warn("!!! $fname: $text");
+    logger->append(color('red'));
+    logger->warn("!!! $fname: $text")->append(color('reset'));
     return;
 }
 
 sub modstart {
-    logger->debug("||| @{[join(' ', @_)]}");
+    logger->append(color('bold blue'));
+    logger->debug("||| @{[join(' ', @_)]}")->append(color('reset'));
     return;
 }
 

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -69,10 +69,11 @@ our @ovmf_locations = (
 
 our %vars;
 
-sub logger {
-    $logger //= Mojo::Log->new(level => 'debug', format => \&log_format_callback);
-    return $logger;
-}
+sub result_dir { 'testresults' }
+
+sub logger { $logger //= Mojo::Log->new(level => 'debug', format => \&log_format_callback) }
+
+sub init_logger { logger->path(catfile(result_dir, 'autoinst-log.txt')) unless $direct_output }
 
 sub load_vars {
     my $fn  = "vars.json";
@@ -109,27 +110,10 @@ sub save_vars {
     return;
 }
 
-sub result_dir {
-    return "testresults";
-}
-
 our $gocrbin = "/usr/bin/gocr";
 
 # set from isotovideo during initialization
 our $scriptdir;
-
-sub init_logger {
-    my $log = Mojo::Log->new(level => 'debug');
-    $logger = $log->path(catfile(result_dir, 'autoinst-log.txt')) unless $direct_output;
-    $logger->format(
-        sub {
-            my ($time, $level, @lines) = @_;
-            # Unfortunately $time doesn't have the precision we want. So we need to use Time::HiRes
-            $time = gettimeofday;
-            return sprintf(strftime("[%FT%T.%%03d %Z] [$level] ", localtime($time)), 1000 * ($time - int($time))) . join("\n", @lines, '');
-
-        });
-}
 
 sub init {
     load_vars();

--- a/cpanfile
+++ b/cpanfile
@@ -41,6 +41,7 @@ requires 'Net::DBus';
 requires 'Net::SNMP';
 requires 'Net::SSH2';
 requires 'POSIX';
+requires 'Term::ANSIColor';
 requires 'Thread::Queue';
 requires 'Time::HiRes';
 requires 'Try::Tiny';

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -32,7 +32,7 @@ Source0:        %{name}-%{version}.tar.xz
 %define opencv_require pkgconfig(opencv)
 %endif
 %define build_requires %opencv_require autoconf automake gcc-c++ libtool make perl(Module::CPANfile) pkg-config pkgconfig(fftw3) pkgconfig(libpng) pkgconfig(sndfile) pkgconfig(theoraenc)
-%define requires perl(B::Deparse) perl(Carp::Always) perl(Class::Accessor::Fast) perl(Cpanel::JSON::XS) perl(Crypt::DES) perl(Data::Dumper) perl(Exception::Class) perl(File::Touch) perl(File::Which) perl(IO::Scalar) perl(IO::Socket::INET) perl(IPC::Run::Debug) perl(IPC::System::Simple) perl(List::MoreUtils) perl(Mojolicious) >= 7.92 perl(Mojo::IOLoop::ReadWriteProcess) >= 0.23 perl(Net::DBus) perl(Net::IP) perl(Net::SNMP) perl(Net::SSH2) perl(Socket::MsgHdr) perl(Try::Tiny) perl(XML::LibXML) perl(XML::SemanticDiff) perl(autodie) perl-base
+%define requires perl(B::Deparse) perl(Carp::Always) perl(Class::Accessor::Fast) perl(Cpanel::JSON::XS) perl(Crypt::DES) perl(Data::Dumper) perl(Exception::Class) perl(File::Touch) perl(File::Which) perl(IO::Scalar) perl(IO::Socket::INET) perl(IPC::Run::Debug) perl(IPC::System::Simple) perl(List::MoreUtils) perl(Mojolicious) >= 7.92 perl(Mojo::IOLoop::ReadWriteProcess) >= 0.23 perl(Net::DBus) perl(Net::IP) perl(Net::SNMP) perl(Net::SSH2) perl(Socket::MsgHdr) perl(Term::ANSIColor) perl(Try::Tiny) perl(XML::LibXML) perl(XML::SemanticDiff) perl(autodie) perl-base
 %define requires_not_needed_in_tests git-core
 # all requirements needed by the tests, do not require on this in the package
 # itself or any sub-packages


### PR DESCRIPTION
* Define custom log color selection compatible with reverse video terminals
* Use colors in all log calls if colors are available
* Reduce code duplication in bmwqemu::init_logger
* Simplify logger init in bmwqemu
* t: Prevent errors on local, uncommited files in compile-check

Example output of colors in terminal windows. Black-on-white when Mojo::Log::Colored is not available (top-left), Black-on-white (bottom-left), White-on-black (right):

![screenshot_os-autoinst_log_colors_white_and_black_background](https://user-images.githubusercontent.com/1693432/81951834-f2c1a000-9605-11ea-8f7e-e3a6d98dee3a.png)

Example output of colors in terminal windows with additional colors using https://github.com/os-autoinst/os-autoinst/pull/1403/commits/a65b8389a5755d45387393a889f7611aa7c98890 . Black-on-white when Mojo::Log::Colored is not available (top-left), Black-on-white (bottom-left), White-on-black (right):

![screenshot_os-autoinst_log_colors_white_and_black_background_with_colors_for_modstart_and_fctres](https://user-images.githubusercontent.com/1693432/81954061-af1c6580-9608-11ea-92d4-db8f1b1e4821.png)
