### PR TITLE
t: Prevent sporadic timeout failure in 10-virtio_terminal.t

### DIFF
--- a/t/10-virtio_terminal.t
+++ b/t/10-virtio_terminal.t
@@ -3,9 +3,8 @@
 
 use Test::Most;
 
-use FindBin '$Bin';
-use lib "$Bin/../external/os-autoinst-common/lib";
-use OpenQA::Test::TimeLimit '10';
+# OpenQA::Test::TimeLimit not used as `prepare_pipes` defines an ALRM handler
+# internally already
 use Test::MockModule;
 use Test::Output;
 use POSIX 'mkfifo';


### PR DESCRIPTION
A problem was found in various CI runs of tests where t/10-virtio_terminal.t
would run into a timeout, especially when tests are running within OBS.

I could reprodce the problem locally using
https://github.com/okurz/scripts/tree/master/count_fail_ratio

```
env runs=4000 count_fail_ratio prove -I. t/10-virtio_terminal.t
```

which showed 4/4000 fails, showing

```
t/10-virtio_terminal.t .. Bailout called.  Further testing stopped:  test exceeds runtime limit of '10' seconds
Timeout for pipe other side helper at t/10-virtio_terminal.t line 33.
FAILED--Further testing stopped: test exceeds runtime limit of '10' seconds
```

so a fail rate of only 0.1% but still reproducible. This is depending on timing
behaviour if this can happen more often, for example in a CI environment or
when running with coverage analysis enabled.

Line 33 is an internal alarm handler. Because we try to use an alarm handler
for the overall test module timeout here as well this can cause conflicts. The
actual problem seems to be deeper within t/10-virtio_terminal.t as when
disabling OpenQA::Test::TimeLimit I could find:

```
t/10-virtio_terminal.t ..

Timeout for pipe other side helper at t/10-virtio_terminal.t line 32.
t/10-virtio_terminal.t .. ok
All tests successful.
Files=1, Tests=1, 60 wallclock secs ( 0.02 usr  0.00 sys +  0.33 cusr  0.04 csys =  0.39 CPU)
```

so there is a timeout, it is handled internally but not failing the test.
Considering that normally the test module takes less than 1 second I consider
this suboptimal but to prevent non-actionable failures due to a too short
timeout I disable OpenQA::Test::TimeLimit with this commit.

Related progress issue: https://progress.opensuse.org/issues/81150