### PR TITLE
t: Fix regex for warning (multiline)

### DIFF
--- a/t/18-qemu.t
+++ b/t/18-qemu.t
@@ -153,7 +153,7 @@ $proc->deserialise_state(path($path)->slurp());
 is_deeply(\@gcmdl, \@cmdl, 'Multipath Command line after serialisation and deserialisation');
 
 $ENV{QEMU_IMG_CREATE_TRIES} = 2;
-my $expected = qr/failed after 2 tries.*No such.*directory/;
+my $expected = qr/failed after 2 tries.*No such.*directory/s;
 my @warnings = warnings {
     like exception { $proc->init_blockdev_images() }, $expected, 'init_blockdev_images can report error';
 };


### PR DESCRIPTION
Apparently on some platforms/versions of qemu the error message is
multiline, so the regex needs an /s modifier.

    'init_blockdev_images: 'create -f qcow2 raid/hd0 420G' failed after 2 tries: runcmd 'qemu-img create -f qcow2 raid/hd0 420G' failed with exit code 1: 'Formatting 'raid/hd0', fmt=qcow2 cluster_size=65536 compression_type=zlib size=450971566080 lazy_refcounts=off refcount_bits=16
    qemu-img: raid/hd0: Could not create file: No such file or directory' at /home/abuild/rpmbuild/BUILD/os-autoinst-4.6.1597406683.45b10929/osutils.pm line 121.

Issue: https://progress.opensuse.org/issues/70120

(It was only failing in OBS on a couple of platforms.)