### PR TITLE
CI: Install possibly new dependencies

### DIFF
--- a/tools/docker_run_ci
+++ b/tools/docker_run_ci
@@ -8,5 +8,5 @@ docker images | grep opensuse
 
 docker run --env "QEMU_QMP_CONNECT_ATTEMPTS=10" --env "EXPECTED_QEMU_START_S=20" \
   $CI_ENV --rm --entrypoint '' -v "$PWD":/opt $IMAGE \
-  sh -c 'cd /opt && ./autogen.sh && make && make check coverage-codecov VERBOSE=1'
+  sh -c 'cd /opt && ./tools/install-new-deps.sh && ./autogen.sh && make && make check coverage-codecov VERBOSE=1'
 

--- a/tools/install-new-deps.sh
+++ b/tools/install-new-deps.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# This script is used for CI testing.
+# Used to install new dependencies.
+# If there are new dependencies, they won't be installed in the docker
+# container yet, so we just install all deps again.
+
+set -e
+
+OLDDEPS=/tmp/deps.txt
+NEWDEPS=/tmp/new-deps.txt
+DIFFDEPS=/tmp/diff-deps.txt
+
+source ./tools/tools.sh
+
+listdeps > $OLDDEPS
+
+DEPS=($(getdeps_docker))
+
+sudo zypper --no-refresh install -y -C ${DEPS[@]}
+
+listdeps > $NEWDEPS
+
+echo "Checking updated packages"
+if diff $OLDDEPS $NEWDEPS > $DIFFDEPS; then
+    echo "NO DIFF"
+else
+    echo "=============== DIFF"
+    cat $DIFFDEPS
+    echo "=============== DIF END"
+fi
+

--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Installation tools
+
+# Get all dependencies needed for the docker environment
+getdeps_docker() {
+    perl -MYAML::PP=Load -0wE'
+        my $d = Load<>;
+        say for sort grep {!/^%/} map { keys %{$d->{$_."_requires"}} }
+        @{$d->{targets}->{docker}}
+    ' < dependencies.yaml
+}
+
+listdeps() {
+    rpm -qa --qf "%{NAME}-%{VERSION}\n" | grep -v ^gpg-pubkey | sort
+}

--- a/tools/update-deps
+++ b/tools/update-deps
@@ -35,9 +35,10 @@ my ($modules, $test_modules, $cover_modules, $devel_modules) = get_modules();
 
 update_spec();
 update_cpanfile($modules, $test_modules, $cover_modules, $devel_modules);
-update_dockerfile() if $dockerfile;
+update_dockerfile($dockerfile) if $dockerfile;
 
 sub update_dockerfile {
+    my ($dockerfile) = @_;
     my $docker = path($dockerfile)->slurp;
     my @perl;
     my @pkg;


### PR DESCRIPTION
This way we can add a new dependency and use it in the same PR.
    
In the future `tools/tools.sh` can also be used within the Dockerfile,
so we don't have to generate the dependencies there.
    
For that OBS needs to be configured to extract dependencies.yaml and
tools/tools.sh first.

Issue: https://progress.opensuse.org/issues/56525

Followup-to: #1423 