### PR TITLE
Make persistent SOL console configurable

### DIFF
--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -112,7 +112,7 @@ sub do_start_vm {
     $self->get_mc_status;
     $self->restart_host unless $bmwqemu::vars{IPMI_DO_NOT_RESTART_HOST};
     $self->truncate_serial_file;
-    my $sol = $testapi::distri->add_console('sol', 'ipmi-xterm', {persistent => 1});
+    my $sol = $testapi::distri->add_console('sol', 'ipmi-xterm', {persistent => $bmwqemu::vars{IPMI_SOL_PERSISTENT_CONSOLE} // 0});
     $sol->backend($self);
     return {};
 }

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -65,6 +65,7 @@ IPMI_MC_RESET_SLEEP_TIME_S;integer;10;Time to sleep after sending mc reset comma
 IPMI_MC_RESET_TIMEOUT;integer;60;Counts to try to reach IPMI interface after mc reset
 IPMI_MC_RESET_PING_COUNT;integer;1;Ping counts that must be successful after mc reset
 IPMI_MC_RESET_IPMI_TRIES;integer;3;Maximum number of IPMI command tries that are conducted after mc reset
+IPMI_SOL_PERSISTENT_CONSOLE;boolean;0;Make SOL console persistent and don't reset it, disabled by default
 |====================
 
 .QEMU backend


### PR DESCRIPTION
PR https://github.com/os-autoinst/os-autoinst/pull/1652#issuecomment-824505667 made IPMI SOL console persistent to increase stability, there was raised concern: *suggest to make the sol console persistent option configurable* .  Configuration can be done at test suite level, machine defintion,  wrokers.ini file...

Fix poo#60437: It is possible to use IPMI_SOL_PERSISTENT_CONSOLE
variable to configure SOL console persistency. It is disabled by default.

Progress: https://progress.opensuse.org/issues/60437

Verification runs:
IPMI_SOL_PERSISTENT_CONSOLE enabled:
VT test: http://black-bit.suse.cz/tests/158
Installation: http://black-bit.suse.cz/tests/159
Kdump:  http://black-bit.suse.cz/tests/160


Special brute force reset test for variable:
persistency enabled: http://black-bit.suse.cz/tests/169#step/ipmi_reset/30 ok
persistency disabled:  http://black-bit.suse.cz/tests/168#step/ipmi_reset/8  fail