### PR TITLE
Fix invalid "installprefix" replacement in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ add_custom_command(
 add_custom_command(
     COMMENT "Make install version of isotovideo"
     COMMAND
-        sed -e "\"s,\$installprefix = undef\;,\$installprefix = '${CMAKE_INSTALL_PREFIX}/${OS_AUTOINST_DATA_DIR}'\;,\""
+        sed -e "\"s,\\$$installprefix = undef\;,\\$$installprefix = '${CMAKE_INSTALL_PREFIX}/${OS_AUTOINST_DATA_DIR}'\;,\""
         "${CMAKE_CURRENT_SOURCE_DIR}/isotovideo" > "${CMAKE_CURRENT_BINARY_DIR}/install-target/isotovideo"
     DEPENDS "isotovideo" "CMakeLists.txt" "${CMAKE_CURRENT_BINARY_DIR}/install-target"
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/install-target/isotovideo"
@@ -154,7 +154,7 @@ add_custom_command(
 add_custom_command(
     COMMENT "Make install version of cv.pm"
     COMMAND
-        sed -e "\"s,\\$sysdir = undef\;,\\$sysdir = '${CMAKE_INSTALL_PREFIX}/${OS_AUTOINST_DATA_DIR}'\;,\""
+        sed -e "\"s,\\$$sysdir = undef\;,\\$$sysdir = '${CMAKE_INSTALL_PREFIX}/${OS_AUTOINST_DATA_DIR}'\;,\""
         "${CMAKE_CURRENT_SOURCE_DIR}/cv.pm" > "${CMAKE_CURRENT_BINARY_DIR}/install-target/cv.pm"
     DEPENDS "cv.pm" "CMakeLists.txt" "${CMAKE_CURRENT_BINARY_DIR}/install-target"
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/install-target/cv.pm"


### PR DESCRIPTION
1557575b introduced the problem that the internal sed call in
CMakeLists.txt replaced all occurences of " = undef" with the static
install path of os-autoinst causing all isotovideo calls to fail with

```
Can't locate object method "pid" via package "/usr/lib/os-autoinst"
```

and similar as incorrect perl code was created with the replacement. The
previous approach in Makefile.am already used a double `$$` to escape
the dollar sign for make. The same we need to do for cmake, just quoting
is not enough. Additionally the escaping of the back-slash is necessary
as well with `\\` as we need to preserve the escaping with `\$` for the
shell environment in which we call sed.

The generated resulting file can be checked with e.g.

```
mkdir -p build
cd build
cmake -GNinja ..
ninja -v
diff ../isotovideo install-target/isotovideo
```

same for cv.pm.

Related progress issue: https://progress.opensuse.org/issues/69343