### PR TITLE
dist: Bump timeout scaling factor for slow OBS tests

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -181,7 +181,7 @@ export NO_BRP_STALE_LINK_ERROR=yes
 export CI=1
 # account for sporadic slowness in build environments
 # https://progress.opensuse.org/issues/89059
-export OPENQA_TEST_TIMEOUT_SCALE_CI=8
+export OPENQA_TEST_TIMEOUT_SCALE_CI=10
 cd %{__builddir}
 %cmake_build check-pkg-build
 


### PR DESCRIPTION
Executed locally and the relevant group of tests locally only takes 1
second without coverage:

```
$ time prove -I. t/18-backend-qemu.t t/18-qemu.t
t/18-backend-qemu.t .. ok
t/18-qemu.t .......... ok
All tests successful.
Files=2, Tests=57,  4 wallclock secs ( 0.05 usr  0.00 sys +  1.70 cusr  0.30 csys =  2.05 CPU)
Result: PASS
```

Originally on OBS the output was not clear which test timed out. The
related ticket mentions that likely t/18-backend-qemu.t would be the
culprit which is actually ignored from testing in OBS so I suspect it is
t/18-qemu.t which has the same base 5 second timeout.

Related progress issue: https://progress.opensuse.org/issues/97241