### PR TITLE
Add missing reference to get_var

### DIFF
--- a/consoles/localXvnc.pm
+++ b/consoles/localXvnc.pm
@@ -26,6 +26,7 @@ use IPC::Run ();
 require IPC::System::Simple;
 use Socket;
 use File::Which;
+use testapi 'get_var';
 
 # helper function
 # Keep ssh session for the maximum of ServerAliveCountMax x ServerAliveInterval seconds


### PR DESCRIPTION
Some tests failed becuase: "Test died: Undefined subroutine &consoles::localXvnc::get_var called at /usr/lib/os-autoinst/consoles/localXvnc.pm line 39."

[Failed test run](https://openqa.suse.de/tests/4723104#)
