### PR TITLE
Fix render calls in error handling of asset upload

### DIFF
--- a/commands.pm
+++ b/commands.pm
@@ -165,7 +165,8 @@ sub upload_file {
 
     # choose 'target' field from curl form, otherwise default 'assets_private', assume the pool directory is the current working dir
     my $target = $self->param('target') || 'assets_private';
-    mkdir($target) or die "Unable to create directory for upload: $!" unless -d $target;
+    eval { mkdir $target unless -d $target };
+    if (my $error = $@) { return $self->render(text => "Unable to create directory for upload: $error", status => 500) }
 
     my $upname   = $self->param('upname');
     my $filename = basename($upname ? $upname : $self->param('filename'));

--- a/commands.pm
+++ b/commands.pm
@@ -1,5 +1,5 @@
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2020 SUSE LLC
+# Copyright © 2012-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -160,8 +160,8 @@ sub get_asset {
 sub upload_file {
     my ($self) = @_;
 
-    return $self->render(message => 'File is too big', status => 400) if $self->req->is_limit_exceeded;
-    return $self->render(message => 'Upload file content missing', status => 400) unless my $upload = $self->req->upload('upload');
+    return $self->render(text => 'File is too big', status => 400) if $self->req->is_limit_exceeded;
+    return $self->render(text => 'Upload file content missing', status => 400) unless my $upload = $self->req->upload('upload');
 
     # choose 'target' field from curl form, otherwise default 'assets_private', assume the pool directory is the current working dir
     my $target = $self->param('target') || 'assets_private';

--- a/t/07-commands.t
+++ b/t/07-commands.t
@@ -194,6 +194,11 @@ subtest 'upload api' => sub {
     subtest 'file content missing' => sub {
         $t->post_ok("$base_url/$job/upload_asset/foo")->status_is(400)->content_is('Upload file content missing');
     };
+    subtest 'target directory cannot be created' => sub {
+        $pool_directory->child('a-file')->touch;
+        $t->post_ok("$base_url/$job/upload_asset/foo", form => {upload => {content => 'foo'}, target => 'a-file'});
+        $t->status_is(500)->content_like(qr/Unable to create directory for upload.*File exists/);
+    };
     subtest 'successful upload' => sub {
         $t->post_ok("$base_url/$job/upload_asset/private-asset", form => {upload => {content => 'private-content'}});
         $t->status_is(200)->content_is("OK: private-asset\n");


### PR DESCRIPTION
It looks like using `message` does not work here:
```
Could not render a response at /usr/lib/perl5/vendor_perl/5.26.1/Mojolicious/Controller.pm line 151.
        Mojolicious::Controller::render(Mojolicious::Controller=HASH(0x1000e203040), "message", "File is too big", "status", 400) called at /usr/lib/os-autoinst/commands.pm line 163
```

`message` isn't documented¹ so I assume `text` is supposed to be used here.

---

¹ https://metacpan.org/pod/Mojolicious::Controller#render