### PR TITLE
Get rid of unnecessary explicit test list in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -227,47 +227,9 @@ clean-local:
 	-rm -rf *.tar.*
 	-rm -rf cover_db/
 
-# Prevent error "blank line following trailing backslash" when deleting last
-# line in list in spec file to exclude tests
-EMPTY =
-TESTS ?= \
-	00-compile-check-all.t \
-	01-test_needle.t \
-	02-test_ocr.t \
-	03-testapi.t \
-	04-check_vars_docu.t \
-	05-pod.t \
-	06-pod-coverage.t \
-	07-commands.t \
-	08-autotest.t \
-	09-lockapi.t \
-	10-terminal.t \
-	10-virtio_terminal.t \
-	10-test-image-conversion-benchmark.t \
-	11-image-ppm.t \
-	12-bmwqemu.t \
-	13-osutils.t \
-	14-isotovideo.t \
-	15-logging.t \
-	16-send_with_fd.t \
-	17-basetest.t \
-	18-qemu.t \
-	18-backend-qemu.t \
-	18-qemu-options.t \
-	19-isotovideo-command-processing.t \
-	20-openqa-benchmark-stopwatch-utils.t \
-	21-needle-downloader.t \
-	22-svirt.t \
-	23-baseclass.t \
-	24-myjsonrpc.t \
-	24-myjsonrpc-debug.t \
-	25-spvm.t \
-	26-serial_screen.t \
-	26-ssh_screen.t \
-	27-make-update-deps.t \
-	99-full-stack.t \
-	$(EMPTY)
-
+# TESTS: Specify individual test files in a space separated lists to overwrite
+# recursive search
+TESTS ?= -r
 PATHRE = ^|$(PWD)/|\.\./
 COVER_OPTS = \
 	PERL5OPT="-MDevel::Cover=-db,$(abs_builddir)/cover_db,-select,($(PATHRE))(OpenQA|backend|consoles|ppmclibs)/|($(PATHRE))isotovideo|($(PATHRE))[^/]+\.pm,-ignore,\.t|data/tests/|fake/tests/|/usr/bin/prove,-coverage,statement"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -84,6 +84,7 @@ test_requires:
   qemu:
   qemu-tools:
   qemu-x86:
+  procps:
   python3-setuptools:
   python3-yamllint:
 

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -104,7 +104,6 @@ sed  -i 's/ my $thisversion = qx{git.*rev-parse HEAD}.*;/ my $thisversion = "%{v
 # 07-commands: https://progress.opensuse.org/issues/60755
 for i in 07-commands 13-osutils 14-isotovideo 18-qemu-options 18-backend-qemu 99-full-stack; do
     rm t/$i.t
-    sed -i "s/ \?$i\.t//g" Makefile.am
 done
 
 %build

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -52,7 +52,7 @@ Source0:        %{name}-%{version}.tar.xz
 %define make_check_args CHECK_DOC=0
 %endif
 # The following line is generated from dependencies.yaml
-%define test_requires %build_requires %main_requires %spellcheck_requires perl(Benchmark) perl(Devel::Cover) perl(FindBin) perl(Pod::Coverage) perl(Test::Exception) perl(Test::Fatal) perl(Test::Mock::Time) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::More) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 perl(YAML::PP) python3-setuptools python3-yamllint qemu qemu-tools qemu-x86
+%define test_requires %build_requires %main_requires %spellcheck_requires perl(Benchmark) perl(Devel::Cover) perl(FindBin) perl(Pod::Coverage) perl(Test::Exception) perl(Test::Fatal) perl(Test::Mock::Time) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::More) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 perl(YAML::PP) procps python3-setuptools python3-yamllint qemu qemu-tools qemu-x86
 # The following line is generated from dependencies.yaml
 %define devel_requires %test_requires perl(Devel::Cover) perl(Devel::Cover::Report::Codecov) perl(Perl::Tidy)
 BuildRequires:  %test_requires

--- a/docker/travis_test/Dockerfile
+++ b/docker/travis_test/Dockerfile
@@ -25,6 +25,7 @@ RUN zypper in -y -C \
        make \
        perl-base \
        pkg-config \
+       procps \
        python3-setuptools \
        python3-yamllint \
        qemu \


### PR DESCRIPTION
Since some time we rely on `prove` to run tests not needing to specify tests as
standalone applications in Makefile.am anymore. So instead we can just call
`prove -r` to list tests recursively.