### PR TITLE
t: Add 'external' to search path of tests

### DIFF
--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -3,13 +3,14 @@
 use 5.018;
 use Test::Most;
 
+use FindBin '$Bin';
+use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use Test::MockModule;
 use Test::MockObject;
 use Test::Output qw(combined_like stderr_like);
 use Test::Warnings qw(:all :report_warnings);
 use Test::Fatal;
-use FindBin '$Bin';
 use Mojo::File 'tempdir';
 use Mojo::Util qw(scope_guard);
 

--- a/t/18-qemu-options.t
+++ b/t/18-qemu-options.t
@@ -16,6 +16,8 @@
 
 use Test::Most;
 use Test::Warnings ':report_warnings';
+use FindBin '$Bin';
+use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '40';
 use Try::Tiny;
 use File::Basename;
@@ -23,7 +25,6 @@ use Cwd 'abs_path';
 use Mojo::File qw(path tempdir);
 use Mojo::JSON qw(encode_json);
 use Benchmark ':hireswallclock';
-use FindBin '$Bin';
 use Mojo::Util qw(scope_guard);
 
 my $dir          = tempdir("/tmp/$FindBin::Script-XXXX");

--- a/t/18-qemu.t
+++ b/t/18-qemu.t
@@ -3,12 +3,13 @@
 use 5.018;
 use Test::Most;
 
+use FindBin '$Bin';
+use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use Test::Fatal;
 use Test::Warnings qw(warnings :report_warnings);
 use Mojo::File qw(tempfile tempdir path);
 use Carp 'cluck';
-use FindBin '$Bin';
 use Mojo::Util qw(scope_guard);
 
 use OpenQA::Qemu::BlockDevConf;

--- a/t/28-signalblocker.t
+++ b/t/28-signalblocker.t
@@ -20,6 +20,8 @@
 
 use Test::Most;
 
+use FindBin '$Bin';
+use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use File::Basename qw(dirname);
 use Test::Warnings qw(warnings :report_warnings);

--- a/t/29-backend-generalhw.t
+++ b/t/29-backend-generalhw.t
@@ -21,11 +21,12 @@ use Test::Most;
 my @invoked_cmds;
 BEGIN { *CORE::GLOBAL::sleep = sub { push @invoked_cmds, [sleep => shift] } }
 
+use FindBin '$Bin';
+use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use Test::MockModule;
 use Test::Warnings qw(:all :report_warnings);
 use Test::Fatal;
-use FindBin qw($Bin);
 use Mojo::File qw(tempdir);
 
 use bmwqemu;

--- a/t/30-mmapi.t
+++ b/t/30-mmapi.t
@@ -28,6 +28,8 @@ BEGIN {
     $ENV{MOJO_CONNECT_TIMEOUT}               = 0.01;
 }
 
+use FindBin;
+use lib "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use Test::Output;
 use Test::MockModule;

--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -17,13 +17,14 @@
 
 use Test::Most;
 
+use FindBin '$Bin';
+use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '240';
 use Test::Warnings ':report_warnings';
 use Try::Tiny;
 use File::Basename;
 use Cwd 'abs_path';
 use Mojo::JSON 'decode_json';
-use FindBin '$Bin';
 use Mojo::File 'tempdir';
 use Mojo::Util qw(scope_guard);
 


### PR DESCRIPTION
Same as done in openQA. This allows easy calls with `prove -I. t/`
instead of needing to specify the external directory as well all the
time.