### PR TITLE
Fix use of QEMU_NUMA on qemu >= 5.2

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -978,7 +978,12 @@ sub start_qemu {
         }
         if ($vars->{QEMU_NUMA}) {
             for my $i (0 .. ($vars->{QEMUCPUS} - 1)) {
-                sp('numa', [qv "node nodeid=$i"]);
+                my $m = int($vars->{QEMURAM} / $vars->{QEMUCPUS});
+                # add the rest to the first node to ensure all memory is
+                # allocated
+                $m += $vars->{QEMURAM} % $vars->{QEMUCPUS} if $i == 0;
+                sp('object', "memory-backend-ram,size=${m}m,id=m$i");
+                sp('numa',   [qv "node nodeid=$i,memdev=m$i"]);
             }
         }
 


### PR DESCRIPTION
The qemu parameter "-numa node" needs the memory specified explicitly in
qemu >= 5.2 as the old behaviour was removed, see
https://qemu-stsquad.readthedocs.io/en/docs-next/system/removed-features.html
for reference. Also the parameter "mem" is not supported anymore since
5.1 so it is necessary to configure and use memory devices.

By default we likely always want the memory assigned to the virtual
machine to be evenly split so based on the assigned memory we calculate
an even share, create a memory backed RAM device for each node and
assign the memory device to each node accordingly.

Also verified manually by me for qemu 4.2 on openSUSE Leap 15.2 and
Martchus for qemu 6.0 on openSUSE Tumbleweed.

Related progress issue: https://progress.opensuse.org/issues/94850