### PR TITLE
t: Prevent git test destroying user-local git config

### DIFF
--- a/t/34-git.t
+++ b/t/34-git.t
@@ -74,14 +74,14 @@ done_testing;
 
 sub initialize_git_repo {
     my $git_init = <<"EOM";
-mkdir $git_dir
-cd $git_dir
-git init >/dev/null 2>&1
-git config user.email "you\@example.com" >/dev/null
-git config user.name "Your Name" >/dev/null
-git config init.defaultBranch main >/dev/null
-touch README
-git add README
+mkdir $git_dir && \
+cd $git_dir && \
+git init >/dev/null 2>&1 && \
+git config user.email "you\@example.com" >/dev/null && \
+git config user.name "Your Name" >/dev/null && \
+git config init.defaultBranch main >/dev/null && \
+touch README && \
+git add README && \
 git commit -mInit >/dev/null
 EOM
     system $git_init;


### PR DESCRIPTION
Calling "system" on a here-document does not ensure that each command
succeeds. As I observed locally that suddenly my git commits were
created as "Your Name" likely in t/34-git.t "mkdir" and "cd" to a
temporary directory failed but still the succeeding git commands were
executed altering my personal git configuration in the os-autoinst git
checkout. This commit ensures that the command in each line as appened
to the next one with "&&" so that commands need to succeed before we
continue.

Just in case anyone else ran into the problem as well: I fixed all my 
local commits in all branches of the os-autoinst working copy with the
command:

```
for i in $(git branch-raw); do git co $i && git rebase -x 'git hijack-commit' origin/master || break; done
```

using "git-branch-raw" and "git-hijack-commit" from
https://github.com/os-autoinst/scripts/