### PR TITLE
Improve error message when cloning git repository

### DIFF
--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -59,7 +59,7 @@ sub checkout_git_repo_and_branch {
 
     my $branch      = $url->fragment;
     my $clone_url   = $url->fragment(undef)->to_string;
-    my $local_path  = $url->path->parts->[-1] =~ s/.git//r;
+    my $local_path  = $url->path->parts->[-1] =~ s/\.git$//r;
     my $clone_cmd   = 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git clone';
     my $clone_args  = "--depth $args{clone_depth}";
     my $branch_args = '';
@@ -93,7 +93,7 @@ sub checkout_git_repo_and_branch {
                 $return_code = $?;
                 bmwqemu::diag "git fetch: @out";
                 die "Unable to fetch Git repository '$dir' specified via $dir_variable (see log for details)" unless $return_code == 0;
-                die "Could not find '$branch' in complete history" if grep /remote: Total 0/, @out;
+                die "Could not find '$branch' in complete history in cloned Git repository '$dir'" if grep /remote: Total 0/, @out;
             }
             qx{git -C $local_path checkout $branch};
             die "Unable to checkout branch '$branch' in cloned Git repository '$dir'" unless $? == 0;

--- a/t/34-git.t
+++ b/t/34-git.t
@@ -1,0 +1,103 @@
+#!/usr/bin/perl
+#
+# Copyright (c) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use Test::Most;
+use File::Path qw(rmtree);
+use FindBin '$Bin';
+use Test::Output qw(combined_from);
+use OpenQA::Isotovideo::Utils qw(checkout_git_repo_and_branch);
+use OpenQA::Test::TimeLimit '5';
+use Test::Warnings ':report_warnings';
+
+use Mojo::File 'tempdir';
+my $tmpdir    = tempdir("/tmp/$FindBin::Script-XXXX");
+my $git_dir   = "$tmpdir/tmpgitrepo";
+my $clone_dir = "$Bin/tmpgitrepo";
+
+chdir $Bin;
+
+my $head        = initialize_git_repo();
+my $case_dir_ok = "file://$git_dir#$head";
+my $case_dir    = "file://$git_dir#abcdef";
+
+subtest 'failing clone' => sub {
+    %bmwqemu::vars = (
+        CASEDIR => $case_dir,
+    );
+    my $path;
+    my $out = combined_from {
+        eval { $path = checkout_git_repo_and_branch('CASEDIR') };
+    };
+    my $error = $@;
+    like $error, qr{Could not find 'abcdef' in complete history in cloned Git repository '\Q$case_dir\E'}, "Error message when trying to clone wrong git hash";
+    like $out,   qr{Cloning git URL.*Fetching more remote objects.*git fetch:}s,                           'git fetch was called to get more commits';
+};
+
+cleanup();
+
+subtest 'successful clone' => sub {
+    my $path;
+    %bmwqemu::vars = (
+        CASEDIR => $case_dir_ok,
+    );
+    my $out = combined_from {
+        $path = checkout_git_repo_and_branch('CASEDIR');
+    };
+    is $path, $clone_dir, 'checkout_git_repo_and_branch returned correct path';
+    like $out, qr{Cloning git URL.*Fetching more remote objects}s, 'git clone was called again to fetch a git hash';
+
+    %bmwqemu::vars = (
+        CASEDIR => $case_dir_ok,
+    );
+    $out = combined_from {
+        $path = checkout_git_repo_and_branch('CASEDIR');
+    };
+    is $path, $clone_dir, 'checkout_git_repo_and_branch with existing local directory returned correct path';
+    like $out, qr{Skipping to clone.*tmpgitrepo already exists}, 'Log says that local directory already exists';
+};
+
+done_testing;
+
+sub initialize_git_repo {
+    my $git_init = <<"EOM";
+mkdir $git_dir
+cd $git_dir
+git init >/dev/null 2>&1
+git config user.email "you\@example.com" >/dev/null
+git config user.name "Your Name" >/dev/null
+git config init.defaultBranch main >/dev/null
+touch README
+git add README
+git commit -mInit >/dev/null
+EOM
+    system $git_init;
+
+    # Create some dummy commits so the code has to increase the clone depth a
+    # couple of times
+    for (1 .. 10) {
+        my $git_add = qq{cd $git_dir; echo $_ >>README; git add README; git commit -m"Commit $_" >/dev/null};
+        system $git_add;
+    }
+    chomp(my $head = qx{git -C $git_dir rev-parse HEAD});
+    return $head;
+}
+
+sub cleanup { rmtree $clone_dir }
+
+END {
+    cleanup();
+}


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/94678

If a user sees the error message

    Could not find 'abcdef' in complete history

then it's not clear where the git repo was cloned from.

The git directory or URL is now added to the error message.

Also this commit fixes the removal of the `.git` suffix.