### PR TITLE
 Rework add drives mechanism in svirt 

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -509,9 +509,10 @@ EOT
         if ($args->{cdrom}) {
             $dev_type = "sd$dev_id";
             $bus_type = 'scsi';
+        } else {
+            $dev_type = "xvd$dev_id";
+            $bus_type = 'xen';
         }
-        $dev_type = "xvd$dev_id";
-        $bus_type = 'xen';
     }
     elsif ($self->vmm_family eq 'vmware') {
         $dev_type = "hd$dev_id";


### PR DESCRIPTION
SLEM 5.1 builds bootable, ready to use images for z/KVM. To make sure
that images can be expanded we need to add additional functionality to
`add_disk` to create a backingfile of given size.
For `svirt` backend ( except of hyperv ), we should be able to create
drives in following modes.

1. Create empty drive
2. Create a backing image file of given size
3. Re-use given image
4. Add cd-rom drive with given iso image