### PR TITLE
Add option to skip initial SUT restarts on ipmi backend

### DIFF
--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -108,7 +108,7 @@ sub do_start_vm {
     # So keep it for flexibility.
     $self->do_mc_reset if $bmwqemu::vars{IPMI_BACKEND_MC_RESET};
     $self->get_mc_status;
-    $self->restart_host;
+    $self->restart_host unless $bmwqemu::vars{IPMI_DO_NOT_RESTART_HOST};
     $self->truncate_serial_file;
     my $sol = $testapi::distri->add_console('sol', 'ipmi-xterm');
     $sol->backend($self);

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -47,6 +47,7 @@ IPMI_HOSTNAME;string;undef;Hostname/IP for IPMI interface
 IPMI_PASSWORD;string;undef;Password for the IPMI interface
 IPMI_USER;string;undef;Username for the IPMI interface
 IPMI_DO_NOT_POWER_OFF;boolean;undef;Don't power off the machine after test
+IPMI_DO_NOT_RESTART_HOST;boolean;undef;Don't restart the machine before test
 IPMI_BACKEND_MC_RESET;boolean;undef;Reset ipmi main board before test for sol console stability
 IPMI_SKIP_SELFTEST;boolean;undef;Don't perform BMC selftest
 IPMI_HW;string;supermicro;Hardware used for IPMI interface


### PR DESCRIPTION
As the new setting, START_DIRECTLY_AFTER_TEST, was introduced to create chained tests. A series tests are run on a same SUT, then we have the need not to restart the SUT at the begging of each test run. It is similar to the setting which controls the SUT power off, IPMI_DO_NOT_POWER_OFF.

Here is the verification run locally:
http://10.67.133.97/tests/855