### PR TITLE
VNC: Improve error message on key mapping

### DIFF
--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -738,7 +738,7 @@ sub map_and_send_key {
             next;
         }
         else {
-            die "No map for '$key'";
+            die "Key '$key' not found in map ($keys)";
         }
     }
 


### PR DESCRIPTION
A failed assert_script_run with unicode - lookalike characters leads to a message like `No map for 'Ã'`. The error should clarify the intention and refer to all keys to provide more context. So the error should make more sense as a "reason" w/o reading os-autoinst source code.

~@ilausuch might have a ticket reference shortly~ [poo#88061](https://progress.opensuse.org/issues/88061)

The offending line was `assert_script_run("podman run -d -e POSTGRES_PASSWORD=openqa -e POSTGRES_USER=openqa -e POSTGRES_DB=openqa –network-alias=db --name db postgres", timeout => 600);` in the particular case. Look really hard if you don't see the problem with this command.