### PR TITLE
Increase MOJO_MAX_MESSAGE_SIZE to 40 due to SP4 migration

### DIFF
--- a/commands.pm
+++ b/commands.pm
@@ -236,8 +236,8 @@ sub get_temp_file {
 sub run_daemon {
     my ($port, $isotovideo) = @_;
 
-    # allow up to 20GB - hdd images
-    $ENV{MOJO_MAX_MESSAGE_SIZE}   = 1024 * 1024 * 1024 * 20;
+    # allow up to 40GB - hdd images
+    $ENV{MOJO_MAX_MESSAGE_SIZE}   = 1024 * 1024 * 1024 * 40;
     $ENV{MOJO_INACTIVITY_TIMEOUT} = 300;
 
     # avoid leaking token


### PR DESCRIPTION
MOJO_MAX_MESSAGE_SIZE in test does not affect value on the worker

Fail: https://openqa.suse.de/tests/6986119
VR: https://openqa.suse.de/tests/6987492