### PR TITLE
Prevent calling cv::imwrite with an empty image

### DIFF
--- a/ppmclibs/tinycv_impl.cc
+++ b/ppmclibs/tinycv_impl.cc
@@ -347,6 +347,10 @@ Image* image_from_ppm(const unsigned char* data, size_t len)
 
 bool image_write(const Image* const s, const char* filename)
 {
+    if (s->img.empty()) {
+        std::cerr << "Could not write image " << filename << ": image is empty\n";
+        return false;
+    }
     return imwrite(filename, s->img);
 }
 

--- a/videoencoder.cpp
+++ b/videoencoder.cpp
@@ -373,7 +373,7 @@ int main(int argc, char* argv[])
             fprintf(stderr, "unknown command line: %s\n", line);
         }
 
-        if (!last_frame_converted && need_last_png()) {
+        if (!last_frame_converted && !last_frame_image.empty() && need_last_png()) {
             struct timeval tv;
             gettimeofday(&tv, 0);
             char path[PATH_MAX];


### PR DESCRIPTION
See https://progress.opensuse.org/issues/68554