### PR TITLE
Distinguish test compilation errors from backend crashes

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -115,6 +115,7 @@ sub loadtest {
     if ($@) {
         my $msg = "error on $script: $@";
         bmwqemu::diag($msg);
+        bmwqemu::serialize_state(component => 'tests', msg => "unable to load $script, check the log for the cause (e.g. syntax error)");
         die $msg;
     }
     $test             = $name->new($category);

--- a/autotest.pm
+++ b/autotest.pm
@@ -1,5 +1,5 @@
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -40,10 +40,7 @@ use MIME::Base64 'encode_base64';
 use List::Util 'min';
 use List::MoreUtils 'uniq';
 use Scalar::Util 'looks_like_number';
-use Mojo::JSON qw(encode_json);
 use Mojo::File 'path';
-
-use constant STATE_FILE => 'base_state.json';
 
 # should be a singleton - and only useful in backend process
 our $backend;
@@ -91,19 +88,10 @@ sub handle_command {
     return $self->$func($cmd->{arguments});
 }
 
-# Write a JSON representation of the process termination to disk
-sub _serialize_state {
-    my $msg = shift;
-    return undef if -e STATE_FILE;
-    path(STATE_FILE)->spurt(encode_json({
-                msg => $msg,
-    }));
-}
-
 sub die_handler {
     my $msg = shift;
     bmwqemu::diag "Backend process died, backend errors are reported below in the following lines:\n$msg";
-    _serialize_state($msg);
+    bmwqemu::serialize_state(component => 'backend', msg => $msg);
     $backend->stop_vm();
     $backend->close_pipes();
 }

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -25,11 +25,12 @@ use IO::Socket;
 use Fcntl ':flock';
 use POSIX;
 use Carp;
-use Mojo::JSON;    # booleans
+use Mojo::JSON qw(encode_json);
 use Cpanel::JSON::XS ();
 use File::Path 'remove_tree';
 use Data::Dumper;
 use Mojo::Log;
+use Mojo::File;
 use File::Spec::Functions;
 use Exporter 'import';
 use POSIX 'strftime';
@@ -75,6 +76,14 @@ sub result_dir { 'testresults' }
 sub logger { $logger //= Mojo::Log->new(level => 'debug', format => \&log_format_callback) }
 
 sub init_logger { logger->path(catfile(result_dir, 'autoinst-log.txt')) unless $direct_output }
+
+use constant STATE_FILE => 'base_state.json';
+
+# Write a JSON representation of the process termination to disk
+sub serialize_state {
+    return undef if -e STATE_FILE;
+    Mojo::File->new(STATE_FILE)->spurt(encode_json({@_}));
+}
 
 sub load_vars {
     my $fn  = "vars.json";

--- a/isotovideo
+++ b/isotovideo
@@ -280,16 +280,25 @@ if ($bmwqemu::vars{SCHEDULE}) {
 }
 my $productdir = $bmwqemu::vars{PRODUCTDIR};
 my $main_path  = File::Spec->catfile($productdir, 'main.pm');
-if (-e $main_path) {
-    unshift @INC, '.';
-    require $main_path;
+try {
+    if (-e $main_path) {
+        unshift @INC, '.';
+        require $main_path;
+    }
+    elsif (!File::Spec->file_name_is_absolute($productdir) && -e File::Spec->catfile($bmwqemu::vars{CASEDIR}, $main_path)) {
+        require File::Spec->catfile($bmwqemu::vars{CASEDIR}, $main_path);
+    }
+    elsif (!$bmwqemu::vars{SCHEDULE}) {
+        die '\'SCHEDULE\' not set and ' . $productdir . '/main.pm not found, need one of both';
+    }
 }
-elsif (!File::Spec->file_name_is_absolute($productdir) && -e File::Spec->catfile($bmwqemu::vars{CASEDIR}, $main_path)) {
-    require File::Spec->catfile($bmwqemu::vars{CASEDIR}, $main_path);
-}
-elsif (!$bmwqemu::vars{SCHEDULE}) {
-    die '\'SCHEDULE\' not set and ' . $productdir . '/main.pm not found, need one of both';
-}
+catch {
+    # record that the exception is caused by the tests themselves before letting it pass
+    my $error_message = $_;
+    bmwqemu::serialize_state(component => 'tests', msg => 'unable to load main.pm, check the log for the cause (e.g. syntax error)');
+    die "$error_message\n";
+};
+
 @INC = @oldINC;
 
 if ($bmwqemu::vars{_EXIT_AFTER_SCHEDULE}) {

--- a/isotovideo
+++ b/isotovideo
@@ -84,7 +84,7 @@ use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 Getopt::Long::Configure("no_ignore_case");
 use OpenQA::Isotovideo::CommandHandler;
 use OpenQA::Isotovideo::Interface;
-use OpenQA::Isotovideo::Utils qw(checkout_git_repo_and_branch checkout_git_refspec);
+use OpenQA::Isotovideo::Utils qw(checkout_git_repo_and_branch checkout_git_refspec load_test_schedule);
 
 session->enable;
 session->enable_subreaper;
@@ -268,43 +268,7 @@ $bmwqemu::vars{TEST_GIT_HASH} = checkout_git_refspec($bmwqemu::vars{CASEDIR} => 
 # set a default distribution if the tests don't have one
 $testapi::distri = distribution->new;
 
-# add lib of the test distributions - but only for main.pm not to pollute
-# further dependencies (the tests get it through autotest)
-my @oldINC = @INC;
-unshift @INC, $bmwqemu::vars{CASEDIR} . '/lib';
-if ($bmwqemu::vars{SCHEDULE}) {
-    diag 'Enforced test schedule by \'SCHEDULE\' variable in action';
-    $bmwqemu::vars{INCLUDE_MODULES} = undef;
-    autotest::loadtest($_ . '.pm') foreach split(',', $bmwqemu::vars{SCHEDULE});
-    $bmwqemu::vars{INCLUDE_MODULES} = 'none';
-}
-my $productdir = $bmwqemu::vars{PRODUCTDIR};
-my $main_path  = File::Spec->catfile($productdir, 'main.pm');
-try {
-    if (-e $main_path) {
-        unshift @INC, '.';
-        require $main_path;
-    }
-    elsif (!File::Spec->file_name_is_absolute($productdir) && -e File::Spec->catfile($bmwqemu::vars{CASEDIR}, $main_path)) {
-        require File::Spec->catfile($bmwqemu::vars{CASEDIR}, $main_path);
-    }
-    elsif (!$bmwqemu::vars{SCHEDULE}) {
-        die '\'SCHEDULE\' not set and ' . $productdir . '/main.pm not found, need one of both';
-    }
-}
-catch {
-    # record that the exception is caused by the tests themselves before letting it pass
-    my $error_message = $_;
-    bmwqemu::serialize_state(component => 'tests', msg => 'unable to load main.pm, check the log for the cause (e.g. syntax error)');
-    die "$error_message\n";
-};
-
-@INC = @oldINC;
-
-if ($bmwqemu::vars{_EXIT_AFTER_SCHEDULE}) {
-    diag 'Early exit has been requested with _EXIT_AFTER_SCHEDULE. Only evaluating test schedule.';
-    exit 0;
-}
+load_test_schedule;
 
 # start the command fork before we get into the backend, the command child
 # is not supposed to talk to the backend directly

--- a/isotovideo
+++ b/isotovideo
@@ -265,10 +265,6 @@ bmwqemu::ensure_valid_vars();
 
 $bmwqemu::vars{TEST_GIT_HASH} = checkout_git_refspec($bmwqemu::vars{CASEDIR} => 'TEST_GIT_REFSPEC');
 
-# start the command fork before we get into the backend, the command child
-# is not supposed to talk to the backend directly
-($cmd_srv_process, $cmd_srv_fd) = commands::start_server($cmd_srv_port = $bmwqemu::vars{QEMUPORT} + 1);
-
 # set a default distribution if the tests don't have one
 $testapi::distri = distribution->new;
 
@@ -300,6 +296,11 @@ if ($bmwqemu::vars{_EXIT_AFTER_SCHEDULE}) {
     diag 'Early exit has been requested with _EXIT_AFTER_SCHEDULE. Only evaluating test schedule.';
     exit 0;
 }
+
+# start the command fork before we get into the backend, the command child
+# is not supposed to talk to the backend directly
+($cmd_srv_process, $cmd_srv_fd) = commands::start_server($cmd_srv_port = $bmwqemu::vars{QEMUPORT} + 1);
+
 testapi::init();
 needle::init();
 bmwqemu::save_vars();

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -3,12 +3,15 @@
 use strict;
 use warnings;
 use autodie ':all';
+use Test::Exception;
 use Test::More;
 use File::Basename;
 use File::Path qw(remove_tree rmtree);
 use Cwd 'abs_path';
-use Mojo::File 'tempdir';
+use Mojo::File qw(tempdir path);
+use Mojo::JSON qw(decode_json);
 use FindBin '$Bin';
+use OpenQA::Isotovideo::Utils qw(load_test_schedule);
 
 my $dir          = tempdir("/tmp/$FindBin::Script-XXXX");
 my $toplevel_dir = abs_path(dirname(__FILE__) . '/..');
@@ -34,6 +37,30 @@ sub is_in_log {
     local $Test::Builder::Level = $Test::Builder::Level + 2;
     is(system("grep -q \"$regex\" autoinst-log.txt"), 0, $msg);
 }
+
+subtest 'error handling when loading test schedule' => sub {
+    my $base_state = path(bmwqemu::STATE_FILE);
+    subtest 'no schedule at all' => sub {
+        $base_state->remove;
+        $bmwqemu::vars{CASEDIR} = $bmwqemu::vars{PRODUCTDIR} = $dir;
+        throws_ok { load_test_schedule } qr/'SCHEDULE' not set and/, 'error logged';
+        my $state = decode_json($base_state->slurp);
+        if (is(ref $state, 'HASH', 'state file contains object')) {
+            is($state->{component}, 'tests', 'state file contains component message');
+            like($state->{msg}, qr/unable to load main\.pm/, 'state file contains error message');
+        }
+    };
+    subtest 'unable to load test module' => sub {
+        $base_state->remove;
+        $bmwqemu::vars{SCHEDULE} = 'foo/bar';
+        throws_ok { load_test_schedule } qr/Can't locate foo\/bar\.pm/, 'error logged';
+        my $state = decode_json($base_state->slurp);
+        if (is(ref $state, 'HASH', 'state file contains object')) {
+            is($state->{component}, 'tests', 'state file contains component message');
+            like($state->{msg}, qr/unable to load foo\/bar\.pm/, 'state file contains error message');
+        }
+    };
+};
 
 subtest 'standalone isotovideo without vars.json file and only command line parameters' => sub {
     chdir($pool_dir);


### PR DESCRIPTION
* Together with https://github.com/os-autoinst/openQA/pull/3096 the incompletion reasons are more specific about the component (tests vs. backend) when a compilation error occurs, e.g.
    * `tests died: unable to load tests/installation/bootloader.pm, check the log for the cause (e.g. syntax error)`
    * `backend died: Migrate to file failed`
* Runtime errors during the test execution are still treated as before (test result is failed and a failed step with the exception message is added).
* See particular commit messages and https://progress.opensuse.org/issues/64884