### PR TITLE
docker: Add Dockerfile for isotovideo+qemu-x86

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -78,7 +78,7 @@ Issues are tracked on https://progress.opensuse.org/projects/openqav3/.
 For an overview of the architecture, see link:doc/architecture.md[doc/architecture.md].
 
 Rules for commits
-^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~
 
 * Every commit is checked by https://travis-ci.org/travis[Travis CI] as soon as
 you create a pull request but you *should* run the os-autoinst tests locally. Checkout
@@ -98,7 +98,7 @@ Build instructions
 ------------------
 
 Installing dependencies
-^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~
 
 On openSUSE one can install the package
 link:https://build.opensuse.org/project/show/devel:openQA[`os-autoinst-devel`] which
@@ -109,7 +109,7 @@ within that file are specific to openSUSE but can be easily transferred to other
 distributions.)
 
 Conducting the build
-^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~
 
 Create a build directory outside of the source directory. The following commands need
 to be invoked within that directory.

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -28,12 +28,22 @@ link:http://open.qa/docs/#_development_version_repository[openQA documentation].
 
 For building os-autoinst manually checkout the build instructions below.
 
-To execute an instance of os-autoinst one needs to create a file named
-`vars.json`. It stores the values of the different variables that will configure
-the behavior of the test execution.
+The main executable `isotovideo` can read test parameters from the command
+line or read test parameters from a file named `vars.json`. This file stores
+the values of the different variables that will configure the behavior of the
+test execution.
 
-There are some variables used by os-autoinst itself and other that are
-used by the tests. A minimal `vars.json` file can be:
+Additional test variables can be supplied on the command line. There are some
+variables used by os-autoinst itself and other that are used by the tests. A
+minimal command line can look like this:
+
+[source,sh]
+----
+isotovideo distri=opensuse casedir=/full/path/for/tests iso=/full/path/for/iso
+----
+
+As alternative or completementary a corresponding `vars.json` with additional
+parameters could be:
 
 [source, javascript]
 -------------------------------------------------------------------

--- a/docker/isotovideo/Dockerfile.qemu-x86
+++ b/docker/isotovideo/Dockerfile.qemu-x86
@@ -1,0 +1,5 @@
+#!BuildTag: isotovideo:qemu-x86
+
+FROM opensuse/tumbleweed
+RUN zypper -n in os-autoinst qemu-x86 qemu-tools
+ENTRYPOINT ["/usr/bin/isotovideo"]

--- a/isotovideo
+++ b/isotovideo
@@ -20,7 +20,7 @@
 
 isotovideo [OPTIONS] [TEST PARAMETER]
 
-Parses vars.json and tests the given assets/ISOs.
+Parses command line parameters, vars.json and tests the given assets/ISOs.
 
 =head1 OPTIONS
 


### PR DESCRIPTION
I had
https://build.opensuse.org/package/view_file/home:okurz:container/isotovideo/Dockerfile
since about a year. This commit pushes that upstream to os-autoinst and
adapts to work in more general CI pipelines in a limited way, e.g. also
github actions where no nested virt and hence no KVM is available. With
this commit we can publish the container and image as an easier entry
point for users and also to be used within CI pipelines of other
projects.

The same Dockerfile configuration was used
in
https://build.opensuse.org/package/view_file/home:okurz:container/isotovideo-qemu-x86/Dockerfile?expand=1
which in turn was used in 
https://github.com/os-autoinst/os-autoinst-distri-example/pull/4
to show how isotovideo can be run as part of a CI pipeline using github
actions.

Related progress issue: https://progress.opensuse.org/issues/77905