### PR TITLE
Suggest using the check target (instead of test target) in the README

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -125,7 +125,7 @@ source directory so `isotovideo` can find them.
 
 Run all tests:
 ----
-make test
+make check
 ----
 
 By default CTest is invoked in verbose mode because prove already provides condensed


### PR DESCRIPTION
Only then the following sentence is actually true. Unfortunately the `test` target itself can not easily be adjusted because it is a special target provided by CMake itself.

At least it is consistent with the Autotools check target this way.