### PR TITLE
Update Perl::Tidy to 20210111

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -52,7 +52,7 @@ __PACKAGE__->mk_accessors(
       reference_screenshot assert_screen_tags assert_screen_needles
       assert_screen_deadline assert_screen_fails assert_screen_last_check
       stall_detected
-      ));
+    ));
 
 sub new {
     my $class = shift;

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -813,7 +813,7 @@ sub start_qemu {
         }
     }
 
-    bmwqemu::save_vars();                     # update variables
+    bmwqemu::save_vars();    # update variables
 
     mkpath($basedir);
 

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -25,7 +25,7 @@ __PACKAGE__->mk_accessors(
       no_endian_conversion  _pixinfo _colourmap _framebuffer _rfb_version screen_on
       _bpp _true_colour _do_endian_conversion absolute ikvm keymap _last_update_received
       _last_update_requested check_vnc_stalls _vnc_stalled vncinfo old_ikvm dell
-      ));
+    ));
 
 our $VERSION = '0.40';
 
@@ -36,7 +36,7 @@ my $client_is_big_endian = unpack('h*', pack('s', 1)) =~ /01/ ? 1 : 0;
 
 # The numbers in the hashes below were acquired from the VNC source code
 my %supported_depths = (
-    32 => {                                              # same as 24 actually
+    32 => {    # same as 24 actually
         bpp         => 32,
         true_colour => 1,
         red_max     => 255,
@@ -175,7 +175,7 @@ sub login {
         $self->_client_initialization();
         $self->_server_initialization();
     };
-    my $error = $@;                                  # store so it doesn't get overwritten
+    my $error = $@;    # store so it doesn't get overwritten
     if ($error) {
 
         # clean up so socket can be garbage collected
@@ -462,18 +462,18 @@ sub _server_initialization {
     }
 
     my $info = tinycv::new_vncinfo(
-        $self->_do_endian_conversion, $self->_true_colour, $self->_bpp / 8, $pixinfo{red_max}, $pixinfo{red_shift},
-        $pixinfo{green_max}, $pixinfo{green_shift}, $pixinfo{blue_max}, $pixinfo{blue_shift});
+        $self->_do_endian_conversion, $self->_true_colour,   $self->_bpp / 8,    $pixinfo{red_max}, $pixinfo{red_shift},
+        $pixinfo{green_max},          $pixinfo{green_shift}, $pixinfo{blue_max}, $pixinfo{blue_shift});
     $self->vncinfo($info);
 
     # setpixelformat
     $socket->print(
         pack(
             'CCCCCCCCnnnCCCCCC',
-            0,     # message_type
-            0,     # padding
-            0,     # padding
-            0,     # padding
+            0,    # message_type
+            0,    # padding
+            0,    # padding
+            0,    # padding
             $self->_bpp,
             $self->depth,
             $self->_do_endian_conversion,
@@ -484,9 +484,9 @@ sub _server_initialization {
             $pixinfo{red_shift},
             $pixinfo{green_shift},
             $pixinfo{blue_shift},
-            0,     # padding
-            0,     # padding
-            0,     # padding
+            0,    # padding
+            0,    # padding
+            0,    # padding
         ));
 
     # set encodings

--- a/consoles/sshSerial.pm
+++ b/consoles/sshSerial.pm
@@ -44,7 +44,7 @@ sub disable {
 }
 
 sub activate {
-    my ($self) = @_;
+    my ($self)   = @_;
     my $hostname = $self->{args}->{hostname} || die('we need a hostname to ssh to');
     my $password = $self->{args}->{password} // $testapi::password;
     my $username = $self->{args}->{user}     // 'root';

--- a/cpanfile
+++ b/cpanfile
@@ -95,7 +95,7 @@ on 'test' => sub {
 on 'devel' => sub {
     requires 'Devel::Cover';
     requires 'Devel::Cover::Report::Codecov';
-    requires 'Perl::Tidy', '== 20201207';
+    requires 'Perl::Tidy', '== 20210111';
 
 };
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -43,7 +43,7 @@ devel_requires:
   '%test_requires':
   perl(Devel::Cover):
   perl(Devel::Cover::Report::Codecov):
-  perl(Perl::Tidy): '== 20201207'
+  perl(Perl::Tidy): '== 20210111'
 
 docker_requires:
   pkgconfig(opencv):

--- a/t/00-compile-check-all.t
+++ b/t/00-compile-check-all.t
@@ -49,7 +49,7 @@ if (-d '.git' and which('git')) {
         my @all_git_files = qx{git ls-files};
         chomp(@all_git_files);
         my $files_to_skip = $Test::Strict::TEST_SKIP || [];
-        my %skip = map { $_ => undef } @$files_to_skip;
+        my %skip          = map { $_ => undef } @$files_to_skip;
         return map { $root . $_ } grep { !exists $skip{$_} } @all_git_files;    # Exclude files to skip
     }
 }

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -387,7 +387,7 @@ is(match_has_tag,        undef, 'match_has_tag on no value -> undef');
 is(match_has_tag('foo'), undef, 'match_has_tag on not matched tag -> undef');
 subtest 'assert_and_click' => sub {
     my $mock_testapi = Test::MockModule->new('testapi');
-    my @areas = ({x => 1, y => 2, w => 10, h => 20});
+    my @areas        = ({x => 1, y => 2, w => 10, h => 20});
     $mock_testapi->redefine(assert_screen => {area => \@areas});
 
     $cmds = [];
@@ -442,8 +442,8 @@ subtest 'assert_and_click' => sub {
     is_deeply($cmds->[-1], {cmd => 'backend_mouse_hide', offset => 0}, 'assert_and_click succeeds and hides mouse with mousehide => 1');
 
     ok(assert_and_click('foo', button => 'right'));
-    is_deeply($cmds->[-2], {bstate => 0, button => 'right', cmd => 'backend_mouse_button'}, 'assert_and_click succeeds with right click');
-    is_deeply($cmds->[-1], {cmd => 'backend_mouse_set', x => 100, y => 100}, 'assert_and_click succeeds and move to old mouse set');
+    is_deeply($cmds->[-2], {bstate => 0,                   button => 'right', cmd => 'backend_mouse_button'}, 'assert_and_click succeeds with right click');
+    is_deeply($cmds->[-1], {cmd    => 'backend_mouse_set', x      => 100,     y   => 100}, 'assert_and_click succeeds and move to old mouse set');
 };
 
 subtest 'assert_and_dclick' => sub {
@@ -726,7 +726,7 @@ subtest '_calculate_clickpoint' => sub {
 
 subtest 'mouse_drag' => sub {
     my $mock_testapi = Test::MockModule->new('testapi');
-    my @area = ({x => 100, y => 100, w => 20, h => 20});
+    my @area         = ({x => 100, y => 100, w => 20, h => 20});
     $mock_testapi->redefine(assert_screen => {area => \@area});
 
     my ($startx, $starty) = (0,   0);

--- a/t/10-terminal.t
+++ b/t/10-terminal.t
@@ -278,7 +278,7 @@ sub test_terminal_directly {
         no_regex    => 1,
         buffer_size => 256
     );
-    report_child_test(is => length($result->{string}), 256, 'direct: returned data is same length as buffer');
+    report_child_test(is   => length($result->{string}), 256,                               'direct: returned data is same length as buffer');
     report_child_test(like => $result->{string}, qr/\Q$US_keyboard_data\E$stop_code_data$/, 'direct: read a large amount of data with small ring buffer');
     type_string($next_test);
 

--- a/t/29-backend-generalhw.t
+++ b/t/29-backend-generalhw.t
@@ -79,7 +79,7 @@ subtest 'start VM' => sub {
     is_deeply($backend->do_start_vm, {}, 'return value');
     is_deeply(\@invoked_cmds, [
             [$cmd_ctl, 'poweroff'], [$cmd_ctl, 'flash', 'light', '/hdd', '5G'], [$cmd_ctl, 'poweroff'],
-            ['sleep', 3], [$cmd_ctl, 'poweron'], 'start_serial_grab'
+            ['sleep',  3],          [$cmd_ctl, 'poweron'], 'start_serial_grab'
     ], 'poweroff/on commands invoked') or diag explain \@invoked_cmds;
     is_deeply(\@vnc_logins, [['vnc.server']], 'tried to connect to VNC server') or diag explain \@vnc_logins;
 };


### PR DESCRIPTION
Let's see whether the failure from https://github.com/os-autoinst/os-autoinst/pull/1613 happens here as well.

EDIT: It doesn't but Perl::Tidy needs to be updated.