### PR TITLE
Prevent backend ipmi send power off when a machine is power off already

### DIFF
--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -67,12 +67,15 @@ sub dell_sleep {
 sub restart_host {
     my ($self) = @_;
 
-    $self->ipmitool("chassis power off");
-    while (1) {
-        sleep(3);
-        my $stdout = $self->ipmitool('chassis power status');
-        last if $stdout =~ m/is off/;
-        $self->ipmitool('chassis power off');
+    my $stdout = $self->ipmitool('chassis power status');
+    if ( $stdout !~ m/is off/ ) {
+        $self->ipmitool("chassis power off");
+        while (1) {
+            sleep(3);
+            my $stdout = $self->ipmitool('chassis power status');
+            last if $stdout =~ m/is off/;
+            $self->ipmitool('chassis power off');
+        }
     }
 
     $self->ipmitool("chassis power on");

--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -68,7 +68,7 @@ sub restart_host {
     my ($self) = @_;
 
     my $stdout = $self->ipmitool('chassis power status');
-    if ( $stdout !~ m/is off/ ) {
+    if ($stdout !~ m/is off/) {
         $self->ipmitool("chassis power off");
         while (1) {
             sleep(3);


### PR DESCRIPTION
When a machine is power off status, backend ipmi will send power off via ipmi, BMC may reply abnormal information like "ipmitool -I lanplus -H 10.67.135.47 -U root -P susetesting chassis power off: Set Chassis Power Control to Down/Off failed: Command not supported in present state at /usr/lib/os-autoinst/backend/ipmi.pm line 65."  Refer to test URL: http://10.67.134.217/tests/10231. That will cause the testing always failure except power on the machine manually.

Add checking machine power status, if it is power off already, send power on command, if it is power on, send power off then power on command.

Verify run: http://10.67.18.234/tests/14#