### PR TITLE
Fix issue where 99-full-stack.t can't clean up temp dir on test failure

### DIFF
--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -11,6 +11,7 @@ use File::Path qw(remove_tree rmtree);
 use Cwd 'abs_path';
 use Mojo::File qw(tempdir path);
 use Mojo::JSON qw(decode_json);
+use Mojo::Util qw(scope_guard);
 use FindBin '$Bin';
 use OpenQA::Isotovideo::Utils qw(load_test_schedule);
 
@@ -19,6 +20,7 @@ my $toplevel_dir = abs_path(dirname(__FILE__) . '/..');
 my $data_dir     = "$toplevel_dir/t/data";
 my $pool_dir     = "$dir/pool";
 chdir $dir;
+my $cleanup = scope_guard sub { chdir $Bin; undef $dir };
 mkdir $pool_dir;
 
 sub isotovideo {
@@ -142,7 +144,6 @@ subtest 'upload assets on demand even in failed jobs' => sub {
 
 done_testing();
 
-chdir $Bin;
 END {
     rmtree "$Bin/data/tests/product";
 }

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -8,9 +8,11 @@ use Test::Fatal;
 use File::Basename;
 use FindBin '$Bin';
 use Mojo::File 'tempdir';
+use Mojo::Util qw(scope_guard);
 
 my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
 chdir $dir;
+my $cleanup = scope_guard sub { chdir $Bin; undef $dir };
 mkdir 'testresults';
 
 use basetest;
@@ -327,5 +329,3 @@ subtest 'execute_time' => sub {
 };
 
 done_testing;
-
-chdir $Bin;

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -12,11 +12,13 @@ use Test::Warnings qw(:all :report_warnings);
 use Test::Fatal;
 use FindBin '$Bin';
 use Mojo::File 'tempdir';
+use Mojo::Util qw(scope_guard);
 
 use backend::qemu;
 
 my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
 chdir $dir;
+my $cleanup = scope_guard sub { chdir $Bin; undef $dir };
 
 my $proc = Test::MockModule->new('OpenQA::Qemu::Proc');
 $proc->redefine(exec_qemu            => undef);
@@ -65,5 +67,3 @@ $backend->power({action => 'acpi'});
 is_deeply($called{handle_qmp_command}, {execute => 'system_powerdown'}, 'powerdown has been called for acpi');
 
 done_testing();
-
-chdir $Bin;

--- a/t/18-qemu-options.t
+++ b/t/18-qemu-options.t
@@ -25,6 +25,7 @@ use Mojo::File qw(path tempdir);
 use Mojo::JSON qw(encode_json);
 use Benchmark ':hireswallclock';
 use FindBin '$Bin';
+use Mojo::Util qw(scope_guard);
 
 # optional but very useful
 eval 'use Test::More::Color';
@@ -36,6 +37,7 @@ my $data_dir     = "$Bin/data";
 my $pool_dir     = "$dir/pool";
 mkdir $pool_dir;
 chdir $pool_dir;
+my $cleanup = scope_guard sub { chdir $Bin; undef $dir };
 
 # just save ourselves some time during testing
 $ENV{OSUTILS_WAIT_ATTEMPT_INTERVAL} //= 1;
@@ -146,5 +148,3 @@ subtest qemu_tpm_option => sub {
 };
 
 done_testing();
-
-chdir $Bin;

--- a/t/18-qemu.t
+++ b/t/18-qemu.t
@@ -10,6 +10,7 @@ use Test::Warnings qw(warnings :report_warnings);
 use Mojo::File qw(tempfile tempdir path);
 use Carp 'cluck';
 use FindBin '$Bin';
+use Mojo::Util qw(scope_guard);
 
 use OpenQA::Qemu::BlockDevConf;
 use OpenQA::Qemu::Proc;
@@ -18,6 +19,7 @@ use constant TMPPATH => '/tmp/18-qemu.t/';
 
 my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
 chdir $dir;
+my $cleanup = scope_guard sub { chdir $Bin; undef $dir };
 mkdir "$dir/testresults";
 
 $SIG{__DIE__} = sub { cluck(shift); };
@@ -387,5 +389,3 @@ subtest DriveDevice => sub {
 };
 
 done_testing();
-chdir $Bin;
-

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -1,5 +1,4 @@
 #!/usr/bin/perl
-# Copyright © 2018-2019 SUSE LLC
 
 use strict;
 use warnings;
@@ -19,9 +18,11 @@ use testapi qw(get_var get_required_var check_var set_var);
 use backend::svirt qw(SERIAL_CONSOLE_DEFAULT_PORT SERIAL_TERMINAL_DEFAULT_DEVICE SERIAL_TERMINAL_DEFAULT_PORT);
 use FindBin '$Bin';
 use Mojo::File 'tempdir';
+use Mojo::Util qw(scope_guard);
 
 my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
 chdir $dir;
+my $cleanup = scope_guard sub { chdir $Bin; undef $dir };
 mkdir 'testresults';
 
 bmwqemu::init_logger;
@@ -280,5 +281,3 @@ subtest 'Method backend::svirt::open_serial_console_via_ssh()' => sub {
 };
 
 done_testing;
-
-chdir $Bin;

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -16,9 +16,11 @@ use backend::baseclass;
 use POSIX 'tzset';
 use FindBin '$Bin';
 use Mojo::File 'tempdir';
+use Mojo::Util qw(scope_guard);
 
 my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
 chdir $dir;
+my $cleanup = scope_guard sub { chdir $Bin; undef $dir };
 mkdir 'testresults';
 
 # make the test time-zone neutral
@@ -209,5 +211,3 @@ subtest 'running test' => sub {
 };
 
 done_testing;
-
-chdir $Bin;

--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -26,6 +26,7 @@ use Cwd 'abs_path';
 use Mojo::JSON 'decode_json';
 use FindBin '$Bin';
 use Mojo::File 'tempdir';
+use Mojo::Util qw(scope_guard);
 
 # optional but very useful
 eval 'use Test::More::Color';
@@ -41,6 +42,8 @@ note("data dir: $data_dir");
 note("pool dir: $pool_dir");
 
 chdir($pool_dir);
+my $cleanup = scope_guard sub { chdir $Bin; undef $dir };
+
 open(my $var, '>', 'vars.json');
 print $var <<EOV;
 {
@@ -126,5 +129,3 @@ is(system('grep -q "isotovideo done" autoinst-log.txt'),                 0, 'iso
 is(system('grep -q "EXIT 0" autoinst-log.txt'),                          0, 'Test finished as expected');
 
 done_testing();
-
-chdir $Bin;


### PR DESCRIPTION
The problem was that the test chdir's into the temp dir, so it can't be
automatically deleted. Solution is to use a scope guard to chdir back
out and then delete the temp dir.

Since the same problem applies to a few more tests i've also included
a fix for those.

Progress: https://progress.opensuse.org/issues/69133