### PR TITLE
[WIP]Enhance deactivate sol operation in reset 

### DIFF
--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -198,4 +198,16 @@ sub do_mc_reset {
     die "IPMI mc reset failure after $max_tries tries! Exit...";
 }
 
+sub deactivate_sol {
+    my ($self) = @_;
+    eval { $self->ipmitool("sol deactivate"); };
+    my $ipmi_response = $@;
+    if ($ipmi_response) {
+        # IPMI response like SOL payload already de-activated is expected
+        die "Unexpect IPMI response: $ipmi_response" unless
+          ($ipmi_response =~ /SOL payload already de-activated/);
+    }
+    1;
+}
+
 1;

--- a/consoles/sshXtermIPMI.pm
+++ b/consoles/sshXtermIPMI.pm
@@ -40,13 +40,7 @@ sub activate {
     my $cstr   = join(' ', @command);
 
     # Try to deactivate IPMI SOL before activate
-    eval { $self->backend->ipmitool("sol deactivate"); };
-    my $ipmi_response = $@;
-    if ($ipmi_response) {
-        # IPMI response like SOL payload already de-activated is expected
-        die "Unexpect IPMI response: $ipmi_response" unless
-          ($ipmi_response =~ /SOL payload already de-activated/);
-    }
+    $self->backend->deactivate_sol();
 
     $self->callxterm($cstr, "ipmitool:$testapi_console");
 }
@@ -56,7 +50,7 @@ sub reset {
 
     # Deactivate sol connection if it is activated
     if ($self->{activated}) {
-        $self->backend->ipmitool("sol deactivate");
+        $self->backend->deactivate_sol();
         $self->{activated} = 0;
     }
     return;

--- a/t/29-backend-ipmi.t
+++ b/t/29-backend-ipmi.t
@@ -46,7 +46,8 @@ $testapi::distri = distribution->new;
 ok $backend->do_start_vm, 'can call do_start_vm';
 ok $backend->do_stop_vm,  'can call do_stop_vm';
 ok !$backend->check_socket, 'check_socket not returning true by default';
-ok $backend->get_mc_status, 'can call get_mc_status';
+ok $backend->get_mc_status,  'can call get_mc_status';
+ok $backend->deactivate_sol, 'can call deactivate_sol';
 
 # reduce retries for testing
 $bmwqemu::vars{IPMI_MC_RESET_MAX_TRIES} = $bmwqemu::vars{IPMI_MC_RESET_TIMEOUT} = 3;


### PR DESCRIPTION
Make deactivate sol operation not exit when sol connecton already terminated in before.

Ticket : https://progress.opensuse.org/issues/88514
Test: In process