### PR TITLE
Improve error handling when running commands in generalhw backend

### DIFF
--- a/backend/generalhw.pm
+++ b/backend/generalhw.pm
@@ -41,9 +41,7 @@ sub get_cmd {
     my ($self, $cmd) = @_;
 
     my $dir = get_required_var('GENERAL_HW_CMD_DIR');
-    if (!-d $dir) {
-        die "GENERAL_HW_CMD_DIR is not pointing to a directory";
-    }
+    die 'GENERAL_HW_CMD_DIR is not pointing to a directory' unless -d $dir;
 
     my %GENERAL_HW_ARG_VARIABLES_BY_CMD = ('GENERAL_HW_FLASH_CMD' => 'GENERAL_HW_FLASH_ARGS', 'GENERAL_HW_SOL_CMD' => 'GENERAL_HW_SOL_ARGS', 'GENERAL_HW_POWERON_CMD' => 'GENERAL_HW_POWERON_ARGS', 'GENERAL_HW_POWEROFF_CMD' => 'GENERAL_HW_POWEROFF_ARGS');
     my $args = get_var($GENERAL_HW_ARG_VARIABLES_BY_CMD{$cmd}) if get_var($GENERAL_HW_ARG_VARIABLES_BY_CMD{$cmd});
@@ -77,7 +75,7 @@ sub run_cmd {
     chomp $stdout;
     chomp $stderr;
 
-    die $cmd . ": $stderr" unless ($ret);
+    die "$cmd: $stderr" unless $ret;
     bmwqemu::diag("IPMI: $stdout");
     return $stdout;
 }

--- a/backend/generalhw.pm
+++ b/backend/generalhw.pm
@@ -63,11 +63,7 @@ sub get_cmd {
 
     $cmd = get_required_var($cmd);
     $cmd = "$dir/" . basename($cmd);
-    if (!-x $cmd) {
-        die "CMD $cmd is not an executable";
-    }
     $cmd .= " $args" if $args;
-
     return $cmd;
 }
 
@@ -76,7 +72,8 @@ sub run_cmd {
     my @full_cmd = split / /, $self->get_cmd($cmd);
 
     my ($stdin, $stdout, $stderr, $ret);
-    $ret = IPC::Run::run([@full_cmd], \$stdin, \$stdout, \$stderr);
+    eval { $ret = IPC::Run::run([@full_cmd], \$stdin, \$stdout, \$stderr) };
+    die "Unable to run command '@full_cmd' (deduced from test variable $cmd): $@\n" if $@;
     chomp $stdout;
     chomp $stderr;
 

--- a/t/29-backend-generalhw.t
+++ b/t/29-backend-generalhw.t
@@ -1,0 +1,108 @@
+#!/usr/bin/perl
+
+# Copyright (c) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use strict;
+use warnings;
+
+# mock sleeps
+my @invoked_cmds;
+BEGIN { *CORE::GLOBAL::sleep = sub { push @invoked_cmds, [sleep => shift] } }
+
+use Test::Exception;
+use Test::More;
+use Test::MockModule;
+use Test::Warnings qw(:all :report_warnings);
+use Test::Fatal;
+use FindBin qw($Bin);
+use Mojo::File qw(tempdir);
+
+use bmwqemu;
+use backend::generalhw;
+use distribution;
+use testapi;
+
+# setup test variables
+my $cmd_dir = tempdir;
+my $cmd_ctl = "$cmd_dir/ctl";
+$bmwqemu::vars{WORKER_HOSTNAME}         = 'worker-hostname';
+$bmwqemu::vars{GENERAL_HW_CMD_DIR}      = $cmd_dir;
+$bmwqemu::vars{GENERAL_HW_POWERON_CMD}  = 'ctl poweron';
+$bmwqemu::vars{GENERAL_HW_POWEROFF_CMD} = 'ctl poweroff';
+$bmwqemu::vars{GENERAL_HW_SOL_CMD}      = 'ctl console';
+$bmwqemu::vars{GENERAL_HW_SOL_ARGS}     = 'console';
+$bmwqemu::vars{GENERAL_HW_FLASH_CMD}    = 'ctl flash';
+$bmwqemu::vars{GENERAL_HW_FLASH_ARGS}   = 'light';
+$bmwqemu::vars{GENERAL_HW_VNC_IP}       = 'vnc.server';
+$bmwqemu::vars{HDD_1}                   = '/hdd';
+$bmwqemu::vars{HDDSIZEGB_1}             = 5;
+
+# initialize distribution and backend
+my $distri  = $testapi::distri = distribution->new;
+my $backend = backend::generalhw->new;
+
+# mock IPC::Run and the VNC console
+my $ipc_run_mock = Test::MockModule->new('IPC::Run');
+my $fake_ipc_error;
+$ipc_run_mock->redefine(run => sub {
+        my ($args, $stdin, $stdout, $stderr) = @_;
+        die $fake_ipc_error if $fake_ipc_error;
+        push @invoked_cmds, $args;
+        $$stdin  = 'stdin';
+        $$stdout = 'stdout';
+        $$stderr = 'stderr';
+});
+my $vnc_mock = Test::MockModule->new('consoles::VNC');
+my @vnc_logins;
+$vnc_mock->redefine(login => sub { push @vnc_logins, [shift->hostname] });
+$vnc_mock->redefine($_    => sub { }) for (qw(_receive_message _send_frame_buffer send_update_request));
+
+subtest 'start VM' => sub {
+    # start the "VM" which should actually just run a few commands via IPC::Run and start the VNC and serial consoles
+    is_deeply($backend->do_start_vm, {}, 'return value');
+    is_deeply(\@invoked_cmds, [[$cmd_ctl, 'poweroff'], [$cmd_ctl, 'flash', 'light', '/hdd', '5G'], [$cmd_ctl, 'poweroff'], ['sleep', 3], [$cmd_ctl, 'poweron']], 'poweroff/on commands invoked') or diag explain \@invoked_cmds;
+    is_deeply(\@vnc_logins, [['vnc.server']], 'tried to connect to VNC server') or diag explain \@vnc_logins;
+    isnt($backend->{serialpid}, undef, 'serial console started');
+};
+
+subtest 'stop VM' => sub {
+    @invoked_cmds = ();
+    is_deeply($backend->do_stop_vm, {},                 'return value');
+    is_deeply(\@invoked_cmds, [[$cmd_ctl, 'poweroff']], 'poweroff/on commands invoked') or diag explain \@invoked_cmds;
+};
+
+subtest 'error handling' => sub {
+    $fake_ipc_error = 'fake error';
+    throws_ok(
+        sub { $backend->run_cmd('GENERAL_HW_POWEROFF_CMD') },
+        qr/Unable to run command '$cmd_ctl poweroff' \(deduced from test variable GENERAL_HW_POWEROFF_CMD\): fake error/,
+        'IPC error thrown with context'
+    );
+    $bmwqemu::vars{GENERAL_HW_CMD_DIR} = 'does-not-exist';
+    throws_ok(
+        sub { $backend->run_cmd('GENERAL_HW_POWEROFF_CMD') },
+        qr/GENERAL_HW_CMD_DIR .* not .* directory/,
+        'error when GENERAL_HW_CMD_DIR is not a directory'
+    );
+    $bmwqemu::vars{WORKER_HOSTNAME} = undef;
+    throws_ok(
+        sub { backend::generalhw->new },
+        qr/WORKER_HOSTNAME/,
+        'WORKER_HOSTNAME required'
+    );
+};
+
+done_testing();


### PR DESCRIPTION
* Remove explicit check for the command being executable because it does
  not help in any case anyways, e.g. https://progress.opensuse.org/issues/70135
* Rather catch the exception from IPC::Run, add some context information
  and re-throw it

---

I'm wondering whether there are unit tests for this code. If not, maybe it is time to create a test for this backend - at least for the command code.