### PR TITLE
Separate lint requires from test requires, don't include in spec

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -73,6 +73,8 @@ on 'test' => sub {
     requires 'FindBin';
     requires 'Perl::Critic';
     requires 'Perl::Critic::Freenode';
+    requires 'Perl::Critic::Policy';
+    requires 'Perl::Critic::Utils';
     requires 'Pod::Coverage';
     requires 'Test::Exception';
     requires 'Test::Fatal';

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -8,9 +8,9 @@
 #######################################################
 ---
 targets:
-  cpanfile: [        cover, devel,         main,             test ]
-  spec:     [ build,        devel,         main, spellcheck, test ]
-  docker:   [ build,        devel, docker, main, spellcheck, test ]
+  cpanfile: [        cover, devel,         main,             lint, test ]
+  spec:     [ build,        devel,         main, spellcheck,       test ]
+  docker:   [ build,        devel, docker, main, spellcheck, lint, test ]
 
 build_requires:
   '%opencv_require':
@@ -49,6 +49,12 @@ spellcheck_requires:
   aspell-en:
   perl(Pod::Spell):
 
+lint_requires:
+  perl(Perl::Critic):
+  perl(Perl::Critic::Freenode):
+  perl(Perl::Critic::Policy):
+  perl(Perl::Critic::Utils):
+
 test_requires:
   '%build_requires':
   '%main_requires':
@@ -56,8 +62,6 @@ test_requires:
   perl(Benchmark):
   perl(Devel::Cover):
   perl(FindBin):
-  perl(Perl::Critic):
-  perl(Perl::Critic::Freenode):
   perl(Pod::Coverage):
   perl(Test::Exception):
   perl(Test::Fatal):

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -52,7 +52,7 @@ Source0:        %{name}-%{version}.tar.xz
 %define make_check_args CHECK_DOC=0
 %endif
 # The following line is generated from dependencies.yaml
-%define test_requires %build_requires %main_requires %spellcheck_requires perl(Benchmark) perl(Devel::Cover) perl(FindBin) perl(Perl::Critic) perl(Perl::Critic::Freenode) perl(Pod::Coverage) perl(Test::Exception) perl(Test::Fatal) perl(Test::Mock::Time) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::More) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 perl(YAML::PP) qemu qemu-tools qemu-x86
+%define test_requires %build_requires %main_requires %spellcheck_requires perl(Benchmark) perl(Devel::Cover) perl(FindBin) perl(Pod::Coverage) perl(Test::Exception) perl(Test::Fatal) perl(Test::Mock::Time) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::More) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 perl(YAML::PP) qemu qemu-tools qemu-x86
 # The following line is generated from dependencies.yaml
 %define devel_requires %test_requires perl(Devel::Cover) perl(Devel::Cover::Report::Codecov) perl(Perl::Tidy)
 BuildRequires:  %test_requires

--- a/docker/travis_test/Dockerfile
+++ b/docker/travis_test/Dockerfile
@@ -87,6 +87,8 @@ RUN zypper in -y -C \
        'perl(POSIX)' \
        'perl(Perl::Critic)' \
        'perl(Perl::Critic::Freenode)' \
+       'perl(Perl::Critic::Policy)' \
+       'perl(Perl::Critic::Utils)' \
        'perl(Perl::Tidy)' \
        'perl(Pod::Coverage)' \
        'perl(Pod::Html)' \

--- a/t/00-compile-check-all.t
+++ b/t/00-compile-check-all.t
@@ -31,5 +31,6 @@ $Test::Strict::TEST_SKIP     = [
     't/data/tests/main.pm',
     't/data/tests/product/main.pm',
     't/pool/product/foo/main.pm',
+    'tools/lib/perlcritic/Perl/Critic/Policy/HashKeyQuotes.pm',
 ];
 all_perl_files_ok('.');

--- a/tools/update-deps
+++ b/tools/update-deps
@@ -123,7 +123,7 @@ sub get_modules {
             if (ref $version) {
                 $version = $version->{perl};
             }
-            if ($target eq 'test') {
+            if ($target eq 'test' || $target eq 'lint') {
                 $test{$module} = $version;
             }
             elsif ($target eq 'cover') {


### PR DESCRIPTION
The Critic requirements are not really test requirements. You
don't need them to run `make test`. They are only needed to run
the linting checks in `make check`. We don't run those tests in
the RPM spec, so including these deps in the test requirements
and hence in the RPM spec's BuildRequires is technically wrong.

This splits those requirements into a new dependencies.yaml group
and adjusts the logic a bit to handle this new group.

One wrinkle here is that the 00-compile-check-all.t check finds
the custom Critic policy module we ship under tools/ and tries
to compile check it; if the Critic deps are not available, that
will fail. This deals with that by just excepting that file from
the test. It's not really a part of the installed tool, after
all, so arguably `make test` shouldn't syntax check it.

Signed-off-by: Adam Williamson <awilliam@redhat.com>