### PR TITLE
qemu: Ensure chattr ends within reasonable time to prevent potential blockage

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -335,6 +335,7 @@ sub init_blockdev_images {
         die "init_blockdev_images: '@$qicmd' failed after $tries tries: $@" if $@;
     }
 
+    bmwqemu::diag('init_blockdev_images: Finished creating block devices');
     $self->blockdev_conf->mark_all_created();
 }
 

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -754,6 +754,7 @@ sub start_qemu {
     # do not use autodie here, it can fail on tmpfs, xfs, ...
     run_diag('/usr/bin/chattr', '-f', '+C', $basedir);
 
+    bmwqemu::diag('Configuring storage controllers and block devices');
     my $keephdds = $vars->{KEEPHDDS} || $vars->{SKIPTO};
     if ($keephdds) {
         $self->{proc}->load_state();
@@ -762,6 +763,7 @@ sub start_qemu {
         $self->{proc}->configure_blockdevs($bootfrom, $basedir, $vars);
         $self->{proc}->configure_pflash($vars);
     }
+    bmwqemu::diag('Initializing block device images');
     $self->{proc}->init_blockdev_images();
 
     sp('only-migratable') if $self->can_handle({function => 'snapshots', no_warn => 1});

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -752,7 +752,9 @@ sub start_qemu {
     mkpath($basedir);
 
     # do not use autodie here, it can fail on tmpfs, xfs, ...
-    run_diag('/usr/bin/chattr', '-f', '+C', $basedir);
+    # timeout with arbitrary value to catch a potential indefinite blocking
+    # chattr call, also see https://progress.opensuse.org/issues/81828
+    run_diag('timeout 30 /usr/bin/chattr', '-f', '+C', $basedir);
 
     bmwqemu::diag('Configuring storage controllers and block devices');
     my $keephdds = $vars->{KEEPHDDS} || $vars->{SKIPTO};


### PR DESCRIPTION
Somes openQA tests calling isotovideo hand indefinitely until the job is
aborted after multi-hour timeout. The last output is seen from the
"chattr" command which might hang or just be the last successfully
executed command. To ensure that chattr is not stuck too long this
commits adds an according timeout command.

Related progress issue: https://progress.opensuse.org/issues/81828