### PR TITLE
Fix qemu failing on ppc64 with "Requested safe cache capability level not supported by kvm"

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -734,6 +734,10 @@ sub start_qemu {
         $vars->{QEMUMACHINE} //= "usb=off";
         sp('g', '1024x768');
         $use_usb_kbd = 1;
+        # newer qemu needs safe cache capability level quirk settings
+        # https://progress.opensuse.org/issues/75259
+        my $caps = ',cap-cfpc=broken,cap-sbbc=broken,cap-ibs=broken';
+        $vars->{QEMUMACHINE} .= $caps if $self->{qemu_version} >= '4' && $vars->{QEMUMACHINE} !~ /$caps/;
     }
     sp('vga', $vars->{QEMUVGA}) if $vars->{QEMUVGA};
 


### PR DESCRIPTION
After we upgraded a ppc64 worker host running qemu version 3.1.1.1 on
openSUSE Leap 15.1 to openSUSE Leap 15.2 with qemu version 4.2.1
all our openQA tests on this machine failed with

```
QEMU: QEMU emulator version 4.2.1 (openSUSE Leap 15.2)
QEMU: Copyright (c) 2003-2019 Fabrice Bellard and the QEMU Project developers
QEMU: Unknown host!
QEMU: Unknown host!
QEMU: Unknown host!
QEMU: qemu-system-ppc64: Requested safe cache capability level not supported by kvm, try appending -machine cap-cfpc=broken
```

This commit adds the corresponding necessary options to the QEMUMACHINE
test variable depending on the detected qemu version.

Note: I am not aware which version of qemu exactly introduced the change
of behaviour but switching based on a major version is probably a good
initial approach :)

Related progress issue: https://progress.opensuse.org/issues/75259