### PR TITLE
Handle '&' terminator in "script_run"; Add new test API function "enter_cmd"

### DIFF
--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -1,4 +1,4 @@
-# Copyright © 2018-2019 SUSE LLC
+# Copyright © 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,7 +22,7 @@ use warnings;
 # -> increment on every change of such APIs
 # -> never move that variable to another place (when refactoring)
 #    because it may be accessed by the tests itself
-our $version = 20;
+our $version = 21;
 
 # major version of the (web socket) API relevant to the developer mode
 # -> increment when making non-backward compatible changes to that API

--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -22,7 +22,7 @@ use warnings;
 # -> increment on every change of such APIs
 # -> never move that variable to another place (when refactoring)
 #    because it may be accessed by the tests itself
-our $version = 21;
+our $version = 22;
 
 # major version of the (web socket) API relevant to the developer mode
 # -> increment when making non-backward compatible changes to that API

--- a/distribution.pm
+++ b/distribution.pm
@@ -141,8 +141,9 @@ sub script_run {
     }
     testapi::type_string "$cmd";
     if ($args{timeout} > 0) {
-        my $str    = testapi::hashed_string("SR" . $cmd . $args{timeout});
-        my $marker = "; echo $str-\$?-" . ($args{output} ? "Comment: $args{output}" : '');
+        my $terminator = ((substr $cmd, -1) eq '&') ? '' : ';';
+        my $str        = testapi::hashed_string("SR" . $cmd . $args{timeout});
+        my $marker     = "$terminator echo $str-\$?-" . ($args{output} ? "Comment: $args{output}" : '');
         if (testapi::is_serial_terminal) {
             testapi::type_string($marker);
             testapi::wait_serial($cmd . $marker, no_regex => 1, quiet => $args{quiet});

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -153,6 +153,10 @@ subtest 'type_string' => sub {
     is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 10, text => 'hal'}, {cmd => 'backend_type_string', max_interval => 10, text => 'lo'},]);
     $cmds = [];
 
+    type_string 'true', lf => 1;
+    is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 250, text => "true\n"}]);
+    $cmds = [];
+
     $testapi::password = 'stupid';
     type_password;
     is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 100, text => 'stupid'}]);

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -171,6 +171,12 @@ subtest 'type_string' => sub {
     $cmds = [];
 };
 
+subtest 'enter_cmd' => sub {
+    enter_cmd 'true';
+    is_deeply($cmds, [{cmd => 'backend_type_string', max_interval => 250, text => "true\n"}]);
+    $cmds = [];
+};
+
 subtest 'type_string with wait_still_screen' => sub {
     my $wait_still_screen_called = 0;
     my $module                   = Test::MockModule->new('testapi');

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -20,7 +20,7 @@ use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use Test::Warnings qw(:all :report_warnings);
-use Test::Fatal qw(lives_ok);
+use Test::Fatal;
 use Test::MockModule;
 
 subtest 'script_run' => sub {
@@ -40,8 +40,8 @@ subtest 'script_run' => sub {
     lives_ok { $d->script_run('foo') } 'script_run succeeds with trivial command';
     like $typed_string, qr/foo; echo .* > .*serial/, 'command is typed plus marker and redirection';
     $typed_string = '';
-    lives_ok { $d->script_run('foo &') } 'script_run with valid terminator ends';
-    like $typed_string, qr/foo & echo .* > .*serial/, 'command with already included terminator handled correctly';
+    like(exception { $d->script_run('foo &') }, qr/Terminator.*found.*type_string/, 'script_run with terminator is caught');
+    lives_ok { $d->script_run('foo\&') }, 'escaped terminator is accepted';
 };
 
 done_testing;

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -1,0 +1,49 @@
+#!/usr/bin/perl
+
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use Test::Most;
+use FindBin '$Bin';
+use lib "$Bin/../external/os-autoinst-common/lib";
+use OpenQA::Test::TimeLimit '5';
+use Test::Warnings qw(:all :report_warnings);
+use Test::Fatal qw(lives_ok);
+use Test::MockModule;
+
+subtest 'script_run' => sub {
+    require distribution;
+    my $d            = distribution->new;
+    my $mock_testapi = Test::MockModule->new('testapi');
+    $mock_testapi->redefine(type_string => undef);
+    $mock_testapi->redefine(wait_serial => undef);
+    like(warning { $d->script_run }->[0],   qr/^Use of uninitialized.*\$cmd/,     'Warning on incorrect usage');
+    like(warning { $d->script_run('foo') }, qr/^Use of uninitialized.*serialdev/, 'Warning on undefined serialdev');
+    {
+        no warnings 'once';
+        $testapi::serialdev = 'my_serial';
+    }
+    my $typed_string = '';
+    $mock_testapi->redefine(type_string => sub { $typed_string .= $_[0] });
+    lives_ok { $d->script_run('foo') } 'script_run succeeds with trivial command';
+    like $typed_string, qr/foo; echo .* > .*serial/, 'command is typed plus marker and redirection';
+    $typed_string = '';
+    lives_ok { $d->script_run('foo &') } 'script_run with valid terminator ends';
+    like $typed_string, qr/foo & echo .* > .*serial/, 'command with already included terminator handled correctly';
+};
+
+done_testing;
+
+1;

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -42,7 +42,7 @@ sub isotovideo {
 subtest 'get the version number' => sub {
     # Make sure we're in a folder we can't write to, no base_state.json should be created here
     chdir('/');
-    combined_like { system $^X, "$toplevel_dir/isotovideo", '--version' } qr/Current version is.+\[interface v20\]/, 'version printed';
+    combined_like { system $^X, "$toplevel_dir/isotovideo", '--version' } qr/Current version is.+\[interface v[0-9]+\]/, 'version printed';
     ok(!-e bmwqemu::STATE_FILE, 'no state file was written');
 };
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -44,6 +44,7 @@ our @EXPORT = qw($realname $username $password $serialdev %cmd %vars
   get_var get_required_var check_var set_var get_var_array check_var_array autoinst_url
 
   send_key send_key_until_needlematch type_string type_password
+  enter_cmd
   hold_key release_key
 
   assert_screen check_screen assert_and_dclick save_screenshot
@@ -87,6 +88,7 @@ sub send_key;
 sub check_screen;
 sub type_string;
 sub type_password;
+sub enter_cmd;
 
 
 =head1 introduction
@@ -1467,7 +1469,7 @@ A convenience wrapper around C<type_string>, which doesn't log the string.
 
 Uses C<$testapi::password> if no string is given.
 
-You can pass same optional parameters as for C<type_string> function.
+You can pass the same optional parameters as for C<type_string> function.
 
 =cut
 
@@ -1475,6 +1477,22 @@ sub type_password {
     my ($string, %args) = @_;
     $string //= $password;
     type_string $string, secret => 1, max_interval => ($args{max_interval} // 100), %args;
+}
+
+=head2 enter_cmd
+
+  enter_cmd($string [, max_interval => <num> ] [, wait_screen_changes => <num> ] [, wait_still_screen => <num> ] [, secret => 1 ]
+  [, timeout => <num>] [, similarity_level => <num>] );
+
+A convenience wrapper around C<type_string>, that adds a linefeed to execute a
+command within a command line prompt.
+
+You can pass the same optional parameters as for C<type_string> function.
+
+=cut
+
+sub enter_cmd {
+    type_string shift, lf => 1, @_;
 }
 
 =head1 mouse support

--- a/testapi.pm
+++ b/testapi.pm
@@ -1383,7 +1383,7 @@ sub send_key_until_needlematch {
 =head2 type_string
 
   type_string($string [, max_interval => <num> ] [, wait_screen_changes => <num> ] [, wait_still_screen => <num> ] [, secret => 1 ]
-  [, timeout => <num>] [, similarity_level => <num>] );
+  [, timeout => <num>] [, similarity_level => <num>] [, lf => 1 ]);
 
 send a string of characters, mapping them to appropriate key names as necessary
 
@@ -1404,6 +1404,9 @@ C<similarity_level> can be passed as argument for wrapped C<wait_still_screen> c
 
 C<secret (bool)> suppresses logging of the actual string typed.
 
+C<lf (bool)> finishes the string with an additional line feed, for example to
+enter a command line.
+
 =cut
 
 sub type_string {
@@ -1417,6 +1420,7 @@ sub type_string {
         %args = @_;
     }
     my $log = $args{secret} ? 'SECRET STRING' : $string;
+    $string .= "\n" if $args{lf};
 
     if (is_serial_terminal) {
         bmwqemu::log_call(text => $log, %args);


### PR DESCRIPTION
See individual commits

Related progress issue: https://progress.opensuse.org/issues/88452