### PR TITLE
Allow more modern perl style with consistent "use Mojo::Base -strict"

### DIFF
--- a/OpenQA/Benchmark/Stopwatch.pm
+++ b/OpenQA/Benchmark/Stopwatch.pm
@@ -1,7 +1,6 @@
 package OpenQA::Benchmark::Stopwatch;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 our $VERSION = '0.05';
 use Time::HiRes;

--- a/OpenQA/Exceptions.pm
+++ b/OpenQA/Exceptions.pm
@@ -15,8 +15,7 @@
 
 package OpenQA::Exceptions;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use Exception::Class (
     'OpenQA::Exception::InternalException' => {

--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -15,8 +15,7 @@
 
 package OpenQA::Isotovideo::Interface;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 # version of the test API and the API relevant to the worker
 # -> increment on every change of such APIs

--- a/backend/amt.pm
+++ b/backend/amt.pm
@@ -15,8 +15,7 @@
 
 package backend::amt;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use autodie ':all';
 
 use base 'backend::baseclass';

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -17,8 +17,7 @@
 # this is an abstract class
 package backend::baseclass;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use feature 'say';
 use autodie ':all';
 

--- a/backend/console_proxy.pm
+++ b/backend/console_proxy.pm
@@ -22,8 +22,7 @@
 
 package backend::console_proxy;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use feature 'say';
 
 sub new {

--- a/backend/driver.pm
+++ b/backend/driver.pm
@@ -21,8 +21,7 @@
 
 package backend::driver;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use autodie ':all';
 
 use Carp 'croak';

--- a/backend/generalhw.pm
+++ b/backend/generalhw.pm
@@ -18,8 +18,7 @@
 
 package backend::generalhw;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use autodie ':all';
 
 use base 'backend::baseclass';

--- a/backend/ikvm.pm
+++ b/backend/ikvm.pm
@@ -16,8 +16,7 @@
 
 package backend::ikvm;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use autodie ':all';
 
 use base 'backend::ipmi';

--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -16,8 +16,7 @@
 
 package backend::ipmi;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use autodie ':all';
 
 use base 'backend::baseclass';

--- a/backend/null.pm
+++ b/backend/null.pm
@@ -15,8 +15,7 @@
 
 package backend::null;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base 'backend::baseclass';
 

--- a/backend/pvm.pm
+++ b/backend/pvm.pm
@@ -15,8 +15,7 @@
 
 package backend::pvm;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use autodie ':all';
 
 use base 'backend::baseclass';

--- a/backend/pvm_hmc.pm
+++ b/backend/pvm_hmc.pm
@@ -15,8 +15,7 @@
 
 package backend::pvm_hmc;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base 'backend::virt';
 

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -16,8 +16,7 @@
 
 package backend::qemu;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use autodie ':all';
 
 use base 'backend::virt';

--- a/backend/s390x.pm
+++ b/backend/s390x.pm
@@ -16,8 +16,7 @@
 
 package backend::s390x;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use autodie ':all';
 
 use base 'backend::baseclass';

--- a/backend/spvm.pm
+++ b/backend/spvm.pm
@@ -15,8 +15,7 @@
 
 package backend::spvm;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base 'backend::virt';
 

--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -16,8 +16,7 @@
 
 package backend::svirt;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base 'backend::virt';
 

--- a/backend/virt.pm
+++ b/backend/virt.pm
@@ -15,8 +15,7 @@
 
 package backend::virt;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base 'backend::baseclass';
 

--- a/basetest.pm
+++ b/basetest.pm
@@ -16,8 +16,7 @@
 
 package basetest;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use autodie ':all';
 
 use bmwqemu ();

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -16,8 +16,7 @@
 
 package bmwqemu;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use autodie ':all';
 use Fcntl ':flock';
 use Time::HiRes qw(sleep gettimeofday);

--- a/check_needles.pl
+++ b/check_needles.pl
@@ -1,7 +1,6 @@
 #!/usr/bin/perl -w
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use File::Basename;
 

--- a/check_qemu_oom
+++ b/check_qemu_oom
@@ -25,8 +25,7 @@ check_qemu_oom qemu_pid
 
 =cut
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 my $qemu_pid = $ARGV[0];
 

--- a/commands.pm
+++ b/commands.pm
@@ -16,8 +16,7 @@
 
 package commands;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use autodie ':all';
 
 require IPC::System::Simple;

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -1,7 +1,6 @@
 package consoles::VNC;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use bytes;
 use feature 'say';
 

--- a/consoles/amtSol.pm
+++ b/consoles/amtSol.pm
@@ -15,8 +15,7 @@
 
 package consoles::amtSol;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use autodie ':all';
 
 use base 'consoles::console';

--- a/consoles/console.pm
+++ b/consoles/console.pm
@@ -28,8 +28,7 @@ of other functions. See vnc_base and virtio_terminal to see how this works.
 
 package consoles::console;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use autodie ':all';
 use testapi 'check_var';
 

--- a/consoles/ipmiSol.pm
+++ b/consoles/ipmiSol.pm
@@ -15,8 +15,7 @@
 
 package consoles::ipmiSol;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use autodie ':all';
 
 use base 'consoles::console';

--- a/consoles/localXvnc.pm
+++ b/consoles/localXvnc.pm
@@ -16,8 +16,7 @@
 
 package consoles::localXvnc;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use autodie ':all';
 
 use base 'consoles::vnc_base';

--- a/consoles/network_console.pm
+++ b/consoles/network_console.pm
@@ -16,8 +16,7 @@
 
 package consoles::network_console;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base 'consoles::console';
 

--- a/consoles/remoteVnc.pm
+++ b/consoles/remoteVnc.pm
@@ -16,8 +16,7 @@
 
 package consoles::remoteVnc;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base 'consoles::vnc_base';
 

--- a/consoles/s3270.pm
+++ b/consoles/s3270.pm
@@ -16,8 +16,7 @@
 
 package consoles::s3270;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use feature 'say';
 
 use base 'consoles::localXvnc';

--- a/consoles/serial_screen.pm
+++ b/consoles/serial_screen.pm
@@ -15,8 +15,7 @@
 package consoles::serial_screen;
 
 use 5.018;
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use integer;
 
 use English -no_match_vars;

--- a/consoles/sshIucvconn.pm
+++ b/consoles/sshIucvconn.pm
@@ -18,8 +18,7 @@
 
 package consoles::sshIucvconn;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use autodie ':all';
 
 use base 'consoles::network_console';

--- a/consoles/sshSerial.pm
+++ b/consoles/sshSerial.pm
@@ -18,8 +18,7 @@
 
 package consoles::sshSerial;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base 'consoles::console';
 

--- a/consoles/sshVirtshSUT.pm
+++ b/consoles/sshVirtshSUT.pm
@@ -15,8 +15,7 @@
 
 package consoles::sshVirtshSUT;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base 'consoles::console';
 

--- a/consoles/sshX3270.pm
+++ b/consoles/sshX3270.pm
@@ -16,8 +16,7 @@
 
 package consoles::sshX3270;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base 'consoles::localXvnc';
 

--- a/consoles/sshXtermIPMI.pm
+++ b/consoles/sshXtermIPMI.pm
@@ -16,8 +16,7 @@
 
 package consoles::sshXtermIPMI;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use autodie ':all';
 
 use base 'consoles::localXvnc';

--- a/consoles/sshXtermVt.pm
+++ b/consoles/sshXtermVt.pm
@@ -16,8 +16,7 @@
 
 package consoles::sshXtermVt;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use autodie ':all';
 
 use base 'consoles::localXvnc';

--- a/consoles/ttyConsole.pm
+++ b/consoles/ttyConsole.pm
@@ -16,8 +16,7 @@
 
 package consoles::ttyConsole;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use autodie ':all';
 
 use base 'consoles::console';

--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -15,8 +15,7 @@
 package consoles::virtio_terminal;
 
 use 5.018;
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use autodie;
 
 use base 'consoles::console';

--- a/consoles/vnc_base.pm
+++ b/consoles/vnc_base.pm
@@ -16,8 +16,7 @@
 
 package consoles::vnc_base;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use feature 'say';
 
 use base 'consoles::network_console';

--- a/cv.pm
+++ b/cv.pm
@@ -17,8 +17,7 @@
 # wrapper around tinycv
 
 package cv;
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use constant BPP => 3;
 use ExtUtils::testlib;
 

--- a/distribution.pm
+++ b/distribution.pm
@@ -15,8 +15,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package distribution;
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use testapi ();
 use Carp 'croak';

--- a/isotovideo
+++ b/isotovideo
@@ -47,8 +47,7 @@ automatically for convenience.
 
 =cut
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use autodie ':all';
 no autodie 'kill';
 

--- a/lockapi.pm
+++ b/lockapi.pm
@@ -16,8 +16,7 @@
 ## synchronization API
 package lockapi;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use Scalar::Util 'looks_like_number';
 use Time::Seconds;
 use base 'Exporter';

--- a/mmapi.pm
+++ b/mmapi.pm
@@ -16,8 +16,7 @@
 ## Multi-Machine API
 package mmapi;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base 'Exporter';
 our @EXPORT = qw(get_children_by_state get_children get_parents

--- a/myjsonrpc.pm
+++ b/myjsonrpc.pm
@@ -15,8 +15,7 @@
 
 package myjsonrpc;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use Carp qw(cluck confess);
 use IO::Select;
 use Errno;

--- a/needle.pm
+++ b/needle.pm
@@ -16,8 +16,7 @@
 
 package needle;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use autodie ':all';
 
 use Cwd 'cwd';

--- a/ocr.pm
+++ b/ocr.pm
@@ -15,8 +15,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package ocr;
-use strict;
-use warnings;
+use Mojo::Base -strict;
 require IPC::System::Simple;
 use autodie ':all';
 

--- a/os-autoinst-openvswitch
+++ b/os-autoinst-openvswitch
@@ -1,8 +1,7 @@
 #!/usr/bin/perl
 package OVS;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use autodie ':all';
 
 use base 'Net::DBus::Object';
@@ -224,7 +223,7 @@ sub show {
 
 ################################################################################
 package main;
-use strict;
+use Mojo::Base -strict;
 
 use Net::DBus;
 use Net::DBus::Reactor;

--- a/osutils.pm
+++ b/osutils.pm
@@ -15,8 +15,7 @@
 package osutils;
 
 require 5.002;
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use Carp;
 use base 'Exporter';

--- a/ppmclibs/tinycv.pm
+++ b/ppmclibs/tinycv.pm
@@ -16,8 +16,7 @@
 
 package tinycv;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use bmwqemu 'fctwarn';
 use File::Basename;
@@ -34,8 +33,7 @@ bootstrap tinycv $VERSION;
 
 package tinycv::Image;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 sub mean_square_error {
     my ($areas) = @_;

--- a/t/00-compile-check-all.t
+++ b/t/00-compile-check-all.t
@@ -14,8 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 # We need :no_end_test here because otherwise it would output a no warnings
 # test for each of the modules, but with the same test number
 use Test::Warnings qw(:no_end_test :report_warnings);

--- a/t/04-testapi-python.t
+++ b/t/04-testapi-python.t
@@ -1,7 +1,6 @@
 #!/usr/bin/perl
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use Test::More;
 use Test::Fatal;

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -338,6 +338,7 @@ subtest 'load test successfully when CASEDIR is a relative path' => sub {
     loadtest 'start';
 };
 
+pass autotest::loadtest('tests/test.py'), 'can load python test module at all';
 loadtest 'test.py', 'we can also parse python test modules';
 
 done_testing();

--- a/t/data/tests/bar/baz.pm
+++ b/t/data/tests/bar/baz.pm
@@ -1,4 +1,3 @@
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use base 'basetest';
 1;

--- a/t/data/tests/foo.pm
+++ b/t/data/tests/foo.pm
@@ -1,4 +1,3 @@
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use base 'basetest';
 1;

--- a/t/data/tests/lib/testdistribution.pm
+++ b/t/data/tests/lib/testdistribution.pm
@@ -15,8 +15,7 @@
 
 package testdistribution;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base 'distribution';
 

--- a/t/data/tests/main.pm
+++ b/t/data/tests/main.pm
@@ -13,8 +13,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use Cwd 'abs_path';
 

--- a/t/data/tests/tests/assert_screen.pm
+++ b/t/data/tests/tests/assert_screen.pm
@@ -13,8 +13,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base 'basetest';
 

--- a/t/data/tests/tests/assert_screen_fail_test.pm
+++ b/t/data/tests/tests/assert_screen_fail_test.pm
@@ -14,8 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 use 5.018;
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base 'basetest';
 

--- a/t/data/tests/tests/boot.pm
+++ b/t/data/tests/tests/boot.pm
@@ -13,8 +13,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base "basetest";
 

--- a/t/data/tests/tests/failing_module.pm
+++ b/t/data/tests/tests/failing_module.pm
@@ -14,8 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 use 5.018;
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base 'basetest';
 

--- a/t/data/tests/tests/freeze.pm
+++ b/t/data/tests/tests/freeze.pm
@@ -13,8 +13,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base 'basetest';
 

--- a/t/data/tests/tests/modify_and_upload_file.pm
+++ b/t/data/tests/tests/modify_and_upload_file.pm
@@ -13,8 +13,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base "basetest";
 

--- a/t/data/tests/tests/noop.pm
+++ b/t/data/tests/tests/noop.pm
@@ -13,8 +13,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base "basetest";
 

--- a/t/data/tests/tests/reload_needles.pm
+++ b/t/data/tests/tests/reload_needles.pm
@@ -14,8 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 use 5.018;
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base 'basetest';
 

--- a/t/data/tests/tests/select_console_fail_test.pm
+++ b/t/data/tests/tests/select_console_fail_test.pm
@@ -14,8 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 use 5.018;
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base 'basetest';
 

--- a/t/data/tests/tests/select_ssh_console_fail_test.pm
+++ b/t/data/tests/tests/select_ssh_console_fail_test.pm
@@ -14,8 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 use 5.018;
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base 'basetest';
 

--- a/t/data/tests/tests/shutdown.pm
+++ b/t/data/tests/tests/shutdown.pm
@@ -14,8 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 use 5.018;
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base 'basetest';
 

--- a/t/data/tests/tests/typing.pm
+++ b/t/data/tests/tests/typing.pm
@@ -13,8 +13,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base "basetest";
 

--- a/t/fake/tests/fatal.pm
+++ b/t/fake/tests/fatal.pm
@@ -1,5 +1,4 @@
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use base 'basetest';
 
 sub run { }

--- a/t/fake/tests/ignore_failure.pm
+++ b/t/fake/tests/ignore_failure.pm
@@ -1,5 +1,4 @@
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use base 'basetest';
 
 sub run { }

--- a/t/fake/tests/run_args.pm
+++ b/t/fake/tests/run_args.pm
@@ -1,6 +1,5 @@
 use 5.018;
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use base 'basetest';
 

--- a/t/fake/tests/scheduler.pm
+++ b/t/fake/tests/scheduler.pm
@@ -1,5 +1,4 @@
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use base 'basetest';
 use autotest 'loadtest';
 

--- a/t/fake/tests/start.pm
+++ b/t/fake/tests/start.pm
@@ -1,5 +1,4 @@
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use base 'basetest';
 
 sub run { }

--- a/tools/absolutize
+++ b/tools/absolutize
@@ -1,7 +1,6 @@
 #!/usr/bin/perl
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 $_ = shift;
 unless (m{^/}) {

--- a/tools/check_coverage
+++ b/tools/check_coverage
@@ -1,7 +1,6 @@
 #!/usr/bin/env perl
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use autodie;
 
 

--- a/tools/lib/perlcritic/Perl/Critic/Policy/HashKeyQuotes.pm
+++ b/tools/lib/perlcritic/Perl/Critic/Policy/HashKeyQuotes.pm
@@ -1,7 +1,6 @@
 package Perl::Critic::Policy::HashKeyQuotes;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use Perl::Critic::Utils qw( :severities :classification :ppi );
 use base 'Perl::Critic::Policy';


### PR DESCRIPTION
Used

```
sed -i "s/^use strict;$/use Mojo::Base -strict;/" $(git ls-files)
for i in $(git grep -l 'use \(strict\|warnings\)'); do grep -q 'use Mojo::Base -strict' $i && sed -i '/use \(strict\|warnings\)/d' $i; done
```

to convert all files.