### PR TITLE
Change root to bernhard for s390x

### DIFF
--- a/consoles/sshIucvconn.pm
+++ b/consoles/sshIucvconn.pm
@@ -32,7 +32,7 @@ sub connect_remote {
     my $zvmguest = get_var('ZVM_GUEST');
 
     # ssh connection to SUT for agetty
-    my $ttyconn = $self->backend->new_ssh_connection(hostname => $hostname, password => $args->{password}, username => 'root');
+    my $ttyconn = $self->backend->new_ssh_connection(hostname => $hostname, password => $args->{password}, username => 'bernhard');
 
     # start agetty to ensure that iucvconn is not killed
     my $chan = $ttyconn->channel() || $ttyconn->die_with_error();


### PR DESCRIPTION
As described in https://progress.opensuse.org/issues/93949, you can not login in the test reconnect_mgmt_console  any more.
That affects all s390x tests. Therefore, I want to switch to the user Bernhard.

That has been recommended in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12757

