### PR TITLE
spec: Fix 'update-deps' not to be packaged

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -117,7 +117,7 @@ make INSTALLDIRS=vendor %{?_smp_mflags}
 %install
 %make_install INSTALLDIRS=vendor
 # only internal stuff
-rm %{buildroot}/usr/lib/os-autoinst/tools/{tidy,check_coverage,absolutize,docker_run_ci}
+rm %{buildroot}/usr/lib/os-autoinst/tools/{tidy,check_coverage,absolutize,docker_run_ci,update-deps}
 rm -r %{buildroot}/usr/lib/os-autoinst/tools/lib/perlcritic
 #
 ls -lR %buildroot


### PR DESCRIPTION
This fixes the problem reported in OBS

```
error: Installed (but unpackaged) file(s) found:
    /usr/lib/os-autoinst/tools/update-deps
```

See https://build.opensuse.org/package/live_build_log/devel:openQA/os-autoinst/openSUSE_Factory/x86_64