### PR TITLE
 Make command server utilize asset cache instead of only relying on ASSETDIR

### DIFF
--- a/commands.pm
+++ b/commands.pm
@@ -113,15 +113,19 @@ sub _test_data_file {
     return $self->reply->asset(Mojo::Asset::File->new(path => $file));
 }
 
+sub _is_allowed_path {
+    my ($path) = @_;
+    return !(!defined $path || $path =~ /^(.*\/)*\.\.(\/.*)*$/);    # do not allow .. in path
+}
+
 sub test_data {
     my ($self) = @_;
 
-    my $path    = $bmwqemu::vars{CASEDIR} . "/data/";
+    my $path    = path($bmwqemu::vars{CASEDIR}, 'data');
     my $relpath = $self->param('relpath');
     if (defined $relpath) {
-        # do not allow .. in path
-        return $self->reply->not_found if $relpath =~ /^(.*\/)*\.\.(\/.*)*$/;
-        $path .= $relpath;
+        return $self->reply->not_found unless _is_allowed_path($relpath);
+        $path = $path->child($relpath);
     }
 
     $self->app->log->info("Test data requested: $path");
@@ -136,8 +140,7 @@ sub get_asset {
     my $path    = join '/', $bmwqemu::vars{ASSETDIR}, $self->param('assettype'), $self->param('assetname');
     my $relpath = $self->param('relpath');
     if (defined $relpath) {
-        # do not allow .. in path
-        return $self->reply->not_found if $relpath =~ /^(.*\/)*\.\.(\/.*)*$/;
+        return $self->reply->not_found unless _is_allowed_path($relpath);
         $path .= "/$relpath";
     }
 

--- a/t/data/assets/other/01377523-autoinst.xml
+++ b/t/data/assets/other/01377523-autoinst.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns"><!-- fake profile within assets dir --></profile>

--- a/t/data/pool/01377524-autoinst.xml
+++ b/t/data/pool/01377524-autoinst.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns"><!-- fake profile within pool dir --></profile>


### PR DESCRIPTION
* Serve assets from working/pool directory and not just from ASSETDIR
* No longer only rely on ASSETDIR being mounted
* See https://progress.opensuse.org/issues/70723