### PR TITLE
Fix tools/tidy

### DIFF
--- a/tools/tidy
+++ b/tools/tidy
@@ -58,7 +58,7 @@ fi
 find-files() {
     local files=()
     [[ -d script ]] && files+=(script/*)
-    files=($(file --mime-type * "${files[@]}" | grep text/x-perl | awk -F':' '{ print $1 }'))
+    files=($(file --mime-type * "${files[@]}" | (grep text/x-perl || true) | awk -F':' '{ print $1 }'))
     files+=('**.p[ml]' '**.t')
     if $only_changed; then
         git status --porcelain "${files[@]}" | awk '{ print $2 }'


### PR DESCRIPTION
In certain cases, `file --mime-type` doesn't return perl, and so the
grep would actually fail, and abort the script.

This was the case on travis ci for os-autoinst-distri-opensuse.