### PR TITLE
Fix return value of _dbus_do_call

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -141,8 +141,9 @@ sub _dbus_do_call {
     my $bus         = Net::DBus->system(private => 1);
     my $bus_service = $bus->get_service("org.opensuse.os_autoinst.switch");
     my $bus_object  = $bus_service->get_object("/switch", "org.opensuse.os_autoinst.switch");
-    $bus_object->$fn(@args);
+    my @result      = $bus_object->$fn(@args);
     $bus->get_connection->disconnect;
+    return @result;
 }
 
 sub _dbus_call {


### PR DESCRIPTION
This was relying on perl's default return behaviour before
(return the result of the final line of the function, if it's an
expression). But now that's wrong, as the last line is something
else. We need to be explicit about what we're returning (which
would generally be a good thing to do anyway).

Related progress issue: https://progress.opensuse.org/issues/91163

Signed-off-by: Adam Williamson <awilliam@redhat.com>