### PR TITLE
Add test coverage for mouse_tclick testapi function

### DIFF
--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -467,17 +467,17 @@ subtest 'assert_and_click' => sub {
     is_deeply($cmds->[-1], {cmd    => 'backend_mouse_set', x      => 100,     y   => 100}, 'assert_and_click succeeds and move to old mouse set');
 };
 
-subtest 'assert_and_dclick' => sub {
+subtest 'assert_and_dclick and assert_and_tclick' => sub {
     my $mock_testapi = Test::MockModule->new('testapi');
     $mock_testapi->redefine(assert_screen => {area => [{x => 1, y => 2, w => 3, h => 4}]});
-    ok(assert_and_dclick('foo', mousehide => 1));
+    ok(assert_and_dclick and assert_and_tclick('foo', mousehide => 1));
     for (-2, -4) {
-        is_deeply($cmds->[$_], {bstate => 0, button => 'left', cmd => 'backend_mouse_button'}, 'assert_and_dclick succeeds with bstate => 0');
+        is_deeply($cmds->[$_], {bstate => 0, button => 'left', cmd => 'backend_mouse_button'}, 'assert_and_dclick and assert_and_tclick succeeds with bstate => 0');
     }
     for (-3, -5) {
-        is_deeply($cmds->[$_], {bstate => 1, button => 'left', cmd => 'backend_mouse_button'}, 'assert_and_dclick succeeds with bstate => 1');
+        is_deeply($cmds->[$_], {bstate => 1, button => 'left', cmd => 'backend_mouse_button'}, 'assert_and_dclick and assert_and_tclick succeeds with bstate => 1');
     }
-    is_deeply($cmds->[-1], {cmd => 'backend_mouse_hide', offset => 0}, 'assert_and_dclick succeeds and hides mouse with mousehide => 1');
+    is_deeply($cmds->[-1], {cmd => 'backend_mouse_hide', offset => 0}, 'assert_and_dclick and assert_and_tclick succeeds and hides mouse with mousehide => 1');
 };
 
 subtest 'record_info' => sub {

--- a/testapi.pm
+++ b/testapi.pm
@@ -48,7 +48,7 @@ our @EXPORT = qw($realname $username $password $serialdev %cmd %vars
   hold_key release_key
 
   assert_screen check_screen assert_and_dclick save_screenshot
-  assert_and_click mouse_hide mouse_set mouse_click
+  assert_and_click mouse_hide mouse_set mouse_click assert_and_tclick
   mouse_dclick mouse_tclick match_has_tag click_lastmatch mouse_drag
 
   assert_script_run script_run background_script_run
@@ -581,6 +581,12 @@ sub click_lastmatch {
     }
 }
 
+sub assert_and_tclick {
+    my ($mustmatch, %args) = @_;
+    $args{dclick} = 1;
+    return assert_and_click($mustmatch, %args);
+}
+
 =head2 assert_and_dclick
 
   assert_and_dclick($mustmatch [, timeout => $timeout] [, button => $button] [, clicktime => $clicktime ] [, dclick => 1 ] [, mousehide => 1 ]);
@@ -594,6 +600,8 @@ sub assert_and_dclick {
     $args{dclick} = 1;
     return assert_and_click($mustmatch, %args);
 }
+
+
 
 =head2 wait_screen_change
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -581,6 +581,14 @@ sub click_lastmatch {
     }
 }
 
+=head2 assert_and_tclick
+
+  assert_and_tclick($mustmatch [, timeout => $timeout] [, button => $button] [, clicktime => $clicktime ] [, dclick => 1 ] [, mousehide => 1 ]);
+
+Alias for C<assert_and_click> with C<$dclick> set.
+
+=cut
+
 sub assert_and_tclick {
     my ($mustmatch, %args) = @_;
     $args{dclick} = 1;


### PR DESCRIPTION
Add subtest for assert_and_dclick in the t/03-testapi.t file.
Add new function for assert_and_dclick in the testapi.pm file.

Fixes: https://progress.opensuse.org/issues/94315