### PR TITLE
Output additional errno value on "encoder not accepting data"

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -154,7 +154,7 @@ sub _write_buffered_data_to_file_handle {
     # write as much data as possible (this is called when $fh is ready to write)
     my $data         = shift @$array_of_buffers;
     my $data_written = $fh->syswrite($data);
-    die "$program_name not accepting data" unless defined $data_written;
+    die "$program_name not accepting data: $!" unless defined $data_written;
 
     # put remaining data it back into the queue
     unshift @$array_of_buffers, substr($data, $data_written) unless $data_written == length($data);


### PR DESCRIPTION
Sometimes openQA test runs fail with

```
Encoder not accepting data at /usr/lib/os-autoinst/backend/baseclass.pm line 157.
```

The reason is unclear. However the function "syswrite" sets the errno
variable in case of an error, i.e. when `$data_written` returned by
"syswrite" is undef. So we should output the information that is
available to have more details.

Related progress issue: https://progress.opensuse.org/issues/70873