### PR TITLE
Set default value for HDDSIZEGB as in QEMU or PVM backends

### DIFF
--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -54,8 +54,8 @@ sub do_start_vm {
     my ($self) = @_;
 
     my $vars = \%bmwqemu::vars;
-    my $n    = $vars->{NUMDISKS} // 1;
-    $vars->{NUMDISKS} //= defined($vars->{RAIDLEVEL}) ? 4 : $n;
+    $vars->{HDDSIZEGB} //= 10;
+    $vars->{NUMDISKS}  //= defined($vars->{RAIDLEVEL}) ? 4 : 1;
     $self->truncate_serial_file;
     my $ssh = $testapi::distri->add_console(
         'svirt',

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -329,13 +329,13 @@ sub add_disk {
 
     my $backingfile             = $args->{backingfile};
     my $cdrom                   = $args->{cdrom};
+    my $size                    = $args->{size} || '20G';
     my $name                    = $self->name;
     my $file                    = $name . $args->{dev_id} . ($self->vmm_family eq 'vmware' ? '.vmdk' : '.img');
     my $basedir                 = '/var/lib/libvirt/images/';
     my $vmware_datastore        = get_var('VMWARE_DATASTORE', '');
     my $vmware_openqa_datastore = "/vmfs/volumes/$vmware_datastore/openQA/";
     if ($args->{create}) {
-        my $size = $args->{size} || '20G';
         if ($self->vmm_family eq 'vmware') {
             my $vmware_disk_path = $vmware_openqa_datastore . $file;
             # Power VM off, delete it's disk image, and create it again.
@@ -417,7 +417,7 @@ sub add_disk {
             }
             else {
                 $file = $basedir . $file;
-                $self->run_cmd(sprintf("qemu-img create '${file}' -f qcow2 -b '$basedir/%s'", $file_basename))
+                $self->run_cmd(sprintf("qemu-img create '${file}' -f qcow2 -b '$basedir/%s' $size", $file_basename))
                   && die 'qemu-img create with backing file failed';
             }
         }


### PR DESCRIPTION
As a follow-up for [SLE Micro: update schedule to properly boot s390x image](os-autoinst/os-autoinst-distri-opensuse#12759)
and to provide fix for [image size failure check](https://openqa.suse.de/tests/6397443#step/image_checks/7) we need
to create backing image file of specified size as it is in [SLEM-qemu](https://openqa.suse.de/tests/6299772#step/image_checks/4) or [MicroOS](https://openqa.opensuse.org/tests/1829744#step/image_checks/4).

```
[2021-07-08T10:50:30.408 CEST] [debug] <<< backend::console_proxy::__ANON__(wrapped_call={
    "console" => "svirt",
    "function" => "add_disk",
    "args" => [
                {
                  "file" => "/var/lib/openqa/share/factory/hdd/SUSE-MicroOS.s390x-5.1.0-Default-kvm-Build6.3.qcow2",
                  "dev_id" => "a",
                  "backingfile" => 1,
                  "size" => "30G"
                }
              ],
    "wantarray" => undef
  })
```