### PR TITLE
Allow overriding Mojolicious limits for the file upload

### DIFF
--- a/commands.pm
+++ b/commands.pm
@@ -1,5 +1,5 @@
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2020 SUSE LLC
+# Copyright © 2012-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -236,9 +236,9 @@ sub get_temp_file {
 sub run_daemon {
     my ($port, $isotovideo) = @_;
 
-    # allow up to 20GB - hdd images
-    $ENV{MOJO_MAX_MESSAGE_SIZE}   = 1024 * 1024 * 1024 * 20;
-    $ENV{MOJO_INACTIVITY_TIMEOUT} = 300;
+    # allow up to 20 GiB for uploads of big hdd images
+    $ENV{MOJO_MAX_MESSAGE_SIZE}   //= ($bmwqemu::vars{UPLOAD_MAX_MESSAGE_SIZE_GB} // 20) * 1024**3;
+    $ENV{MOJO_INACTIVITY_TIMEOUT} //= ($bmwqemu::vars{UPLOAD_INACTIVITY_TIMEOUT}  // 300);
 
     # avoid leaking token
     app->mode('production');

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -35,7 +35,9 @@ PAUSE_ON_SCREEN_MISMATCH;boolean;0;Pause test execution on the next screen misma
 PAUSE_ON_NEXT_COMMAND;boolean;0;Pause test execution on the next test API command. Same notes as for `PAUSE_AT` apply.
 _QUIET_SCRIPT_CALLS;boolean;0;Add quiet flag to all the calls to script_run, script_output and validate_script_output. It will omit all the squares "wait_serial expected" on the Details view of the test case. This option might be useful for serial terminal tests.
 AUTOINST_URL_HOSTNAME;string;;hostname or IP address of host running the autoinst webserver endpoint, defaults to the local IP address within the qemu network for the qemu backend or the `WORKER_HOSTNAME` otherwise.
-UPLOAD_METER;boolean;0;Display curl progress meter in `upload_logs()` and `upload_assets()` subroutines.
+UPLOAD_METER;boolean;0;Display curl progress meter in `upload_logs()` and `upload_assets()` test API functions.
+UPLOAD_MAX_MESSAGE_SIZE_GB;integer;20;Specifies the max. upload size in GiB for the test API functions `upload_logs()` and `upload_assets()` and the underlying command server API.
+UPLOAD_INACTIVITY_TIMEOUT;integer;300;Specifies the inactivity timeout in seconds for the test API functions `upload_logs()` and `upload_assets()` and underlying the command server API.
 
 |====================
 


### PR DESCRIPTION
There are test failures in production because the currently hard-coded
limit of 20 GiB is exceeded:
https://openqa.nue.suse.com/tests/6975596#step/svirt_upload_assets/8