### PR TITLE
14-isovideo.t: create 'foo' branch in test git repo

### DIFF
--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -71,7 +71,7 @@ subtest 'isotovideo with custom git repo parameters specified' => sub {
     $base_state->remove       if -e $base_state;
     path('vars.json')->remove if -e 'vars.json';
     path('repo.git')->make_path;
-    my $git_init_output = qx{git init -q --bare repo.git 2>&1};
+    my $git_init_output = qx{git init -q --bare -b foo repo.git 2>&1};
     is($?, 0, 'initialized test repo') or diag explain $git_init_output;
     # Ensure the checkout folder does not exist so that git clone tries to
     # create a new checkout on every test run


### PR DESCRIPTION
The test uses this branch, but doesn't create it when setting up
the repo. Somehow this seems to work most of the time - I'm not
sure how - but fails on package builds in Fedora infrastructure
(it works doing a package build locally in mock, oddly). Creating
the branch when setting up the repo seems to avoid the problem.

Signed-off-by: Adam Williamson <awilliam@redhat.com>