### PR TITLE
doc: Correct explanation for NICVLAN

### DIFF
--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -98,7 +98,7 @@ NICMAC;any MAC address;52:54:00:12:34:56;MAC address to be assigned to virtual n
 NICMODEL;see qemu -device ?;virtio-net;Network device virtual NIC.
 NICTYPE;user|tap|vde;user;Instruct QEMU to either use user networking or to connect virtual NIC to existin system TAP device
 NICTYPE_USER_OPTIONS;string;undef;Arbitrary options for NICTYPE
-NICVLAN;integer;undef;network (vlan) number to which the NIC should be connected, assigned by scheduler to jobs with NICTYPE != user
+NICVLAN;integer;undef;Comma-separated list of network (vlan) numbers to which the NIC should be connected, assigned by scheduler to jobs with NICTYPE != user
 NUMDISKS;integer;1;Number of disks to be created and attached to VM, can be 0 to disable disks
 OFFLINE_SUT;boolean;0;Disable network for a VM
 OFW;boolean;0;QEMU Open Firmware is in use


### PR DESCRIPTION
Internally NICVLAN takes a comma-separated list so we should explain
that.