### PR TITLE
stop appending the basename to a set log_name

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -2230,7 +2230,7 @@ sub upload_logs {
     }
     bmwqemu::log_call(file => $file, failok => $failok, timeout => $timeout, %args);
     my $basename = basename($file);
-    my $upname   = ($args{log_name} || $autotest::current_test->{name}) . '-' . $basename;
+    my $upname   = $args{log_name} || ($autotest::current_test->{name} . '-' . $basename);
     my $cmd      = "curl --form upload=\@$file --form upname=$upname ";
     $cmd .= autoinst_url("/uploadlog/$basename");
     if ($failok) {


### PR DESCRIPTION
At present, if one calls upload_logs thus:

  upload_logs( '/var/log/syslog', log_name => 'SysLog.txt' );

the filename that shows up in the webUI is 'SysLog.txt-syslog' whereas
it should be just 'SysLog.txt' -- this tiny patch fixes that.

BTW one could fix this by simply removing the parentheses, but I prefer to move them as it makes sure that the intent is clear.