### PR TITLE
Make hyperv powershell commands work in non-interactive ssh session

### DIFF
--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -83,7 +83,7 @@ sub do_stop_vm {
         if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
             my $ps = 'powershell -Command';
             $self->run_ssh_cmd("$ps Stop-VM -Force -VMName $vmname -TurnOff");
-            $self->run_ssh_cmd("$ps Remove-VM -Force -VMName $vmname");
+            $self->run_ssh_cmd(qq($ps "\$ProgressPreference='SilentlyContinue'; Remove-VM -Force -VMName $vmname"));
         }
         else {
             my $virsh = 'virsh';
@@ -153,7 +153,7 @@ sub save_snapshot {
     if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
         my $ps = 'powershell -Command';
         $self->run_ssh_cmd("$ps Remove-VMSnapshot -VMName $vmname -Name $snapname");
-        $rsp = $self->run_ssh_cmd("$ps Checkpoint-VM -VMName $vmname -SnapshotName $snapname");
+        $rsp = $self->run_ssh_cmd(qq($ps "\$ProgressPreference='SilentlyContinue'; Checkpoint-VM -VMName $vmname -SnapshotName $snapname"));
     }
     else {
         my $libvirt_connector = get_var('VMWARE_REMOTE_VMM', '');
@@ -173,7 +173,7 @@ sub load_snapshot {
     my $post_load_snapshot_command = '';
     if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
         my $ps = 'powershell -Command';
-        $rsp = $self->run_ssh_cmd("$ps Restore-VMSnapshot -VMName $vmname -Name $snapname -Confirm:\$false");
+        $rsp = $self->run_ssh_cmd(qq($ps "\$ProgressPreference='SilentlyContinue'; Restore-VMSnapshot -VMName $vmname -Name $snapname -Confirm:\$false"));
         $self->run_ssh_cmd("mv -v xfreerdp_${vmname}_stop xfreerdp_${vmname}_stop.bkp", $self->get_ssh_credentials('hyperv'));
 
         for my $i (1 .. 5) {

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -193,6 +193,9 @@ subtest 'SSH usage in svirt' => sub {
     isnt($svirt->run_ssh_cmd('test 23 -eq 42'), 0, 'Command failed exit');
     my @output = $svirt->run_ssh_cmd('echo -n "foo"', wantarray => 1);
     is_deeply(\@output, [0, 'foo', ''], 'Command successful exit with output');
+    # Check more complicated command (like those we execute against Hyper-V on Windows
+    my $ps = 'echo powershell -Command';
+    is($svirt->run_ssh_cmd(qq($ps "\$ProgressPreference='SilentlyContinue'; Remove-VM -Force -VMName Test-VM-1")), 0, 'Hyper-V command successful exit');
 
     $ssh_expect_credentials->{password} = '2+3=5';
     is($svirt->run_ssh_cmd('echo -n "foo"', password => '2+3=5'), 0, 'Allow SSH credentials per run_ssh_cmd() call');


### PR DESCRIPTION
As some Hyper-V PowerShell commands in Windows Server 2019 require
interactive SSH session we need to change this behavior using
special variables provided in each SSH call.

- os-autoinst: os-autoinst/os-autoinst-distri-opensuse#12098
- Verification run: [Win2k19](http://pdostal-server.suse.cz/tests/11198) [Win2k16](http://pdostal-server.suse.cz/tests/11212) [Win2k12r2](http://pdostal-server.suse.cz/tests/11211)