### PR TITLE
dist: Bump test timeout due to failures in OBS tests

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -169,7 +169,7 @@ export NO_BRP_STALE_LINK_ERROR=yes
 export CI=1
 # account for sporadic slowness in build environments
 # https://progress.opensuse.org/issues/89059
-export OPENQA_TEST_TIMEOUT_SCALE_CI=4
+export OPENQA_TEST_TIMEOUT_SCALE_CI=6
 cd %{__builddir}
 %cmake_build check-pkg-build
 


### PR DESCRIPTION
t/18-backend-qemu.t timed out in
https://build.opensuse.org/package/live_build_log/devel:openQA/os-autoinst/openSUSE_Leap_15.2/x86_64