### PR TITLE
Include "t/" in coverage analysis as well to prevent never called tests

### DIFF
--- a/tools/invoke-tests
+++ b/tools/invoke-tests
@@ -58,7 +58,5 @@ if [[ $TESTS = *[!\ ]* ]]; then
     "$prove_path" $PROVE_ARGS $TESTS
 else
     # shellcheck disable=SC2086
-    cd t && "$prove_path" $PROVE_ARGS -r
-    # shellcheck disable=SC2086
-    cd ../xt && "$prove_path" $PROVE_ARGS -r
+    "$prove_path" $PROVE_ARGS -r t/ xt/
 fi

--- a/tools/invoke-tests
+++ b/tools/invoke-tests
@@ -43,7 +43,7 @@ db="$build_directory/cover_db"
 export PERL5LIB="$source_directory:$source_directory/ppmclibs:$source_directory/ppmclibs/blib/arch/auto/tinycv:$PERL5LIB"
 if [[ $WITH_COVER_OPTIONS ]]; then
     path_regex="^|$source_directory/|\\.\\./"
-    select="($path_regex)(OpenQA|backend|consoles|ppmclibs)/|($path_regex)isotovideo|($path_regex)[^/]+\.pm,-ignore,\.t|data/tests/|fake/tests/|/CheckGitStatus.pm|$prove_path"
+    select="($path_regex)(OpenQA|backend|consoles|ppmclibs|t)/|($path_regex)isotovideo|($path_regex)[^/]+\.(pm|t),-ignore,/CheckGitStatus.pm|$prove_path"
     export PERL5OPT="-I$source_directory/t/lib -MOpenQA::Test::CheckGitStatus -MDevel::Cover=-db,$db,-select,$select,-coverage,statement"
 fi
 


### PR DESCRIPTION
Last time this was proposed in https://github.com/os-autoinst/os-autoinst/pull/1289

Other previous approaches:
* https://github.com/os-autoinst/os-autoinst/pull/1291
* https://github.com/os-autoinst/os-autoinst/pull/1292
* https://github.com/os-autoinst/os-autoinst/pull/1537
* https://github.com/os-autoinst/os-autoinst/pull/1591
* https://github.com/os-autoinst/os-autoinst/pull/1624

why am I even trying?