### PR TITLE
signalblocker: Fix typo in log message

### DIFF
--- a/signalblocker.pm
+++ b/signalblocker.pm
@@ -29,7 +29,7 @@ sub new {
     my ($class, @args) = @_;
 
     # block signals
-    bmwqemu::diag('Blocking SIGCHLD and SIGCHLD');
+    bmwqemu::diag('Blocking SIGCHLD and SIGTERM');
     my %old_sig = %SIG;
     $SIG{TERM} = 'IGNORE';
     $SIG{INT}  = 'IGNORE';


### PR DESCRIPTION
No functional difference, but I see my typo every time I look at a log and it's annoying!