### PR TITLE
Indent the new lines in logs using the log format

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -191,10 +191,16 @@ our $backend;
 # util and helper functions
 
 sub log_format_callback {
-    my ($time, $level, @lines) = @_;
+    my ($time, $level, @items) = @_;
+
+    my $lines = join("\n", @items, '');
+
+    # ensure indentation for multi-line output
+    $lines =~ s/(?<!\A)^/  /gm;
+
     # Unfortunately $time doesn't have the precision we want. So we need to use Time::HiRes
     $time = gettimeofday;
-    return sprintf(strftime("[%FT%T.%%03d %Z] [$level] ", localtime($time)), 1000 * ($time - int($time))) . join("\n", @lines, '');
+    return sprintf(strftime("[%FT%T.%%03d %Z] [$level] ", localtime($time)), 1000 * ($time - int($time))) . $lines;
 }
 
 sub diag {

--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -64,6 +64,12 @@ subtest 'log_call' => sub {
         bmwqemu::log_call("bar\tbaz\rboo\n");
     }
     stderr_like(\&log_call_test_single, qr{\Q<<< main::log_call_test_single("bar\tbaz\rboo\n")}, 'log_call escapes special characters');
+
+    sub log_call_indent {
+        my $lines = ["a", ["b"]];
+        bmwqemu::log_call(test => $lines);
+    }
+    stderr_like(\&log_call_indent, qr{\Q<<< main::log_call_indent(test=[\E\n\Q    "a",\E\n\Q    [\E\n\Q      "b"\E\n\Q    ]\E\n\Q  ])}, 'log_call auto indentation');
 };
 
 subtest 'update_line_number' => sub {


### PR DESCRIPTION
Previously the new lines appear without indentation. But for a
better reading and parsing the new lines that belongs to a
log entry are indented

```
[2021-05-12T16:34:22.474 CEST] [debug] <<< testapi::assert_screen(mustmatch=[
  "partitioning-edit-proposal-button",
  "before-role-selection",
  "inst-instmode",
  "online-repos"
], timeout=120)
```

This is the new format:

```
[2021-05-12T16:34:22.474 CEST] [debug] <<< testapi::assert_screen(mustmatch=[
    "partitioning-edit-proposal-button",
    "before-role-selection",
    "inst-instmode",
    "online-repos"
  ], timeout=120)
```

http://progress.opensuse.org/issues/91527