### PR TITLE
tests: Avoid failures when running openQA's test suite

### DIFF
--- a/t/data/tests/main.pm
+++ b/t/data/tests/main.pm
@@ -37,15 +37,18 @@ sub cleanup_needles {
 $needle::cleanuphandler = \&cleanup_needles;
 
 # openQA tests set INTEGRATION_TESTS to 1 when reusing the os-autoinst tests
-#
-autotest::loadtest "tests/freeze.pm" unless get_var('INTEGRATION_TESTS');
+my $integration_tests = get_var('INTEGRATION_TESTS');
+
+autotest::loadtest "tests/freeze.pm" unless $integration_tests;
 
 # Add import path for local test python modules from pool directory
-use Inline Python => "import os.path, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.curdir, '../..')))";
+unless ($integration_tests) {
+    use Inline Python => "import os.path, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.curdir, '../..')))";
+    autotest::loadtest "tests/pre_boot.py";
+}
 
-autotest::loadtest "tests/pre_boot.py";
 autotest::loadtest "tests/boot.pm";
-unless (get_var('INTEGRATION_TESTS')) {
+unless ($integration_tests) {
     autotest::loadtest "tests/assert_screen.pm";
     autotest::loadtest "tests/typing.pm";
     autotest::loadtest "tests/select_console_fail_test.pm";


### PR DESCRIPTION
* Disable Python-based module when running test distribution as part of
  openQA's test suite
* Test failures look like this (where the test ends up incomplete with the
  failed module `pre_boot` and therefore a developer session can not be
  created):
  ```
    # <== {"data":null,"type":"error","what":"unable to create (further) development session"}
    # status: Connection closed, trying to reconnect in 500 ms
    # status: Connecting to ws:/localhost:9528/liveviewhandler/tests/1/developer/ws-proxy
    # status: Using proxy: yes
  ```