### PR TITLE
Fix the issue could not find `ssh_VMwareServer` in ssh_credentials

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -348,7 +348,7 @@ sub add_disk {
               'fi;' .
               "vmkfstools -v1 -U $vmware_disk_path;" .
               "vmkfstools -v1 -c $size --diskformat thin $vmware_disk_path; sleep 10 ) 2>&1";
-            my $retval = $self->run_cmd($cmd, domain => 'ssh_VMwareServer');
+            my $retval = $self->run_cmd($cmd, domain => 'sshVMwareServer');
             die "Can't create VMware image $vmware_disk_path" if $retval;
         }
         else {


### PR DESCRIPTION
when `$self->vmm_family eq 'vmware'`, the key defined in `ssh_credentials` is
`sshVMwareServer`, so the job failed because of could not find the key
`ssh_VMwareServer`.

The log of failed job showed that
```
Unknown ssh credentials domain ssh_VMwareServer at /usr/lib/os-autoinst/consoles/sshVirtsh.pm line 90.
```
See: http://openqa.suse.de/tests/4342402/file/autoinst-log.txt