### PR TITLE
Avoid crashes due to signals being handled by OpenCV threads

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -406,6 +406,8 @@ sub exec_qemu {
     return $self->_process->read_stream;
 }
 
+sub qemu_pid { shift->_process->process_id }
+
 =head3 connect_qmp
 
 Connect to QEMU's QMP command socket so that we can control QEMU's execution

--- a/autotest.pm
+++ b/autotest.pm
@@ -27,6 +27,7 @@ use Socket;
 use IO::Handle;
 use POSIX '_exit';
 use cv;
+use signalblocker;
 use Scalar::Util 'blessed';
 use Mojo::IOLoop::ReadWriteProcess 'process';
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
@@ -265,8 +266,11 @@ sub start_process {
             $SIG{HUP}  = 'DEFAULT';
             $SIG{CHLD} = 'DEFAULT';
 
+            my $signal_blocker = signalblocker->new;
             cv::init;
             require tinycv;
+            tinycv::create_threads();
+            undef $signal_blocker;
 
             $0 = "$0: autotest";
             my $line = <$isotovideo>;

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -164,7 +164,15 @@ sub _dbus_call {
 
 sub do_stop_vm {
     my $self = shift;
-    $self->{proc}->save_state();
+
+    my $proc = $self->{proc};
+    if ($bmwqemu::vars{QEMU_WAIT_FINISH}) {
+        # wait until QEMU finishes on its own; used in t/18-qemu-options.t
+        if (my $qemu_pid = $proc->qemu_pid) {
+            waitpid $qemu_pid, 0;
+        }
+    }
+    $proc->save_state;
     $self->stop_qemu;
 }
 

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -89,6 +89,7 @@ OFFLINE_SUT;boolean;0;Disable network for a VM
 OFW;boolean;0;QEMU Open Firmware is in use
 OVS_DEBUG;integer;undef;Set debug mode if value is 1
 QEMU_ONLY_EXEC;boolean;undef;If set, only execute the qemu process but return early before connecting to the process. This can be helpful for cutting testing time or to connect to the qemu process manually.
+QEMU_WAIT_FINISH;boolean;undef;Only used for internal testing, see comment in t/18-qemu-options.t for details.
 QEMU_OVERRIDE_VIDEO_DEVICE_AARCH64;boolean;undef;If set, for aarch64 systems use VGA as video adapter
 QEMU_DISABLE_SNAPSHOTS;boolean;undef;If set, disable snapshots in case the worker has slow disks to avoid save_vm calls failing due to timeouts (See https://bugzilla.suse.com/show_bug.cgi?id=1035453[bsc#1035453])
 QEMU_QMP_CONNECT_ATTEMPTS;integer;20;The number of attempts to connect to qemu qmp. Usually used for internal testing

--- a/ppmclibs/tinycv.h
+++ b/ppmclibs/tinycv.h
@@ -1,4 +1,4 @@
-// Copyright © 2012-2016 SUSE LLC
+// Copyright © 2012-2020 SUSE LLC
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -18,6 +18,7 @@
 
 // opaque type to seperate perl from opencv
 struct Image;
+void create_opencv_threads(int thread_count);
 void image_destroy(Image *s);
 Image *image_new(long width, long height);
 Image *image_read(const char *filename);

--- a/ppmclibs/tinycv.xs
+++ b/ppmclibs/tinycv.xs
@@ -63,6 +63,11 @@ CODE:
 OUTPUT:
        RETVAL
 
+void
+create_threads(int thread_count = -1)
+CODE:
+       create_opencv_threads(thread_count);
+
 tinycv::Image new(long width, long height)
   CODE:
     RETVAL = image_new(width, height);

--- a/signalblocker.pm
+++ b/signalblocker.pm
@@ -1,0 +1,56 @@
+# Copyright © 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package signalblocker;
+use Mojo::Base -base;
+
+use bmwqemu;
+use POSIX ':signal_h';
+
+# OpenCV forks a lot of threads and the TERM signal we may get from the
+# parent process would be delivered to an undefined thread. But as those
+# threads do not have a perl interpreter, the perl signal handler (we set
+# later) would crash. So we need to block the TERM signal in the forked
+# processes before we set the signal handler of our choice.
+
+sub new {
+    my ($class, @args) = @_;
+
+    # block signals
+    bmwqemu::diag('Blocking SIGTERM');
+    my %old_sig = %SIG;
+    $SIG{TERM} = 'IGNORE';
+    $SIG{INT}  = 'IGNORE';
+    $SIG{HUP}  = 'IGNORE';
+    my $sigset = POSIX::SigSet->new(SIGTERM);
+    die "Could not block SIGTERM\n" unless defined sigprocmask(SIG_BLOCK, $sigset, undef);
+
+    # create the actual object holding the information to restore the previous state
+    my $self = $class->SUPER::new(@args);
+    $self->{_old_sig} = \%old_sig;
+    $self->{_sigset}  = $sigset;
+    return $self;
+}
+
+sub DESTROY {
+    my ($self) = @_;
+
+    # set back signal handling to default to be able to terminate properly
+    bmwqemu::diag('Unblocking SIGTERM');
+    die "Could not unblock SIGTERM\n" unless defined sigprocmask(SIG_UNBLOCK, $self->{_sigset}, undef);
+    %SIG = %{$self->{_old_sig}};
+}
+
+1;

--- a/t/18-qemu-options.t
+++ b/t/18-qemu-options.t
@@ -55,6 +55,7 @@ my @common_options = (
     HDDMODEL        => 'ide-drive',
     WORKER_INSTANCE => 3,
     VERSION         => 1,
+    SCHEDULE        => 'tests/noop',
 );
 my $vars_json = path('vars.json');
 my $log_file  = path('autoinst-log.txt');
@@ -67,14 +68,13 @@ sub run_isotovideo {
 
 # test QEMU_APPEND with different options
 subtest qemu_append_option => sub {
-    # note: No option starts a full qemu test.
 
     # print version and also measure time of startup and shutdown: call isotovideo with QEMU_APPEND
     my $time = timeit(1, sub { run_isotovideo(QEMU_ONLY_EXEC => 1, QEMU_APPEND => 'version') });
-    like($log, qr/-version/,                                        '-version option added');
-    like($log, qr/QEMU emulator version/,                           'QEMU version printed');
-    like($log, qr/Fabrice Bellard and the QEMU Project developers/, 'Copyright printed');
-    like($log, qr/Returning early as requested by QEMU_ONLY_EXEC/,  'Copyright printed');
+    like($log, qr/-version/,                                              '-version option added');
+    like($log, qr/QEMU emulator version/,                                 'QEMU version printed');
+    like($log, qr/Fabrice Bellard and the QEMU Project developers/,       'Copyright printed');
+    like($log, qr/Not connecting to QEMU as requested by QEMU_ONLY_EXEC/, 'QEMU_ONLY_EXEC option has effect');
     unlike($log, qr/\: invalid option/, 'no invalid option detected');
     cmp_ok($time->[0], '<', $ENV{EXPECTED_QEMU_START_S}, 'Execution time of isotovideo is within reasonable limits');
 

--- a/t/18-qemu-options.t
+++ b/t/18-qemu-options.t
@@ -40,7 +40,7 @@ chdir $pool_dir;
 # just save ourselves some time during testing
 $ENV{OSUTILS_WAIT_ATTEMPT_INTERVAL} //= 1;
 $ENV{QEMU_QMP_CONNECT_ATTEMPTS}     //= 1;
-$ENV{EXPECTED_QEMU_START_S}         //= 4;
+$ENV{EXPECTED_ISOTOVIDEO_RUNTIME}   //= 8;
 
 my @common_options = (
     ARCH            => 'i386',
@@ -76,7 +76,7 @@ subtest qemu_append_option => sub {
     like($log, qr/Fabrice Bellard and the QEMU Project developers/,       'Copyright printed');
     like($log, qr/Not connecting to QEMU as requested by QEMU_ONLY_EXEC/, 'QEMU_ONLY_EXEC option has effect');
     unlike($log, qr/\: invalid option/, 'no invalid option detected');
-    cmp_ok($time->[0], '<', $ENV{EXPECTED_QEMU_START_S}, 'Execution time of isotovideo is within reasonable limits');
+    cmp_ok($time->[0], '<', $ENV{EXPECTED_ISOTOVIDEO_RUNTIME}, 'Execution time of isotovideo is within reasonable limits');
 
     # list machines: call isotovideo with QEMU_APPEND, to list machines
     run_isotovideo(@common_options, QEMU_APPEND => 'M ?');

--- a/t/28-signalblocker.t
+++ b/t/28-signalblocker.t
@@ -1,0 +1,78 @@
+#!/usr/bin/perl
+#
+# Copyright (c) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# This test covers the signalblocker module and tinycv's helper to create
+# threads upfront.
+
+use strict;
+use warnings;
+
+use File::Basename qw(dirname);
+use Test::More;
+use Test::Warnings qw(warnings :report_warnings);
+use Time::HiRes qw(sleep);
+use POSIX ':signal_h';
+use signalblocker;
+
+no warnings 'redefine';
+sub bmwqemu::diag { note $_[0] }
+
+# make the number of threads to spawn configurable
+my $fix_thread_count_for_testing = $ENV{OS_AUTOINST_TEST_THREAD_COUNT} // 8;
+
+# make the usage of the signal blocker configurable
+# note: The test will fail if this variable is set. This configuration is used to verify that the
+#       test itself is actually able to show negative results.
+my $no_signal_blocker = $ENV{OS_AUTOINST_TEST_NO_SIGNAL_BLOCKER};
+
+# define a helper to find the number of threads spawned by this test
+sub thread_count { scalar split("\n", `ps huH p $$`) }
+is(my $last_thread_count = thread_count, 1, 'initially one thread');
+
+# count SIGTERMs we receive; this handler should work after creating/destroying the signal blocker
+my $received_sigterm = 0;
+$SIG{TERM} = sub { $received_sigterm += 1; note "received SIGTERM $received_sigterm"; };
+
+# initialize OpenCV via signalblocker and create_threads
+{
+    my $signal_blocker = $no_signal_blocker || signalblocker->new;
+    require cv;
+    cv::init();
+    require tinycv;
+    tinycv::create_threads($fix_thread_count_for_testing);
+    is($last_thread_count = thread_count, $fix_thread_count_for_testing, "$fix_thread_count_for_testing threads created");
+}
+
+# do some native calls; no further threads should be created
+my $img = tinycv::read(dirname(__FILE__) . '/data/accept-ssh-host-key.png');
+$img->search_needle($img, 0, 0, 50, 50, 0);
+$img->similarity($img);
+is(thread_count, $last_thread_count, 'no new threads after searching for a needle');
+
+# send a lot of SIGTERMs to ourselves; expect no crashes
+# notes: Not simply using Perl's kill function here because using that I've never been able to actually observe
+#        any crashes without the signal blocker in place (OS_AUTOINST_TEST_NO_SIGNAL_BLOCKER=1).
+my $pid     = $$;
+my $timeout = 5;
+exec bash => '-e', '-c', "for i in {1..100}; do echo \"# sending SIGTERM \$i\" && kill $pid; done" unless my $fork = fork;
+waitpid $fork, 0;
+note 'waiting for at least one signal to be handled' and sleep .2 until $received_sigterm >= 1 || ($timeout -= .2) < 0;
+note "handled $received_sigterm TERM signals";
+ok($received_sigterm > 0, "received SIGTERM $received_sigterm times; no crashes after at least 200 ms idling time");
+is(thread_count, $last_thread_count, 'all threads still alive');
+
+done_testing;

--- a/t/data/tests/tests/noop.pm
+++ b/t/data/tests/tests/noop.pm
@@ -1,0 +1,31 @@
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use strict;
+use warnings;
+
+use base "basetest";
+
+use testapi;
+
+sub run {
+    # supposed to do nothing
+}
+
+sub test_flags {
+    return {};
+}
+
+1;

--- a/tools/docker_run_ci
+++ b/tools/docker_run_ci
@@ -6,7 +6,7 @@ IMAGE=registry.opensuse.org/devel/openqa/containers/os-autoinst_dev
 docker pull $IMAGE
 docker images | grep opensuse
 
-docker run --env "QEMU_QMP_CONNECT_ATTEMPTS=10" --env "EXPECTED_QEMU_START_S=20" \
+docker run --env "QEMU_QMP_CONNECT_ATTEMPTS=10" --env "EXPECTED_ISOTOVIDEO_RUNTIME=20" \
   $CI_ENV --rm --entrypoint '' -v "$PWD":/opt $IMAGE \
   sh -c 'cd /opt && ./tools/install-new-deps.sh && ./autogen.sh && make && make check coverage-codecov VERBOSE=1'
 


### PR DESCRIPTION
* Create OpenCV's threads upfront
* Use the existing sigprocmask approach also within autotest (and not only the backend)
* Add a basic unit test
* See https://progress.opensuse.org/issues/53999

---

Still WIP because I could not actually reproduce the issue locally (despite the unit test). It is also not clear whether this change is actually sufficient (e.g. OpenCV might spawn more threads in other situations I'm currently not aware of).

Note that this does not cover the OpenBLAS threads observed in autotest crashes yet.