### PR TITLE
Support UEFI_PFLASH_VARS is a basename

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -281,7 +281,7 @@ sub configure_pflash {
           ->unit(0)
           ->readonly('on');
 
-        $fw = $vars->{UEFI_PFLASH_VARS};
+        $fw = File::Spec->rel2abs($vars->{UEFI_PFLASH_VARS});
         die 'Need UEFI_PFLASH_VARS with UEFI_PFLASH_CODE' unless $fw;
         $bdc->add_pflash_drive('pflash-vars', $fw, $self->get_img_size($fw))
           ->unit(1);


### PR DESCRIPTION
Fix a regression issue caused by
https://github.com/os-autoinst/openQA/pull/3863.

When UEFI_PFLASH_VARS is a basename, we do symlink on openQA worker side
and set the value as a basename. But we still need to use the absolute path when
doing qemu-img.

Here is an incomplete job example: https://openqa.opensuse.org/tests/1735786