### PR TITLE
Support assets symlink

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -36,6 +36,7 @@ use Mojo::Base -base;
 use Data::Dumper;
 use File::Basename;
 use File::Which;
+use File::Spec;
 use Mojo::JSON qw(encode_json decode_json);
 use Mojo::File 'path';
 use OpenQA::Qemu::BlockDevConf;
@@ -187,6 +188,7 @@ sub configure_blockdevs {
         $size .= 'G' if defined($size);
 
         if (defined $backing_file) {
+            $backing_file = File::Spec->rel2abs($backing_file);
             # Handle files compressed as *.xz
             my ($name, $path, $ext) = fileparse($backing_file, ".xz");
             if ($ext =~ qr /.xz/) {
@@ -218,6 +220,7 @@ sub configure_blockdevs {
 
     my $iso = $vars->{ISO};
     if ($iso) {
+        $iso = File::Spec->rel2abs($iso);
         my $size = $self->get_img_size($iso);
         if ($vars->{USBBOOT}) {
             $size = $vars->{USBSIZEGB} . 'G' if $vars->{USBSIZEGB};
@@ -232,7 +235,7 @@ sub configure_blockdevs {
     }
     my $is_first = 1;
     for my $k (sort grep { /^ISO_\d+$/ } keys %$vars) {
-        my $addoniso = $vars->{$k};
+        my $addoniso = File::Spec->rel2abs($vars->{$k});
         my $i        = $k;
         $i =~ s/^ISO_//;
 

--- a/t/18-qemu.t
+++ b/t/18-qemu.t
@@ -388,4 +388,18 @@ subtest DriveDevice => sub {
 
 };
 
+subtest 'relative assets' => sub {
+    $vars{$_} = "Core-7.2.iso" for qw(ISO ISO_1 HDD_1);
+    symlink("$Bin/data/Core-7.2.iso", "./Core-7.2.iso");
+    $proc = OpenQA::Qemu::Proc->new()
+      ->_static_params(['-foo'])
+      ->qemu_bin('qemu-kvm')
+      ->qemu_img_bin('qemu-img')
+      ->configure_blockdevs('disk', 'raid', \%vars);
+    my @gcmdl = $proc->blockdev_conf->gen_qemu_img_cmdlines();
+    @cmdl = map { [qw(create -f qcow2 -b), "$dir/Core-7.2.iso", "raid/$_-overlay0", 11116544] } qw(hd0 cd0 cd1);
+    is_deeply(\@gcmdl, \@cmdl, 'find the asset real path');
+    unlink("./Core-7.2.iso");
+};
+
 done_testing();


### PR DESCRIPTION
On the worker side, there is a plan that does symlink assets from the project
asset directory to the working directory. For os-autoinst, we need to find the
absolute directory of asset when running `qemu-img`.

Related: https://progress.opensuse.org/issues/81703