### PR TITLE
Update perltidy to 20201001

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -95,7 +95,7 @@ on 'test' => sub {
 on 'devel' => sub {
     requires 'Devel::Cover';
     requires 'Devel::Cover::Report::Codecov';
-    requires 'Perl::Tidy', '== 20200907';
+    requires 'Perl::Tidy', '== 20201001';
 
 };
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -52,7 +52,7 @@ devel_requires:
   '%test_requires':
   perl(Devel::Cover):
   perl(Devel::Cover::Report::Codecov):
-  perl(Perl::Tidy): '== 20200907'
+  perl(Perl::Tidy): '== 20201001'
 
 docker_requires:
   pkgconfig(opencv):


### PR DESCRIPTION
See corresponding change https://github.com/os-autoinst/openQA/pull/3456

I checked os-autoinst-distri-opensuse but this changes seems to demand no tidy changes there: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/11169