### PR TITLE
Create symlinks by default in convenience Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 .PHONY: all
 all: build/CMakeCache.txt
-	ninja -C build/ all
+	ninja -C build/ symlinks
 
 .DEFAULT: build/CMakeCache.txt
 	ninja -C build/ $@

--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ all: build/CMakeCache.txt
 
 build/CMakeCache.txt:
 	@mkdir -p build
-	@(cd build && cmake -GNinja ..)
+	@cmake -B build -S . -G Ninja


### PR DESCRIPTION
*  Create symlinks by default in convenience Makefile

   This should help with the use-case where the user only reads the first
   paragraph of the build instructions to use the convenience Makefile for
   local development (see https://progress.opensuse.org/issues/89077).
* Simplify the CMake invocation within the convenience Makefile
