### PR TITLE
Add current path to lib when CASEDIR is a relative path

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -108,6 +108,7 @@ sub loadtest {
     my $fullname = "$category-$name";
     # perl code generating perl code is overcool
     my $code = "package $name;";
+    $code .= "use lib '.';" unless File::Spec->file_name_is_absolute($casedir);
     $code .= "use lib '$casedir/lib';";
     my $basename = dirname($script_path);
     $code .= "use lib '$basename';";

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -330,6 +330,12 @@ is(autotest::parse_test_path("$sharedir/tests/sle/tests/x11/firefox.pm"),       
 is(autotest::parse_test_path("$sharedir/tests/sle/tests/x11/toolkits/motif.pm"), 'x11/toolkits');
 is(autotest::parse_test_path("$sharedir/factory/other/sysrq.pm"),                'other');
 
+subtest 'load test successfully when CASEDIR is a relative path' => sub {
+    symlink($bmwqemu::vars{CASEDIR}, 'foo');
+    $bmwqemu::vars{CASEDIR} = 'foo';
+    loadtest 'start';
+};
+
 done_testing();
 
 END {


### PR DESCRIPTION
When loading test in `autotest`, we do `use lib $casedir/xxx`. If
CASEDIR is a relative path, it will report an error
`unable to load tests/module/xxx.pm`. In this scenario, we should
add the current path `.` to the lib.

Fail example: http://openqa.suse.de/tests/5657544
Verify run: http://10.67.19.103/tests/515