### PR TITLE
Fix `eject_cd` command by using `id` and `force` parameters

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -109,7 +109,10 @@ sub power {
 
 sub eject_cd {
     my ($self, $args) = @_;
-    $self->handle_qmp_command({execute => 'eject', arguments => {device => ($args->{device} // 'cd0')}});
+    $self->handle_qmp_command({execute => 'eject', arguments => {
+                (defined $args->{id} || !defined $args->{device} ? (id => $args->{id} // 'cd0-device') : (device => $args->{device})),
+                force => (!defined $args->{force} || $args->{force} ? Mojo::JSON->true : Mojo::JSON->false)
+    }});
 }
 
 sub execute_qmp_command {

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -112,6 +112,11 @@ sub eject_cd {
     $self->handle_qmp_command({execute => 'eject', arguments => {device => ($args->{device} // 'cd0')}});
 }
 
+sub execute_qmp_command {
+    my ($self, $args) = @_;
+    $self->handle_qmp_command($args->{query});
+}
+
 sub cpu_stat {
     my $self = shift;
     my $stat = bmwqemu::fileContent("/proc/" . $self->{proc}->_process->pid . "/stat");

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -1,5 +1,5 @@
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2020 SUSE LLC
+# Copyright © 2012-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -108,8 +108,8 @@ sub power {
 }
 
 sub eject_cd {
-    my $self = shift;
-    $self->handle_qmp_command({execute => 'eject', arguments => {device => 'cd0'}});
+    my ($self, $args) = @_;
+    $self->handle_qmp_command({execute => 'eject', arguments => {device => ($args->{device} // 'cd0')}});
 }
 
 sub cpu_stat {

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -177,6 +177,13 @@ subtest 'enter_cmd' => sub {
     $cmds = [];
 };
 
+subtest 'eject_cd' => sub {
+    eject_cd;
+    eject_cd device => 'foo';
+    is_deeply $cmds, [{cmd => 'backend_eject_cd'}, {cmd => 'backend_eject_cd', device => 'foo'}];
+    $cmds = [];
+};
+
 subtest 'type_string with wait_still_screen' => sub {
     my $wait_still_screen_called = 0;
     my $module                   = Test::MockModule->new('testapi');

--- a/testapi.pm
+++ b/testapi.pm
@@ -1,5 +1,5 @@
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2019 SUSE LLC
+# Copyright © 2012-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -1965,8 +1965,9 @@ if backend supports it, eject the CD
 =cut
 
 sub eject_cd {
-    bmwqemu::log_call();
-    query_isotovideo('backend_eject_cd');
+    my (%nargs) = @_;
+    bmwqemu::log_call(%nargs);
+    query_isotovideo(backend_eject_cd => \%nargs);
 }
 
 =head2 save_memory_dump


### PR DESCRIPTION
* The `device` parameter is deprecated and it seems not possible to refer
  to the correct CD device with it (always got `DeviceNotFound` error). It
  seems to work with the `id` parameter and apparently `cd0-device` is the
  correct ID for the device providing the default ISO.
* The force parameter is enabled to make sure it works in any situation.
  The conversion to Mojo::JSON->true/false is required because QEMU is
  picky on the type.
* Tested by sending the command via the developer console. As expected, the
  machine showed the screen that no bootable device has been found (after
  resetting the system via the QMP command `system_reset`).
* See https://progress.opensuse.org/issues/91971
* See https://qemu-project.gitlab.io/qemu/interop/qemu-qmp-ref.html#qapidoc-966

---

Note that the extra commit "Add function to QEMU backend which allows executing any QMP command" adds a function which I've been using to play around with the QMP interface. It is likely very useful for testing other QMP-related behavior so I'd like to keep it and added a unit test for it.