### PR TITLE
Ensure qemu dbus failures are handled correctly

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -142,11 +142,12 @@ sub _dbus_do_call {
 }
 
 sub _dbus_call {
-    my $self = shift;
-    my $fn   = shift;
-    my @args = @_;
-    return $self->_dbus_do_call($fn, @args) if $bmwqemu::vars{QEMU_FATAL_DBUS_CALL};
+    my ($self, $fn, @args) = @_;
     my ($rt, $message);
+    if (!$bmwqemu::vars{QEMU_NON_FATAL_DBUS_CALL}) {
+        ($rt, $message) = $self->_dbus_do_call($fn, @args);
+        die $message unless $rt == 0;
+    }
     eval {
         # do not die on unconfigured service
         local $SIG{__DIE__};

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -119,7 +119,7 @@ QEMU_AUDIODEV;see qemu -device ?;intel-hda;Audio device to use with audiodev to 
 QEMU_AUDIOBACKEND;see qemu -audio-help;none;Audio backend to use with audiodev (for qemu >= 4.2)
 QEMU_COMPRESS_LEVEL;integer;6;Sets the compression level used for memory dumps and snapshots. Zero turns compression off and 9 is the maximum level. Generally there is little improvement in compression ratio by increasing the level, but the CPU time can be high on some platforms.
 QEMU_COMPRESS_THREADS;integer;QEMUCPUS;Number of threads used for compressing memory dumps and snapshots.
-QEMU_FATAL_DBUS_CALL;boolean;0;Yield fatal error on failed dbus calls instead of just recording the error and continuing
+QEMU_NON_FATAL_DBUS_CALL;boolean;0;Ignore failed dbus calls and ignore instead of fatal exits
 QEMU_MAX_BANDWIDTH;integer;INT_MAX;Limits the transfer rate during a snapshot.
 QEMU_DUMP_COMPRESS_METHOD;string;xz;The compression to use during a memory dump. Can be set to xz, bzip2 or internal (QEMU's internal compression, not compatible with crash or gdb). If xz is set, but not available, it will fallback to bzip2. Also see QEMU_COMPRESSION_LEVEL.
 QEMU_APPEND;string;;Append parameters on qemu command line. The first item will have '-' prepended to it.

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -50,9 +50,12 @@ is($called{add_console}, 1, 'one console has been added');
 
 my $expected = qr/The name.*not provided|Failed to connect/;
 my $msg      = 'error about missing service';
-combined_like { ok($backend->_dbus_call('show'), 'failed dbus call ignored gracefully') } $expected, $msg;
-$bmwqemu::vars{QEMU_FATAL_DBUS_CALL} = 1;
 like exception { $backend->_dbus_call('show') }, $expected, $msg . ' in exception';
+$bmwqemu::vars{QEMU_NON_FATAL_DBUS_CALL} = 1;
+combined_like { ok($backend->_dbus_call('show'), 'failed dbus call ignored gracefully') } $expected, $msg;
+$bmwqemu::vars{QEMU_NON_FATAL_DBUS_CALL} = 0;
+$backend_mock->redefine(_dbus_do_call => sub { (1, 'failed') });
+like exception { $backend->_dbus_call('show') }, qr/failed/, 'failed dbus call throws exception';
 
 $backend_mock->redefine(handle_qmp_command => sub { $called{handle_qmp_command} = $_[1] });
 $backend->power({action => 'off'});


### PR DESCRIPTION
In fca0e75e we added optional fatal handling for qemu dbus calls for
easier error analysis of MM tests. This however did not work as expected
as there are no exceptions at all in case of error so the error would
not stop the test and also leave no message. This commit simplifies the
handling and makes the fatal handling the default while still providing
a way to ignore fatal handling where this is desired.

Tested using real multi-machine tests with three manual test cases:

1. Scheduling tests against openQA worker instances that do not have tap
devices assigned with fatal error handling -> jobs incomplete correctly
with helpful error message
2. Scheduling tests against openQA worker instances that do not have tap
devices assigned with non-fatal error handling -> errors reported in log
but jobs continue
3. Scheduling tests against openQA worker instances with correct tap
devices -> no errors and jobs pass

Related progress issue: https://progress.opensuse.org/issues/66376
