### PR TITLE
Skip empty ISO_X variables when configuring block devices

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -235,6 +235,7 @@ sub configure_blockdevs {
     }
     my $is_first = 1;
     for my $k (sort grep { /^ISO_\d+$/ } keys %$vars) {
+        next unless $vars->{$k};
         my $addoniso = File::Spec->rel2abs($vars->{$k});
         my $i        = $k;
         $i =~ s/^ISO_//;

--- a/t/18-qemu.t
+++ b/t/18-qemu.t
@@ -401,4 +401,19 @@ subtest 'qemu was killed due to the system being out of memory' => sub {
     unlink("./Core-7.2.iso");
 };
 
+subtest 'qemu is not called on an empty file when ISO_1 is an empty string' => sub {
+    my $mock_proc  = Test::MockModule->new('OpenQA::Qemu::Proc');
+    my $call_count = 0;
+    $mock_proc->redefine(get_img_size => sub {
+            my ($iso) = @_;
+            $call_count++;
+            die 'get_img_size called on an empty string' unless $iso;
+    });
+
+    my %empty_iso_vars = (ISO_1 => '', NUMDISKS => 0);
+
+    OpenQA::Qemu::Proc->new()->configure_blockdevs('disk', 'raid', \%empty_iso_vars);
+    is($call_count, 0, 'get_img_size call count check');
+};
+
 done_testing();


### PR DESCRIPTION
We are currently checking whether ISO is actually defined but do not perform the
same check for ISO_X, which could be an empty string. In that case os-autoinst
calls qemu on an empty file and fails in a non-obvious way.
Instead we now skip adding ISO_X as a blockdevice if the value is not truthy.