### PR TITLE
t: Skip 27-make-update-deps.t when there is no .git

### DIFF
--- a/t/27-make-update-deps.t
+++ b/t/27-make-update-deps.t
@@ -20,6 +20,12 @@ use Test::More;
 use Test::Warnings;
 use FindBin '$Bin';
 
+if (not -e "$Bin/../.git") {
+    pass("Skipping all tests, not in a git repository");
+    done_testing;
+    exit;
+}
+
 chdir "$Bin/..";
 my $make = "make update-deps";
 my @out  = qx{$make};


### PR DESCRIPTION
Otherwise we get (in OBS):
```
[  533s] fatal: Not a git repository (or any of the parent directories): .git
```