### PR TITLE
Increase sleep time after mc cold reset in case host not ready

### DIFF
--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -168,7 +168,7 @@ sub do_mc_reset {
         else {
             bmwqemu::diag("IPMI mc reset success!");
             # wait seconds until mc reset really sent to board
-            sleep 10;
+            sleep 120;
             bmwqemu::diag("sleep 10 ends, will do ping");
             # check until  mc reset is done and ipmi recovered
             my $count    = 0;


### PR DESCRIPTION
We have some hardware need more time to be ready after mc reset cold.
1 openqa ipmi backend  connecting at a wrong status of mc may cause timeout issue
2 it works well at second connecting by ipmitool manually 



