### PR TITLE
Serial failure detection: Support 'info' type

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -705,14 +705,17 @@ sub parse_serial_output_qemu {
             my $type    = $regexp_table->{type};
 
             # Input parameters validation
-            die "Wrong type defined for serial failure. Only 'soft' or 'hard' allowed. Got: $type" if $type !~ /^soft|hard|fatal$/;
-            die "Message not defined for serial failure for the pattern: '$regexp', type: $type"   if !defined $message;
+            die "Wrong type defined for serial failure. Only 'info', 'soft', 'hard' or 'fatal' allowed. Got: $type" if $type !~ /^info|soft|hard|fatal$/;
+            die "Message not defined for serial failure for the pattern: '$regexp', type: $type"                    if !defined $message;
 
             # If you want to match a simple string please be sure that you create it with quotemeta
             if (!exists $regexp_matched{$regexp} and $line =~ /$regexp/) {
                 $regexp_matched{$regexp} = 1;
                 my $fail_type = 'softfail';
-                if ($type =~ 'hard|fatal') {
+                if ($type eq 'info') {
+                    $fail_type = 'ok';
+                }
+                elsif ($type =~ 'hard|fatal') {
                     $die                   = 1;
                     $fail_type             = 'fail';
                     $self->{fatal_failure} = $type eq 'fatal';

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -82,6 +82,13 @@ subtest parse_serial_output => sub {
     is($message,            undef, 'test details do not have extra message');
 
     $basetest->{serial_failures} = [
+        {type => 'info', message => 'CPU soft lockup detected', pattern => qr/Serial/},
+    ];
+    $basetest->parse_serial_output_qemu();
+    is($basetest->{result}, 'ok',                                                       'test result set to ok');
+    is($message,            'CPU soft lockup detected - Serial error: Serial to match', 'log message matches output');
+
+    $basetest->{serial_failures} = [
         {type => 'soft', message => 'SimplePattern', pattern => qr/Serial/},
     ];
 


### PR DESCRIPTION
Checks and subsequent logic added for the new fail type `info`, added in `known_bugs.pm`.

- Related ticket: https://progress.opensuse.org/issues/46502
- Related pr: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12491