### PR TITLE
Revert "Workaround "No route to ..." after upstream fix

### DIFF
--- a/t/data/tests/tests/modify_and_upload_file.pm
+++ b/t/data/tests/tests/modify_and_upload_file.pm
@@ -44,9 +44,6 @@ sub run {
     my $url = autoinst_url . '/files/modified.xml';
     $content =~ s/PASSWORD/nots3cr3t/g;
     save_tmp_file('modified.xml', $content);
-    # ensure we have an IP to workaround "No route to host" error
-    # note: Note sure why the IP address is not assigned automatically anymore as it used to be.
-    assert_script_run('sudo ifconfig eth0 add 10.0.2.2\24');
     # Verify that correct file is downloaded
     assert_script_run("wget -q $url");
     script_run "echo '72d2c15cb10535f36862d7d2eecc8a79  modified.xml' > modified.md5";


### PR DESCRIPTION
This reverts commit 3cd3e5fe076ad4c1ee55ace70eade03d1f1f9bc8 as
https://build.opensuse.org/request/show/907726 brought a proper solution
to the upstream issue.