### PR TITLE
Prevent Inline::Python failing in downstream projects

### DIFF
--- a/container/os-autoinst_dev/Dockerfile
+++ b/container/os-autoinst_dev/Dockerfile
@@ -70,7 +70,6 @@ RUN zypper in -y -C \
        'perl(IPC::Open3)' \
        'perl(IPC::Run::Debug)' \
        'perl(IPC::System::Simple)' \
-       'perl(Inline::Python)' \
        'perl(List::MoreUtils)' \
        'perl(List::Util)' \
        'perl(Mojo::IOLoop::ReadWriteProcess)' \

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -86,6 +86,10 @@ test_base_requires:
 
 test_version_only_requires:
   perl(Mojo::IOLoop::ReadWriteProcess): '>= 0.28'
+  # only require Inline::Python as optional dependency for os-autoinst, not
+  # pulled in in dependant projects, see
+  # https://progress.opensuse.org/issues/90761
+  perl(Inline::Python):
 
 yamllint_requires:
   python3-yamllint:
@@ -96,7 +100,6 @@ test_requires:
   '%spellcheck_requires':
   '%yamllint_requires':
   perl(YAML::PP):
-  perl(Inline::Python):
 
 main_requires:
   git-core:

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -65,9 +65,9 @@ Source0:        %{name}-%{version}.tar.xz
 # The following line is generated from dependencies.yaml
 %define test_base_requires %main_requires cpio perl(Benchmark) perl(Devel::Cover) perl(FindBin) perl(Pod::Coverage) perl(Test::Fatal) perl(Test::Mock::Time) perl(Test::MockModule) perl(Test::MockObject) perl(Test::Mojo) perl(Test::Most) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 procps python3-setuptools qemu qemu-tools qemu-x86
 # The following line is generated from dependencies.yaml
-%define test_version_only_requires perl(Mojo::IOLoop::ReadWriteProcess) >= 0.28
+%define test_version_only_requires perl(Inline::Python) perl(Mojo::IOLoop::ReadWriteProcess) >= 0.28
 # The following line is generated from dependencies.yaml
-%define test_requires %build_requires %spellcheck_requires %test_base_requires %yamllint_requires perl(Inline::Python) perl(YAML::PP)
+%define test_requires %build_requires %spellcheck_requires %test_base_requires %yamllint_requires perl(YAML::PP)
 # The following line is generated from dependencies.yaml
 %define devel_requires %test_requires perl(Devel::Cover) perl(Devel::Cover::Report::Codecov) perl(Perl::Tidy)
 BuildRequires:  %test_requires %test_version_only_requires


### PR DESCRIPTION
E.g. see
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12238/checks?check_run_id=2286115726#step:5:32
failing with

```
! Configure failed for Inline-Python-0.56. See /github/home/.cpanm/work/1617787806.1116/build.log for details.
```

I would not have expected that os-autoinst-distri-opensuse CI checks try
to install that package as was listed as only a "test" requirement in
cpanfile#L75 and the actual error why it fails to be pulled in is not
obvious. We should look into both errors but to avoid this for now this
commit is moving the dependency into the dependency list which is really
only used within the local test environment of os-autoinst.

Related progress issue: https://progress.opensuse.org/issues/90761