### PR TITLE
Add CMake build script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,6 @@ set(PERL_FILES
     consoles/virtio_terminal.pm
     consoles/vnc_base.pm
     consoles/VNC.pm
-    cv.pm
     distribution.pm
     lockapi.pm
     mmapi.pm
@@ -85,9 +84,6 @@ set(MISC_FILES
     dmidata/dell_e6330/smbios_type_2.bin
     dmidata/dell_e6330/smbios_type_3.bin
     dmidata/dump
-)
-set(EXECUTABLE_FILES
-    isotovideo
 )
 
 # determine install directories
@@ -132,10 +128,30 @@ add_custom_target(
     COMMAND ln -fs $<TARGET_FILE:tinycv> "${CMAKE_CURRENT_SOURCE_DIR}/ppmclibs/blib/arch/auto/tinycv/tinycv.so"
 )
 
+# create installable versions of isotovideo and cv.pm
+add_custom_command(
+    COMMENT "Make install version of isotovideo"
+    COMMAND
+        sed -e "\"s,\$installprefix = undef\;,\$installprefix = '${CMAKE_INSTALL_PREFIX}/${OS_AUTOINST_DATA_DIR}'\;,\""
+        "${CMAKE_CURRENT_SOURCE_DIR}/isotovideo" > "${CMAKE_CURRENT_BINARY_DIR}/isotovideo"
+    DEPENDS "isotovideo" "CMakeLists.txt"
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/isotovideo"
+)
+add_custom_command(
+    COMMENT "Make install version of cv.pm"
+    COMMAND
+        sed -e "\"s,\\$sysdir = undef\;,\\$sysdir = '${CMAKE_INSTALL_PREFIX}/${OS_AUTOINST_DATA_DIR}'\;,\""
+        "${CMAKE_CURRENT_SOURCE_DIR}/cv.pm" > "${CMAKE_CURRENT_BINARY_DIR}/cv.pm"
+    DEPENDS "cv.pm" "CMakeLists.txt"
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cv.pm"
+)
+add_custom_target(generate_install_versions ALL
+    COMMENT "Generate install version of isotovideo and cv.pm"
+    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/isotovideo" "${CMAKE_CURRENT_BINARY_DIR}/cv.pm"
+)
+
 # install non-C++ files
-foreach (FILE ${EXECUTABLE_FILES})
-    install(FILES "${FILE}" DESTINATION "${CMAKE_INSTALL_BINDIR}")
-endforeach ()
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/isotovideo" DESTINATION "${CMAKE_INSTALL_BINDIR}")
 foreach (FILE README.asciidoc INSTALL.asciidoc COPYING)
     install(FILES "${FILE}" DESTINATION "${OS_AUTOINST_DOC_DIR}")
 endforeach ()
@@ -143,3 +159,4 @@ foreach (FILE ${PERL_FILES} ${MISC_FILES})
     get_filename_component(SUB_DIR ${FILE} DIRECTORY)
     install(FILES "${FILE}" DESTINATION "${OS_AUTOINST_DATA_DIR}/${SUB_DIR}")
 endforeach ()
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/cv.pm" DESTINATION "${OS_AUTOINST_DATA_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,11 @@ cmake_minimum_required(VERSION 3.3.0)
 
 # list non-C++ source files
 set(DOC_FILES
-    README.asciidoc
-    INSTALL.asciidoc
-    COPYING
-    doc/basetest.html
-    doc/testapi.html
+    doc/architecture.md
+    doc/backend_vars.asciidoc
+    doc/backends.md
+    doc/memorydumps.asciidoc
+    doc/networking.md
 )
 set(PERL_FILES
     autotest.pm
@@ -75,32 +75,47 @@ set(PERL_FILES
     OpenQA/Qemu/Snapshot.pm
     OpenQA/Test/RunArgs.pm
     osutils.pm
-    ppmclibs/tinycv.pm
     signalblocker.pm
     testapi.pm
 )
-set(SCRIPT_FILES
+set(MISC_FILES
+    consoles/icewm.cfg
     crop.py
-    os-autoinst-openvswitch
+    dmidata/dell_e6330/smbios_type_1.bin
+    dmidata/dell_e6330/smbios_type_2.bin
+    dmidata/dell_e6330/smbios_type_3.bin
+    dmidata/dump
+)
+set(EXECUTABLE_FILES
     isotovideo
 )
+
+# determine install directories
+# note: Not using ${CMAKE_INSTALL_LIBDIR} here because this seems always lib in our packaging (and
+#       never lib64) regardless of the architecture.
+include(GNUInstallDirs)
+set(OS_AUTOINST_DATA_DIR "lib/os-autoinst"
+    CACHE STRING "directory to install os-autoinst internal Perl modules and misc files to")
+set(OS_AUTOINST_DOC_DIR "${CMAKE_INSTALL_DATAROOTDIR}/doc/packages/os-autoinst"
+    CACHE STRING "directory to install documentation to")
 
 # common dependency lookup
 find_package(OpenCV REQUIRED)
 include(FindPkgConfig)
 
-# build tools/libraries in sub directories
+# build and install tools/libraries in sub directories
 add_subdirectory(debugviewer)
 add_subdirectory(snd2png)
 add_subdirectory(ppmclibs)
 
-# build videoencoder
+# build and install videoencoder
 add_executable(videoencoder videoencoder.cpp)
 pkg_check_modules(THEORAENC theoraenc>=1.1)
 target_link_libraries(videoencoder PRIVATE opencv_core opencv_imgcodecs ${THEORAENC_LIBRARIES})
 target_include_directories(videoencoder PRIVATE ${THEORAENC_INCLUDE_DIRS})
 target_compile_options(videoencoder PRIVATE ${THEORAENC_CFLAGS})
 target_link_options(videoencoder PRIVATE ${THEORAENC_LDFLAGS})
+install(TARGETS videoencoder RUNTIME DESTINATION "${OS_AUTOINST_DATA_DIR}")
 
 # allow symlinking created executables into source directory
 # note: This target is supposed to be used for making a development environment. The symlinks will
@@ -116,3 +131,15 @@ add_custom_target(
     COMMAND ln -fs "../../tinycv.pm" "${CMAKE_CURRENT_SOURCE_DIR}/ppmclibs/blib/lib/tinycv.pm"
     COMMAND ln -fs $<TARGET_FILE:tinycv> "${CMAKE_CURRENT_SOURCE_DIR}/ppmclibs/blib/arch/auto/tinycv/tinycv.so"
 )
+
+# install non-C++ files
+foreach (FILE ${EXECUTABLE_FILES})
+    install(FILES "${FILE}" DESTINATION "${CMAKE_INSTALL_BINDIR}")
+endforeach ()
+foreach (FILE README.asciidoc INSTALL.asciidoc COPYING)
+    install(FILES "${FILE}" DESTINATION "${OS_AUTOINST_DOC_DIR}")
+endforeach ()
+foreach (FILE ${PERL_FILES} ${MISC_FILES})
+    get_filename_component(SUB_DIR ${FILE} DIRECTORY)
+    install(FILES "${FILE}" DESTINATION "${OS_AUTOINST_DATA_DIR}/${SUB_DIR}")
+endforeach ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ include(FindPkgConfig)
 add_subdirectory(debugviewer)
 add_subdirectory(snd2png)
 add_subdirectory(ppmclibs)
+add_subdirectory(doc)
 
 # build and install videoencoder
 add_executable(videoencoder videoencoder.cpp)
@@ -152,7 +153,7 @@ add_custom_target(generate_install_versions ALL
 
 # install non-C++ files
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/isotovideo" DESTINATION "${CMAKE_INSTALL_BINDIR}")
-foreach (FILE README.asciidoc INSTALL.asciidoc COPYING)
+foreach (FILE README.asciidoc INSTALL.asciidoc COPYING ${GENERATED_DOC_FILES})
     install(FILES "${FILE}" DESTINATION "${OS_AUTOINST_DOC_DIR}")
 endforeach ()
 foreach (FILE ${PERL_FILES} ${MISC_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,118 @@
+project(os-autoinst CXX)
+cmake_minimum_required(VERSION 3.3.0)
+
+# list non-C++ source files
+set(DOC_FILES
+    README.asciidoc
+    INSTALL.asciidoc
+    COPYING
+    doc/basetest.html
+    doc/testapi.html
+)
+set(PERL_FILES
+    autotest.pm
+    backend/amt.pm
+    backend/baseclass.pm
+    backend/console_proxy.pm
+    backend/driver.pm
+    backend/generalhw.pm
+    backend/ikvm.pm
+    backend/ipmi.pm
+    backend/null.pm
+    backend/pvm_hmc.pm
+    backend/pvm.pm
+    backend/qemu.pm
+    backend/s390x.pm
+    backend/spvm.pm
+    backend/svirt.pm
+    backend/virt.pm
+    basetest.pm
+    bmwqemu.pm
+    commands.pm
+    consoles/amtSol.pm
+    consoles/console.pm
+    consoles/ipmiSol.pm
+    consoles/localXvnc.pm
+    consoles/network_console.pm
+    consoles/remoteVnc.pm
+    consoles/s3270.pm
+    consoles/serial_screen.pm
+    consoles/sshIucvconn.pm
+    consoles/ssh_screen.pm
+    consoles/sshVirtsh.pm
+    consoles/sshVirtshSUT.pm
+    consoles/sshX3270.pm
+    consoles/sshXtermIPMI.pm
+    consoles/sshXtermVt.pm
+    consoles/ttyConsole.pm
+    consoles/virtio_terminal.pm
+    consoles/vnc_base.pm
+    consoles/VNC.pm
+    cv.pm
+    distribution.pm
+    lockapi.pm
+    mmapi.pm
+    myjsonrpc.pm
+    needle.pm
+    ocr.pm
+    OpenQA/Benchmark/Stopwatch.pm
+    OpenQA/Commands.pm
+    OpenQA/Exceptions.pm
+    OpenQA/Isotovideo/CommandHandler.pm
+    OpenQA/Isotovideo/Interface.pm
+    OpenQA/Isotovideo/NeedleDownloader.pm
+    OpenQA/Isotovideo/Utils.pm
+    OpenQA/Qemu/BlockDevConf.pm
+    OpenQA/Qemu/BlockDev.pm
+    OpenQA/Qemu/ControllerConf.pm
+    OpenQA/Qemu/DriveController.pm
+    OpenQA/Qemu/DriveDevice.pm
+    OpenQA/Qemu/DrivePath.pm
+    OpenQA/Qemu/MutParams.pm
+    OpenQA/Qemu/PFlashDevice.pm
+    OpenQA/Qemu/Proc.pm
+    OpenQA/Qemu/SnapshotConf.pm
+    OpenQA/Qemu/Snapshot.pm
+    OpenQA/Test/RunArgs.pm
+    osutils.pm
+    ppmclibs/tinycv.pm
+    signalblocker.pm
+    testapi.pm
+)
+set(SCRIPT_FILES
+    crop.py
+    os-autoinst-openvswitch
+    isotovideo
+)
+
+# common dependency lookup
+find_package(OpenCV REQUIRED)
+include(FindPkgConfig)
+
+# build tools/libraries in sub directories
+add_subdirectory(debugviewer)
+add_subdirectory(snd2png)
+add_subdirectory(ppmclibs)
+
+# build videoencoder
+add_executable(videoencoder videoencoder.cpp)
+pkg_check_modules(THEORAENC theoraenc>=1.1)
+target_link_libraries(videoencoder PRIVATE opencv_core opencv_imgcodecs ${THEORAENC_LIBRARIES})
+target_include_directories(videoencoder PRIVATE ${THEORAENC_INCLUDE_DIRS})
+target_compile_options(videoencoder PRIVATE ${THEORAENC_CFLAGS})
+target_link_options(videoencoder PRIVATE ${THEORAENC_LDFLAGS})
+
+# allow symlinking created executables into source directory
+# note: This target is supposed to be used for making a development environment. The symlinks will
+#       allow isotovideo to find all native executables created by this build.
+add_custom_target(
+    symlinks
+    COMMENT "Symlinking created executables into source directory"
+    COMMAND mkdir -p "${CMAKE_CURRENT_SOURCE_DIR}/ppmclibs/blib/arch/auto/tinycv"
+    COMMAND mkdir -p "${CMAKE_CURRENT_SOURCE_DIR}/ppmclibs/blib/lib"
+    COMMAND ln -fs $<TARGET_FILE:videoencoder> "${CMAKE_CURRENT_SOURCE_DIR}/videoencoder"
+    COMMAND ln -fs $<TARGET_FILE:snd2png> "${CMAKE_CURRENT_SOURCE_DIR}/snd2png/snd2png"
+    COMMAND ln -fs $<TARGET_FILE:debugviewer> "${CMAKE_CURRENT_SOURCE_DIR}/debugviewer/debugviewer"
+    COMMAND ln -fs "../../tinycv.pm" "${CMAKE_CURRENT_SOURCE_DIR}/ppmclibs/blib/lib/tinycv.pm"
+    COMMAND ln -fs $<TARGET_FILE:tinycv> "${CMAKE_CURRENT_SOURCE_DIR}/ppmclibs/blib/arch/auto/tinycv/tinycv.so"
+)

--- a/debugviewer/CMakeLists.txt
+++ b/debugviewer/CMakeLists.txt
@@ -3,3 +3,4 @@ cmake_minimum_required(VERSION 3.3.0)
 
 add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE opencv_core opencv_imgcodecs opencv_highgui)
+install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/debugviewer/CMakeLists.txt
+++ b/debugviewer/CMakeLists.txt
@@ -1,0 +1,5 @@
+project(debugviewer)
+cmake_minimum_required(VERSION 3.3.0)
+
+add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE opencv_core opencv_imgcodecs opencv_highgui)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,0 +1,26 @@
+project(doc CXX)
+cmake_minimum_required(VERSION 3.3.0)
+
+find_program(POD2HTML_PATH pod2html)
+if (NOT PODT2HTML_PATH)
+    message(FATAL_ERROR "Unable to find pod2html.")
+endif ()
+
+set(GENERATED_DOC_FILES)
+foreach (PERL_MODULE basetest testapi)
+    add_custom_command(
+        COMMENT "Generating ${PERL_MODULE}.html"
+        COMMAND "${POD2HTML_PATH}"
+            --infile "${CMAKE_CURRENT_SOURCE_DIR}/../${PERL_MODULE}.pm"
+            --outfile "${CMAKE_CURRENT_BINARY_DIR}/${PERL_MODULE}.html"
+        DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../${PERL_MODULE}.pm"
+        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${PERL_MODULE}.html"
+    )
+    list(APPEND GENERATED_DOC_FILES "${CMAKE_CURRENT_BINARY_DIR}/${PERL_MODULE}.html")
+endforeach ()
+
+add_custom_target(generate_documentation ALL
+    COMMENT "Generate documentation"
+    DEPENDS ${GENERATED_DOC_FILES}
+)
+set(GENERATED_DOC_FILES "${GENERATED_DOC_FILES}" PARENT_SCOPE)

--- a/ppmclibs/CMakeLists.txt
+++ b/ppmclibs/CMakeLists.txt
@@ -6,11 +6,26 @@ find_program(PERL_PATH perl)
 if (NOT PERL_PATH)
     message(FATAL_ERROR "Unable to find perl.")
 endif ()
+message(STATUS "Perl executable: ${PERL_PATH}")
 execute_process(
     COMMAND "${PERL_PATH}" -e "print(join(';', @INC))"
     OUTPUT_VARIABLE PERL_INCLUDE_PATHS
 )
 message(STATUS "Detected Perl include paths: ${PERL_INCLUDE_PATHS}")
+
+# find directory to install the tinycv Perl module to
+set(PERL_INSTALL_CONFIGURATION_VARIABLE "installvendorarch"
+    CACHE STRING "Perl configuration variable to query for the tinycv install directory")
+execute_process(
+    COMMAND "${PERL_PATH}" "-V:${PERL_INSTALL_CONFIGURATION_VARIABLE}"
+    OUTPUT_VARIABLE PERL_INSTALL_VENDORARCH
+)
+if (PERL_INSTALL_VENDORARCH MATCHES "${PERL_INSTALL_CONFIGURATION_VARIABLE}='(.*)';")
+    set(PERL_INSTALL_VENDORARCH "${CMAKE_MATCH_1}")
+    message(STATUS "Detected Perl ${PERL_INSTALL_CONFIGURATION_VARIABLE} (for tinycv): ${PERL_INSTALL_VENDORARCH}")
+else ()
+    message(FATAL_ERROR "Unable to detect Perl ${PERL_INSTALL_CONFIGURATION_VARIABLE} (for tinycv).")
+endif ()
 
 # find Perl's header files
 set(PERL_INCLUDE_DIRECTORY)
@@ -39,6 +54,7 @@ find_program(XSUBPP_PATH xsubpp)
 if (NOT XSUBPP_PATH)
     message(FATAL_ERROR "Unable to find xsubpp.")
 endif ()
+message(STATUS "xsubpp executable: ${XSUBPP_PATH}")
 set(PREPROCESSED_XS_FILE "${CMAKE_CURRENT_BINARY_DIR}/tinycv-xs.cpp")
 add_custom_command(
     COMMENT "Preprocessing Perl XS file"
@@ -61,3 +77,8 @@ add_library(tinycv MODULE
 target_link_libraries(tinycv PRIVATE opencv_core opencv_imgcodecs)
 target_include_directories(tinycv PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}" "${PERL_INCLUDE_DIRECTORY}")
 target_compile_definitions(tinycv PRIVATE "-DVERSION=\"1.0\"" "-DXS_VERSION=\"1.0\"" "-D_LARGEFILE_SOURCE" "-D_FILE_OFFSET_BITS=64")
+set_target_properties(tinycv PROPERTIES PREFIX "") # remove lib prefix (library is *not* supposed to be called libtinycv.so)
+
+# install the native library and Perl code
+install(TARGETS tinycv LIBRARY DESTINATION "${PERL_INSTALL_VENDORARCH}/auto/tinycv")
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/tinycv.pm" DESTINATION "${PERL_INSTALL_VENDORARCH}")

--- a/ppmclibs/CMakeLists.txt
+++ b/ppmclibs/CMakeLists.txt
@@ -1,0 +1,63 @@
+project(ppmclibs CXX)
+cmake_minimum_required(VERSION 3.3.0)
+
+# find perl
+find_program(PERL_PATH perl)
+if (NOT PERL_PATH)
+    message(FATAL_ERROR "Unable to find perl.")
+endif ()
+execute_process(
+    COMMAND "${PERL_PATH}" -e "print(join(';', @INC))"
+    OUTPUT_VARIABLE PERL_INCLUDE_PATHS
+)
+message(STATUS "Detected Perl include paths: ${PERL_INCLUDE_PATHS}")
+
+# find Perl's header files
+set(PERL_INCLUDE_DIRECTORY)
+foreach(PERL_INCLUDE_PATH ${PERL_INCLUDE_PATHS})
+    if (EXISTS "${PERL_INCLUDE_PATH}/CORE/EXTERN.h")
+        set(PERL_INCLUDE_DIRECTORY "${PERL_INCLUDE_PATH}/CORE")
+    endif ()
+endforeach()
+if (NOT PERL_INCLUDE_DIRECTORY)
+    message(FATAL_ERROR "Unable to find Perl's header within ${PERL_INCLUDE_PATHS}.")
+endif()
+
+# find typemap file used by xsubpp
+set(PERL_TYPEMAP)
+foreach(PERL_INCLUDE_PATH ${PERL_INCLUDE_PATHS})
+    if (EXISTS "${PERL_INCLUDE_PATH}/ExtUtils/typemap")
+        set(PERL_TYPEMAP "${PERL_INCLUDE_PATH}/ExtUtils/typemap")
+    endif ()
+endforeach()
+if (NOT PERL_TYPEMAP)
+    message(FATAL_ERROR "Unable to find ExtUtils/typemap within ${PERL_INCLUDE_PATHS}.")
+endif()
+
+# make rule for invoking xsubpp
+find_program(XSUBPP_PATH xsubpp)
+if (NOT XSUBPP_PATH)
+    message(FATAL_ERROR "Unable to find xsubpp.")
+endif ()
+set(PREPROCESSED_XS_FILE "${CMAKE_CURRENT_BINARY_DIR}/tinycv-xs.cpp")
+add_custom_command(
+    COMMENT "Preprocessing Perl XS file"
+    COMMAND "${XSUBPP_PATH}" -C++
+        -typemap "${PERL_TYPEMAP}"
+        -typemap "${CMAKE_CURRENT_SOURCE_DIR}/typemap"
+        "${CMAKE_CURRENT_SOURCE_DIR}/tinycv.xs"
+        > "${PREPROCESSED_XS_FILE}"
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/tinycv.xs"
+    OUTPUT "${PREPROCESSED_XS_FILE}"
+)
+
+# finally create the tinycv library
+add_library(tinycv MODULE
+    tinycv.h
+    tinycv_ast2100.cc
+    tinycv_impl.cc
+    "${PREPROCESSED_XS_FILE}"
+)
+target_link_libraries(tinycv PRIVATE opencv_core opencv_imgcodecs)
+target_include_directories(tinycv PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}" "${PERL_INCLUDE_DIRECTORY}")
+target_compile_definitions(tinycv PRIVATE "-DVERSION=\"1.0\"" "-DXS_VERSION=\"1.0\"" "-D_LARGEFILE_SOURCE" "-D_FILE_OFFSET_BITS=64")

--- a/snd2png/CMakeLists.txt
+++ b/snd2png/CMakeLists.txt
@@ -1,0 +1,12 @@
+project(snd2png CXX)
+cmake_minimum_required(VERSION 3.3.0)
+
+add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)
+
+pkg_check_modules(FFTW3 fftw3)
+pkg_check_modules(SNDFILE sndfile)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE opencv_core opencv_imgcodecs ${FFTW3_LIBRARIES} ${SNDFILE_LIBRARIES})
+target_include_directories(${PROJECT_NAME} PRIVATE ${FFTW3_INCLUDE_DIRS} ${SNDFILE_INCLUDE_DIRS})
+target_compile_options(${PROJECT_NAME} PRIVATE ${FFTW3_CFLAGS} ${SNDFILE_CFLAGS})
+target_link_options(${PROJECT_NAME} PRIVATE ${FFTW3_LDFLAGS} ${SNDFILE_LDFLAGS})

--- a/snd2png/CMakeLists.txt
+++ b/snd2png/CMakeLists.txt
@@ -10,3 +10,4 @@ target_link_libraries(${PROJECT_NAME} PRIVATE opencv_core opencv_imgcodecs ${FFT
 target_include_directories(${PROJECT_NAME} PRIVATE ${FFTW3_INCLUDE_DIRS} ${SNDFILE_INCLUDE_DIRS})
 target_compile_options(${PROJECT_NAME} PRIVATE ${FFTW3_CFLAGS} ${SNDFILE_CFLAGS})
 target_link_options(${PROJECT_NAME} PRIVATE ${FFTW3_LDFLAGS} ${SNDFILE_LDFLAGS})
+install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")


### PR DESCRIPTION
This is only WIP because I'd like to do further testing. Otherwise I'd like
to develop the CMake build script step by step instead of making a mega
PR. For compatibility we will need to keep the autotools-base build system
for a while anyways alongside the CMake-based one.

---

So far this only allows to build native binaries and symlink them into the
source tree for using them in a development setup.

Most importantly, no paths are hard-coded and xsubpp is invoked directly
via CMake without relying on another Makefile generator. That should work
much better compared to the autotools-based build system and also allows
to use e.g. ninja instead of make.