### PR TITLE
Add python binding/import/wrapping code for testapi

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -131,7 +131,7 @@ sub loadtest {
     eval $code;
     if ($@) {
         my $msg = "error on $script: $@";
-        bmwqemu::diag($msg);
+        bmwqemu::fctwarn($msg);
         bmwqemu::serialize_state(component => 'tests', msg => "unable to load $script, check the log for the cause (e.g. syntax error)");
         die $msg;
     }

--- a/autotest.pm
+++ b/autotest.pm
@@ -1,5 +1,5 @@
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2020 SUSE LLC
+# Copyright © 2012-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -116,13 +116,14 @@ sub loadtest {
         $code .= "require '$script_path';";
     }
     elsif ($script =~ m/\.py$/) {
-        # import the test API and all methods from the test API by default
-        # into python context
+        # Adding the include path of os-autoinst into python context
+        my $inc = File::Basename::dirname(__FILE__);
         $code .= "
             use base 'basetest';
-            use Inline Python => <<'END_OF_PYTHON_CODE';\n";
-        $code .= `cat $casedir/$script`;
-        $code .= "\nEND_OF_PYTHON_CODE\n";
+            use Mojo::File 'path';
+            use Inline Python => 'import sys; sys.path.append(\"$inc\")';
+            use Inline Python => path('$casedir/$script')->slurp;
+            ";
     }
     else {
         die "impossible codepath";

--- a/autotest.pm
+++ b/autotest.pm
@@ -112,7 +112,21 @@ sub loadtest {
     $code .= "use lib '$casedir/lib';";
     my $basename = dirname($script_path);
     $code .= "use lib '$basename';";
-    $code .= "require '$script_path';";
+    if ($script =~ m/\.pm$/) {
+        $code .= "require '$script_path';";
+    }
+    elsif ($script =~ m/\.py$/) {
+        # import the test API and all methods from the test API by default
+        # into python context
+        $code .= "
+            use base 'basetest';
+            use Inline Python => <<'END_OF_PYTHON_CODE';\n";
+        $code .= `cat $casedir/$script`;
+        $code .= "\nEND_OF_PYTHON_CODE\n";
+    }
+    else {
+        die "impossible codepath";
+    }
     eval $code;
     if ($@) {
         my $msg = "error on $script: $@";
@@ -162,14 +176,14 @@ our $last_milestone_console;
 
 sub parse_test_path {
     my ($script_path) = @_;
-    unless ($script_path =~ m,(\w+)/([^/]+)\.pm$,) {
-        die "loadtest: script path '$script_path' does not match required pattern \\w.+/[^/]+.pm\n";
+    unless ($script_path =~ m,(\w+)/([^/]+)\.p[my]$,) {
+        die "loadtest: script path '$script_path' does not match required pattern \\w.+/[^/]+.p[my]\n";
     }
     my $category = $1;
     my $name     = $2;
     if ($category ne 'other') {
         # show full folder hierachy as category for non-sideloaded tests
-        my $pattern = qr,(tests/[^/]+/)?tests/([\w/]+)/([^/]+)\.pm$,;
+        my $pattern = qr,(tests/[^/]+/)?tests/([\w/]+)/([^/]+)\.p[my]$,;
         if ($script_path =~ $pattern) {
             $category = $2;
         }

--- a/container/os-autoinst_dev/Dockerfile
+++ b/container/os-autoinst_dev/Dockerfile
@@ -72,6 +72,7 @@ RUN zypper in -y -C \
        'perl(IPC::Open3)' \
        'perl(IPC::Run::Debug)' \
        'perl(IPC::System::Simple)' \
+       'perl(Inline::Python)' \
        'perl(List::MoreUtils)' \
        'perl(List::Util)' \
        'perl(Mojo::IOLoop::ReadWriteProcess)' \

--- a/cpanfile
+++ b/cpanfile
@@ -72,6 +72,7 @@ on 'test' => sub {
     requires 'Benchmark';
     requires 'Devel::Cover';
     requires 'FindBin';
+    requires 'Inline::Python';
     requires 'Mojo::IOLoop::ReadWriteProcess', '>= 0.28';
     requires 'Perl::Critic';
     requires 'Perl::Critic::Freenode';

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -96,6 +96,7 @@ test_requires:
   '%spellcheck_requires':
   '%yamllint_requires':
   perl(YAML::PP):
+  perl(Inline::Python):
 
 main_requires:
   git-core:

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -67,7 +67,7 @@ Source0:        %{name}-%{version}.tar.xz
 # The following line is generated from dependencies.yaml
 %define test_version_only_requires perl(Mojo::IOLoop::ReadWriteProcess) >= 0.28
 # The following line is generated from dependencies.yaml
-%define test_requires %build_requires %spellcheck_requires %test_base_requires %yamllint_requires perl(YAML::PP)
+%define test_requires %build_requires %spellcheck_requires %test_base_requires %yamllint_requires perl(Inline::Python) perl(YAML::PP)
 # The following line is generated from dependencies.yaml
 %define devel_requires %test_requires perl(Devel::Cover) perl(Devel::Cover::Report::Codecov) perl(Perl::Tidy)
 BuildRequires:  %test_requires %test_version_only_requires
@@ -76,6 +76,8 @@ Recommends:     tesseract-ocr
 Recommends:     /usr/bin/xkbcomp /usr/bin/Xvnc dumponlyconsole
 Recommends:     qemu >= 2.0.0
 Recommends:     /usr/bin/qemu-img
+# Optional dependency for Python test API support
+Recommends:     perl(Inline::Python)
 Requires(pre):  %{_bindir}/getent
 Requires(pre):  %{_sbindir}/useradd
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/t/04-testapi-python.t
+++ b/t/04-testapi-python.t
@@ -1,0 +1,26 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Fatal;
+use Test::Warnings;
+
+BEGIN {
+    unshift @INC, '..';
+}
+
+# This test merely shows how perl objects and modules can be accessed from
+# python
+
+# import all test API methods into global scope of python test modules so that
+# we do not need to write any prefix on each call like "perl.get_var"
+use testapi;
+use Inline Python => "for i in dir(perl): globals()[i] = getattr(perl, i)";
+
+use Inline 'Python';
+done_testing;
+__END__
+__Python__
+print(get_var('FOO', 'foo'))

--- a/t/04-testapi-python.t
+++ b/t/04-testapi-python.t
@@ -24,3 +24,5 @@ done_testing;
 __END__
 __Python__
 print(get_var('FOO', 'foo'))
+set_var('MY_PYTHON_VARIABLE', 42)
+assert get_required_var('MY_PYTHON_VARIABLE') == 42, "Could not find get_var/set_var variable"

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -29,8 +29,10 @@ qr/loadtest needs a script below.*is not/,
   'loadtest outputs on stderr';
 
 sub loadtest {
-    my ($test, $args) = @_;
-    stderr_like { autotest::loadtest "tests/$test.pm" } qr@scheduling $test#?[0-9]* tests/$test.pm|$test already scheduled@, \$args;
+    my ($test, $msg) = @_;
+    my $filename = $test =~ /\.p[my]$/ ? $test : $test . '.pm';
+    $test =~ s/\.p[my]//;
+    stderr_like { autotest::loadtest "tests/$filename" } qr@scheduling $test#?[0-9]* tests/$test|$test already scheduled@, $msg;
 }
 
 sub fake_send {
@@ -335,6 +337,8 @@ subtest 'load test successfully when CASEDIR is a relative path' => sub {
     $bmwqemu::vars{CASEDIR} = 'foo';
     loadtest 'start';
 };
+
+loadtest 'test.py', 'we can also parse python test modules';
 
 done_testing();
 

--- a/t/data/tests/main.pm
+++ b/t/data/tests/main.pm
@@ -16,6 +16,8 @@
 use strict;
 use warnings;
 
+use Cwd 'abs_path';
+
 use testapi;
 use testdistribution;
 
@@ -37,6 +39,11 @@ $needle::cleanuphandler = \&cleanup_needles;
 # openQA tests set INTEGRATION_TESTS to 1 when reusing the os-autoinst tests
 #
 autotest::loadtest "tests/freeze.pm" unless get_var('INTEGRATION_TESTS');
+
+# Add import path for local test python modules from pool directory
+use Inline Python => "import os.path, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.curdir, '../..')))";
+
+autotest::loadtest "tests/pre_boot.py";
 autotest::loadtest "tests/boot.pm";
 unless (get_var('INTEGRATION_TESTS')) {
     autotest::loadtest "tests/assert_screen.pm";

--- a/t/data/tests/tests/pre_boot.py
+++ b/t/data/tests/tests/pre_boot.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2019-2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+import sys
+print(sys.path)
+from testapi import *
+
+def run(self):
+    send_key('esc')
+    if not check_screen('should_not_match', 0):
+        return
+    raise Exception('Should not reach here')
+
+
+def test_flags(self):
+    return dict([('fatal', 1)])

--- a/t/fake/tests/test.py
+++ b/t/fake/tests/test.py
@@ -1,0 +1,4 @@
+from testapi import *
+
+def run(self):
+    pass

--- a/testapi.py
+++ b/testapi.py
@@ -1,0 +1,21 @@
+# Copyright © 2019-2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# publish all test API methods over perl into the modules context.
+# Use with `import testapi; testapi.method()` or `from testapi import *`
+import perl
+perl.use('testapi')
+for i in dir(perl):
+    locals()[i] = getattr(perl, i)

--- a/testapi.py
+++ b/testapi.py
@@ -17,5 +17,5 @@
 # Use with `import testapi; testapi.method()` or `from testapi import *`
 import perl
 perl.use('testapi')
-for i in dir(perl):
-    locals()[i] = getattr(perl, i)
+for i in dir(perl.testapi):
+    locals()[i] = getattr(perl.testapi, i)


### PR DESCRIPTION
This is based on bmwiedemann's work, see for example the initial idea in
https://github.com/os-autoinst/os-autoinst/pull/364 .
The idea for "python bindings" was recently brought up as well in
See https://trello.com/c/GSXjk2wZ/35-python-bindings-for-openqa

With this test modules can written in python code importing the testapi
module from python. All perl objects not within the testapi can still be
accessed using the dynamic python module "perl".

Detailed changes:

* 08-autotest.t: Add test for python test modules
* t: Add test for python test modules using perl testapi
* Add python testapi interface

This is a resubmit of
https://github.com/os-autoinst/os-autoinst/pull/1089 updated to the
current state of the project but keeping the original idea. By now
different approaches have been followed to improve the maintainability
of complex test plans. However the concerns in
https://github.com/os-autoinst/os-autoinst/pull/1089 have not been in
addressed to change the design.

Related progress issue: https://progress.opensuse.org/issues/72868