### PR TITLE
consoles::sshVirtsh: Remove unnecessary second argument

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -495,7 +495,7 @@ sub resume ($self) {
 
 sub get_remote_vmm () { get_var('VMWARE_REMOTE_VMM', '') }
 
-sub define_and_start ($self, $args) {
+sub define_and_start ($self) {
     my $remote_vmm = "";
     if ($self->vmm_family eq 'vmware') {
         my ($fh, $libvirtauthfilename) = tempfile(DIR => "/tmp/");


### PR DESCRIPTION
The problem was introduced in
https://github.com/os-autoinst/os-autoinst/pull/1753. This should fix
some failed openQA tests that fail on this method.

Related progress issue: https://progress.opensuse.org/issues/98087