### PR TITLE
Cover all test output in t/13-osutils and remove unneeded debug messages

### DIFF
--- a/backend/driver.pm
+++ b/backend/driver.pm
@@ -120,7 +120,6 @@ sub start_vm {
     close $runf;
 
     # remove old screenshots
-    print "remove_tree $bmwqemu::screenshotpath\n";
     remove_tree($bmwqemu::screenshotpath);
     mkdir $bmwqemu::screenshotpath;
 

--- a/backend/driver.pm
+++ b/backend/driver.pm
@@ -84,7 +84,6 @@ sub start {
             undef $signal_blocker;
 
             $self->{backend}->run(fileno($process->channel_in), fileno($process->channel_out));
-            _exit(0);
         })->start;
 
     $backend_process->on(collected => sub { bmwqemu::diag("backend process exited: " . shift->exit_status) });


### PR DESCRIPTION
* t: Cover all test output in t/13-osutils.t with Test::Output
* driver: Remove confusing log about 'remove_tree'
* driver: No need for explicit exit in process sub