### PR TITLE
Filter out carriage returns

### DIFF
--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -233,13 +233,13 @@ sub start_serial_grab {
         # libvirt esx driver does not support `virsh console', so
         # we have to connect to VM's serial port via TCP which is
         # provided by ESXi server.
-        $cmd = 'nc ' . get_var('VMWARE_HOST') . ' ' . get_var('VMWARE_SERIAL_PORT');
+        $cmd = 'socat - TCP4:' . get_var('VMWARE_HOST') . ':' . get_var('VMWARE_SERIAL_PORT') . ',crnl';
     }
     elsif (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
         # Hyper-V does not support serial console export via TCP, just
         # windows named pipes (e.g. \\.\pipe\mypipe). Such a named pipe
         # has to be enabled by a namedpipe-to-TCP on HYPERV_SERVER application.
-        $cmd = 'nc ' . get_var('HYPERV_SERVER') . ' ' . get_var('HYPERV_SERIAL_PORT');
+        $cmd = 'socat - TCP4:' . get_var('HYPERV_SERVER') . ':' . get_var('HYPERV_SERIAL_PORT') . ',crnl';
     }
     else {
         $cmd = 'virsh console ' . $name;
@@ -280,13 +280,13 @@ sub open_serial_console_via_ssh {
         # libvirt esx driver does not support `virsh console', so
         # we have to connect to VM's serial port via TCP which is
         # provided by ESXi server.
-        $cmd = 'nc ' . get_var('VMWARE_HOST') . ' ' . $port;
+        $cmd = 'socat - TCP4:' . get_var('VMWARE_HOST') . ':' . $port . ',crnl';
     }
     elsif (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
         # Hyper-V does not support serial console export via TCP, just
         # windows named pipes (e.g. \\.\pipe\mypipe). Such a named pipe
         # has to be enabled by a namedpipe-to-TCP on HYPERV_SERVER application.
-        $cmd = 'nc ' . get_var('HYPERV_SERVER') . ' ' . $port;
+        $cmd = 'socat - TCP4:' . get_var('HYPERV_SERVER') . ':' . $port . ',crnl';
     }
     else {
         $cmd = "virsh console $name $devname$port";

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -261,16 +261,16 @@ subtest 'Method backend::svirt::open_serial_console_via_ssh()' => sub {
 
     $bmwqemu::vars{VIRSH_VMM_FAMILY} = 'vmware';
     $bmwqemu::vars{VMWARE_HOST}      = 'my.vmware.host';
-    $run_ssh_expect                  = 'nc my.vmware.host\s*;';
+    $run_ssh_expect                  = 'socat - TCP4:my.vmware.host:,crnl;';
     $svirt->open_serial_console_via_ssh('NAME');
-    $run_ssh_expect = 'nc my.vmware.host 666\s*;';
+    $run_ssh_expect = 'socat - TCP4:my.vmware.host:666,crnl;';
     $svirt->open_serial_console_via_ssh('NAME', port => 666);
 
     $bmwqemu::vars{VIRSH_VMM_FAMILY} = 'hyperv';
     $bmwqemu::vars{HYPERV_SERVER}    = 'my.hyperv.server';
-    $run_ssh_expect                  = 'nc my.hyperv.server\s*;';
+    $run_ssh_expect                  = 'socat - TCP4:my.hyperv.server:,crnl;';
     $svirt->open_serial_console_via_ssh('NAME');
-    $run_ssh_expect = 'nc my.hyperv.server 666\s*;';
+    $run_ssh_expect = 'socat - TCP4:my.hyperv.server:666,crnl;';
     $svirt->open_serial_console_via_ssh('NAME', port => 666);
 
     # Disable command check, as we do not care anymore

--- a/testapi.pm
+++ b/testapi.pm
@@ -927,6 +927,8 @@ sub wait_serial {
     # record_serialresult()
     $matched = $matched ? 'ok' : 'fail';
     # convert dos2unix (poo#20542)
+    # hyperv and vmware (backend/svirt.pm) connect serial line over TCP/IP (socat)
+    # convert CRLF to LF only
     $ret->{string} =~ s,\r\n,\n,g;
     $autotest::current_test->record_serialresult(bmwqemu::pp($regexp), $matched, $ret->{string}) unless ($args{quiet});
     bmwqemu::fctres("$regexp: $matched");


### PR DESCRIPTION
Jobs running on hyperv or vmware usually contain LF and CR.
In our particular case `0d  0d  0a` seems to be present in each line of
SUTs output.

Received string from hyperv job:

```
 $VAR1 = 'n1~0x

NAME="SLES"

VERSION="15-SP3 Beta2"

VERSION_ID="15.3"

PRETTY_NAME="SUSE Linux Enterprise Server 15 SP3 (Beta2)"

ID="sles"

ID_LIKE="suse"

ANSI_COLOR="0;32"

CPE_NAME="cpe:/o:suse:sles:15:sp3"

DOCUMENT_URL="https://documentation.suse.com/"

SCRIPT_FINISHEDn1~0x-0-

';
```
Ouput in hex:

```
$VAR1 = ' 6e  31  7e  30  78  0d  0d  0a  4e  41  4d  45  3d  22  53  4c  45  53  22  0d  0d  0a  56  45  52  53  49  4f  4e  3d  22  31  35  2d  53  50  33  20  42  65  74  61  32  22  0d  0d  0a  56  45  52  53  49  4f  4e  5f  49  44  3d  22  31  35  2e  33  22  0d  0d  0a  50  52  45  54  54  59  5f  4e  41  4d  45  3d  22  53  55  53  45  20  4c  69  6e  75  78  20  45  6e  74  65  72  70  72  69  73  65  20  53  65  72  76  65  72  20  31  35  20  53  50  33  20  28  42  65  74  61  32  29  22  0d  0d  0a  49  44  3d  22  73  6c  65  73  22  0d  0d  0a  49  44  5f  4c  49  4b  45  3d  22  73  75  73  65  22  0d  0d  0a  41  4e  53  49  5f  43  4f  4c  4f  52  3d  22  30  3b  33  32  22  0d  0d  0a  43  50  45  5f  4e  41  4d  45  3d  22  63  70  65  3a  2f  6f  3a  73  75  73  65  3a  73  6c  65  73  3a  31  35  3a  73  70  33  22  0d  0d  0a  44  4f  43  55  4d  45  4e  54  5f  55  52  4c  3d  22  68  74  74  70  73  3a  2f  2f  64  6f  63  75  6d  65  6e  74  61  74  69  6f  6e  2e  73  75  73  65  2e  63  6f  6d  2f  22  0d  0d  0a  53  43  52  49  50  54  5f  46  49  4e  49  53  48  45  44  6e  31  7e  30  78  2d  30  2d  0d  0d  0a ';
```

After filtering:

```
$VAR1 = 'n1~0x
NAME="SLES"
VERSION="15-SP3 Beta2"
VERSION_ID="15.3"
PRETTY_NAME="SUSE Linux Enterprise Server 15 SP3 (Beta2)"
ID="sles"
ID_LIKE="suse"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:suse:sles:15:sp3"
DOCUMENT_URL="https://documentation.suse.com/"
SCRIPT_FINISHEDn1~0x-0-
';
```

```
$VAR1 = ' 6e  31  7e  30  78  0a  4e  41  4d  45  3d  22  53  4c  45  53  22  0a  56  45  52  53  49  4f  4e  3d  22  31  35  2d  53  50  33  20  42  65  74  61  32  22  0a  56  45  52  53  49  4f  4e  5f  49  44  3d  22  31  35  2e  33  22  0a  50  52  45  54  54  59  5f  4e  41  4d  45  3d  22  53  55  53  45  20  4c  69  6e  75  78  20  45  6e  74  65  72  70  72  69  73  65  20  53  65  72  76  65  72  20  31  35  20  53  50  33  20  28  42  65  74  61  32  29  22  0a  49  44  3d  22  73  6c  65  73  22  0a  49  44  5f  4c  49  4b  45  3d  22  73  75  73  65  22  0a  41  4e  53  49  5f  43  4f  4c  4f  52  3d  22  30  3b  33  32  22  0a  43  50  45  5f  4e  41  4d  45  3d  22  63  70  65  3a  2f  6f  3a  73  75  73  65  3a  73  6c  65  73  3a  31  35  3a  73  70  33  22  0a  44  4f  43  55  4d  45  4e  54  5f  55  52  4c  3d  22  68  74  74  70  73  3a  2f  2f  64  6f  63  75  6d  65  6e  74  61  74  69  6f  6e  2e  73  75  73  65  2e  63  6f  6d  2f  22  0a  53  43  52  49  50  54  5f  46  49  4e  49  53  48  45  44  6e  31  7e  30  78  2d  30  2d  0a ';
```