### PR TITLE
Improve spec file

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -178,34 +178,34 @@ cd %{__builddir}
 %files -f %{name}.files
 %defattr(-,root,root)
 %{_docdir}/os-autoinst
-%dir %{_libexecdir}/os-autoinst
-%{_libexecdir}/os-autoinst/videoencoder
-%{_libexecdir}/os-autoinst/basetest.pm
+%dir %{_prefix}/lib/os-autoinst
+%{_prefix}/lib/os-autoinst/videoencoder
+%{_prefix}/lib/os-autoinst/basetest.pm
 #
-%{_libexecdir}/os-autoinst/dmidata
+%{_prefix}/lib/os-autoinst/dmidata
 #
-%{_libexecdir}/os-autoinst/bmwqemu.pm
-%{_libexecdir}/os-autoinst/commands.pm
-%{_libexecdir}/os-autoinst/distribution.pm
-%{_libexecdir}/os-autoinst/testapi.pm
-%{_libexecdir}/os-autoinst/mmapi.pm
-%{_libexecdir}/os-autoinst/lockapi.pm
-%{_libexecdir}/os-autoinst/cv.pm
-%{_libexecdir}/os-autoinst/ocr.pm
-%{_libexecdir}/os-autoinst/needle.pm
-%{_libexecdir}/os-autoinst/osutils.pm
-%{_libexecdir}/os-autoinst/signalblocker.pm
-%{_libexecdir}/os-autoinst/myjsonrpc.pm
-%{_libexecdir}/os-autoinst/backend
-%{_libexecdir}/os-autoinst/OpenQA
-%{_libexecdir}/os-autoinst/consoles
-%{_libexecdir}/os-autoinst/autotest.pm
-%{_libexecdir}/os-autoinst/crop.py
+%{_prefix}/lib/os-autoinst/bmwqemu.pm
+%{_prefix}/lib/os-autoinst/commands.pm
+%{_prefix}/lib/os-autoinst/distribution.pm
+%{_prefix}/lib/os-autoinst/testapi.pm
+%{_prefix}/lib/os-autoinst/mmapi.pm
+%{_prefix}/lib/os-autoinst/lockapi.pm
+%{_prefix}/lib/os-autoinst/cv.pm
+%{_prefix}/lib/os-autoinst/ocr.pm
+%{_prefix}/lib/os-autoinst/needle.pm
+%{_prefix}/lib/os-autoinst/osutils.pm
+%{_prefix}/lib/os-autoinst/signalblocker.pm
+%{_prefix}/lib/os-autoinst/myjsonrpc.pm
+%{_prefix}/lib/os-autoinst/backend
+%{_prefix}/lib/os-autoinst/OpenQA
+%{_prefix}/lib/os-autoinst/consoles
+%{_prefix}/lib/os-autoinst/autotest.pm
+%{_prefix}/lib/os-autoinst/crop.py
 
 %files openvswitch
 %defattr(-,root,root)
-%{_libexecdir}/os-autoinst/os-autoinst-openvswitch
-/usr/lib/systemd/system/os-autoinst-openvswitch.service
+%{_prefix}/lib/os-autoinst/os-autoinst-openvswitch
+%{_unitdir}/os-autoinst-openvswitch.service
 %config /etc/dbus-1/system.d/org.opensuse.os_autoinst.switch.conf
 %{_sbindir}/rcos-autoinst-openvswitch
 

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -125,7 +125,7 @@ autoreconf -f -i
 make %{?_smp_mflags} INSTALLDIRS=vendor
 %else
 %define __builder ninja
-%cmake -DOS_AUTOINST_DOC_DIR:STRING=%{_docdir}/%{name}
+%cmake -DOS_AUTOINST_DOC_DIR:STRING="%{_docdir}/%{name}" -DSYSTEMD_SERVICE_DIR:STRING="%{_unitdir}"
 %cmake_build
 %endif
 


### PR DESCRIPTION
* See particular commit messages.
* Motivated by similar changes in openQA: https://github.com/os-autoinst/openQA/pull/3326

---

```
[11:08] <DimStar> Martchus: I'd suggest to use %{_prefix}/lib/os-autoinst in the .spec file instead of %{_libexecdir}/os-autoinst
[11:13] <DimStar> preferably you pass %{_unitdir} to cmake for this then (which is /usr/lib/systemd/system)
```