### PR TITLE
Show only one newline between serial output lines

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -457,7 +457,7 @@ sub record_serialresult {
     # take screenshot for documentation (screenshot does not represent fail itself)
     $self->take_screenshot() unless (testapi::is_serial_terminal);
 
-    my $output = "# wait_serial expected: $ref\n\n";
+    my $output = "# wait_serial expected: $ref\n";
     $output .= "# Result:\n";
     $output .= "$string\n";
     $self->record_resultfile('wait_serial', $output, result => $res);


### PR DESCRIPTION
This should result in a nicer output in the openQA webui

See https://github.com/os-autoinst/openQA/pull/3340 and https://progress.opensuse.org/issues/70648