### PR TITLE
os-autoinst-openvswitch: Fix spurious network startup race-conditions (2nd)

### DIFF
--- a/os-autoinst-openvswitch
+++ b/os-autoinst-openvswitch
@@ -33,10 +33,14 @@ sub init_switch {
     }
     system('ovs-vsctl', 'br-exists', $self->{BRIDGE});
 
-    my $bridge_conf = `ip addr show $self->{BRIDGE}`;
-
-    $self->{MAC} = $1 if $bridge_conf =~ /ether\s+(([0-9a-f]{2}:){5}[0-9a-f]{2})\s/;
-    $self->{IP}  = $1 if $bridge_conf =~ /inet\s+(([0-9]+.){3}[0-9]+\/[0-9]+)\s/;
+    for (my $timeout = 60; $timeout > 0; --$timeout) {
+        my $bridge_conf = `ip addr show $self->{BRIDGE}`;
+        $self->{MAC} = $1 if $bridge_conf =~ /ether\s+(([0-9a-f]{2}:){5}[0-9a-f]{2})\s/;
+        $self->{IP}  = $1 if $bridge_conf =~ /inet\s+(([0-9]+.){3}[0-9]+\/[0-9]+)\s/;
+        last if $self->{IP};
+        print "Waiting for IP on bridge '$self->{BRIDGE}', ${timeout}s left ...\n";
+        sleep 1;
+    }
 
     die "can't parse bridge local port MAC" unless $self->{MAC};
     die "can't parse bridge local port IP"  unless $self->{IP};


### PR DESCRIPTION
Similar as in 05a44404 we need to wait further until also an IP is ready
on the device as the original problem is still present. It looks like
just waiting for the bridge device is not enough to ensure an IP is
configured so we should wait for that explicitly as well.

Tested manually on openqaworker12 with

```
$ ./os-autoinst-openvswitch
Waiting for bridge 'br0' to be created and configured...
Waiting for bridge 'br0' to be created and configured...
…
```

and

```
env OS_AUTOINST_USE_BRIDGE=br1 ./os-autoinst-openvswitch
```

Related progress issue: https://progress.opensuse.org/issues/59300