### PR TITLE
qemu: remove medium from cd when ejecting

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -104,10 +104,13 @@ sub power {
 
 sub eject_cd {
     my ($self, $args) = @_;
+    die "'device' parameter is not supported anymore, use 'id'" if defined $args->{device};
+    my $id = $args->{id} // 'cd0-device';
     $self->handle_qmp_command({execute => 'eject', arguments => {
-                (defined $args->{id} || !defined $args->{device} ? (id => $args->{id} // 'cd0-device') : (device => $args->{device})),
+                id    => $id,
                 force => (!defined $args->{force} || $args->{force} ? Mojo::JSON->true : Mojo::JSON->false)
     }});
+    $self->handle_qmp_command({execute => 'blockdev-remove-medium', arguments => {id => $id}});
 }
 
 sub execute_qmp_command {

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -72,15 +72,19 @@ is_deeply($called{handle_qmp_command}, [{execute => 'system_powerdown'}], 'power
 $called{handle_qmp_command} = undef;
 
 subtest 'eject cd' => sub {
-    my %default_eject_params = (execute => 'eject', arguments => {id     => 'cd0-device', force => Mojo::JSON->true});
-    my %legacy_eject_params  = (execute => 'eject', arguments => {device => 'cd0',        force => Mojo::JSON->false});
+    my %default_eject_params  = (execute => 'eject',                  arguments => {id => 'cd0-device', force => Mojo::JSON->true});
+    my %default_remove_params = (execute => 'blockdev-remove-medium', arguments => {id => 'cd0-device'});
+    my %custom_eject_params   = (execute => 'eject',                  arguments => {id => 'cd1', force => Mojo::JSON->false});
+    my %custom_remove_params  = (execute => 'blockdev-remove-medium', arguments => {id => 'cd1'});
 
     $called{handle_qmp_command} = undef;
     $backend->eject_cd;
-    is_deeply $called{handle_qmp_command}[0], \%default_eject_params, 'eject called with correct defaults';
+    is_deeply $called{handle_qmp_command}[0], \%default_eject_params,  'eject called with correct defaults';
+    is_deeply $called{handle_qmp_command}[1], \%default_remove_params, 'blockdev-remove-medium called with correct defaults';
     $called{handle_qmp_command} = undef;
-    $backend->eject_cd({device => 'cd0', force => 0});
-    is_deeply $called{handle_qmp_command}[0], \%legacy_eject_params, 'eject called with custom parameters';
+    $backend->eject_cd({id => 'cd1', force => 0});
+    is_deeply $called{handle_qmp_command}[0], \%custom_eject_params,  'eject called with custom parameters';
+    is_deeply $called{handle_qmp_command}[1], \%custom_remove_params, 'blockdev-remove-medium called with custom parameters';
 };
 
 subtest 'execute arbitrary QMP command' => sub {


### PR DESCRIPTION
Just ejecting the cd does not prevent the SUT to access it - the tray
can be injected again (even by the OS itself). This makes the 'eject_cd'
much less useful in tests that verify if the system indeed (or the
installer itself) works independently of the boot CD/DVD.

Improve this by executing also 'blockdev-remove-medium' QMP command, that
indeed remove the medium after ejecting the CD. Note this command
accepts only 'id' parameter (doesn't support 'device' param), so use
only that. In practice, on calls just 'eject_cd()' anyway.