### PR TITLE
Remove unnecesary parameter on a git call in tidy

### DIFF
--- a/tools/tidy
+++ b/tools/tidy
@@ -47,7 +47,7 @@ cleanup
 # Exclude any "os-autoinst" subdirectory which for example is used for "os-autoinst-distri-opensuse"
 # which symlinks "tools/tidy" into their own tests
 if [ -n "$onlychanged" ]; then
-    git status --porcelain --ignored '**.p[ml]' '**.t' | awk '{ print $2 }' \
+    git status --porcelain '**.p[ml]' '**.t' | awk '{ print $2 }' \
         | xargs -I {} perltidy --pro=.../.perltidyrc "{}"
 else
     find . \( -name '*.p[lm]' -o -name '*.t' \) -not -path '*/.git/*' -not -path '*/os-autoinst/*' -print0 \


### PR DESCRIPTION
By calling `git status` with `--ignored` tidy would end up also looking
at the wrong files, rendering the next call of `tidy --only-changed`
unusable