### PR TITLE
t: Import stderr_from

### DIFF
--- a/t/15-logging.t
+++ b/t/15-logging.t
@@ -20,7 +20,7 @@
 use strict;
 use warnings;
 use Test::More;
-use Test::Output;
+use Test::Output qw(stderr_from);
 use bmwqemu;
 use Mojo::File 'tempfile';
 use Data::Dumper;


### PR DESCRIPTION
in OBS we get:

    [  376s] Undefined subroutine &main::stderr_from called at 15-logging.t line 38.

Because the Test::Output version is too old:

    [   86s] perl-Test-Output-1.03-5.2.noarch

Confirmed behaviour locally with Test-Output-1.03.tar.gz

https://build.opensuse.org/package/live_build_log/devel:openQA/os-autoinst/SLE_12_SP4/x86_64