### PR TITLE
Fix tty key definition after initialization

### DIFF
--- a/consoles/console.pm
+++ b/consoles/console.pm
@@ -50,11 +50,9 @@ sub new {
 
 sub init {
     my ($self) = @_;
-    return unless $self->{args}->{tty};
     # Special keys like Ctrl-Alt-Fx are not passed to the VM by xfreerdp.
     # That means switch from graphical to console is not possible on Hyper-V.
-    my $hotkey = check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 'alt-f' : 'ctrl-alt-f';
-    $self->{console_key} = $hotkey . $self->{args}->{tty};
+    $self->{console_hotkey} = check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 'alt-f' : 'ctrl-alt-f';
 }
 
 # SUT was e.g. rebooted
@@ -106,6 +104,12 @@ sub set_tty {
     $self->{args}->{tty} = $tty;
     # no need to send changes to right process; console proxy already takes care
     # that this method is called in the right process
+}
+
+sub console_key {
+    my ($self) = @_;
+    return undef unless $self->{console_hotkey} && $self->{args}->{tty};
+    return $self->{console_hotkey} . $self->{args}->{tty};
 }
 
 1;

--- a/consoles/ttyConsole.pm
+++ b/consoles/ttyConsole.pm
@@ -27,7 +27,7 @@ use testapi 'check_var';
 
 sub trigger_select {
     my ($self) = @_;
-    $self->screen->send_key({key => $self->{console_key}});
+    $self->screen->send_key({key => $self->console_key});
     return;
 }
 

--- a/t/10-terminal.t
+++ b/t/10-terminal.t
@@ -238,7 +238,7 @@ sub test_terminal_directly {
     $tb->reset;
 
     my $term = consoles::virtio_terminal->new('unit-test-console', {tty => 3});
-    report_child_test(ok => $term->{console_key} eq "ctrl-alt-f3", 'console_key set correct');
+    report_child_test(ok => $term->console_key eq "ctrl-alt-f3", 'console_key set correct');
 
     $term->activate;
     my $scrn = $term->screen;

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -62,6 +62,7 @@ is_deeply($svirt_sut_console, {
         activated       => 0,
         args            => {},
         class           => 'consoles::sshVirtshSUT',
+        console_hotkey  => 'ctrl-alt-f',
         libvirt_domain  => 'openQA-SUT-1',
         serial_port_no  => 1,
         testapi_console => 'sut-serial',


### PR DESCRIPTION
This fixes a regression introduced in c2ba84c4 when tests update the
"tty" of a console after initialization. By introducing a method to read
the console key combination we can evaluate the configuration
dynamically.

Verification run: http://lord.arch.suse.de/tests/2793