### PR TITLE
Simplify basetest and others

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -1,5 +1,5 @@
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/backend/ikvm.pm
+++ b/backend/ikvm.pm
@@ -1,5 +1,5 @@
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2015 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,21 +21,6 @@ use warnings;
 use autodie ':all';
 
 use base 'backend::ipmi';
-
-require File::Temp;
-use File::Temp ();
-use Time::HiRes qw(sleep gettimeofday);
-use IO::Select;
-use IO::Socket::UNIX 'SOCK_STREAM';
-use IO::Handle;
-use Data::Dumper;
-use POSIX qw(strftime :sys_wait_h);
-require Carp;
-use Fcntl;
-use bmwqemu qw(fileContent diag save_vars diag);
-use testapi 'get_required_var';
-use IPC::Run ();
-require IPC::System::Simple;
 
 sub new {
     my $class = shift;

--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -93,10 +93,7 @@ sub do_start_vm {
     # It is expected generally that ipmi machine's stability is higher with this mc reset.
     # However there maybe exceptions on machines from different vendors.
     # So keep it for flexibility.
-    if ($bmwqemu::vars{IPMI_BACKEND_MC_RESET}) {
-        $self->do_mc_reset;
-    }
-
+    $self->do_mc_reset if $bmwqemu::vars{IPMI_BACKEND_MC_RESET};
     $self->get_mc_status;
     $self->restart_host;
     $self->truncate_serial_file;
@@ -108,12 +105,8 @@ sub do_start_vm {
 sub do_stop_vm {
     my ($self) = @_;
 
-    if (!$bmwqemu::vars{IPMI_DO_NOT_POWER_OFF}) {
-        $self->ipmitool("chassis power off");
-    }
-    if (defined $testapi::distri->{consoles}->{sol}) {
-        $self->deactivate_console({testapi_console => 'sol'});
-    }
+    $self->ipmitool("chassis power off") unless $bmwqemu::vars{IPMI_DO_NOT_POWER_OFF};
+    $self->deactivate_console({testapi_console => 'sol'}) if defined $testapi::distri->{consoles}->{sol};
     return {};
 }
 
@@ -126,9 +119,7 @@ sub is_shutdown {
 sub check_socket {
     my ($self, $fh, $write) = @_;
 
-    if ($self->check_ssh_serial($fh)) {
-        return 1;
-    }
+    return 1 if $self->check_ssh_serial($fh);
     return $self->SUPER::check_socket($fh, $write);
 }
 

--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -1,5 +1,5 @@
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2015 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,17 +22,7 @@ use autodie ':all';
 
 use base 'backend::baseclass';
 
-require File::Temp;
-use File::Temp ();
-use Time::HiRes qw(sleep gettimeofday);
-use IO::Select;
-use IO::Socket::UNIX 'SOCK_STREAM';
-use IO::Handle;
-use Data::Dumper;
-use POSIX qw(strftime :sys_wait_h);
-require Carp;
-use Fcntl;
-use bmwqemu qw(fileContent diag save_vars diag);
+use Time::HiRes qw(sleep);
 use testapi 'get_required_var';
 use IPC::Run ();
 require IPC::System::Simple;

--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -334,9 +334,7 @@ sub serial_terminal_log_file {
 sub check_socket {
     my ($self, $fh, $write) = @_;
 
-    if ($self->check_ssh_serial($fh, $write)) {
-        return 1;
-    }
+    return 1 if $self->check_ssh_serial($fh, $write);
     return $self->SUPER::check_socket($fh, $write);
 }
 

--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -1,5 +1,5 @@
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2019 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,7 +23,6 @@ use base 'backend::virt';
 
 use File::Basename;
 use IO::Scalar;
-use IO::Select;
 use Time::HiRes 'usleep';
 use testapi qw(get_var get_required_var check_var);
 

--- a/basetest.pm
+++ b/basetest.pm
@@ -337,6 +337,8 @@ sub run_post_fail {
     die $msg . "\n";
 }
 
+sub execution_time { time - shift }
+
 sub runtest {
     my ($self) = @_;
     my $starttime = time;
@@ -389,7 +391,7 @@ sub runtest {
     }
 
     $self->done();
-    $self->{execution_time} = time - $starttime;
+    $self->{execution_time} = execution_time($starttime);
     bmwqemu::diag(sprintf("||| finished %s %s at %s (%d s)", $name, $self->{category}, POSIX::strftime('%F %T', gmtime), $self->{execution_time}));
     return;
 }

--- a/basetest.pm
+++ b/basetest.pm
@@ -1,5 +1,5 @@
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2015 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,7 +22,6 @@ use autodie ':all';
 
 use bmwqemu ();
 use ocr;
-use Time::HiRes;
 use POSIX;
 use testapi  ();
 use autotest ();

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -1,5 +1,5 @@
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2015 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -33,7 +33,6 @@ use Mojo::Log;
 use File::Spec::Functions;
 use Exporter 'import';
 use POSIX 'strftime';
-use Time::HiRes 'gettimeofday';
 
 our $VERSION;
 our @EXPORT    = qw(fileContent save_vars);

--- a/consoles/vnc_base.pm
+++ b/consoles/vnc_base.pm
@@ -24,7 +24,7 @@ use base 'consoles::network_console';
 
 use consoles::VNC;
 use List::Util 'max';
-use Time::HiRes qw(usleep time);
+use Time::HiRes qw(usleep);
 
 use Try::Tiny;
 use testapi 'get_var';

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -319,10 +319,11 @@ subtest 'execute_time' => sub {
     my $mock_basetest  = Test::MockModule->new($basetest_class);
     my $test           = basetest->new('foo');
     is($test->{execution_time}, 0, 'the execution time is initiated correctly');
-    $mock_basetest->mock(run => sub { sleep 2; });
-    $mock_basetest->redefine(done => sub { });
+    $mock_basetest->mock(execution_time => 42);
+    $mock_basetest->mock(run            => undef);
+    $mock_basetest->redefine(done => undef);
     $test->runtest;
-    is($test->{execution_time}, 2, 'the execution time is correct');
+    is($test->{execution_time}, 42, 'the execution time is correct');
 };
 
 done_testing;

--- a/t/20-openqa-benchmark-stopwatch-utils.t
+++ b/t/20-openqa-benchmark-stopwatch-utils.t
@@ -1,5 +1,4 @@
 #!/usr/bin/perl
-# Do not add to makefile.am
 
 use strict;
 use warnings;


### PR DESCRIPTION
* Simplify some code in baseclass
* Slightly simplify backends ipmi+svirt
* t: Delete obsolete comment in 20-openqa-benchmark-stopwatch-utils.t
* Delete unused imports
* Fix sporadic failures in t/17-basetest.t