### PR TITLE
Remove contradicting timezone stamps

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -392,7 +392,7 @@ sub runtest {
 
     $self->done();
     $self->{execution_time} = execution_time($starttime);
-    bmwqemu::diag(sprintf("||| finished %s %s at %s (%d s)", $name, $self->{category}, POSIX::strftime('%F %T', gmtime), $self->{execution_time}));
+    bmwqemu::diag(sprintf("||| finished %s %s at %s (%d s)", $name, $self->{category}, $self->{execution_time}));
     return;
 }
 


### PR DESCRIPTION
Delete contradicting timezone stamps observed in the autoinst-log.txt
Amending basetest.pm deletes the second timestamp that is UTC contradicting with the initial CEST observed at the beginning of the line
The changes should be should produce the following example ;
  [2021-07-05T17:14:58.348 CEST] [debug] ||| finished grub_test installation (8 s)       instead of
  [2021-07-05T17:14:58.348 CEST] [debug] ||| finished grub_test installation at 2021-07-05 15:14:58 (8 s)
Reference:   #1720
See: https://progress.opensuse.org/issues/95149