### PR TITLE
Improve error handling of isotovideo

### DIFF
--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -62,13 +62,19 @@ sub checkout_git_repo_and_branch {
     my $clone_cmd   = 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git clone';
     my $clone_args  = "--depth $args{clone_depth}";
     my $branch_args = '';
+    my ($return_code, @out);
+    my $handle_output = sub {
+        bmwqemu::diag "@out" if @out;
+        die "Unable to clone Git repository '$dir' specified via $dir_variable (see log for details)" unless $return_code == 0;
+    };
     if ($branch) {
         bmwqemu::diag "Checking out git refspec/branch '$branch'";
         $branch_args = " --branch $branch";
     }
     if (!-e $local_path) {
         bmwqemu::diag "Cloning git URL '$clone_url' to use as test distribution";
-        my @out = qx{$clone_cmd $clone_args $branch_args $clone_url 2>&1};
+        @out         = qx{$clone_cmd $clone_args $branch_args $clone_url 2>&1};
+        $return_code = $?;
         if ($branch && grep /warning: Could not find remote branch/, @out) {
             # maybe we misspelled or maybe someone gave a commit hash instead
             # for which we need to take a different approach by downloading the
@@ -77,17 +83,22 @@ sub checkout_git_repo_and_branch {
             # * https://stackoverflow.com/questions/18515488/how-to-check-if-the-commit-exists-in-a-git-repository-by-its-sha-1
             # * https://stackoverflow.com/questions/26135216/why-isnt-there-a-git-clone-specific-commit-option
             bmwqemu::diag "Fetching more remote objects to ensure availability of '$branch'";
-            qx{$clone_cmd $clone_args $clone_url};
+            @out         = qx{$clone_cmd $clone_args $clone_url 2>&1};
+            $return_code = $?;
+            $handle_output->();
             while (qx[git -C $local_path cat-file -e $branch^{commit} 2>&1] =~ /Not a valid object/) {
                 $args{clone_depth} *= 2;
-                @out = qx[git -C $local_path fetch --progress --depth=$args{clone_depth} 2>&1];
+                @out         = qx[git -C $local_path fetch --progress --depth=$args{clone_depth} 2>&1];
+                $return_code = $?;
                 bmwqemu::diag "git fetch: @out";
+                die "Unable to fetch Git repository '$dir' specified via $dir_variable (see log for details)" unless $return_code == 0;
                 die "Could not find '$branch' in complete history" if grep /remote: Total 0/, @out;
             }
             qx{git -C $local_path checkout $branch};
+            die "Unable to checkout branch '$branch' in cloned Git repository '$dir'" unless $? == 0;
         }
         else {
-            bmwqemu::diag "@out\n";
+            $handle_output->();
         }
     }
     else {

--- a/isotovideo
+++ b/isotovideo
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2019 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -53,10 +53,16 @@ use autodie ':all';
 no autodie 'kill';
 
 my $installprefix;    # $bmwqemu::scriptdir
+my $fatal_error;      # the last error message catched by the die handler
 
 BEGIN {
     # the following line is modified during make install
     $installprefix = undef;
+
+    # record the last die message
+    # note: It might *not* be a fatal error so we don't call bmwqemu::serialize_state here
+    #       immediately but only in the END block.
+    $SIG{__DIE__} = sub { $fatal_error = shift };
 
     my ($wd) = $0 =~ m-(.*)/-;
     $wd            ||= '.';
@@ -461,6 +467,9 @@ sub handle_generated_assets {
 }
 handle_generated_assets;
 
+# clear any previously recorded die message; it was not fatal after all if the execution came this far
+$fatal_error = undef;
+
 END {
     stop_backend;
     stop_commands('test execution ended through exception');
@@ -469,6 +478,7 @@ END {
     # in case of early exit, e.g. help display
     $return_code //= 0;
 
+    bmwqemu::serialize_state(component => 'isotovideo', msg => $fatal_error) if $fatal_error;
     print "$$: EXIT $return_code\n";
     $? = $return_code;
 }


### PR DESCRIPTION
See particular commit messages and https://progress.opensuse.org/issues/63718#note-15

---

I've tested this locally by giving it no commit hash, a valid commit hash and a wrong commit hash. It works, and in case of the invalid commit hash the reason is passed as expected:

```
Reason: isotovideo died: Could not find '69611aa007502c65c56c591bc4aaf5f357649c23' in complete history at /hdd/openqa-devel/repos/os-autoinst/OpenQA/Isotovideo/Utils.pm line 95.
```

In case the URL is completely misspelled, it looks like this:

```
Reason: isotovideo died: Unable to clone Git repository 'https://github.com/Martchus/os-autoinst-distri-opensus.git' specified via CASEDIR (see log for details) at /hdd/openqa-devel/repos/os-autoinst/OpenQA/Isotovideo/Utils.pm line 68.
```

This should only have an effect if isotovideo is the immediate place where the error happened so I also tested whether it doesn't interfere with other cases, e.g.:

```
Reason: backend died: External encoder not accepting data at /hdd/openqa-devel/repos/os-autoinst/backend/baseclass.pm line 157.
```

---

It might make sense to actually catch these failures within isotovideo explicitly and treat them as test failures (similar to failures when loading test modules). However, Git errors might not necessarily be caused by a wrong URL so that's not a clear improvement and I'll leave it therefore for a follow-up PR.