### PR TITLE
testapi: Add wait_still_screen option to send_key

### DIFF
--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -549,6 +549,12 @@ subtest 'wait_still_screen & assert_still_screen' => sub {
         'assert_still_screen forwards arguments to wait_still_screen');
 };
 
+subtest 'send_key with wait_still_screen' => sub {
+    my $mock_testapi = Test::MockModule->new('testapi');
+    $mock_testapi->redefine(wait_still_screen => sub { die "wait_still_screen(@_)" });
+    like(exception { send_key 'ret', wait_still_screen => 2 }, qr/wait_still_screen\(stilltime 2\)/, 'wait_still_screen called by send_key');
+};
+
 subtest 'set console tty and other args' => sub {
     # ensure previously emitted commands are cleared
     $cmds = ();

--- a/testapi.pm
+++ b/testapi.pm
@@ -1279,7 +1279,7 @@ sub hashed_string {
 
 =head2 send_key
 
-  send_key($key [, wait_screen_change => $wait_screen_change]);
+  send_key($key [, wait_screen_change => <num> ] [, wait_still_screen => <num> ]);
 
 Send one C<$key> to SUT keyboard input. Waits for the screen to change when
 C<$wait_screen_change> is true.
@@ -1304,6 +1304,8 @@ sub send_key {
     else {
         query_isotovideo('backend_send_key', {key => $key});
     }
+    my $stilltime = $args{wait_still_screen} // 0;
+    wait_still_screen stilltime => $stilltime if $stilltime;
 }
 
 =head2 hold_key


### PR DESCRIPTION
Fixes: [poo#65109](https://progress.opensuse.org/issues/65109)