### PR TITLE
Fix "Use of uninitialized value in numeric eq" on connection errors in mmapi

### DIFF
--- a/mmapi.pm
+++ b/mmapi.pm
@@ -33,6 +33,7 @@ use Mojo::URL;
 # private ua
 my $ua;
 my $url;
+my $app;
 
 sub _init {
     # init $ua and $url
@@ -60,6 +61,11 @@ sub _init {
             my ($ua, $tx) = @_;
             $tx->req->headers->add('X-API-JobToken' => $secret);
         });
+}
+
+sub set_app {
+    _init unless $ua;
+    $ua->server->app($app = shift);
 }
 
 sub api_call {
@@ -208,6 +214,7 @@ sub get_job_autoinst_vars {
     $url .= '/vars';
 
     my $ua = Mojo::UserAgent->new;
+    $ua->server->app($app) if $app;
     my $tx = $ua->get($url);
     return undef if _handle_api_error($tx, 'get_job_autoinst_vars');
     return $tx->res->json('/vars');

--- a/mmapi.pm
+++ b/mmapi.pm
@@ -118,7 +118,7 @@ Returns an array ref conaining ids of children in given state.
 sub get_children_by_state {
     my ($state) = @_;
     my ($res, $tx) = api_call(get => "mm/children/$state");
-    return undef if _handle_api_error($tx);
+    return undef if _handle_api_error($tx, 'get_children_by_state');
     return $res->json('/jobs');
 }
 
@@ -133,7 +133,7 @@ Returns a hash ref conaining { id => state } pair for each child job.
 
 sub get_children {
     my ($res, $tx) = api_call(get => 'mm/children');
-    return undef if _handle_api_error($tx);
+    return undef if _handle_api_error($tx, 'get_children');
     return $res->json('/jobs');
 }
 
@@ -148,7 +148,7 @@ Returns an array ref conaining ids of parent jobs.
 
 sub get_parents {
     my ($res, $tx) = api_call(get => 'mm/parents');
-    return undef if _handle_api_error($tx);
+    return undef if _handle_api_error($tx, 'get_parents');
     return $res->json('/jobs');
 }
 
@@ -164,7 +164,7 @@ Returns a hash containin job information provided by openQA server.
 sub get_job_info {
     my ($target_id) = @_;
     my ($res, $tx) = api_call(get => "jobs/$target_id");
-    return undef if _handle_api_error($tx);
+    return undef if _handle_api_error($tx, 'get_job_info');
     return $res->json('/job');
 }
 

--- a/t/30-mmapi.t
+++ b/t/30-mmapi.t
@@ -1,0 +1,74 @@
+#!/usr/bin/perl
+#
+# Copyright (c) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# This test covers the signalblocker module and tinycv's helper to create
+# threads upfront.
+
+use Test::Most;
+
+use OpenQA::Test::TimeLimit '5';
+use Test::MockModule;
+use Mojolicious;
+use mmapi;
+
+# setup a fake server
+my $mock_srv = Mojolicious->new;
+my $routes   = $mock_srv->routes;
+my $fake_api = $routes->any('/api/v1');
+$fake_api->get('/mm/children' => sub {
+        my ($self) = @_;
+        return $self->render(status => 403, text => 'not authorized') if ($self->tx->req->headers->header('X-API-JobToken') || '') ne 'fake-jobtoken';
+        return $self->render(json   => {jobs => [1, 2, 3]});
+});
+$fake_api->get('/mm/children/#state' => sub {
+        my ($self) = @_;
+        return $self->render(status => 404, json => {jobs => []}) if $self->stash('state') ne 'some-state';
+        return $self->render(json => {jobs => [1]});
+});
+$fake_api->get('/mm/parents' => sub { shift->render(json => {jobs => [4, 5, 6]}) });
+$fake_api->get('/jobs/100'   => sub { shift->render(json => {job  => {the => 'job info'}}) });
+$fake_api->get('/workers' => sub {
+        shift->render(json => {workers => [{
+                        jobid      => '100',
+                        host       => 'fake-host',
+                        instance   => 42,
+                        properties => {JOBTOKEN => 'fake-jobtoken'},
+        }]});
+});
+$routes->get('/autoinst/vars' => sub { shift->render(json => {vars => {foo => 'bar'}}) });
+
+# make mmapi connect to the fake server
+$bmwqemu::vars{OPENQA_URL} = '/not/relevant';
+$bmwqemu::vars{JOBTOKEN}   = 'fake-jobtoken';
+mmapi::set_app($mock_srv);
+
+# test mmapi's `get_` functions
+is_deeply(mmapi::get_children(),                         [1, 2, 3],                              'query children');
+is_deeply(mmapi::get_children_by_state('some-state'),    [1],                                    'query children by state');
+is_deeply(mmapi::get_children_by_state('another-state'), undef,                                  'query children by state (no results)');
+is_deeply(mmapi::get_parents(),                          [4, 5, 6],                              'query parents');
+is_deeply(mmapi::get_job_info(100),                      {the => 'job info'},                    'query job info');
+is_deeply(mmapi::get_job_info(101),                      undef,                                  'query job info (no result)');
+is_deeply(mmapi::get_job_autoinst_url(100),              "http://fake-host:20423/fake-jobtoken", 'get autoinst URL');
+is_deeply(mmapi::get_job_autoinst_vars(101),             undef,                                  'get autoinst vars (no result)');
+
+# test with mocked get_job_autoinst_url
+my $mmapi_mock = Test::MockModule->new('mmapi');
+$mmapi_mock->redefine(get_job_autoinst_url => sub { '/autoinst' });
+is_deeply(mmapi::get_job_autoinst_vars(100), {foo => 'bar'}, 'get autoinst vars');
+
+done_testing;


### PR DESCRIPTION
* Show the connection error instead
* See https://progress.opensuse.org/issues/80264

---

There seem to be no tests for this code so I'll either create some or resort to manual testing for now.