### PR TITLE
Prevent confusing error message "unable to inform.*Connection refused"

### DIFF
--- a/isotovideo
+++ b/isotovideo
@@ -157,40 +157,26 @@ sub stop_commands {
     return unless $cmd_srv_process->is_running;
 
     my $pid = $cmd_srv_process->pid;
-    diag("terminating command server $pid because $reason");
+    diag("stopping command server $pid because $reason");
 
-    # inform websocket clients
-    # note: If the job is stopped by the worker because it has been aborted, the worker will send this command
-    #       on its own to the command server and also stop the command server. So this is only done in the case
-    #       the test execution just ends.
     if ($cmd_srv_port && $reason && $reason eq 'test execution ended') {
         my $job_token = $bmwqemu::vars{JOBTOKEN};
         my $url       = "http://127.0.0.1:$cmd_srv_port/$job_token/broadcast";
         diag('isotovideo: informing websocket clients before stopping command server: ' . $url);
 
+        # note: If the job is stopped by the worker because it has been
+        # aborted, the worker will send this command on its own to the command
+        # server and also stop the command server. So this is only done in the
+        # case the test execution just ends.
+
         my $timeout = 15;
-        my $ua      = Mojo::UserAgent->new(request_timeout => $timeout);
-        my $tx      = $ua->post($url, json => {stopping_test_execution => $reason});
-        try {
-            my $res = $tx->result;
-            if ($res->code != 200) {
-                my $error_message = $res->to_string;
-                diag('isotovideo: unable to inform websocket clients about stopping command server: ' . $error_message);
-                if ($error_message =~ qr/.*timeout.*/i) {
-                    diag("isotovideo: The command server could be under heavy load and the timeout of $timeout seconds has been exceeded. This message is most likely not be related to the MAX_JOB_TIME of the current job possibly being exceeded.");
-                }
-                else {
-                    diag('The command server might have already been stopped by the worker after the user has aborted the job or the job timeout has been exceeded.');
-                }
-            }
-        }
-        catch {
-            diag('isotovideo: unable to inform websocket clients about stopping command server: ' . $_);
-        };
+        # The command server might have already been stopped by the worker
+        # after the user has aborted the job or the job timeout has been
+        # exceeded so no checks for failure done.
+        Mojo::UserAgent->new(request_timeout => $timeout)->post($url, json => {stopping_test_execution => $reason});
     }
 
-    # stop the command server
-    $cmd_srv_process->stop() if $cmd_srv_process->is_running;
+    $cmd_srv_process->stop();
     $cmd_srv_process = undef;
     diag('done with command server');
 }


### PR DESCRIPTION
When isotovideo is in the process of terminating it tries to inform
websocket clients over an RPC call to stop. This needs a responsive
"command server" during this time. If the command server is not running
(anymore) this step is already skipped. However it can come to a race
condition that the command server process still reports as "running"
whereas the internal RPC handling is not active anymore in case the
commands server had already been instructed to terminate, e.g. by
receiving a signal as well. In this case isotovideo would still try to
send out RPC calls but complain with an error message like

```
isotovideo: unable to inform websocket clients about stopping command server: Connection refused at /usr/bin/isotovideo line 175.
```

which can be confusing to readers as that behaviour can be expected in
this instance.

This commit simplifies the handling by accepting any failure to send out
the RPC data to the commands server process during termination. Also
we harmonize code and messages to be more similar again to the other
stop methods.

Additionally tested manually with

```
(cd t/data && timeout -s INT -v 4 ../../isotovideo -d casedir=/home/okurz/local/os-autoinst/os-autoinst/t/data/tests)
```

which can, depending on timing, look like:

```
timeout: sending signal INT to command ‘../../isotovideo’
[2020-08-05T20:41:49.678 CEST] [debug] isotovideo received signal INT 
[2020-08-05T20:41:49.678 CEST] [debug] isotovideo received signal INT 
[2020-08-05T20:41:49.678 CEST] [debug] isotovideo received signal INT 
[2020-08-05T20:41:49.679 CEST] [debug] stopping backend process 28993
[2020-08-05T20:41:49.679 CEST] [debug] QEMU: qemu-system-x86_64: terminating on signal 2 from pid 28970 (timeout)
[2020-08-05T20:41:49.680 CEST] [debug] backend got TERM
[2020-08-05T20:41:49.680 CEST] [info] ::: OpenQA::Qemu::Proc::save_state: Saving QEMU state to qemu_state.json
[2020-08-05T20:41:49.687 CEST] [debug] commands process exited: 0
[2020-08-05T20:41:49.687 CEST] [debug] [autotest] process exited: 0
C[2020-08-05T20:41:51.706 CEST] [debug] flushing frames
[2020-08-05T20:41:51.710 CEST] [debug] sending magic and exit
[2020-08-05T20:41:51.713 CEST] [debug] backend process exited: 0
[2020-08-05T20:41:51.814 CEST] [debug] done with backend process
[2020-08-05T20:41:51.814 CEST] [debug] stopping autotest process 28978
[2020-08-05T20:41:51.814 CEST] [debug] done with autotest process
```

when the commands process exits early or

```
timeout: sending signal INT to command ‘../../isotovideo’
[2020-08-05T20:36:18.255 CEST] [debug] isotovideo received signal INT 
[2020-08-05T20:36:18.255 CEST] [debug] isotovideo received signal INT 
[2020-08-05T20:36:18.256 CEST] [debug] QEMU: qemu-system-x86_64: terminating on signal 2 from pid 28412 (timeout)
[2020-08-05T20:36:18.256 CEST] [debug] no change: 13.6s
[2020-08-05T20:36:18.257 CEST] [debug] stopping command server 28417 because test execution ended
[2020-08-05T20:36:18.257 CEST] [debug] isotovideo: informing websocket clients before stopping command server: http://127.0.0.1:15223/PYkrRjvtBG/broadcast
[2020-08-05T20:36:18.263 CEST] [debug] commands process exited: 0
[2020-08-05T20:36:18.265 CEST] [debug] [autotest] process exited: 0 
[2020-08-05T20:36:18.267 CEST] [debug] done with command server
[2020-08-05T20:36:18.268 CEST] [debug] stopping autotest process 28420
[2020-08-05T20:36:18.268 CEST] [debug] done with autotest process
[2020-08-05T20:36:18.268 CEST] [debug] isotovideo failed
[2020-08-05T20:36:18.269 CEST] [debug] stopping backend process 28435
[2020-08-05T20:36:18.269 CEST] [debug] backend got TERM
[2020-08-05T20:36:18.270 CEST] [info] ::: OpenQA::Qemu::Proc::save_state: Saving QEMU state to qemu_state.json
[2020-08-05T20:36:20.282 CEST] [debug] flushing frames
[2020-08-05T20:36:20.286 CEST] [debug] sending magic and exit
[2020-08-05T20:36:20.474 CEST] [debug] done with backend process
```

when a request had been sent (regardless of the result).

Related progress issue: https://progress.opensuse.org/issues/65118