### PR TITLE
Add support for TPMv2 emulation via swtpm

### DIFF
--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -101,6 +101,7 @@ QEMUMACHINE;see qemu -machine ?;undef;Machine and chipset to emulate
 QEMUPORT;integer;20002 + worker instance * 10;Port on which QEMU monitor should listen
 QEMURAM;integer;1024;Size of RAM of VM in MiB
 QEMUTHREADS;integer;0;Number of cpu threads used by VM
+QEMUTPM;'instance' or appropriate value for local swtpm config;undef;Configure VM to use a TPM emulator device, with appropriate args for the arch; sysadmin is responsible for running swtpm with a socket at /tmp/mytpmX, where X is the value of QEMUTPM or the worker instance number if QEMUTPM is set to 'instance'
 QEMUVGA;see qemu -device ?;cirrus;VGA device to use with VM
 QEMU_COMPRESS_QCOW2;boolean;1;compress qcow2 images intended for upload
 QEMU_IMG_CREATE_TRIES;integer;3;Define number of tries for qemu-img commands


### PR DESCRIPTION
This adds support in os-autoinst for running qemu with a TPM
emulator device, using swtpm running on the worker host. See
https://www.qemu.org/docs/master/specs/tpm.html for general
background on this.

All this code does is run qemu with appropriate arguments if
the QEMUTPM setting is set. We use `/tmp/mytpmX/swtpm-sock` as
the socket path, where X is replaced by the worker's instance
number if QEMUTPM is set to 'instance', or by the QEMUTPM value
otherwise.

We explicitly do not handle running and shutting down swtpm
itself; I considered that design but thought it would get too
complex. Instead the admin is expected to handle that themselves,
by using a systemd unit or something similar.

I've tested this on x86_64 and it works. I haven't tested on
the other two arches yet as Fedora is moving data centres so
we're on reduced capacity, and I don't have aarch64 or ppc64le
worker hosts up yet.

Signed-off-by: Adam Williamson <awilliam@redhat.com>