### PR TITLE
Fix test execution - prevent duplicate running of tests in the wrong directory

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -256,8 +256,11 @@ make test-perl-testsuite
 
 Run individual tests by specifying them explicitly:
 ----
-make test-perl-testsuite TESTS="15-logging.t 28-signalblocker.t"
+make test-perl-testsuite TESTS="t/15-logging.t t/28-signalblocker.t"
 ----
+
+Notice that the user needs to include the test directory for each test (either t for normal or 
+xt for developer-centric tests) when specifying individual tests.
 
 Add additional arguments to the `prove` invocation, e.g. enable verbose output:
 ----

--- a/tools/invoke-tests
+++ b/tools/invoke-tests
@@ -52,5 +52,10 @@ export OS_AUTOINST_BUILD_DIRECTORY=$build_directory
 export OS_AUTOINST_MAKE_TOOL=$make_path
 
 # invoke tests within the t and xt directory
-cd t && "$prove_path" $PROVE_ARGS ${TESTS:-'-r'}
-cd ../xt && "$prove_path" $PROVE_ARGS ${TESTS:-'-r'}
+if [[ $TESTS = *[!\ ]* ]]
+then
+	"$prove_path" $PROVE_ARGS $TESTS
+else
+	cd t && "$prove_path" $PROVE_ARGS -r
+	cd ../xt && "$prove_path" $PROVE_ARGS -r
+fi


### PR DESCRIPTION
Fixed script running perl tests in the `t` and `xt` directories. When the user gives specific tests to be run, they need to provide the directory of the test as well. Now each test is only run once and doesn't fail trying to execute in both directories.

- Related issue: https://progress.opensuse.org/issues/92497