### PR TITLE
Add test for missing install specifications

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -196,7 +196,10 @@ dist-hook:
 
 distclean-local: clean-local
 
-check-local:
+check-local-files-specified:
+	for i in $$((git ls-files "*.pm" 2>/dev/null || find -name "*.pm" -printf "%P\n") | grep -v -E '(ppmclibs/|t/|tools/|backend/amt|backend/null|consoles/amtSol)'); do if ! grep -q $$i Makefile.am; then echo "$$i missing from install instructions in Makefile.am" && exit 1; fi; done
+
+check-local: check-local-files-specified
 	$(srcdir)/tools/tidy --check
 	PERL5LIB=tools/lib/perlcritic:$$PERL5LIB perlcritic --gentle --include Perl::Critic::Policy::HashKeyQuote $(srcdir)
 	test x$(CHECK_DOC) = x0 || $(MAKE) check-doc


### PR DESCRIPTION
All openQA tests incomplete but neither package build nor unit tests
fail when a new file is added to os-autoinst without mentioning in
Makefile.am

See e.g. https://openqa.opensuse.org/tests/988325/file/autoinst-log.txt
failing with

```
Can't locate consoles/ssh_screen.pm in @INC (you may need to install the consoles::ssh_screen module) (@INC contains: …) at /usr/lib/os-autoinst/consoles/sshVirtshSUT.pm line 25.
BEGIN failed--compilation aborted at /usr/lib/os-autoinst/consoles/sshVirtshSUT.pm line 25.
```

caused by https://github.com/os-autoinst/os-autoinst/pull/1176

This commit adds a check that prevents a new os-autoinst package to be
installed if a new file was added but not referenced in the Makefile for
installation.

Example output:

```
for i in $((git ls-files "*.pm" 2>/dev/null || find -name "*.pm") | grep -v -E '(ppmclibs/|t/|tools/|backend/amt|backend/null|consoles/amtSol)'); do if ! grep -q $i Makefile.am; then echo "$i missing from install instructions in Makefile.am" && exit 1; fi; done
signalblocker.pm missing from install instructions in Makefile.am
```

Related progress issue: https://progress.opensuse.org/issues/54557