### PR TITLE
Support FORCE_PUBLISH_HDD_ when the job fails

### DIFF
--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -143,7 +143,7 @@ sub handle_generated_assets {
     my ($command_handler, $clean_shutdown) = @_;
     my $return_code = 0;
     # mark hard disks for upload if test finished
-    return unless $command_handler->test_completed && ($bmwqemu::vars{BACKEND} eq 'qemu');
+    return unless $bmwqemu::vars{BACKEND} eq 'qemu';
     my @toextract;
     my $nd = $bmwqemu::vars{NUMDISKS};
     if ($command_handler->test_completed) {


### PR DESCRIPTION
For now when jobs fail, and the failed module with flag 'fatal =>1',
(so do some other specify scenarios)the FORCE_PUBLISH_HDD does not make sense.
We could get this conclusion by this line code:
https://github.com/os-autoinst/os-autoinst/blob/master/autotest.pm#L394

```
if ($t->{fatal_failure} || $flags->{fatal} || (!exists $flags->{fatal} && !$snapshots_supported) || $bmwqemu::vars{TESTDEBUG}) {
                bmwqemu::stop_vm();
                return 0;
}
```
When `isotovideo` deals with the `FORCE_PUBLISH_HDD_` in `handle_generated_assets`,
if the `$command_handler->test_completed` is 0, it does nothing. So when
jobs fail, and the function `runalltests` in `autotest.pm` returns 0, the asset defined
by `FORCE_PUBLISH_HDD` will not be published.

Verify run: http://10.67.19.103/tests/342#downloads
(this job has a setting `FORCE_PUBLISH_HDD_1=test.qcow2`)

Related: https://progress.opensuse.org/issues/65004