### PR TITLE
Consistently use diag in the bmwqemu namespace

### DIFF
--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -20,7 +20,7 @@ use Mojo::URL;
 use Exporter 'import';
 use File::Spec;
 use Cwd;
-use bmwqemu 'diag';
+use bmwqemu;
 use Try::Tiny;
 
 our @EXPORT_OK = qw(checkout_git_repo_and_branch checkout_git_refspec
@@ -170,7 +170,7 @@ sub handle_generated_assets {
     }
     for my $i (1 .. $nd) {
         my $name = $bmwqemu::vars{"FORCE_PUBLISH_HDD_$i"} || next;
-        diag "Requested to force the publication of '$name'";
+        bmwqemu::diag "Requested to force the publication of '$name'";
         push @toextract, _store_asset($i, $name, 'assets_public');
     }
     for my $asset (@toextract) {

--- a/backend/generalhw.pm
+++ b/backend/generalhw.pm
@@ -24,7 +24,7 @@ use autodie ':all';
 
 use base 'backend::baseclass';
 
-use bmwqemu 'diag';
+use bmwqemu;
 use testapi qw(get_required_var get_var);
 use IPC::Run ();
 require IPC::System::Simple;

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -37,8 +37,7 @@ use POSIX 'strftime';
 use Term::ANSIColor;
 
 our $VERSION;
-our @EXPORT    = qw(fileContent save_vars);
-our @EXPORT_OK = qw(diag);
+our @EXPORT_OK = qw(diag fileContent save_vars);
 
 use backend::driver;
 require IPC::System::Simple;

--- a/commands.pm
+++ b/commands.pm
@@ -25,7 +25,7 @@ use Try::Tiny;
 use Socket;
 use POSIX '_exit', 'strftime';
 use myjsonrpc;
-use bmwqemu 'diag';
+use bmwqemu;
 use Mojo::JSON 'to_json';
 use Mojo::File 'path';
 
@@ -362,7 +362,7 @@ sub start_server {
         set_pipes                   => 0)->start;
 
     close($isotovideo);
-    $process->on(collected => sub { diag("commands process exited: " . shift->exit_status); });
+    $process->on(collected => sub { bmwqemu::diag("commands process exited: " . shift->exit_status); });
     return ($process, $child);
 }
 

--- a/consoles/amtSol.pm
+++ b/consoles/amtSol.pm
@@ -23,7 +23,7 @@ use base 'consoles::console';
 
 require IPC::System::Simple;
 use POSIX '_exit';
-use bmwqemu 'diag';
+use bmwqemu;
 use IO::Pipe;
 
 sub activate {

--- a/consoles/ipmiSol.pm
+++ b/consoles/ipmiSol.pm
@@ -23,7 +23,7 @@ use base 'consoles::console';
 
 require IPC::System::Simple;
 use POSIX '_exit';
-use bmwqemu 'diag';
+use bmwqemu;
 use IO::Pipe;
 
 sub activate {

--- a/osutils.pm
+++ b/osutils.pm
@@ -21,7 +21,7 @@ use warnings;
 use Carp;
 use base 'Exporter';
 use Mojo::File 'path';
-use bmwqemu 'diag';
+use bmwqemu;
 use Mojo::IOLoop::ReadWriteProcess 'process';
 
 our @EXPORT_OK = qw(
@@ -90,7 +90,7 @@ sub quote {
 }
 
 sub run {
-    diag "running " . join(' ', @_);
+    bmwqemu::diag "running " . join(' ', @_);
     my @args = @_;
     my $out;
     my $buffer;
@@ -101,7 +101,7 @@ sub run {
             while (defined(my $line = $p->getline)) {
                 $out .= $line;
             }
-            diag $buffer if defined $buffer && length($buffer) > 0;
+            bmwqemu::diag $buffer if defined $buffer && length($buffer) > 0;
     });
     $p->wait_stop;
     close($p->$_ ? $p->$_ : ()) for qw(read_stream write_stream error_stream);
@@ -111,13 +111,13 @@ sub run {
 }
 
 # Do not check for anything - just execute and print
-sub run_diag { my $o = (run(@_))[1]; diag($o) if $o; $o }
+sub run_diag { my $o = (run(@_))[1]; bmwqemu::diag($o) if $o; $o }
 
 # Open a process to run external program and check its return status
 sub runcmd {
     my (@cmd) = @_;
     my ($e, $out) = run(@cmd);
-    diag $out if $out && length($out) > 0;
+    bmwqemu::diag $out if $out && length($out) > 0;
     die "runcmd '" . join(' ', @cmd) . "' failed with exit code $e" . ($out ? ": '$out'" : '') unless $e == 0;
     return $e;
 }
@@ -132,13 +132,13 @@ sub attempt {
     my $attempts = 0;
     my ($total_attempts, $condition, $cb, $or) = ref $_[0] eq 'HASH' ? (@{$_[0]}{qw(attempts condition cb or)}) : @_;
     until ($condition->() || $attempts >= $total_attempts) {
-        diag "Waiting for $attempts attempts";
+        bmwqemu::diag "Waiting for $attempts attempts";
         $cb->();
         wait_attempt;
         $attempts++;
     }
     $or->() if $or && !$condition->();
-    diag "Finished after $attempts attempts";
+    bmwqemu::diag "Finished after $attempts attempts";
 }
 
 1;

--- a/ppmclibs/tinycv.pm
+++ b/ppmclibs/tinycv.pm
@@ -19,7 +19,7 @@ package tinycv;
 use strict;
 use warnings;
 
-use bmwqemu 'diag';
+use bmwqemu;
 use File::Basename;
 use Math::Complex 'sqrt';
 require Exporter;


### PR DESCRIPTION
To avoid *redefining* diag from testapi.