### PR TITLE
sshVirtsh: Allow additional parameters for run_cmd()

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -625,10 +625,13 @@ C<VIRSH_USERNAME> and C<VIRSH_PASSWORD>.
 The second domain B<sshVMwareServer> is available if C<VIRSH_VMM_FAMILY> is
 B<vmware> and defined via C<VMWARE_HOST>, C<VMWARE_PASSWORD> and 'root' as
 username.
+For further arguments see C<baseclass:run_ssh_cmd()>.
 =cut
 sub run_cmd {
     my ($self, $cmd, %args) = @_;
-    return $self->backend->run_ssh_cmd($cmd, $self->get_ssh_credentials($args{domain}), wantarray => $args{wantarray} // 0);
+    my %credentials = $self->get_ssh_credentials($args{domain});
+    delete $args{domain};
+    return $self->backend->run_ssh_cmd($cmd, %credentials, %args);
 }
 
 =head2 get_cmd_output

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -219,9 +219,17 @@ subtest 'SSH usage in svirt' => sub {
     # W/A cause $svirt_console->activate() didn't worked so far
     $svirt_console->_init_ssh($ssh_creds_svirt);
     %{$ssh_expect_credentials} = (%{$ssh_expect_credentials}, %{$ssh_creds_svirt});
-    is($svirt_console->run_cmd('echo "BLAFAFU"'),           0,         "sshVirtsh::run_cmd() test return value ");
+    is($svirt_console->run_cmd('echo "BLAFAFU"'), 0, "sshVirtsh::run_cmd() test return value");
+    $num_ssh_connect = scalar(keys(%{$ssh_obj_data}));
+    is($svirt_console->run_cmd('echo "BLAFAFU"'), 0,                "sshVirtsh::run_cmd() test return value [2]");
+    is(scalar(keys(%{$ssh_obj_data})),            $num_ssh_connect, "sshVirtsh::run_cmd() _no_ new ssh connection created");
+    is_deeply([$svirt_console->run_cmd('echo -n "BLAFAFU"', wantarray => 1)], [0, 'BLAFAFU', ''], "sshVirtsh::run_cmd_(wantarray => 1) ");
     is($svirt_console->get_cmd_output('echo -n "BLAFAFU"'), 'BLAFAFU', "sshVirtsh::get_cmd_output()");
-    is_deeply($svirt_console->get_cmd_output('echo -n "BLAFAFU"', {wantarray => 1}), ['BLAFAFU', ''], "sshVirtsh::get_cmd_output(wantarray => 1) ");
+    is_deeply($svirt_console->get_cmd_output('echo -n "BLAFAFU"', {wantarray => 1}), ['BLAFAFU', ''], "sshVirtsh::get_cmd_output(wantarray => 1 ");
+
+    $num_ssh_connect = scalar(keys(%{$ssh_obj_data}));
+    is($svirt_console->run_cmd('echo "BLAFAFU"', keep_open => 0), 0,                    "sshVirtsh::run_cmd(keep_open=>0) test return value ");
+    is(scalar(keys(%{$ssh_obj_data})),                            $num_ssh_connect + 1, "sshVirtsh::run_cmd(keep_open=>0) new ssh object created");
 };
 
 subtest 'Method backend::svirt::open_serial_console_via_ssh()' => sub {


### PR DESCRIPTION
`sshVirtsh::run_cmd()` is a wrapper for `baseclass::run_ssh_cmd()`.
Allow all possible parameters to `run_ssh_cmd()` like `want_array` and `keep_open`.

Ticked: https://progress.opensuse.org/issues/81878