### PR TITLE
Add background_script_run() testapi function

### DIFF
--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -22,7 +22,7 @@ use warnings;
 # -> increment on every change of such APIs
 # -> never move that variable to another place (when refactoring)
 #    because it may be accessed by the tests itself
-our $version = 22;
+our $version = 23;
 
 # major version of the (web socket) API relevant to the developer mode
 # -> increment when making non-backward compatible changes to that API

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -277,6 +277,10 @@ subtest 'script_run' => sub {
     is(script_run('false'), '1', 'script_run with no check of success, returns exit code');
     is(script_run('false', output => 'foo'), '1',   'script_run with no check of success and output, returns exit code');
     is(script_run('false', 0),               undef, 'script_run with no check of success, returns undef when not waiting');
+
+    $fake_exit = 1234;
+    is(background_script_run('sleep 10'),                  '1234', 'background_script_run returns a PID');
+    is(background_script_run('sleep 10', output => 'foo'), '1234', 'background_script_run with output returns valid PID');
 };
 
 subtest 'check_assert_screen' => sub {
@@ -336,7 +340,7 @@ subtest 'check_assert_screen' => sub {
         is_deeply($autotest::current_test->{details}, [
                 {
                     result     => 'unk',
-                    screenshot => 'basetest-13.png',
+                    screenshot => 'basetest-15.png',
                     frametime  => [qw(1.75 1.79)],
                     tags       => [qw(fake tags)],
                 }

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -41,7 +41,9 @@ subtest 'script_run' => sub {
     like $typed_string, qr/foo; echo .* > .*serial/, 'command is typed plus marker and redirection';
     $typed_string = '';
     like(exception { $d->script_run('foo &') }, qr/Terminator.*found.*type_string/, 'script_run with terminator is caught');
-    lives_ok { $d->script_run('foo\&') }, 'escaped terminator is accepted';
+    lives_ok sub { $d->script_run('foo\&') }, 'escaped terminator is accepted';
+    lives_ok sub { $d->script_run('foo && bar') }, 'AND operator is accepted';
+    lives_ok sub { $d->script_run('foo "x&"') }, 'quoted & is accepted';
 };
 
 done_testing;

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -40,10 +40,10 @@ subtest 'script_run' => sub {
     lives_ok { $d->script_run('foo') } 'script_run succeeds with trivial command';
     like $typed_string, qr/foo; echo .* > .*serial/, 'command is typed plus marker and redirection';
     $typed_string = '';
-    like(exception { $d->script_run('foo &') }, qr/Terminator.*found.*type_string/, 'script_run with terminator is caught');
-    lives_ok sub { $d->script_run('foo\&') }, 'escaped terminator is accepted';
+    like(exception { $d->script_run('foo &') }, qr/Terminator.*found.*background_script_run/, 'script_run with terminator is caught');
+    lives_ok sub { $d->script_run('foo\&') },      'escaped terminator is accepted';
     lives_ok sub { $d->script_run('foo && bar') }, 'AND operator is accepted';
-    lives_ok sub { $d->script_run('foo "x&"') }, 'quoted & is accepted';
+    lives_ok sub { $d->script_run('foo "x&"') },   'quoted & is accepted';
 };
 
 done_testing;

--- a/testapi.pm
+++ b/testapi.pm
@@ -51,8 +51,8 @@ our @EXPORT = qw($realname $username $password $serialdev %cmd %vars
   assert_and_click mouse_hide mouse_set mouse_click
   mouse_dclick mouse_tclick match_has_tag click_lastmatch mouse_drag
 
-  assert_script_run script_run assert_script_sudo script_sudo
-  script_output validate_script_output
+  assert_script_run script_run background_script_run
+  assert_script_sudo script_sudo script_output validate_script_output
 
   start_audiocapture assert_recorded_sound check_recorded_sound
 
@@ -1039,6 +1039,33 @@ sub script_run {
 
     bmwqemu::log_call(cmd => $cmd, %args);
     return $distri->script_run($cmd, %args);
+}
+
+=head2 background_script_run
+
+  background_script_run($cmd [, output => ''] [, quiet => $quiet]);
+
+Run C<$cmd> in background without waiting for it to finish. Remember to redirect output,
+otherwise the PID marker may get corrupted.
+
+C<$output> can be used as an explanatory text that will be displayed with the execution of
+the command.
+
+<Returns> PID of the I<$cmd> process running in the background.
+
+I<The implementation is distribution specific and not always available.>
+
+The default implementation should work on *nix operating systems with a configured
+serial device so long as the user has permissions to write to the supplied serial
+device C<$serialdev>.
+
+=cut
+
+sub background_script_run {
+    my ($cmd, %args) = @_;
+
+    bmwqemu::log_call(cmd => $cmd, %args);
+    return $distri->background_script_run($cmd, %args);
 }
 
 =head2 assert_script_sudo


### PR DESCRIPTION
This is a followup to PR #1619. `background_script_run()` is a more convenient way to run background processes than `enter_cmd()`. It'll automatically return the PID of your background process so that you can get its exit code later by calling `wait $pid`.