### PR TITLE
Fix missing qemu-kvm dependency on non-x86_64

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -72,7 +72,6 @@ test_requires:
   perl(Test::Warnings): '>= 0.029'
   perl(YAML::PP):
   qemu:
-  qemu-kvm:
   qemu-tools:
   qemu-x86:
 

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -53,7 +53,7 @@ Source0:        %{name}-%{version}.tar.xz
 %define make_check_args CHECK_DOC=0
 %endif
 # The following line is generated from dependencies.yaml
-%define test_requires %build_requires %main_requires %spellcheck_requires perl(Benchmark) perl(Devel::Cover) perl(FindBin) perl(Perl::Critic) perl(Perl::Critic::Freenode) perl(Pod::Coverage) perl(Test::Exception) perl(Test::Fatal) perl(Test::Mock::Time) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::More) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 perl(YAML::PP) qemu qemu-kvm qemu-tools qemu-x86
+%define test_requires %build_requires %main_requires %spellcheck_requires perl(Benchmark) perl(Devel::Cover) perl(FindBin) perl(Perl::Critic) perl(Perl::Critic::Freenode) perl(Pod::Coverage) perl(Test::Exception) perl(Test::Fatal) perl(Test::Mock::Time) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::More) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 perl(YAML::PP) qemu qemu-tools qemu-x86
 # The following line is generated from dependencies.yaml
 %define devel_requires %requires_not_needed_in_tests %test_requires perl(Devel::Cover) perl(Devel::Cover::Report::Codecov) perl(Perl::Tidy)
 BuildRequires:  %test_requires

--- a/docker/travis_test/Dockerfile
+++ b/docker/travis_test/Dockerfile
@@ -26,7 +26,6 @@ RUN zypper in -y -C \
        perl-base \
        pkg-config \
        qemu \
-       qemu-kvm \
        qemu-tools \
        qemu-x86 \
        sudo \
@@ -129,7 +128,7 @@ RUN zypper in -y -C \
 
 #RUN zypper -n addrepo http://download.opensuse.org/repositories/devel:/openQA:/ci/openSUSE_Leap_15.1 qemu \
 #    && zypper -n --gpg-auto-import-keys --no-gpg-checks refresh \
-#    && zypper -n in --from qemu qemu qemu-x86 qemu-tools qemu-ipxe qemu-sgabios qemu-kvm qemu-seabios
+#    && zypper -n in --from qemu qemu qemu-x86 qemu-tools qemu-ipxe qemu-sgabios qemu-seabios
 
 VOLUME ["/sys/fs/cgroup", "/run"]
 


### PR DESCRIPTION
qemu-kvm was added to the spec file in 8f30ade5 but was mentioned in
before already as part of the test Dockerfile. As it was not provided as
requirement in the spec file as runtime dependencies for the generated
packages we can just try to remove it from dependencies and rely on CI
and package build tests.

OBS test project: https://build.opensuse.org/package/show/home:okurz:branches:devel:openQA:pr1434/os-autoinst

Related progress issue: https://progress.opensuse.org/issues/67837