### PR TITLE
Change BuildTag in Dockerfile

### DIFF
--- a/docker/travis_test/Dockerfile
+++ b/docker/travis_test/Dockerfile
@@ -1,4 +1,4 @@
-#!BuildTag: openqa_dev
+#!BuildTag: os-autoinst_dev
 FROM opensuse/leap:15.1
 
 # Define environment variable


### PR DESCRIPTION
We want to use this under the new name:
https://build.opensuse.org/package/show/devel:openQA/os-autoinst_dev