### PR TITLE
tools: Update path to Tumbleweed based new dev image

### DIFF
--- a/container/os-autoinst_dev/Dockerfile
+++ b/container/os-autoinst_dev/Dockerfile
@@ -20,6 +20,7 @@ RUN zypper in -y -C \
        aspell-en \
        aspell-spell \
        cmake \
+       cpio \
        gcc-c++ \
        git-core \
        ninja \

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -63,6 +63,7 @@ lint_requires:
 
 test_base_requires:
   '%main_requires':
+  cpio:
   perl(Benchmark):
   perl(Devel::Cover):
   perl(FindBin):

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -63,7 +63,7 @@ Source0:        %{name}-%{version}.tar.xz
 %define yamllint_requires %{nil}
 %endif
 # The following line is generated from dependencies.yaml
-%define test_base_requires %main_requires perl(Benchmark) perl(Devel::Cover) perl(FindBin) perl(Pod::Coverage) perl(Test::Fatal) perl(Test::Mock::Time) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::Most) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 procps python3-setuptools qemu qemu-tools qemu-x86
+%define test_base_requires %main_requires cpio perl(Benchmark) perl(Devel::Cover) perl(FindBin) perl(Pod::Coverage) perl(Test::Fatal) perl(Test::Mock::Time) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::Most) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 procps python3-setuptools qemu qemu-tools qemu-x86
 # The following line is generated from dependencies.yaml
 %define test_version_only_requires perl(Mojo::IOLoop::ReadWriteProcess) >= 0.28
 # The following line is generated from dependencies.yaml

--- a/t/07-commands.t
+++ b/t/07-commands.t
@@ -127,8 +127,7 @@ subtest 'web socket route' => sub {
 };
 
 subtest 'data api (directory download)' => sub {
-    # we need `cpio` for these tests
-    ok(-x which 'cpio', 'cpio exists');
+    die "'cpio' is needed for these tests" unless which 'cpio';
 
     $t->get_ok("$base_url/$job/data")->status_is(200)->content_type_is('application/x-cpio');
     my $tmpdir  = tempdir;

--- a/tools/docker_run_ci
+++ b/tools/docker_run_ci
@@ -39,18 +39,20 @@ done
 
 CI_ENV=$(bash <(curl -s https://codecov.io/env))
 
-IMAGE=registry.opensuse.org/devel/openqa/containers15.2/os-autoinst_dev
+IMAGE=registry.opensuse.org/devel/openqa/containers/os-autoinst_dev
 docker pull $IMAGE
 docker images | grep opensuse
 
 # shellcheck disable=SC2086
 docker run --env "QEMU_QMP_CONNECT_ATTEMPTS=10" \
   $CI_ENV --rm --entrypoint '' -v "$PWD":/opt $IMAGE sh -ec "
-echo 'Newer docker versions need a patched qemu with disabled membarrier'
 . /etc/os-release
-zypper -n addrepo http://download.opensuse.org/repositories/devel:/openQA:/ci/openSUSE_Leap_\${VERSION} qemu
-zypper -n --gpg-auto-import-keys --no-gpg-checks refresh
-zypper -n in --from qemu qemu qemu-x86 qemu-tools qemu-ipxe qemu-sgabios qemu-seabios
+if [[ \"$ID\" == \"opensuse-leap\" ]]; then
+    echo 'Newer docker versions need a patched qemu with disabled membarrier'
+    zypper -n addrepo http://download.opensuse.org/repositories/devel:/openQA:/ci/openSUSE_Leap_\${VERSION} qemu
+    zypper -n --gpg-auto-import-keys --no-gpg-checks refresh
+    zypper -n in --from qemu qemu qemu-x86 qemu-tools qemu-ipxe qemu-sgabios qemu-seabios
+fi
 [[ \"$target\" == \"coverage-codecovbash\" ]] && zypper -n in perl-App-cpanminus && cpanm -nq 'Devel::Cover::Report::Codecovbash'
 cd /opt
 ./tools/install-new-deps.sh


### PR DESCRIPTION
The OBS project changed the path under which we can get the new
development image for CI jobs.

Related progress issue: https://progress.opensuse.org/issues/80962