### PR TITLE
Display curl progress meter in upload_logs() & upload_assets()

### DIFF
--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -35,6 +35,7 @@ PAUSE_ON_SCREEN_MISMATCH;boolean;0;Pause test execution on the next screen misma
 PAUSE_ON_NEXT_COMMAND;boolean;0;Pause test execution on the next test API command. Same notes as for `PAUSE_AT` apply.
 _QUIET_SCRIPT_CALLS;boolean;0;Add quiet flag to all the calls to script_run, script_output and validate_script_output. It will omit all the squares "wait_serial expected" on the Details view of the test case. This option might be useful for serial terminal tests.
 AUTOINST_URL_HOSTNAME;string;;hostname or IP address of host running the autoinst webserver endpoint, defaults to the local IP address within the qemu network for the qemu backend or the `WORKER_HOSTNAME` otherwise.
+UPLOAD_METER;boolean;0;Display curl progress meter in `upload_logs()` and `upload_assets()` subroutines.
 
 |====================
 

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -835,4 +835,12 @@ subtest 'mouse_drag' => sub {
     ], 'mouse drag (redundant definition by a needle)') or diag explain $cmds;
 };
 
+subtest 'show_curl_progress_meter' => sub {
+    $testapi::serialdev = 'ttyS0';
+    $bmwqemu::vars{UPLOAD_METER} = 1;
+    is(testapi::show_curl_progress_meter(), '-o /dev/ttyS0 ', 'show_curl_progress_meter returns curl output parameter pointing to /dev/ttyS0');
+    $bmwqemu::vars{UPLOAD_METER} = 0;
+    is(testapi::show_curl_progress_meter(), '', 'show_curl_progress_meter returns "0" when UPLOAD_METER is not set');
+};
+
 done_testing;

--- a/testapi.pm
+++ b/testapi.pm
@@ -2233,6 +2233,7 @@ sub upload_logs {
     my $basename = basename($file);
     my $upname   = $args{log_name} || ($autotest::current_test->{name} . '-' . $basename);
     my $cmd      = "curl --form upload=\@$file --form upname=$upname ";
+    $cmd .= show_curl_progress_meter();
     $cmd .= autoinst_url("/uploadlog/$basename");
     if ($failok) {
         # just use script_run so we don't care if the upload fails
@@ -2280,6 +2281,7 @@ sub upload_asset {
     bmwqemu::log_call(file => $file, public => $public, nocheck => $nocheck);
     my $cmd = "curl --form upload=\@$file ";
     $cmd .= "--form target=assets_public " if $public;
+    $cmd .= show_curl_progress_meter();
     my $basename = basename($file);
     $cmd .= autoinst_url("/upload_asset/$basename");
     if ($nocheck) {
@@ -2312,5 +2314,19 @@ sub compat_args {
     map { $ret{$_} //= $def_args->{$_} } keys(%{$def_args});
     return %ret;
 }
+
+=head2 show_curl_progress_meter
+
+Helper function to alter the curl command to show progress meter.
+Progress meter is shown only when the server output is redirected.
+This works only when uploading where the output is not lately used.
+
+    show_curl_progress_meter( $cmd )
+
+A typical call would look like:
+
+    $cmd .= show_curl_progress_meter($cmd);
+=cut
+sub show_curl_progress_meter { get_var('UPLOAD_METER') ? "-o /dev/$serialdev " : '' }
 
 1;


### PR DESCRIPTION
In `upload_logs()` the `curl` does not display the progress meter.
This is because `curl` by default displays the response output.
We display the meter by redirecting output to `/dev/$serialdev`.

 This is enabled only when `UPLOAD_METER` variable is present.

 * Test runs: [mau-extratests1](http://pdostal-server.suse.cz/tests/12380) [mau-extratests1 UPLOAD_METER](http://pdostal-server.suse.cz/tests/12381) [publiccloud_containers UPLOAD_METER](http://pdostal-server.suse.cz/tests/12379) [publiccloud_containers](http://pdostal-server.suse.cz/tests/12378)