### PR TITLE
[ARM64 ThunderX for openQA] Keep ssh connection alive to display long-time run test result

### DIFF
--- a/consoles/console.pm
+++ b/consoles/console.pm
@@ -74,10 +74,17 @@ sub screen {
 }
 
 # helper function
+# Keep ssh session for the maximum of ServerAliveCountMax x ServerAliveInterval seconds
+# even without receiving any messsage back from the server, and this will not affect normal
+# ssh disconnect and console switching. Ssh console may not display returned result of
+# long-time run test without these options. TCPKeepAlive ensures that if network goes down
+# or the remote host dies, machines will be properly noticed
 sub sshCommand {
     my ($self, $username, $host, $gui) = @_;
 
-    my $sshopts = "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no $username\@$host";
+    my $server_alive_count_max = get_var('_SSH_SERVER_ALIVE_COUNT_MAX', 480);
+    my $server_alive_interval  = get_var('_SSH_SERVER_ALIVE_INTERVAL',  60);
+    my $sshopts = "-o TCPKeepAlive=yes -o ServerAliveCountMax=$server_alive_count_max -o ServerAliveInterval=$server_alive_interval -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no $username\@$host";
 
     if ($gui) {
         $sshopts = "-X $sshopts";

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -38,6 +38,15 @@ AUTOINST_URL_HOSTNAME;string;;hostname or IP adress of host running the autoinst
 
 |====================
 
+.SSH backend
+[grid="rows",format="csv"]
+[options="header",cols="^m,^m,^m,v",separator=";"]
+|====================
+Variable;Values allowed;Default value;Explanation
+_SSH_SERVER_ALIVE_COUNT_MAX;integer;480;Sets the number of server alive messages which may be sent without receiving any messages back from the server. If this threshold is reached while server alive messages are being sent, ssh will disconnect from the server, terminating the session.  The server alive mechanism is valuable when the client or server depend on knowing when a connection has become inactive.
+_SSH_SERVER_ALIVE_INTERVAL;integer;60;Sets a timeout interval in seconds after which if no data has been received from the server, client will send a message through the encrypted channel to request a response from the server.
+|====================
+
 .IPMI backend
 [grid="rows",format="csv"]
 [options="header",cols="^m,^m,^m,v",separator=";"]


### PR DESCRIPTION
* **Ssh** console may halt and can not display returned result from long-time run test. It is easy to address this by adding -o TCPKeepAlive=yes -o ServerAliveCountMax=480 -o ServerAliveInterval=60 to ssh command. This will help keep ssh console alive to the maximum of ServerAliveCountMax x ServerAliveInterval seconds from client's perspective.
* **Without** these options, although the ssh console looks alive, it will not display returned test result after long-time run test. So the test will halt and keep waiting for timeout of the whole test suite.
* **This** issue currently only affects ARM64 ThunderX machine
* **Verification runs:**
  * [Test result is not returned and displayed on screen without this modification](http://10.67.133.40/tests/431)
  * [Test result is returned and displayed on screen with this modification](http://10.67.133.40/tests/441)