### PR TITLE
testapi::compat_args: Fix if given value contains invalid regex

### DIFF
--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -654,6 +654,8 @@ subtest 'compat_args' => sub {
 
     like(warning { testapi::compat_args(\%def_args, [], a => 'Z', 'outch') }->[0], qr/^Odd number of arguments/, 'Warned on Odd number 1');
     like(warning { testapi::compat_args(\%def_args, [], 'outch') }->[0],           qr/^Odd number of arguments/, 'Warned on Odd number 2');
+
+    is_deeply({testapi::compat_args(\%def_args, ['a'], '^[invalid regex string')}, {%def_args, a => '^[invalid regex string'}, 'Check invalid regex string');
 };
 
 subtest 'check quiet option on script runs' => sub {

--- a/testapi.pm
+++ b/testapi.pm
@@ -2308,7 +2308,7 @@ sub compat_args {
     my ($def_args, $fix_keys) = splice(@_, 0, 2);
     my %ret;
     for my $key (@{$fix_keys}) {
-        $ret{$key} = shift if (scalar(@_) >= 1 && (!defined($_[0]) || !grep(/^$_[0]$/, keys(%{$def_args}))));
+        $ret{$key} = shift if (scalar(@_) >= 1 && (!defined($_[0]) || !grep { $_ eq $_[0] } keys(%{$def_args})));
     }
     carp("Odd number of arguments") unless ((@_ % 2) == 0);
     %ret = (%{$def_args}, %ret, @_);


### PR DESCRIPTION
It was discovered during a call like:
```
$instance->run_ssh_command(q(rpm -q --qf '%{VERSION}\\n' ltp));
```
while `publiccloud::instance::run_ssh_command()` used `compat_args`
like:
```
testapi::compat_args({cmd => undef}, ['cmd'], @_);
```
which makes the first argument to `cmd` if not given via as hash (e.g.
`cmd => 'exit 1'`).

But this failed with
```
  Test died: Unescaped left brace in regex is illegal here in regex; marked by <-- HERE in m/^rpm -q --qf '%{ <-- HERE VERSION}\n' ltp$/ at /usr/lib/os-autoinst/testapi.pm line 2311.
  testapi::compat_args(undef, undef, "rpm -q --qf '%{VERSION}\\n' ltp") called at sle/lib/publiccloud/instance.pm line 51
```
because we use the given argument in a regex instead of do a `eq`
compare.