### PR TITLE
os-autoinst-openvswitch: Fix spurious network startup race-conditions

### DIFF
--- a/os-autoinst-openvswitch
+++ b/os-autoinst-openvswitch
@@ -27,7 +27,10 @@ sub init_switch {
     $self->{BRIDGE} = $ENV{OS_AUTOINST_USE_BRIDGE};
     $self->{BRIDGE} //= 'br0';
 
-    #the bridge must be already created and configured
+    until (-e "/sys/class/net/$self->{BRIDGE}") {
+        print "Waiting for bridge '$self->{BRIDGE}' to be created and configured...\n";
+        sleep 1;
+    }
     system('ovs-vsctl', 'br-exists', $self->{BRIDGE});
 
     my $bridge_conf = `ip addr show $self->{BRIDGE}`;


### PR DESCRIPTION
os-autoinst-openvswitch relies on the network bridge to be configured and up
with a valid IP adress. Just waiting in the systemd service for the network is
not enough as it can happen that the interface is not yet fully up. There are
systemd services like `sys-devices-virtual-net-br1.device` but as the device
can be configured using environment variables as well as the environment file
/etc/sysconfig/os-autoinst-openvswitch it is probably better to use something
dynamic.

This commit adds indefinite waiting for the right network interface instead of
failing on startup of os-autoinst-openvswitch.

Related progress issue: https://progress.opensuse.org/issues/59300