### PR TITLE
tools: Add prove arg --timer to be consistent with openQA

### DIFF
--- a/tools/invoke-tests
+++ b/tools/invoke-tests
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+PROVE_ARGS="${PROVE_ARGS:-"--timer"}"
+
 source_directory=$(dirname "$0")/..
 source_directory=$(realpath "$source_directory")
 


### PR DESCRIPTION
Same as for openQA I consider it worthwhile to call prove with the
"--timer" argument so that we get a report about the runtime of 
individual test modules, especially from CI runs.

This commit adds the prove arg "--timer" as default value for the
variable PROVE_ARGS which is used within tools/invoke-tests where prove
is called.