### PR TITLE
Handle PRODUCTDIR logic in here

### DIFF
--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -198,6 +198,7 @@ sub load_test_schedule {
     unshift @INC, $bmwqemu::vars{CASEDIR} . '/lib';
     if ($bmwqemu::vars{SCHEDULE}) {
         bmwqemu::diag 'Enforced test schedule by \'SCHEDULE\' variable in action';
+        unshift @INC, '.' unless File::Spec->file_name_is_absolute($bmwqemu::vars{CASEDIR});
         $bmwqemu::vars{INCLUDE_MODULES} = undef;
         autotest::loadtest($_ . '.pm') foreach split(',', $bmwqemu::vars{SCHEDULE});
         $bmwqemu::vars{INCLUDE_MODULES} = 'none';

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -7,6 +7,7 @@ Supported variables per backend
 |====================
 Variable;Values allowed;Default value;Explanation
 CASEDIR;string;;Path to test distribution. Can be a git repository URL of a test distribution to checkout with an optional refspec or also git hash into the current directory. It tries to follow the definition of https://docs.npmjs.com/files/package.json#git-urls-as-dependencies (e.g. `https://github.com/os-autoinst/os-autoinst-distri-opensuse.git#feature/test` or `git@github.com:os-autoinst/os-autoinst-distri-opensuse.git`). Note that cloning via SSH is only possible if git is configured accordingly on the host where isotovideo is executed. Can be combined with `TEST_GIT_REFSPEC` and `NEEDLES_GIT_REFSPEC`.
+DEFCASEDIR;string;;A default value of CASEDIR. When CASEDIR is a git repository URL of a test distribution, this value will be the path to test distribution. In this scenario it's used to find the correct needles directory.
 PRODUCTDIR;string;;Path to optional "product directory" which includes the test schedule entry point "main.pm" as well as a "needles" subdirectory with the needles to load. Can be relative path.
 NEEDLES_DIR;string;;Path to needles subdirectory to use, defaults to "needles" within `PRODUCTDIR`. Can be a git repository URL, comparable to `CASEDIR`
 INCLUDE_MODULES;string;;comma separated names or fullnames of test modules to be included while excluding all that do not match, e.g. "boot,mod1"

--- a/isotovideo
+++ b/isotovideo
@@ -242,7 +242,10 @@ checkout_git_repo_and_branch('CASEDIR');
 #
 # This allows further structuring the test distribution collections with
 # multiple distributions or flavors in one repository.
-$bmwqemu::vars{PRODUCTDIR} ||= $bmwqemu::vars{CASEDIR};
+my $productdir = $bmwqemu::vars{CASEDIR};
+$productdir = $bmwqemu::vars{CASEDIR} . '/products/' . $bmwqemu::vars{DISTRI}
+  if ($bmwqemu::vars{DISTRI} && -e File::Spec->catfile($bmwqemu::vars{CASEDIR} . '/products/', $bmwqemu::vars{DISTRI}));
+$bmwqemu::vars{PRODUCTDIR} ||= $productdir;
 
 # checkout Git repo NEEDLES_DIR refers to (if it is a URL) and re-assign NEEDLES_DIR to contain the checkout path
 checkout_git_repo_and_branch('NEEDLES_DIR');

--- a/needle.pm
+++ b/needle.pm
@@ -326,7 +326,12 @@ sub default_needles_dir {
 
 sub init {
     $needles_dir = ($bmwqemu::vars{NEEDLES_DIR} // default_needles_dir);
-    $needles_dir = File::Spec->catdir($bmwqemu::vars{CASEDIR}, $needles_dir) unless -d $needles_dir;
+
+    # When CASEDIR is a git repository URL of a test distribution, there is no needles directory under the PRODUCTDIR.
+    # In this scenario, we need to find needles by using DEFCASEDIR. Because this value is the true test distribution directory that the worker used.
+    $needles_dir = File::Spec->catdir("$bmwqemu::vars{DEFCASEDIR}/products/$bmwqemu::vars{DISTRI}", "needles")
+      if ($bmwqemu::vars{DEFCASEDIR} && $bmwqemu::vars{DISTRI} && !-d $needles_dir);
+    $needles_dir = File::Spec->catdir($bmwqemu::vars{DEFCASEDIR}, "needles") if ($bmwqemu::vars{DEFCASEDIR} && !-d $needles_dir);
     die "needles_dir not found: $needles_dir (check vars.json?)" unless -d $needles_dir;
     $bmwqemu::vars{NEEDLES_GIT_HASH} = checkout_git_refspec($needles_dir => 'NEEDLES_GIT_REFSPEC');
 


### PR DESCRIPTION
This pull request is a part of https://github.com/os-autoinst/openQA/pull/3604.
Because PRODUCTDIR is a child directory of CASEDIR, we simply find
`main.pm` throught out CASEDIR.
When users trigger a job using github path as CASEDIR, the CASEDIR does
not include needles, so we need to find needles in `DEFAULT_CASEDIR`.