### PR TITLE
Fix QEMU_COMPRESS_QCOW2 missing implementation introduced with c670720d

### DIFF
--- a/OpenQA/Qemu/DriveDevice.pm
+++ b/OpenQA/Qemu/DriveDevice.pm
@@ -139,8 +139,14 @@ sub gen_qemu_img_cmdlines {
 
 sub gen_qemu_img_convert {
     my ($self, $img_dir, $name) = @_;
-
-    return ['convert', '-c', '-O', QEMU_IMAGE_FORMAT, $self->drive->file, "$img_dir/$name"];
+    my @cmd = qw(convert);
+    # By compressing we are making the images self contained, i.e. they are
+    # portable by not requiring backing files referencing the openQA instance.
+    # Compressing takes longer but the transfer takes shorter amount of time.
+    my $compress = $bmwqemu::vars{QEMU_COMPRESS_QCOW2} //= 1;
+    push @cmd, qw(-c) if $compress;
+    push @cmd, ('-O', QEMU_IMAGE_FORMAT, $self->drive->file, "$img_dir/$name");
+    return \@cmd;
 }
 
 sub gen_unlink_list {

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -54,11 +54,6 @@ use constant VM_SNAPSHOTS_DIR => 'vm-snapshots';
 sub new {
     my $class = shift;
     my $self  = $class->SUPER::new;
-    # By compressing we are making the images self contained, i.e. they are
-    # portable by not requiring backing files referencing the openQA instance.
-    # Compressing takes longer but the transfer takes shorter amount of time.
-    $bmwqemu::vars{QEMU_COMPRESS_QCOW2} //= 1;
-
     $self->{pidfilename} = 'qemu.pid';
     $self->{proc}        = OpenQA::Qemu::Proc->new();
     $self->{proc}->_process->pidfile($self->{pidfilename});

--- a/t/18-qemu.t
+++ b/t/18-qemu.t
@@ -41,13 +41,19 @@ $bdc->add_new_drive('hd1', 'virtio-blk', '10G');
 @gcmdl = $bdc->gen_cmdline();
 is_deeply(\@gcmdl, \@cmdl, 'Generate qemu command line for single new drive');
 
-@cmdl  = ([qw(create -f qcow2 raid/hd1 10G)]);
+@cmdl  = [qw(create -f qcow2 raid/hd1 10G)];
 @gcmdl = $bdc->gen_qemu_img_cmdlines();
 is_deeply(\@gcmdl, \@cmdl, 'Generate qemu-img command line for single new drive');
 
-@cmdl  = (['convert', '-c', '-O', 'qcow2', 'raid/hd1', 'images/hd1.qcow2']);
+@cmdl  = [qw(convert -c -O qcow2 raid/hd1 images/hd1.qcow2)];
 @gcmdl = $bdc->gen_qemu_img_convert(qr/^hd/, 'images', 'hd1.qcow2');
 is_deeply(\@gcmdl, \@cmdl, 'Generate qemu-img convert for single new drive');
+
+@cmdl                               = [qw(convert -O qcow2 raid/hd1 images/hd2.qcow2)];
+$bmwqemu::vars{QEMU_COMPRESS_QCOW2} = 0;
+@gcmdl                              = $bdc->gen_qemu_img_convert(qr/^hd/, 'images', 'hd2.qcow2');
+is_deeply(\@gcmdl, \@cmdl, 'Generate qemu-img convert with disabled compression');
+$bmwqemu::vars{QEMU_COMPRESS_QCOW2} = 1;
 
 @cmdl = ('-blockdev', 'driver=file,node-name=hd1-file,filename=raid/hd1,cache.no-flush=on',
     '-blockdev', 'driver=qcow2,node-name=hd1,file=hd1-file,cache.no-flush=on',


### PR DESCRIPTION
The commit c670720d kept the initial reading of the parameter
QEMU_COMPRESS_QCOW2 and documentation in place but the actual
implementation was removed completely so the parameter had no effect
when specified.
