### PR TITLE
Fix a few typos

### DIFF
--- a/OpenQA/Qemu/BlockDev.pm
+++ b/OpenQA/Qemu/BlockDev.pm
@@ -44,7 +44,7 @@ use constant FILE_POSTFIX => '-file';
 =head3 driver
 
 The file format and software layer used to power the block device.  Usually we
-use qcow2; infact only the backing files for ISOs and firmwares should be in
+use qcow2; in fact only the backing files for ISOs and firmwares should be in
 any other format.
 
 =cut
@@ -79,7 +79,7 @@ has 'size';
 
 =head3 overlay
 
-A link to another OpenQA::Qemu::BlockDev object which represnts the overlay on
+A link to another OpenQA::Qemu::BlockDev object which represents the overlay on
 top of this block device. This can be undefined in which case this is the
 'active layer', that is, the block device which QEMU is writing to (reads may
 still be taken from the backing files in the chain).

--- a/OpenQA/Qemu/PFlashDevice.pm
+++ b/OpenQA/Qemu/PFlashDevice.pm
@@ -22,7 +22,7 @@ drive device and block device chain are created; we can not set the node id of
 the top block device for example nor can we override the backing file AFAIK.
 
 This class is the same as DriveDevice except for a few extra fields and
-gen_cmdline has been overriden to use '-drive' instead.
+gen_cmdline has been overridden to use '-drive' instead.
 
 =cut
 

--- a/autotest.pm
+++ b/autotest.pm
@@ -181,7 +181,7 @@ sub parse_test_path {
     my $category = $1;
     my $name     = $2;
     if ($category ne 'other') {
-        # show full folder hierachy as category for non-sideloaded tests
+        # show full folder hierarchy as category for non-sideloaded tests
         my $pattern = qr,(tests/[^/]+/)?tests/([\w/]+)/([^/]+)\.p[my]$,;
         if ($script_path =~ $pattern) {
             $category = $2;

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -311,7 +311,7 @@ sub check_select_rate {
     if ($time > $upper_limit) {
         $buckets->{TIME} = $time;
 
-        # This is to give the oportunity to recover, if the reboot/restart is slow
+        # This is to give the opportunity to recover, if the reboot/restart is slow
         for (keys %{$buckets->{BUCKET}}) {
             if ($buckets->{BUCKET}{$_} < $hits_limit) {
                 $buckets->{BUCKET} = {$id => 1};
@@ -726,7 +726,7 @@ sub reenable_consoles {
 Should be called when a snapshot of the SUT is taken to save the current state
 of any consoles which have state. For example: text consoles may have
 unprocessed output from the SUT in their buffers which is needed by test
-module after the snpashot.
+module after the snapshot.
 
 =cut
 sub save_console_snapshots {

--- a/backend/driver.pm
+++ b/backend/driver.pm
@@ -130,7 +130,7 @@ sub start_vm {
 sub stop_backend {
     my ($self) = @_;
     $self->_send_json({cmd => 'stop_vm'});
-    # remove if still existant
+    # remove if still existent
     unlink('backend.run') if -e 'backend.run';
     return;
 }

--- a/backend/pvm.pm
+++ b/backend/pvm.pm
@@ -122,7 +122,7 @@ sub pvmctl {
         die "pvmctl: scsi type needs at least both kind and file" unless ($kind && $file);
 
         #so far only disks are reatachable to the master LPAR
-        #set it back to default if argument is omited
+        #set it back to default if argument is omitted
         $lpar = $target if $target;
         dd_gen_params @cmd, "type",    $kind;
         dd_gen_params @cmd, "stor-id", $file;

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -49,7 +49,7 @@ use OpenQA::Qemu::Proc;
 use constant LONG_MAX => (~0 >> 1);
 
 # Folder where RAM/VM state files live. Note that the blockdevice snapshots go
-# in a seperate dir.
+# in a separate dir.
 use constant VM_SNAPSHOTS_DIR => 'vm-snapshots';
 
 sub new {
@@ -382,7 +382,7 @@ sub save_storage_drives {
             format  => "qcow2"
         });
 
-    diag "Sucessfully extracted disk #%d.", $args->{disk};
+    diag "Successfully extracted disk #%d.", $args->{disk};
     return;
 }
 
@@ -893,7 +893,7 @@ sub start_qemu {
             sp('device', [qv "$vars->{NICMODEL} netdev=qanet$i mac=$nicmac[$i]"]);
         }
 
-        # Keep additionnal virtio _after_ Ethernet setup to keep virtio-net as eth0
+        # Keep additional virtio _after_ Ethernet setup to keep virtio-net as eth0
         if ($vars->{QEMU_VIRTIO_RNG}) {
             sp('object', 'rng-random,filename=/dev/urandom,id=rng0');
             sp('device', 'virtio-rng-pci,rng=rng0');

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -159,7 +159,7 @@ sub login {
                 OpenQA::Exception::VNCSetupError->throw(error => $error_message);
             }
             # we might be too fast trying to connect to the VNC host (e.g.
-            # qemu) so ignore the first occurences of a failed
+            # qemu) so ignore the first occurrences of a failed
             # connection attempt.
             bmwqemu::fctwarn($error_message) if $err_cnt > $connect_failure_limit;
             sleep 1;

--- a/consoles/console.pm
+++ b/consoles/console.pm
@@ -17,7 +17,7 @@
 =head2 consoles::console
 
 Base class for consoles. That is, 'user' interfaces between os-autoinst and
-the SUT which are independant of the backend (e.g. QEMU, IPMI). Consoles are
+the SUT which are independent of the backend (e.g. QEMU, IPMI). Consoles are
 used to match needles against the GUI and send key presses (e.g. VNC) or
 communicate with the shell using text (e.g. virtio_terminal).
 

--- a/consoles/localXvnc.pm
+++ b/consoles/localXvnc.pm
@@ -30,7 +30,7 @@ use testapi qw(get_var);
 
 # helper function
 # Keep ssh session for the maximum of ServerAliveCountMax x ServerAliveInterval seconds
-# even without receiving any messsage back from the server, and this will not affect normal
+# even without receiving any message back from the server, and this will not affect normal
 # ssh disconnect and console switching. Ssh console may not display returned result of
 # long-time run test without these options. TCPKeepAlive ensures that if network goes down
 # or the remote host dies, machines will be properly noticed

--- a/consoles/s3270.pm
+++ b/consoles/s3270.pm
@@ -331,7 +331,7 @@ sub nice_3270_status {
         ## is zero.
         'command_execution_time',
         ## The time that it took for the host to respond to the
-        ## previous commnd, in seconds with milliseconds after the
+        ## previous command, in seconds with milliseconds after the
         ## decimal. If the previous command did not require a host
         ## response, this is a dash.
     );

--- a/consoles/serial_screen.pm
+++ b/consoles/serial_screen.pm
@@ -282,7 +282,7 @@ sub read_until {
 
         # If there is not enough free space in the ring buffer; remove an amount
         # equal to the bytes just read minus the free space in $rbuf from the
-        # begining. If we are recording all output, add the removed bytes to
+        # beginning. If we are recording all output, add the removed bytes to
         # $overflow.
         if (length($rbuf) + $read > $buflen) {
             my $remove_len = $read - ($buflen - length($rbuf));
@@ -309,7 +309,7 @@ sub read_until {
 Read and return pending data without consuming it. This is useful if you are
 about to destroy the serial_screen instance, but want to keep any pending
 data. However this does not wait for any data in particular so this races with
-the backend and data transport. Therefor it should only be used when there is
+the backend and data transport. Therefore it should only be used when there is
 no information available about what data is expected to be available.
 
 =cut

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -149,7 +149,7 @@ sub _init_xml {
     # The root of all problems is this: Xen closes VNC and serial console connections
     # on reboot. Unlike KVM. So, to know when we are restarting if we are in the
     # state before, or after restart we have to configure libvirt to destroy
-    # (i.e. turn off) the VM. Then we have to explicitely start it define_and_start.
+    # (i.e. turn off) the VM. Then we have to explicitly start it define_and_start.
     # Even if KVM does not need this, from test code POV it's convenient to have it.
     if ($self->vmm_family eq 'xen' || $self->vmm_family eq 'kvm') {
         $elem = $doc->createElement('on_reboot');
@@ -198,7 +198,7 @@ sub change_domain_element {
         my $parent   = $elem;
         my $tag_name = shift @_;
         $elem = $parent->getElementsByTagName($tag_name)->[0];
-        # create it if not existant
+        # create it if not existent
         if (!$elem) {
             $elem = $doc->createElement($tag_name);
             $parent->appendChild($elem);

--- a/consoles/sshXtermIPMI.pm
+++ b/consoles/sshXtermIPMI.pm
@@ -44,7 +44,7 @@ sub activate {
     my $ipmi_response = $@;
     if ($ipmi_response) {
         # IPMI response like SOL payload already de-activated is expected
-        die "Unexpect IPMI response: $ipmi_response" unless
+        die "Unexpected IPMI response: $ipmi_response" unless
           ($ipmi_response =~ /SOL payload already de-activated/);
     }
 

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -27,14 +27,14 @@ SSH_CONNECT_RETRY;integer;5;Maximum retries to connect to SSH based console targ
 SSH_CONNECT_RETRY_INTERVAL;float;10;Interval in seconds between retries to connect to SSH based console targets. Related to SSH_CONNECT_RETRY
 VNC_STALL_THRESHOLD;integer;4;Time after which is VNC considered stalled
 VNC_TYPING_LIMIT;integer;30;Maximum number of keys per second
-_CHKSEL_RATE_WAIT_TIME;integer;30;The ammount of time isotovideo is going to wait for the VNC console to become responsive
-_CHKSEL_RATE_HITS;integer;15000;The ammount of times, the select should return the same fileno during the _CHKSEL_RATE_WAIT_TIME seconds, to consider the VNC console unresponsive
+_CHKSEL_RATE_WAIT_TIME;integer;30;The amount of time isotovideo is going to wait for the VNC console to become responsive
+_CHKSEL_RATE_HITS;integer;15000;The amount of times, the select should return the same fileno during the _CHKSEL_RATE_WAIT_TIME seconds, to consider the VNC console unresponsive
 TIMEOUT_SCALE;integer;1;This scale parameter can be used based on performance of workers to prevent false positive timeouts based on differing worker performance.
 PAUSE_AT;string;;Test module (name or fullname) to pause test execution at. To be used together with the openQA developer mode to continue test execution. Be aware that the openQA web UI will only reflect this within the developer mode after confirming to control the test.
 PAUSE_ON_SCREEN_MISMATCH;boolean;0;Pause test execution on the next screen mismatch. Same notes as for `PAUSE_AT` apply.
 PAUSE_ON_NEXT_COMMAND;boolean;0;Pause test execution on the next test API command. Same notes as for `PAUSE_AT` apply.
 _QUIET_SCRIPT_CALLS;boolean;0;Add quiet flag to all the calls to script_run, script_output and validate_script_output. It will omit all the squares "wait_serial expected" on the Details view of the test case. This option might be useful for serial terminal tests.
-AUTOINST_URL_HOSTNAME;string;;hostname or IP adress of host running the autoinst webserver endpoint, defaults to the local IP adress within the qemu network for the qemu backend or the `WORKER_HOSTNAME` otherwise.
+AUTOINST_URL_HOSTNAME;string;;hostname or IP address of host running the autoinst webserver endpoint, defaults to the local IP address within the qemu network for the qemu backend or the `WORKER_HOSTNAME` otherwise.
 
 |====================
 
@@ -89,7 +89,7 @@ HDDSIZEGB;integer;10;Creates HDD with specified size in GiB
 HDD_$i;filename;;Filename of HDD image to be used for VM. Up to 9
 HDDNUMQUEUES_$i;integer;-1;see qemu-system-x86_64 -device nvme,help - set the number of queues for HDD_$i
 ISO;filename;;Filename of ISO file to be attached to VM
-ISO_$i;filename;;Aditional ISO to be attached to VM. Up to 9
+ISO_$i;filename;;Additional ISO to be attached to VM. Up to 9
 KEEPHDDS;boolean;;Leave created HDD after test finishes. Useful for debugging tests
 LAPTOP;boolean or filename;0;If 1, loads Dell E6330 DMI. If filename, loads specified DMI
 MAKETESTSNAPSHOTS;boolean;0;Save snapshot for each test module in qcow image
@@ -131,7 +131,7 @@ QEMU_NO_TABLET;boolean;0;Don't use USB tablet.
 QEMU_VIRTIO_RNG;boolean;0;Enable virtio random number generator
 QEMU_NUMA;boolean;0;Enable NUMA simulation, requires QEMUCPUS to be greater than one
 QEMU_SMBIOS;see qemu -smbios ?;undef;pass this value to qemu -smbios
-QEMU_SOUNDHW;see qemu -soundhw ?;hda;pass this value to qemu -soundhw (for qemu < 4.2)
+QEMU_SOUNDHW;see qemu -soundhw ?;had;pass this value to qemu -soundhw (for qemu < 4.2)
 QEMU_AUDIODEV;see qemu -device ?;intel-hda;Audio device to use with audiodev to qemu -device (for qemu >= 4.2)
 QEMU_AUDIOBACKEND;see qemu -audio-help;none;Audio backend to use with audiodev (for qemu >= 4.2)
 QEMU_COMPRESS_LEVEL;integer;6;Sets the compression level used for memory dumps and snapshots. Zero turns compression off and 9 is the maximum level. Generally there is little improvement in compression ratio by increasing the level, but the CPU time can be high on some platforms.
@@ -184,7 +184,7 @@ VIRSH_GUEST_PASSWORD;string;;VNC password of the guest
 VIRSH_INSTANCE;integer;;VM's instance number on VIRSH_HOSTNAME
 VMWARE_USERNAME;string;;Administrator's username ('@' is '%40')
 VMWARE_PASSWORD;string;;Administrator's password
-VMWARE_HOST;string;;VCS server for autentication
+VMWARE_HOST;string;;VCS server for authentication
 VMWARE_DATASTORE;string;;VMware datastore
 VMWARE_NFS_DATASTORE;string;;VMware datastore with openQA NFS directories
 VMWARE_SERIAL_PORT;string;;TCP port where is VM's serial port stream to be expected on the ESX server
@@ -225,7 +225,7 @@ QEMURAM;integer;undef;Quantity of RAM
 [options="header",cols="^m,^m,^m,v",separator=";"]
 |====================
 Variable;Values allowed;Default value;Explanation
-ARCH;string;undef;Arquitecture of the pvm backend
+ARCH;string;undef;Architecture of the pvm backend
 MEM;integer;2048;amount of RAM
 LPAR;string;osauto;LPAR name to be created
 LPARID;string;udef;LPAR id
@@ -264,7 +264,7 @@ GENERAL_HW_POWERON_CMD;string;;Shell Command to power on the SUT (in CMD_DIR)
 GENERAL_HW_POWERON_ARGS;string;;Arguments to pass GENERAL_HW_POWERON_CMD Shell script
 GENERAL_HW_POWEROFF_CMD;string;;Shell Command to power off the SUT (in CMD_DIR)
 GENERAL_HW_POWEROFF_ARGS;string;;Arguments to pass GENERAL_HW_POWEROFF_CMD Shell script
-GENERAL_HW_FLASH_CMD;string;;Shell Command to flash a disk image on SUT (in CMD_DIR), optionnal
+GENERAL_HW_FLASH_CMD;string;;Shell Command to flash a disk image on SUT (in CMD_DIR), optional
 GENERAL_HW_FLASH_ARGS;string;;Arguments to pass GENERAL_HW_FLASH_CMD Shell script
 |====================
 

--- a/external/os-autoinst-common/README.md
+++ b/external/os-autoinst-common/README.md
@@ -61,7 +61,7 @@ them and then do:
 
 You can find more information here:
 * [Repository and usage](https://github.com/ingydotnet/git-subrepo)
-* [A good comparison beween subrepo, submodule and
+* [A good comparison between subrepo, submodule and
   subtree](https://github.com/ingydotnet/git-subrepo/blob/master/Intro.pod)
 
 

--- a/isotovideo
+++ b/isotovideo
@@ -53,7 +53,7 @@ use autodie ':all';
 no autodie 'kill';
 
 my $installprefix;    # $bmwqemu::scriptdir
-my $fatal_error;      # the last error message catched by the die handler
+my $fatal_error;      # the last error message caught by the die handler
 
 BEGIN {
     # the following line is modified during make install

--- a/mmapi.pm
+++ b/mmapi.pm
@@ -139,7 +139,7 @@ sub handle_api_error {
     my $children = get_children_by_state('done');
     print $children->[0]
 
-Returns an array ref conaining ids of children in given state.
+Returns an array ref containing ids of children in given state.
 
 =cut
 
@@ -152,10 +152,10 @@ sub get_children_by_state {
 
 =head2 get_children
 
-    my $childern = get_children();
+    my $children = get_children();
     print keys %$children;
 
-Returns a hash ref conaining { id => state } pair for each child job.
+Returns a hash ref containing { id => state } pair for each child job.
 
 =cut
 
@@ -170,7 +170,7 @@ sub get_children {
     my $parents = get_parents
     print $parents->[0]
 
-Returns an array ref conaining ids of parent jobs.
+Returns an array ref containing ids of parent jobs.
 
 =cut
 
@@ -239,7 +239,7 @@ sub get_job_autoinst_vars {
     my $url = get_job_autoinst_url($target_id);
     return undef unless $url;
 
-    # query the os-autoinst webserver of the job specifed by $target_id
+    # query the os-autoinst webserver of the job specified by $target_id
     $url .= '/vars';
 
     my $ua = Mojo::UserAgent->new;

--- a/ppmclibs/tinycv.h
+++ b/ppmclibs/tinycv.h
@@ -16,7 +16,7 @@
 #include <string>
 #include <vector>
 
-// opaque type to seperate perl from opencv
+// opaque type to separate perl from opencv
 struct Image;
 void create_opencv_threads(int thread_count);
 void image_destroy(Image *s);

--- a/snd2png/snd2png.cpp
+++ b/snd2png/snd2png.cpp
@@ -2,7 +2,7 @@
 /*
   snd2png.cpp - idea is from http://snd2fftw.sourceforge.net/, but the code
   doesn't
-  have more similiarity to its grandfather than to a random fftw example
+  have more similarity to its grandfather than to a random fftw example
 */
 
 #include <fftw3.h>
@@ -168,11 +168,11 @@ int main(int argc, char* argv[])
     }
 
     int scale_factor = 3;
-    int height = 768; // make sure it can be devided by the scale_factor
+    int height = 768; // make sure it can be divided by the scale_factor
 
     // we have to cover 3000 hz and 18 hz is the sitance between D4 and E4, so
     // don't
-    // go too low with the number of frequences to cover
+    // go too low with the number of frequencies to cover
     int freqs = height / scale_factor;
     Mat grayscaleMat(height, 1024, CV_8U, Scalar(255));
 

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -832,7 +832,7 @@ subtest 'mouse_drag' => sub {
                 button => 'left',
                 cmd    => 'backend_mouse_button'
             },
-    ], 'mouse drag (redundant definiton by a needle)') or diag explain $cmds;
+    ], 'mouse drag (redundant definition by a needle)') or diag explain $cmds;
 };
 
 done_testing;

--- a/t/10-terminal.t
+++ b/t/10-terminal.t
@@ -344,7 +344,7 @@ sub check_child {
 # The virtio_terminal expects the socket to be ready by the time it is activated
 # so wait for fake terminal to create socket and emit SIGCONT. Sigsuspend only
 # returns if a signal is received which has a handler set. We must initially
-# block the signal incase SIGCONT is emitted before we reach sigsuspend.
+# block the signal in case SIGCONT is emitted before we reach sigsuspend.
 my $pipe_in  = $socket_path . ".in";
 my $pipe_out = $socket_path . ".out";
 

--- a/t/10-virtio_terminal.t
+++ b/t/10-virtio_terminal.t
@@ -111,7 +111,7 @@ subtest "Test open_pipe() error condition" => sub {
 
     $term = consoles::virtio_terminal->new('unit-test-console', {socked_path => $socket_path});
     combined_like { throws_ok { $term->open_pipe() } qr/No such file or directory/, "Throw exception if pipe doesn't exists" }
-    qr/\[debug\] <<<.*open_pipe/, 'log for open_pipe on non-existant pipe';
+    qr/\[debug\] <<<.*open_pipe/, 'log for open_pipe on non-existent pipe';
 };
 
 subtest "Test snapshot handling" => sub {
@@ -150,11 +150,11 @@ subtest "Test snapshot handling" => sub {
     $term->save_snapshot('snap3');
 
     $term->load_snapshot('snap1');
-    is_deeply($term->screen()->peak(), $test_data, '[snap1] carry over buffer sucessful loaded');
+    is_deeply($term->screen()->peak(), $test_data, '[snap1] carry over buffer successful loaded');
     is($term->{activated}, 1, '[snap1] console is still activated');
 
     $term->load_snapshot('snap3');
-    is_deeply($term->screen()->peak(), 'foo', '[snap3] carry over buffer sucessful loaded');
+    is_deeply($term->screen()->peak(), 'foo', '[snap3] carry over buffer successful loaded');
     is($term->{activated}, 0, '[snap3] console is not activated');
 
     $term->disable();

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -54,7 +54,7 @@ subtest modules_test => sub {
     $bmwqemu::vars{INCLUDE_MODULES} = 'bar,baz,foo';
     ok($basetest->is_applicable, 'a passlisted module shows up');
     $bmwqemu::vars{EXCLUDE_MODULES} = 'foo';
-    ok(!$basetest->is_applicable, 'passlisted modules are overriden by blocklist');
+    ok(!$basetest->is_applicable, 'passlisted modules are overridden by blocklist');
 };
 
 subtest parse_serial_output => sub {

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -209,7 +209,7 @@ subtest 'SSH utilities' => sub {
     is($ssh2->{connected},     1, "SSH connection ssh2 connected");
     is($ssh7->{connected},     1, "SSH connection ssh7 connected");
     is($ssh8->{connected},     1, "SSH connection ssh8 connected");
-    # +1 unamed connection form implicit run_ssh_cmd()
+    # +1 unnamed connection form implicit run_ssh_cmd()
 
     is(scalar(@disconnected_ssh), 3, "Expect 3 disconnected SSH connections");
     is($ssh3->{connected},        0, "SSH connection ssh3 disconnected");
@@ -249,7 +249,7 @@ subtest 'SSH utilities' => sub {
         });
         my $exit_value;
         stdout_is { $exit_value = $baseclass->check_ssh_serial($ssh->sock()) } $expect_output, 'Serial output is printed to STDOUT';
-        is(path($baseclass->{serialfile})->slurp(), $expect_output, 'Serial output is writen to serial file');
+        is(path($baseclass->{serialfile})->slurp(), $expect_output, 'Serial output is written to serial file');
         is($exit_value,                             1,              'Check return value on success');
 
         $channel_read_string = undef;

--- a/tools/tidy
+++ b/tools/tidy
@@ -12,7 +12,7 @@ Options:
  -h, -?, --help       display this help
  -c, --check          Only check for style check differences
  -f, --force          Force check even if tidy version mismatches
- -o --only-changed    Only tidy files with uncommited changes in git. This can
+ -o --only-changed    Only tidy files with uncommitted changes in git. This can
                       speed up execution a lot.
 
 perltidy rules can be found in .perltidyrc

--- a/videoencoder.cpp
+++ b/videoencoder.cpp
@@ -35,7 +35,7 @@ The output file path needs to be passed as CLI argument. Passing '-n'
 prevents the actual video encoding so only the PNG is produced
 anymore (as needed).
 
-This program will wait until it recieves a TERM signal to complete the
+This program will wait until it receives a TERM signal to complete the
 video.
 
  ********************************************************************/


### PR DESCRIPTION
The typos have been determined via `codespell --skip .git -w`.
Unfortunately there are too many false-positives to add this as automatic
check.