### PR TITLE
t: Save around 30s from the full stack test

### DIFF
--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -112,7 +112,10 @@ subtest 'productdir variable relative/absolute' => sub {
     unlink("$pool_dir/product/foo/main.pm");
     mkdir("$data_dir/tests/product")                                      unless -e "$data_dir/tests/product";
     symlink("$data_dir/tests/main.pm", "$data_dir/tests/product/main.pm") unless -e "$data_dir/tests/product/main.pm";
-    combined_like { isotovideo(opts => "casedir=$data_dir/tests _exit_after_schedule=1 productdir=product") } qr/\d* scheduling.*shutdown/, 'schedule can still be found for productdir relative to casedir';
+    # additionally testing correct schedule for our "integration tests" mode
+    my $log = combined_from { isotovideo(opts => "casedir=$data_dir/tests _exit_after_schedule=1 productdir=product integration_tests=1") };
+    like $log,   qr/\d* scheduling.*shutdown/, 'schedule can still be found for productdir relative to casedir';
+    unlike $log, qr/assert_screen_fail_test/,  'assert screen test not scheduled';
 };
 
 subtest 'upload assets on demand even in failed jobs' => sub {

--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-# Copyright (C) 2017-2020 SUSE LLC
+# Copyright (C) 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,7 +19,7 @@ use Test::Most;
 
 use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";
-use OpenQA::Test::TimeLimit '360';
+use OpenQA::Test::TimeLimit '300';
 use Test::Warnings ':report_warnings';
 use Try::Tiny;
 use File::Basename;
@@ -100,31 +100,5 @@ subtest 'Assert screen failure' => sub {
 
     is($count, 2, 'Assert screen failures');
 };
-
-open($var, '>', 'vars.json');
-print $var <<EOV;
-{
-   "ARCH" : "i386",
-   "BACKEND" : "qemu",
-   "QEMU" : "i386",
-   "QEMU_NO_KVM" : "1",
-   "QEMU_NO_TABLET" : "1",
-   "QEMU_NO_FDC_SET" : "1",
-   "CASEDIR" : "$data_dir/tests",
-   "ISO" : "$data_dir/Core-7.2.iso",
-   "CDMODEL" : "ide-cd",
-   "HDDMODEL" : "ide-hd",
-   "INTEGRATION_TESTS" : "1",
-   "VERSION" : "1"
-}
-EOV
-
-# call isotovideo with additional test parameters provided by command line
-system("perl $toplevel_dir/isotovideo -d qemu_disable_snapshots=1 2>&1 | tee autoinst-log.txt");
-$log = path('autoinst-log.txt')->slurp;
-unlike $log, qr/assert_screen_fail_test/,         'assert screen test not scheduled';
-like $log,   qr/\d* Snapshots are not supported/, 'Snapshots are not supported';
-like $log,   qr/isotovideo done/,                 'isotovideo is done';
-like $log,   qr/EXIT 0/,                          'Test finished as expected';
 
 done_testing();


### PR DESCRIPTION
By moving the simple check for correct schedule evaluation into
14-isotovideo which stops after schedule evaluation we only loose
coverage of running an actual full-stack test with slightly changed
schedule which should not be needed. By doing this change and not doing
a full-stack run again we can save roughly 30s or more in the
longest-run test.