### PR TITLE
Fix incorrect serialization attempts of paths leading to error

### DIFF
--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -105,7 +105,7 @@ sub checkout_git_repo_and_branch {
     else {
         bmwqemu::diag "Skipping to clone '$clone_url'; $local_path already exists";
     }
-    return $bmwqemu::vars{$dir_variable} = path($local_path)->to_abs;
+    return $bmwqemu::vars{$dir_variable} = path($local_path)->to_abs->to_string;
 }
 
 =head2 checkout_git_refspec

--- a/needle.pm
+++ b/needle.pm
@@ -125,7 +125,7 @@ sub new {
     $self->{name} = basename($jsonfile, '.json');
     my $png = $self->{png} || $self->{name} . ".png";
 
-    $self->{png} = path(dirname($jsonfile), $png);
+    $self->{png} = path(dirname($jsonfile), $png)->to_string;
     warn "Can't find $self->{png}" && return unless -s $self->{png};
     $self = bless $self, $classname;
     $self->register();
@@ -314,7 +314,7 @@ sub init {
     $needles_dir = $init_needles_dir;
     unless (-d $needles_dir) {
         die "Can't init needles from $needles_dir" if (path($needles_dir)->is_abs);
-        $needles_dir = path($bmwqemu::vars{CASEDIR}, $needles_dir);
+        $needles_dir = path($bmwqemu::vars{CASEDIR}, $needles_dir)->to_string;
         die "Can't init needles from $init_needles_dir; If one doesn't specify NEEDLES_DIR, the needles will be loaded from \$PRODUCTDIR/needles firstly or $needles_dir (\$CASEDIR + $init_needles_dir), check vars.json" unless -d $needles_dir;
     }
     $bmwqemu::vars{NEEDLES_GIT_HASH} = checkout_git_refspec($needles_dir => 'NEEDLES_GIT_REFSPEC');


### PR DESCRIPTION
%bmwqemu::vars should only contain strings because we also serialize
that into JSON documents so we should explicitly call the "to_string"
method of Mojo::File.

Related progress issue: https://progress.opensuse.org/issues/97574