### PR TITLE
Handle any Perl warnings within test distribution code as fatal by default

### DIFF
--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -21,6 +21,7 @@ EXTERNAL_VIDEO_ENCODER_OUTPUT_FILE_EXTENSION;string;webm;The extension of the ou
 EXTERNAL_VIDEO_ENCODER_ADDITIONALLY;boolean;0;Whether `EXTERNAL_VIDEO_ENCODER_CMD` should only be invoked additionally to the built-in Theora encoder. This means two videos will be created and uploaded which can be useful for comparison. (Configuring an external video encoder disables the built-in one by default.)
 NOVIDEO;boolean;0;Whether the creation of the video should be disabled and also any `EXTERNAL_VIDEO_ENCODER_` variables be ignored.
 NO_DEBUG_IO;boolean;0;Disable the I/O debug output in case of needle comparison times longer than expected
+NO_FATAL_WARNINGS;boolean;0;Disable the fatal handling of Perl warnings
 OSUTILS_WAIT_ATTEMPT_INTERVAL;float;1;The interval in seconds between "attempts" in osutils, e.g. used for connections to qemu qmp backend
 SCREENSHOTINTERVAL;float;0.5;The interval in seconds at which screenshots are taken internally
 SSH_CONNECT_RETRY;integer;5;Maximum retries to connect to SSH based console targets

--- a/isotovideo
+++ b/isotovideo
@@ -256,6 +256,7 @@ checkout_git_repo_and_branch('NEEDLES_DIR');
 
 bmwqemu::ensure_valid_vars();
 
+$SIG{__WARN__} = sub { die "warning treated fatal (disable with 'NO_FATAL_WARNINGS'): @_" } unless $bmwqemu::vars{NO_FATAL_WARNINGS};
 # as we are about to load the test modules checkout the specified git refspec,
 # if specified, or simply store the git hash that has been used. If it is not a
 # git repo fail silently, i.e. store an empty variable

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -41,32 +41,6 @@ sub is_in_log {
     is(system("grep -q \"$regex\" autoinst-log.txt"), 0, $msg);
 }
 
-subtest 'error handling when loading test schedule' => sub {
-    my $base_state = path(bmwqemu::STATE_FILE);
-    subtest 'no schedule at all' => sub {
-        $base_state->remove;
-        $bmwqemu::vars{CASEDIR} = $bmwqemu::vars{PRODUCTDIR} = $dir;
-        throws_ok { load_test_schedule } qr/'SCHEDULE' not set and/, 'error logged';
-        my $state = decode_json($base_state->slurp);
-        if (is(ref $state, 'HASH', 'state file contains object')) {
-            is($state->{component}, 'tests', 'state file contains component message');
-            like($state->{msg}, qr/unable to load main\.pm/, 'state file contains error message');
-        }
-    };
-    subtest 'unable to load test module' => sub {
-        $base_state->remove;
-        my $module = 'foo/bar';
-        $bmwqemu::vars{SCHEDULE} = $module;
-        combined_like { throws_ok {
-                load_test_schedule } qr/Can't locate $module\.pm/, 'error logged' } qr/error on $module\.pm: Can't locate $module\.pm/, 'debug message logged';
-        my $state = decode_json($base_state->slurp);
-        if (is(ref $state, 'HASH', 'state file contains object')) {
-            is($state->{component}, 'tests', 'state file contains component message');
-            like($state->{msg}, qr/unable to load foo\/bar\.pm/, 'state file contains error message');
-        }
-    };
-};
-
 subtest 'standalone isotovideo without vars.json file and only command line parameters' => sub {
     chdir($pool_dir);
     unlink('vars.json') if -e 'vars.json';
@@ -140,6 +114,32 @@ subtest 'upload assets on demand even in failed jobs' => sub {
     } qr/scheduling failing_module $module\.pm/, 'module scheduled';
     is_in_log('qemu-img.*foo.qcow2', 'requested image is published even though the job failed');
     ok(-e $pool_dir . '/assets_public/foo.qcow2', 'published image exists');
+};
+
+subtest 'error handling when loading test schedule' => sub {
+    my $base_state = path(bmwqemu::STATE_FILE);
+    subtest 'no schedule at all' => sub {
+        $base_state->remove;
+        $bmwqemu::vars{CASEDIR} = $bmwqemu::vars{PRODUCTDIR} = $dir;
+        throws_ok { load_test_schedule } qr/'SCHEDULE' not set and/, 'error logged';
+        my $state = decode_json($base_state->slurp);
+        if (is(ref $state, 'HASH', 'state file contains object')) {
+            is($state->{component}, 'tests', 'state file contains component message');
+            like($state->{msg}, qr/unable to load main\.pm/, 'state file contains error message');
+        }
+    };
+    subtest 'unable to load test module' => sub {
+        $base_state->remove;
+        my $module = 'foo/bar';
+        $bmwqemu::vars{SCHEDULE} = $module;
+        combined_like { throws_ok {
+                load_test_schedule } qr/Can't locate $module\.pm/, 'error logged' } qr/error on $module\.pm: Can't locate $module\.pm/, 'debug message logged';
+        my $state = decode_json($base_state->slurp);
+        if (is(ref $state, 'HASH', 'state file contains object')) {
+            is($state->{component}, 'tests', 'state file contains component message');
+            like($state->{msg}, qr/unable to load foo\/bar\.pm/, 'state file contains error message');
+        }
+    };
 };
 
 done_testing();


### PR DESCRIPTION
To ensure no regressions or problems are introduced without being
explicitly informed this change will introduce fatal handling of any
Perl warning within test distribution code. This behaviour can be
disabled with the test variable 'NO_FATAL_WARNINGS'.

Related progress issue: https://progress.opensuse.org/issues/10704