### PR TITLE
Fix error handling for QMP connection when invoking QEMU twice

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -397,6 +397,7 @@ sub exec_qemu {
     session->enable_subreaper;
 
     my $process = $self->_process;
+    $self->{_qemu_terminated} = 0;
     $process->on(
         collected => sub {
             $self->{_qemu_terminated} = 1;


### PR DESCRIPTION
Follow-up of https://github.com/os-autoinst/os-autoinst/pull/1520 to fix
tests like https://openqa.opensuse.org/tests/1381351 where QEMU is
invoked multiple times.