### PR TITLE
Add generic serial terminal over SSH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ set(PERL_FILES
     consoles/serial_screen.pm
     consoles/sshIucvconn.pm
     consoles/ssh_screen.pm
+    consoles/sshSerial.pm
     consoles/sshVirtsh.pm
     consoles/sshVirtshSUT.pm
     consoles/sshX3270.pm

--- a/consoles/sshSerial.pm
+++ b/consoles/sshSerial.pm
@@ -1,0 +1,83 @@
+# Copyright © 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#
+# Simple serial terminal over SSH
+
+package consoles::sshSerial;
+
+use strict;
+use warnings;
+
+use base 'consoles::console';
+
+use consoles::ssh_screen;
+
+sub new {
+    my ($class, $testapi_console, $args) = @_;
+
+    return $class->SUPER::new($testapi_console, $args);
+}
+
+sub screen { shift->{screen} }
+
+sub disable {
+    my ($self) = @_;
+
+    return unless $self->{ssh};
+    bmwqemu::diag("Closing SSH connection with " . $self->{ssh}->hostname);
+    $self->{ssh}->disconnect;
+    $self->{ssh} = $self->{screen} = undef;
+    return;
+}
+
+sub activate {
+    my ($self) = @_;
+    my $hostname = $self->{args}->{hostname} || die('we need a hostname to ssh to');
+    my $password = $self->{args}->{password} // $testapi::password;
+    my $username = $self->{args}->{user}     // 'root';
+    my $pty_cols = $self->{args}->{pty_cols} // 2048;
+
+    bmwqemu::diag("Connecting SSH serial console for $username\@$hostname");
+
+    my $ssh = $self->backend->new_ssh_connection(
+        hostname => $hostname,
+        password => $password,
+        username => $username
+    );
+    my $chan = $ssh->channel()
+      or $ssh->die_with_error('Cannot open SSH channel');
+
+
+    # Enable echo, no ANSI color codes, $pty_cols character line width
+    # (Sending commands longer than line width will break read-back check)
+    $chan->pty('dumb', {echo => 1}, $pty_cols)
+      or $ssh->die_with_error('PTY request failed');
+    $chan->ext_data('merge');
+    $chan->shell or $ssh->die_with_error('Failed to start remote shell');
+    $chan->blocking(0);
+
+    $self->{screen} = consoles::ssh_screen->new(
+        ssh_connection => $ssh,
+        ssh_channel    => $chan,
+        logfile        => $self->{args}->{logfile} // "serial_terminal.txt"
+    );
+    $self->{ssh} = $ssh;
+    return;
+}
+
+sub is_serial_terminal { 1 }
+
+1;

--- a/consoles/ssh_screen.pm
+++ b/consoles/ssh_screen.pm
@@ -28,6 +28,11 @@ sub new {
     croak('Missing parameter ssh_connection') unless $self->ssh_connection;
     croak('Missing parameter ssh_channel')    unless $self->ssh_channel;
 
+    if ($self->{logfile}) {
+        open($self->{loghandle}, ">>", $self->{logfile})
+          or croak('Cannot open logfile ' . $self->{logfile});
+    }
+
     return $self->SUPER::new($self->ssh_channel);
 }
 
@@ -44,6 +49,7 @@ sub do_read
         my $read = $self->ssh_channel->read($buffer, $args{max_size});
         if (defined($read)) {
             $_[1] = $buffer;
+            print {$self->{loghandle}} $buffer if $self->{loghandle};
             return $read;
         }
 

--- a/distribution.pm
+++ b/distribution.pm
@@ -53,6 +53,7 @@ sub add_console {
 
     my %class_names = (
         'tty-console'       => 'ttyConsole',
+        'ssh-serial'        => 'sshSerial',
         'ssh-xterm'         => 'sshXtermVt',
         'ssh-virtsh'        => 'sshVirtsh',
         'ssh-virtsh-serial' => 'sshVirtshSUT',

--- a/t/31-sshSerial.t
+++ b/t/31-sshSerial.t
@@ -1,0 +1,191 @@
+#!/usr/bin/perl
+
+use Test::Most;
+use FindBin '$Bin';
+use lib "$Bin/../external/os-autoinst-common/lib";
+use OpenQA::Test::TimeLimit '20';
+use Test::MockObject;
+use Test::MockModule;
+use Test::Warnings ':report_warnings';
+use Test::Output;
+use Net::SSH2 'LIBSSH2_ERROR_EAGAIN';
+
+use consoles::sshSerial;
+
+my $eagain = [
+    LIBSSH2_ERROR_EAGAIN,
+    'LIBSSH2_ERROR_EAGAIN',
+    'Operation would block'
+];
+
+my $mock_backend = Test::MockObject->new();
+my $mock_ssh     = Test::MockObject->new();
+my $mock_channel = Test::MockObject->new();
+my $mock_bmwqemu = Test::MockModule->new('bmwqemu');
+
+$mock_ssh->{error} = undef;
+
+$mock_channel->{write_limits} = [];
+$mock_channel->{write_buffer} = '';
+$mock_channel->{read_queue}   = [];
+$mock_channel->{blocking}     = 1;
+
+$mock_channel->mock(pty      => sub { 1 });
+$mock_channel->mock(ext_data => sub { 1 });
+$mock_channel->mock(shell    => sub { 1 });
+$mock_channel->mock(send_eof => sub { 1 });
+
+$mock_ssh->mock(channel => sub { $mock_channel });
+
+$mock_backend->mock(new_ssh_connection => sub { $mock_ssh });
+
+$mock_bmwqemu->noop('diag', 'fctinfo', 'log_call');
+
+$mock_channel->mock(blocking => sub {
+        my ($self, $arg) = @_;
+
+        $self->{blocking} = $arg if defined($arg);
+        return $self->{blocking};
+});
+
+$mock_channel->mock(read => sub {
+        my ($self, undef, $size) = @_;
+
+        my $data = shift @{$self->{read_queue}};
+
+        if (!defined($data)) {
+            $mock_ssh->{error} = $eagain unless defined($mock_ssh->{error});
+            return undef;
+        }
+
+        if (length($data) > $size) {
+            unshift @{$self->{read_queue}}, substr($data, $size);
+            $data = substr($data, 0, $size);
+        }
+
+        $_[1] = $data;
+        return length($data);
+});
+
+$mock_channel->mock(write => sub {
+        my ($self, $data) = @_;
+        my $limit = shift @{$self->{write_limits}};
+
+        if (defined($limit) && $limit < 0) {
+            $mock_ssh->{error} = $eagain unless defined($mock_ssh->{error});
+            return undef;
+        }
+
+        $data = substr($data, 0, $limit) if defined($limit);
+        $self->{write_buffer} .= $data;
+        return length($data);
+});
+
+$mock_ssh->mock(blocking => sub {
+        my ($self, $arg) = @_;
+
+        return $mock_channel->blocking($arg);
+});
+
+$mock_ssh->mock(error => sub {
+        my $self = shift;
+
+        return undef unless defined($self->{error});
+        return ${$self->{error}}[0] if ((caller(0))[5]);
+        return @{$self->{error}};
+});
+
+$mock_ssh->mock(die_with_error => sub {
+        my ($self, $arg);
+
+        die $arg;
+});
+
+subtest 'Read test' => sub {
+    $mock_ssh->{error}            = undef;
+    $mock_channel->{write_limits} = [];
+    $mock_channel->{write_buffer} = '';
+    $mock_channel->{read_queue}   = [
+        'First line',
+        'Second line',
+        undef,
+        'Third line'
+    ];
+    $mock_channel->{blocking} = 1;
+
+    my $console = consoles::sshSerial->new(undef, {hostname => 'localhost'});
+    $console->backend($mock_backend);
+    $console->activate();
+    my $screen = $console->screen();
+    my $data;
+    my $ret;
+
+    ok(!$mock_channel->{blocking}, 'sshSerial sets non-blocking mode');
+
+    $ret = $screen->do_read($data);
+    is($data, 'First line');
+    is($ret,  length($data));
+
+    $ret = $screen->do_read($data);
+    is($data, 'Second line');
+    is($ret,  length($data));
+
+    # Test that do_read() loops on EAGAIN until data is available
+    $ret = $screen->do_read($data, timeout => 1);
+    is($data, 'Third line');
+    is($ret,  length($data));
+
+    # Test do_read() timeout
+    $ret = $screen->do_read($data, timeout => 1);
+    is($ret, undef);
+
+    # Test that read_until() can correctly assemble fragmented messages
+    $mock_channel->{read_queue} = [
+        'This message ',
+        undef,
+        'is fragmented',
+        ' a little b',
+        undef,
+        'it more t',
+        'han usual.',
+    ];
+
+    $ret = $screen->read_until('frag', 1);
+    ok($$ret{matched});
+    is($$ret{string}, 'This message is frag');
+
+    $ret = $screen->read_until('bit', 1);
+    ok($$ret{matched});
+    is($$ret{string}, 'mented a little bit');
+
+    $ret = $screen->read_until('foo', 1);
+    ok(!$$ret{matched});
+    is($$ret{string}, ' more than usual.');
+    is_deeply($mock_channel->{read_queue}, []);
+};
+
+subtest 'Write test' => sub {
+    $mock_ssh->{error}            = undef;
+    $mock_channel->{write_limits} = [];
+    $mock_channel->{write_buffer} = '';
+    $mock_channel->{read_queue}   = [];
+    $mock_channel->{blocking}     = 1;
+
+    my $console = consoles::sshSerial->new(undef, {hostname => 'localhost'});
+    $console->backend($mock_backend);
+    $console->activate();
+    my $screen = $console->screen();
+
+    ok(!$mock_channel->{blocking}, 'sshSerial sets non-blocking mode');
+
+    $screen->type_string({text => 'Hello, world!'});
+    is($mock_channel->{write_buffer}, 'Hello, world!');
+
+    # Test that type_string() will loop until all data is written
+    $mock_channel->{write_buffer} = '';
+    $mock_channel->{write_limits} = [5, 2, -1, 10, -1, -1, -1, 8];
+    $screen->type_string({text => 'A slightly longer test string.'});
+    is($mock_channel->{write_buffer}, 'A slightly longer test string.');
+};
+
+done_testing;


### PR DESCRIPTION
Quite suprisingly, we still don't have a real serial terminal over SSH. Just a lot of VNC-over-SSH tunnels. Having a real serial terminal would significantly speed up tests on baremetal, s390 and SPVM.

This is an implementation of generic text-based SSH serial terminal that'll work with any SUT which runs an SSH server accessible (via network) from the worker instance. One minor limitation is that commands longer than ~2000 characters will not be echoed by SSH in full which will cause `script_run()` errors.

Note that this serial terminal could be modified to execute commands directly without sending special termination markers around but that would require redesign of the `script_run()` logic in `distribution.pm`. This would also eliminate the command length limitation mentioned above.