### PR TITLE
backend: ipmi: Make "mc reset" parameters configurable

### DIFF
--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -95,6 +95,7 @@ sub restart_host {
         last if $ret =~ m/is on/;
         $self->ipmitool('chassis power on');
     }
+    1;
 }
 
 sub do_start_vm {
@@ -159,7 +160,7 @@ sub do_mc_reset {
     local $SIG{__DIE__} = {};
 
     # mc reset cmd should return immediately, try maximum 5 times to ensure cmd executed
-    my $max_tries = 5;
+    my $max_tries = $bmwqemu::vars{IPMI_MC_RESET_MAX_TRIES} // 5;
     for (1 .. $max_tries) {
         eval { $self->ipmitool("mc reset cold"); };
         if ($@) {
@@ -168,7 +169,7 @@ sub do_mc_reset {
         else {
             bmwqemu::diag("IPMI mc reset success!");
             # wait some time until mc reset really sent to board
-            $bmwqemu::vars{IPMI_MC_RESET_SLEEP_TIME_S} // 10;
+            sleep $bmwqemu::vars{IPMI_MC_RESET_SLEEP_TIME_S} // 10;
             bmwqemu::diag("sleep ends, will do ping");
             # check until  mc reset is done and ipmi recovered
             my $count      = 0;
@@ -195,5 +196,3 @@ sub do_mc_reset {
 
     die "IPMI mc reset failure after $max_tries tries! Exit...";
 }
-
-1;

--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -175,7 +175,7 @@ sub do_mc_reset {
             my $count      = 0;
             my $timeout    = $bmwqemu::vars{IPMI_MC_RESET_TIMEOUT}    // 60;
             my $ping_count = $bmwqemu::vars{IPMI_MC_RESET_PING_COUNT} // 1;
-            my $ping_cmd   = "ping -c$ping_count " . $bmwqemu::vars{IPMI_HOSTNAME};
+            my $ping_cmd   = "ping -c$ping_count '$bmwqemu::vars{IPMI_HOSTNAME}'";
             my $ipmi_tries = $bmwqemu::vars{IPMI_MC_RESET_IPMI_TRIES} // 3;
             while ($count++ < $timeout) {
                 eval { system($ping_cmd); };

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -60,6 +60,11 @@ IPMI_DO_NOT_RESTART_HOST;boolean;undef;Don't restart the machine before test
 IPMI_BACKEND_MC_RESET;boolean;undef;Reset ipmi main board before test for sol console stability
 IPMI_SKIP_SELFTEST;boolean;undef;Don't perform BMC selftest
 IPMI_HW;string;supermicro;Hardware used for IPMI interface
+IPMI_MC_RESET_MAX_TRIES;integer;5;Maximum number of overall retries for mc reset
+IPMI_MC_RESET_SLEEP_TIME_S;integer;10;Time to sleep after sending mc reset command before trying to control IPMI
+IPMI_MC_RESET_TIMEOUT;integer;60;Counts to try to reach IPMI interface after mc reset
+IPMI_MC_RESET_PING_COUNT;integer;1;Ping counts that must be successful after mc reset
+IPMI_MC_RESET_IPMI_TRIES;integer;3;Maximum number of IPMI command tries that are conducted after mc reset
 |====================
 
 .QEMU backend

--- a/t/18-backend-ipmi.t
+++ b/t/18-backend-ipmi.t
@@ -1,0 +1,54 @@
+#!/usr/bin/perl
+
+use 5.018;
+use Test::Most;
+
+use OpenQA::Test::TimeLimit '5';
+use Test::Mock::Time;
+use Test::MockModule;
+use Test::MockObject;
+use Test::Output qw(combined_like stderr_like);
+use Test::Warnings qw(:all :report_warnings);
+
+BEGIN { *backend::ipmi::system = sub { 1 } }
+
+use backend::ipmi;    # SUT
+
+$bmwqemu::vars{WORKER_HOSTNAME} = 'localhost';
+ok my $backend = backend::ipmi->new(), 'backend can be created';
+$bmwqemu::vars{"IPMI_$_"} = "fake_$_" foreach qw(HOSTNAME USER PASSWORD);
+my @ipmi_cmdline = $backend->ipmi_cmdline;
+is_deeply \@ipmi_cmdline, [qw(ipmitool -I lanplus -H fake_HOSTNAME -U fake_USER -P fake_PASSWORD)], 'valid ipmi_cmdline';
+
+my $ipmi = Test::MockModule->new('backend::ipmi');
+$ipmi->redefine(ipmi_cmdline => sub { (qw(echo simulating ipmi)) });
+my $ret;
+combined_like { $ret = $backend->ipmitool('foo') } qr/IPMI: simulating ipmi foo/, 'log output for IPMI call';
+is $ret, 'simulating ipmi foo', 'can call ipmitool';
+ok !$backend->dell_sleep, 'dell_sleep would only work on special HW';
+combined_like { $ret = $backend->is_shutdown } qr/IPMI.*power status/, 'log output for is_shutdown';
+ok !$ret, 'is_shutdown returning false by default';
+$ipmi->redefine(ipmitool => sub { rand > 0.5 ? 'is off' : 'is on' });
+ok $backend->restart_host, 'can call restart_host';
+
+my $distri = Test::MockModule->new('distribution');
+$distri->redefine(add_console => sub {
+        my $ret = Test::MockObject->new();
+        $ret->set_true('backend');
+        return $ret;
+});
+$testapi::distri = distribution->new;
+
+ok $backend->do_start_vm, 'can call do_start_vm';
+ok $backend->do_stop_vm,  'can call do_stop_vm';
+ok !$backend->check_socket, 'check_socket not returning true by default';
+ok $backend->get_mc_status, 'can call get_mc_status';
+
+# reduce retries for testing
+$bmwqemu::vars{IPMI_MC_RESET_MAX_TRIES} = $bmwqemu::vars{IPMI_MC_RESET_TIMEOUT} = 3;
+my $main = Test::MockModule->new('main', no_auto => 1);
+combined_like { $backend->do_mc_reset } qr/IPMI mc reset success/, 'can call do_mc_reset';
+
+done_testing;
+
+1;


### PR DESCRIPTION
In some cases the connection to the IPMI interfaces is even less stable
than expected. With this change we are making all common parameters
configurable so that the test or instance admin can configure more and
be more graceful on connection problems.