### PR TITLE
t: Prevent .git files to interfer with local 00-compile-check-all runs

### DIFF
--- a/t/00-compile-check-all.t
+++ b/t/00-compile-check-all.t
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-# Copyright (C) 2015-2019 SUSE LLC
+# Copyright (C) 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,6 +20,7 @@ use warnings;
 # test for each of the modules, but with the same test number
 use Test::Warnings qw(:no_end_test :report_warnings);
 use Test::Strict;
+use File::Which;
 
 use FindBin '$Bin';
 chdir "$Bin/..";
@@ -33,4 +34,21 @@ $Test::Strict::TEST_SKIP     = [
     't/pool/product/foo/main.pm',
     'tools/lib/perlcritic/Perl/Critic/Policy/HashKeyQuotes.pm',
 ];
+
+# Prevent any non-tracked files or files within .git (e.g. in.git/rr-cache) to
+# interfer
+if (-d '.git' and which('git')) {
+    no warnings 'redefine';
+    *Test::Strict::_all_files = sub {
+        my $root = qx{git rev-parse --show-toplevel};
+        chomp($root);
+        $root .= '/';
+        my @all_git_files = qx{git ls-files};
+        chomp(@all_git_files);
+        my $files_to_skip = $Test::Strict::TEST_SKIP || [];
+        my %skip = map { $_ => undef } @$files_to_skip;
+        return map { $root . $_ } grep { !exists $skip{$_} } @all_git_files;    # Exclude files to skip
+    }
+}
+
 all_perl_files_ok('.');


### PR DESCRIPTION
As we look up all files which look like perl files in the root source
dir and all subdirectories also for example files within .git/rr-cache
are picked up. As these files either have the extension .pl, .pm, .t or 
the perl shebang but include patch conflict markers Test::Strict will
unhelpful record failed result. This can be avoided by just listing all
version controlled files which is also faster than manually traversing
the directory tree.