### PR TITLE
Extend test for missing file installations with simulated install

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -198,7 +198,7 @@ dist-hook:
 distclean-local: clean-local
 
 check-local-files-specified:
-	for i in $$((git ls-files "*.pm" 2>/dev/null || find -name "*.pm" -printf "%P\n") | grep -v -E '(ppmclibs/|t/|tools/|backend/amt|backend/null|consoles/amtSol)'); do if ! grep -q $$i Makefile.am; then echo "$$i missing from install instructions in Makefile.am" && exit 1; fi; done
+	$(srcdir)/tools/check-installed-files
 
 test-yaml:
 	@which yamllint >/dev/null 2>&1 || echo "Command 'yamllint' not found, can not execute YAML syntax checks"

--- a/tools/check-installed-files
+++ b/tools/check-installed-files
@@ -1,0 +1,12 @@
+#!/bin/sh -e
+destdir="${destdir:-$(mktemp -d)}"
+make install DESTDIR="$destdir"
+installed_files=$(find "$destdir" -name '*.pm')
+all_source_files=$(git ls-files "*.pm" 2>/dev/null || find "$(dirname "$0")" -name "*.pm" -printf "%P\n")
+source_files=$(echo "$all_source_files" | grep -v -E '(ppmclibs/|t/|tools/|backend/amt|backend/null|consoles/amtSol)')
+for i in $source_files; do
+    if ! echo "$installed_files" | grep -q "$i"; then
+        echo "$i missing from installed files. Add to install instructions in Makefile.am."
+        exit 1
+    fi
+done


### PR DESCRIPTION
Instead of relying on parsing Makefile.am we can conduct a "test
installation" into a temporary directory and check that all perl module
source files can be found in the install tree.

Related progress issue: https://progress.opensuse.org/issues/54557