### PR TITLE
t: Explicitly import Test::Output functions

### DIFF
--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -6,7 +6,7 @@ use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '20';
 use autodie ':all';
 use IPC::System::Simple qw(system);
-use Test::Output;
+use Test::Output qw(combined_like combined_from);
 use File::Basename;
 use File::Path qw(remove_tree rmtree);
 use Cwd 'abs_path';


### PR DESCRIPTION
In Test::Output version 1.032 certain functions don't seem to be exported by
default anymore.
Since explicit imports are preferrable most of the times, we can
just fix it with that.

The error message:

    Can't locate object method "combined_from" via package "12466: EXIT 1
    " (perhaps you forgot to load "12466: EXIT 1
    "?) at t/14-isotovideo.t line 79.

See also #1621 