### PR TITLE
Simplify bmwqemu::fileContent and mark as deprecated before removal

### DIFF
--- a/backend/amt.pm
+++ b/backend/amt.pm
@@ -1,4 +1,4 @@
-# Copyright © 2018 SUSE LLC
+# Copyright © 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -24,7 +24,7 @@ use base 'backend::baseclass';
 use Time::HiRes qw(sleep gettimeofday);
 use Data::Dumper;
 require Carp;
-use bmwqemu qw(fileContent diag save_vars diag);
+use bmwqemu ();
 use testapi 'get_required_var';
 use IPC::Run ();
 require IPC::System::Simple;

--- a/backend/pvm.pm
+++ b/backend/pvm.pm
@@ -1,4 +1,4 @@
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,7 +21,7 @@ use autodie ':all';
 
 use base 'backend::baseclass';
 
-use bmwqemu qw(fileContent diag save_vars);
+use bmwqemu qw(diag);
 use File::Path 'mkpath';
 require IPC::System::Simple;
 use File::Basename;

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -30,6 +30,7 @@ use Time::HiRes qw(sleep gettimeofday);
 use IO::Socket::UNIX 'SOCK_STREAM';
 use IO::Handle;
 use POSIX qw(strftime :sys_wait_h mkfifo);
+use Mojo::File 'path';
 use Mojo::JSON;
 use Carp;
 use Fcntl;
@@ -117,7 +118,7 @@ sub execute_qmp_command {
 
 sub cpu_stat {
     my $self = shift;
-    my $stat = bmwqemu::fileContent("/proc/" . $self->{proc}->_process->pid . "/stat");
+    my $stat = path("/proc/" . $self->{proc}->_process->pid . "/stat")->slurp;
     my @a    = split(" ", $stat);
     return [@a[13, 14]];
 }

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -1043,11 +1043,6 @@ sub start_qemu {
         }
     };
 
-    my $cnt = bmwqemu::fileContent("$ENV{HOME}/.autotestvncpw");
-    if ($cnt) {
-        $self->send($cnt);
-    }
-
     if ($vars->{NICTYPE} eq "tap") {
         $self->{allocated_networks}    = $num_networks;
         $self->{allocated_tap_devices} = \@tapdev;

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -34,7 +34,7 @@ use Mojo::JSON;
 use Carp;
 use Fcntl;
 use Net::DBus;
-use bmwqemu qw(fileContent diag save_vars);
+use bmwqemu qw(diag);
 require IPC::System::Simple;
 use Try::Tiny;
 use osutils qw(find_bin gen_params qv run_diag runcmd);
@@ -786,7 +786,7 @@ sub start_qemu {
     push @tapscript,     "no" until @tapscript >= $num_networks;        #no TAPSCRIPT by default
     push @tapdownscript, "no" until @tapdownscript >= $num_networks;    #no TAPDOWNSCRIPT by default
 
-    # put it back to the vars for save_vars()
+    # put it back to the vars for saving
     $vars->{NICMAC}        = join ',', @nicmac;
     $vars->{NICVLAN}       = join ',', @nicvlan;
     $vars->{TAPDEV}        = join ',', @tapdev        if $vars->{NICTYPE} eq "tap";

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -1,5 +1,5 @@
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2020 SUSE LLC
+# Copyright © 2012-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -295,15 +295,7 @@ sub log_call {
     return;
 }
 
-sub fileContent {
-    my ($fn) = @_;
-    no autodie 'open';
-    open(my $fd, "<", $fn) or return;
-    local $/;
-    my $result = <$fd>;
-    close($fd);
-    return $result;
-}
+sub fileContent { path(shift)->slurp }
 
 # util and helper functions end
 

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -29,8 +29,8 @@ use Cpanel::JSON::XS ();
 use File::Path 'remove_tree';
 use Data::Dumper;
 use Mojo::Log;
-use Mojo::File;
-use File::Spec::Functions;
+use File::Spec::Functions qw(catfile);
+use Mojo::File qw(path);
 use POSIX 'strftime';
 use Term::ANSIColor;
 
@@ -295,7 +295,13 @@ sub log_call {
     return;
 }
 
-sub fileContent { path(shift)->slurp }
+sub fileContent {
+    my ($fn) = @_;
+    warn "DEPRECATED: use 'Mojo::File::path('$fn')->slurp' instead";
+    my $ret = eval { path($fn)->slurp };
+    return undef if ($@);
+    return $ret;
+}
 
 # util and helper functions end
 

--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -26,6 +26,7 @@ use File::Path 'make_path';
 use Cwd 'abs_path';
 use Mojo::JSON;    # booleans
 use Cpanel::JSON::XS ();
+use Test::Warnings qw(warnings :report_warnings);
 
 my $toplevel_dir = abs_path(dirname(__FILE__) . '/..');
 my $data_dir     = "$toplevel_dir/t/data";
@@ -138,6 +139,13 @@ subtest 'HDD variables sanity check' => sub {
     $bmwqemu::vars{PUBLISH_HDD_1} = 'foo.qcow2';
     throws_ok { bmwqemu::_check_publish_vars } qr/HDD_1 also specified in PUBLISH/, 'overwriting source HDD is prevented';
 };
+
+ok -e 'vars.json', 'file exists';
+my @warnings = warnings {
+    like bmwqemu::fileContent('vars.json'),              qr/CASEDIR/, 'fileContent can read file';
+    is bmwqemu::fileContent('vars.json.does_not_exist'), undef,       'fileContent returns undef on errors';
+};
+like $warnings[0], qr{DEPRECATED}, 'fileContent function marked as deprecated';
 
 done_testing;
 


### PR DESCRIPTION
* bmwqemu: Mark fileContent function as deprecated before removing
* Replace bmwqemu::fileContent with cleaner Mojo::File usage
* Remove unused bmwqemu fileContent and save_vars references
* Remove unused use-statements in backend::amt
* Simplify bmwqemu::fileContent with Mojo::File