### PR TITLE
Replace raw prints with the correct logs messages in qemu

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -1080,10 +1080,10 @@ sub start_qemu {
     }
 
     if ($bmwqemu::vars{DELAYED_START}) {
-        print "DELAYED_START set, not starting CPU, waiting for resume_vm()\n";
+        bmwqemu::diag("DELAYED_START set, not starting CPU, waiting for resume_vm()");
     }
     else {
-        print "Start CPU\n";
+        bmwqemu::diag("Start CPU");
         $self->handle_qmp_command({execute => 'cont'});
     }
 


### PR DESCRIPTION
Previously the autoinst-log.txt shows the raw line:
Start CPU

With this commit it shows:
[2021-05-12T12:30:12.407 CEST] [debug] Start CPU

https://progress.opensuse.org/issues/91527