### PR TITLE
Add USBSIZEGB var to set the size of the overlay for USBBOOT

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -220,6 +220,7 @@ sub configure_blockdevs {
     if ($iso) {
         my $size = $self->get_img_size($iso);
         if ($vars->{USBBOOT}) {
+            $size = $vars->{USBSIZEGB} . 'G' if $vars->{USBSIZEGB};
             my $drive = $bdc->add_iso_drive('usbstick', $iso, 'usb-storage', $size);
             $drive->bootindex(0) if $bootfrom ne "disk";
         }

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -155,6 +155,7 @@ PUBLISH_PFLASH_VARS;string;;Specify the file name to publish the UEFI vars file 
 UEFI_PFLASH;boolean;0;(Deprecated, use UEFI_PFLASH_VARS) Enable the pflash mode to write the UEFI variables directly into the firmware file instead of NVvars in the EFI system partition
 UEFI_BIOS;;;Deprecated, use UEFI_PFLASH_CODE
 USBBOOT;boolean;0;Mount ISO as USB disk and boot VM from it
+USBSIZEGB;integer;size of ISO;Size of USB disk for USBBOOT
 VDE_PORT;integer;worker instance + 10;number of vde switch port to connect
 VDE_SOCKETDIR;string;.;directory where vde_switch control socket is to be found
 VDE_USE_SLIRP;integer;1;whether to start slirpvde


### PR DESCRIPTION
This allows testing of features which rely on the added space at the end,
like live media with persistent storage.

Verification runs:

`USBSIZEGB="4"`: http://10.160.67.86/tests/898
No `USBSIZEGB` still works: http://10.160.67.86/tests/899