### PR TITLE
Add conditional skipping of IPMI selftests

### DIFF
--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -147,7 +147,7 @@ sub get_mc_status {
 
     $self->ipmitool("mc guid");
     $self->ipmitool("mc info");
-    $self->ipmitool("mc selftest");
+    $self->ipmitool("mc selftest") unless $bmwqemu::vars{IPMI_SKIP_SELFTEST};
 }
 
 sub do_mc_reset {

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -45,6 +45,7 @@ IPMI_PASSWORD;string;Password for the IPMI interface;
 IPMI_USER;string;Username for the IPMI interface;
 IPMI_DO_NOT_POWER_OFF;boolean;undef;Don't power off the machine after test;
 IPMI_BACKEND_MC_RESET;boolean;undef;Reset ipmi main board before test for sol console stability
+IPMI_SKIP_SELFTEST;boolean;undef;Don't perform BMC selftest
 |====================
 
 .QEMU backend


### PR DESCRIPTION
Some Machines have flaky or buggy IPMI implementations. It can happen,
that the selftest requests to the BMC fails. In some cases we want to
run the tests anyway, for example if we only have one machine of that
architecture and cannot easily replace this.
Simply set IPMI_SKIP_SELFTEST to 1 in order to skip the selftest. By
default, the selftest will be performed.

https://progress.opensuse.org/issues/58466 
and 
https://bugzilla.suse.com/show_bug.cgi?id=1171590
 
http://mmoese-vm.qa.suse.de/tests/96 without IPMI_SKIP_SELFTEST
http://mmoese-vm.qa.suse.de/tests/97 with IPMI_SKIP_SELFTEST=1