### PR TITLE
Fix missing signalblocker.pm introduced by 809f7df5

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -96,7 +96,8 @@ perlexec_DATA = \
 	ocr.pm \
 	cv.pm \
 	needle.pm \
-	osutils.pm
+	osutils.pm \
+	signalblocker.pm
 
 pkglibexec_SCRIPTS = \
 	crop.py \


### PR DESCRIPTION
See https://github.com/os-autoinst/os-autoinst/pull/1456 for the pull
request introducing the problem.