### PR TITLE
qemu: Allow to configure an additional serial device for test-internal use

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -767,8 +767,13 @@ sub start_qemu ($self) {
     $self->{proc}->init_blockdev_images();
 
     sp('only-migratable') if $self->can_handle({function => 'snapshots', no_warn => 1});
-    sp('chardev', 'ringbuf,id=serial0,logfile=serial0,logappend=on');
-    sp('serial', 'chardev:serial0');
+    my $serial_id = 0;
+    if ($vars->{QEMU_SERIAL}) {
+        sp('serial', $vars->{QEMU_SERIAL});
+        $serial_id++;
+    }
+    sp('chardev', "ringbuf,id=serial$serial_id,logfile=serial$serial_id,logappend=on");
+    sp('serial', "chardev:serial$serial_id");
 
     if ($self->requires_audiodev) {
         my $audiodev = $vars->{QEMU_AUDIODEV} // 'intel-hda';

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -153,6 +153,7 @@ QEMU_NO_KVM;boolean;0;Don't use KVM acceleration.
 QEMU_NO_TABLET;boolean;0;Don't use USB tablet.
 QEMU_VIRTIO_RNG;boolean;1;Enable virtio random number generator
 QEMU_NUMA;boolean;0;Enable NUMA simulation, requires QEMUCPUS to be greater than one
+QEMU_SERIAL;string;;Add an additional qemu serial device configuration, e.g. "chardev:serial42"
 QEMU_SMBIOS;see qemu -smbios ?;undef;pass this value to qemu -smbios
 QEMU_SOUNDHW;see qemu -soundhw ?;had;pass this value to qemu -soundhw (for qemu < 4.2)
 QEMU_AUDIODEV;see qemu -device ?;intel-hda;Audio device to use with audiodev to qemu -device (for qemu >= 4.2)


### PR DESCRIPTION
Hotpatched on openqaworker7 with

```
curl -sS https://patch-diff.githubusercontent.com/raw/os-autoinst/os-autoinst/pull/1662.patch | patch -p1 --directory=/usr/lib/os-autoinst
```

* Triggered a test without any additional parameters

```
openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org/tests/2296755 TESTS=os-autoinst_gh_1662 BUILD=okurz-os-autoinst_gh_1662 SCHEDULE=tests/boot/boot_to_desktop,tests/console/ncurses WORKER_CLASS=openqaworker7
```

Created job #2298224: opensuse-Tumbleweed-DVD-x86_64-Build20220413-extra_tests_misc@64bit -> https://openqa.opensuse.org/t2298224 (passed, still default serial device serial0)

* Adding custom serial device config

```
openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org/tests/2296755 TESTS=os-autoinst_gh_1662 BUILD=okurz-os-autoinst_gh_1662 SCHEDULE=tests/boot/boot_to_desktop,tests/console/ncurses WORKER_CLASS=openqaworker7 QEMU_SERIAL=chardev:serial42
```

Created job #2298234: opensuse-Tumbleweed-DVD-x86_64-Build20220413-extra_tests_misc@64bit -> https://openqa.opensuse.org/t2298234

Related progress issue: https://progress.opensuse.org/issues/91965