### PR TITLE
dist: Install testapi.py along with other files for easier inclusion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ set(PERL_FILES
 set(MISC_FILES
     consoles/icewm.cfg
     crop.py
+    testapi.py
     dmidata/dell_e6330/smbios_type_1.bin
     dmidata/dell_e6330/smbios_type_2.bin
     dmidata/dell_e6330/smbios_type_3.bin

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -210,7 +210,7 @@ cd %{__builddir}
 %{_prefix}/lib/os-autoinst/OpenQA
 %{_prefix}/lib/os-autoinst/consoles
 %{_prefix}/lib/os-autoinst/autotest.pm
-%{_prefix}/lib/os-autoinst/crop.py
+%{_prefix}/lib/os-autoinst/*.py
 
 %files openvswitch
 %defattr(-,root,root)


### PR DESCRIPTION
Tested manually on a machine which only has the packaged version of os-autoinst available