### PR TITLE
Avoid updating last_good if there's no possible user of it

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -346,7 +346,8 @@ sub runalltests {
 
     write_test_order();
 
-    for my $t (@testorder) {
+    for my $testindex (0 .. $#testorder) {
+        my $t        = $testorder[$testindex];
         my $flags    = $t->test_flags();
         my $fullname = $t->{fullname};
 
@@ -404,7 +405,13 @@ sub runalltests {
                 load_snapshot('lastgood');
                 $last_milestone->rollback_activated_consoles();
             }
-            if ($snapshots_supported && ($flags->{milestone} || $bmwqemu::vars{TESTDEBUG})) {
+            my $makesnapshot = $bmwqemu::vars{TESTDEBUG};
+            # Only make a snapshot if there is a next test and it's not a fatal milestone
+            if ($testindex ne $#testorder) {
+                my $nexttestflags = $testorder[$testindex + 1]->test_flags();
+                $makesnapshot ||= $flags->{milestone} && !($nexttestflags->{milestone} && $nexttestflags->{fatal});
+            }
+            if ($snapshots_supported && $makesnapshot) {
                 make_snapshot('lastgood');
                 $last_milestone         = $t;
                 $last_milestone_console = $selected_console;

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -93,6 +93,8 @@ subtest 'test always_rollback flag' => sub {
     $mock_autotest->redefine(query_isotovideo => sub { return 0; });
     my $reverts_done = 0;
     $mock_autotest->redefine(load_snapshot => sub { $reverts_done++; });
+    my $snapshots_made = 0;
+    $mock_autotest->redefine(make_snapshot => sub { $snapshots_made++; });
 
     stderr_like { autotest::run_all } qr/finished/, 'run_all outputs status on stderr';
     ($died, $completed) = get_tests_done;
@@ -100,7 +102,9 @@ subtest 'test always_rollback flag' => sub {
     is($completed,    1, 'start+next+start should complete when always_rollback flag is set');
     is($reverts_done, 0, "No snapshots loaded when flag is not explicitly set to true");
     $reverts_done = 0;
-    @sent         = [];
+    is($snapshots_made, 0, 'No snapshots made if snapshots are not supported');
+    $snapshots_made = 0;
+    @sent           = [];
 
     # Test that no rollback is triggered if snapshots are not supported
     $mock_basetest->redefine(test_flags       => sub { return {always_rollback => 1, milestone => 1}; });
@@ -114,7 +118,9 @@ subtest 'test always_rollback flag' => sub {
     is($completed,    1, 'start+next+start should complete when always_rollback flag is set');
     is($reverts_done, 0, "No snapshots loaded if snapshots are not supported");
     $reverts_done = 0;
-    @sent         = [];
+    is($snapshots_made, 0, 'No snapshots made if snapshots are not supported');
+    $snapshots_made = 0;
+    @sent           = [];
 
     # Test that snapshot loading is triggered even when tests are successful
     $mock_basetest->redefine(test_flags       => sub { return {always_rollback => 1}; });
@@ -127,7 +133,9 @@ subtest 'test always_rollback flag' => sub {
     is($completed,    1, 'start+next+start should complete when always_rollback flag is set');
     is($reverts_done, 0, "No snapshots loaded if not test with milestone flag");
     $reverts_done = 0;
-    @sent         = [];
+    is($snapshots_made, 0, 'No snapshots made if snapshots are not supported');
+    $snapshots_made = 0;
+    @sent           = [];
 
     # Test with snapshot available
     $mock_basetest->redefine(test_flags => sub { return {always_rollback => 1, milestone => 1}; });
@@ -136,11 +144,26 @@ subtest 'test always_rollback flag' => sub {
     is($died,         0, 'start+next+start should not die when always_rollback flag is set');
     is($completed,    1, 'start+next+start should complete when always_rollback flag is set');
     is($reverts_done, 2, "Snapshots are loaded even when tests succeed");
-    @sent = [];
+    $reverts_done = 0;
+    is($snapshots_made, 2, 'Milestone snapshots are made for all except the last');
+    $snapshots_made = 0;
+    @sent           = [];
+
+    $mock_basetest->redefine(test_flags => sub { return {milestone => 1, fatal => 1}; });
+    stderr_like { autotest::run_all } qr/finished/, 'run_all outputs status on stderr';
+    ($died, $completed) = get_tests_done;
+    is($died,         0, 'start+next+start should not die as fatal milestones');
+    is($completed,    1, 'start+next+start should complete as fatal milestones');
+    is($reverts_done, 0, 'No rollbacks done');
+    $reverts_done = 0;
+    is($snapshots_made, 0, 'No snapshots made as no test needed them');
+    $snapshots_made = 0;
+    @sent           = [];
 
     # # Revert mocks
     $mock_basetest->unmock('test_flags');
     $mock_autotest->unmock('load_snapshot');
+    $mock_autotest->unmock('make_snapshot');
     $mock_autotest->unmock('query_isotovideo');
 };
 


### PR DESCRIPTION
Taking a snapshot is really expensive, so it should be avoided.
If there are two milestone tests and the latter is fatal, a failure causes
the entire run to fail instead of rolling back, so last_good won't be used.
The last test does not need to update last_good either.

Before: http://10.160.67.86/tests/740 -> 24:00 minutes
After: http://10.160.67.86/tests/739 -> 22:32 minutes

In theory, more patterns could be optimized by just going through the test list until the next milestone and only making a snapshot if there's a non-fatal or always_rollback one, but that would break if some test calls `loadtest`, which is apparently supported...