### PR TITLE
tools/tidy: Use the perltidy version from the calling repo

### DIFF
--- a/tools/tidy
+++ b/tools/tidy
@@ -49,9 +49,14 @@ if ! command -v perltidy > /dev/null 2>&1; then
 fi
 
 # cpan file is in top directory
-dir="$(dirname $(readlink -f $0))/.."
-perltidy_version_found=$(perltidy -version | sed -n '1s/^.*perltidy, v\([0-9]*\)\s*$/\1/p')
+dir="$(dirname $0)/.."
 perltidy_version_expected=$(sed -n "s/^.*Tidy[^0-9]*\([0-9]*\)['];$/\1/p" $dir/cpanfile)
+if [ -z "${perltidy_version_expected}" ]; then
+    # No cpanfile in the linked repo, use the one from os-autoinst instead
+    dir="$(dirname $(readlink -f $0))/.."
+    perltidy_version_expected=$(sed -n "s/^.*Tidy[^0-9]*\([0-9]*\)['];$/\1/p" $dir/cpanfile)
+fi
+perltidy_version_found=$(perltidy -version | sed -n '1s/^.*perltidy, v\([0-9]*\)\s*$/\1/p')
 if [ "$perltidy_version_found" != "$perltidy_version_expected" ]; then
     echo -n "Wrong version of perltidy. Found '$perltidy_version_found', expected '$perltidy_version_expected'."
     if [[ "$force" = "true" ]]; then


### PR DESCRIPTION
tools/tidy is linked into various other repos as well, which use it for running
perltidy on the contained code. Those repos have their own cpanfile which may
specify a different version of Perl::Tidy, which should get used instead.
This is especially important if os-autoinst is always pulled from master, as
changes in its cpanfile otherwise affect other repos as well.

If the repo tools/tidy is run against does not specify a version of Perl::Tidy,
it falls back to the old behaviour.