### PR TITLE
Use Mojolicious::Routes::Route::any instead of deprecated …::route

### DIFF
--- a/commands.pm
+++ b/commands.pm
@@ -250,7 +250,7 @@ sub run_daemon {
 
     my $r = app->routes;
     $r->namespaces(['OpenQA']);
-    my $token_auth = $r->route("/$bmwqemu::vars{JOBTOKEN}");
+    my $token_auth = $r->any("/$bmwqemu::vars{JOBTOKEN}");
 
     # for access all data as CPIO archive
     $token_auth->get('/data' => \&test_data);


### PR DESCRIPTION
Otherwise
```
Mojolicious::Routes::Route::route is DEPRECATED in favor of Mojolicious::Routes::Route::any at …/commands.pm line 253.
```
shows up in the log.