### PR TITLE
Restore compatibility of mmapi::api_call

### DIFF
--- a/mmapi.pm
+++ b/mmapi.pm
@@ -68,6 +68,12 @@ sub set_app {
     $ua->server->app($app = shift);
 }
 
+=head2 api_call_2
+
+Queries openQA's multi-machine API and returns the resulting Mojo::Transaction::HTTP object.
+
+=cut
+
 sub api_call_2 {
     my ($method, $action, $params, $expected_codes) = @_;
     _init                                       unless $ua;
@@ -91,6 +97,12 @@ sub api_call_2 {
     }
     return $tx;
 }
+
+=head2 api_call
+
+Queries openQA's multi-machine API and returns the result as Mojo::Message::Response object.
+
+=cut
 
 sub api_call { api_call_2(@_)->res }
 

--- a/t/30-mmapi.t
+++ b/t/30-mmapi.t
@@ -55,12 +55,15 @@ $fake_api->get('/workers' => sub {
                         properties => {JOBTOKEN => 'fake-jobtoken'},
         }]});
 });
+$fake_api->post('/mutex/foo' => sub { shift->render(json => {some => 'mutex'}) });
 $routes->get('/autoinst/vars' => sub { shift->render(json => {vars => {foo => 'bar'}}) });
 
 # make mmapi connect to the fake server
 $bmwqemu::vars{OPENQA_URL} = '/not/relevant';
 $bmwqemu::vars{JOBTOKEN}   = 'fake-jobtoken';
 mmapi::set_app($mock_srv);
+
+is(api_call(post => 'mutex/foo', {action => 'unlock'})->code, 200, 'api_call returns result');
 
 # test mmapi's `get_` functions
 is_deeply(mmapi::get_children(),                      [1, 2, 3], 'query children');


### PR DESCRIPTION
* Restore return value of mmapi::api_call which has changed in
  3655e0c1383457c49e8b4669c37624b23fb1c240.
* See https://progress.opensuse.org/issues/80412