### PR TITLE
Fix sporadic failures in t/17-basetest.t

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -337,6 +337,8 @@ sub run_post_fail {
     die $msg . "\n";
 }
 
+sub execution_time { time - shift }
+
 sub runtest {
     my ($self) = @_;
     my $starttime = time;
@@ -389,7 +391,7 @@ sub runtest {
     }
 
     $self->done();
-    $self->{execution_time} = time - $starttime;
+    $self->{execution_time} = execution_time($starttime);
     bmwqemu::diag(sprintf("||| finished %s %s at %s (%d s)", $name, $self->{category}, POSIX::strftime('%F %T', gmtime), $self->{execution_time}));
     return;
 }

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -319,10 +319,11 @@ subtest 'execute_time' => sub {
     my $mock_basetest  = Test::MockModule->new($basetest_class);
     my $test           = basetest->new('foo');
     is($test->{execution_time}, 0, 'the execution time is initiated correctly');
-    $mock_basetest->mock(run => sub { sleep 2; });
-    $mock_basetest->redefine(done => sub { });
+    $mock_basetest->mock(execution_time => 42);
+    $mock_basetest->mock(run            => undef);
+    $mock_basetest->redefine(done => undef);
     $test->runtest;
-    is($test->{execution_time}, 2, 'the execution time is correct');
+    is($test->{execution_time}, 42, 'the execution time is correct');
 };
 
 done_testing;


### PR DESCRIPTION
From https://build.opensuse.org/package/live_build_log/devel:openQA:tested/os-autoinst/openSUSE_Factory/x86_64

```
[  167s] [2020-05-14T19:27:59.004 UTC] [debug] ||| finished basetest foo at 2020-05-14 19:27:59 (3 s)
[  167s]
[  167s]     #   Failed test 'the execution time is correct'
[  167s]     #   at 17-basetest.t line 325.
[  167s]     #          got: '3'
[  167s]     #     expected: '2'
[  167s]     # Looks like you failed 1 test of 2.
[  167s]
[  167s] #   Failed test 'execute_time'
[  167s] #   at 17-basetest.t line 326.
[  167s] # Looks like you failed 1 test of 6.
[  167s] 17-basetest.t ..........................
```

A test relying on consistent timing behaviour can hardly be stable. A test
should not rely on exact runtime of internal test modules. The code "sleep 2"
does not ensure that we sleep 2 seconds but can take slightly longer. The test
could be changed to assert "2 or more". A better approach is if the test is
changed to not sleep at all. Also, the test module takes 2s just because of
this code, the rest is way faster.

This commit changes the mocked code to not sleep at all. This fixes the longer
runtime and should be more stable. Theoretically it can still be that the
recorded runtime is more than 0s but yielding to other threads/processes is
highly unlikely during the execution of runtest with no sleep execution in
between.

Related progress issue: https://progress.opensuse.org/issues/66886