### PR TITLE
consoles::sshVirtsh: Remove the unused argument

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -562,9 +562,9 @@ sub attach_to_running ($self, $args) {
     }
 }
 
-sub start_serial_grab ($self, $args) { $self->backend->start_serial_grab($self->name) }
+sub start_serial_grab ($self) { $self->backend->start_serial_grab($self->name) }
 
-sub stop_serial_grab ($self, $args) { $self->backend->stop_serial_grab($self->name) }
+sub stop_serial_grab ($self) { $self->backend->stop_serial_grab($self->name) }
 
 
 =head2 run_cmd


### PR DESCRIPTION
This is a follow up for https://github.com/os-autoinst/os-autoinst/pull/1762

See the related job on OSD: https://openqa.suse.de/tests/7029593#step/update_kernel/65