### PR TITLE
Update qemu argument used to disable floppy drive for qemu 6.0

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -857,7 +857,7 @@ sub start_qemu {
     {
         # Remove floppy drive device on architectures
         unless ($arch eq 'aarch64' || $arch eq 'arm' || $vars->{QEMU_NO_FDC_SET}) {
-            sp('global', 'isa-fdc.driveA=');
+            sp('global', 'isa-fdc.fdtypeA=none');
         }
 
         sp('m',       $vars->{QEMURAM})     if $vars->{QEMURAM};


### PR DESCRIPTION
The way we were doing this before no longer works with qemu 6.0.
Markus Armbruster suggests using -nodefaults, but that's a bigger
gun and we'd have to check we aren't relying on the default
devices in any way before using it. This was his second choice
suggestion "If you'd prefer not to". It does seem to work (with
both older and newer qemu). See:

https://bugs.launchpad.net/bugs/1923663