### PR TITLE
testapi: Use "use Mojo::Base -strict;" to also enforce strictness

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -20,7 +20,7 @@ use base Exporter;
 use Carp;
 use Exporter;
 use 5.018;
-use warnings;
+use Mojo::Base -strict;
 use File::Basename qw(basename dirname);
 use File::Path 'make_path';
 use Time::HiRes qw(sleep gettimeofday tv_interval);


### PR DESCRIPTION
Previously testapi.pm was only using "warnings", not "strict" which we should
do to prevent style issues.