### PR TITLE
Make ipmi SOL console persistent

### DIFF
--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -112,7 +112,7 @@ sub do_start_vm {
     $self->get_mc_status;
     $self->restart_host unless $bmwqemu::vars{IPMI_DO_NOT_RESTART_HOST};
     $self->truncate_serial_file;
-    my $sol = $testapi::distri->add_console('sol', 'ipmi-xterm');
+    my $sol = $testapi::distri->add_console('sol', 'ipmi-xterm', {persistent => 1});
     $sol->backend($self);
     return {};
 }


### PR DESCRIPTION
Fix poo#60437: Persistent console is already implemented for PowerVM
and it works without issue. Ipmi SOL console needs the same
approach. Internal openQA console for SOL should be alive all the time
during the test without stopping and starting it again.

Progress: https://progress.opensuse.org/issues/60437

Verifications without persistent console:
* http://black-bit.suse.cz/tests/135
* http://black-bit.suse.cz/tests/127
* http://black-bit.suse.cz/tests/128

Log contains errors during reconnection to console, test usually fail at some point (soon or later)

Verification with persistent console:
* http://black-bit.suse.cz/tests/138
System survived 32 reboots (just reached max job life time).

More verifications:
system installation: http://black-bit.suse.cz/tests/139
kdump:  http://black-bit.suse.cz/tests/140#step/kdump/47  (console is all the time available after crash, the rest of the test is not ready yet)

VT testing: http://black-bit.suse.cz/tests/143#
VT testing 2nd run: http://black-bit.suse.cz/tests/144#