### PR TITLE
Deduce format of backing file from extension

### DIFF
--- a/OpenQA/Qemu/BlockDev.pm
+++ b/OpenQA/Qemu/BlockDev.pm
@@ -33,7 +33,7 @@ weakened.
 =cut
 
 package OpenQA::Qemu::BlockDev;
-use Mojo::Base 'OpenQA::Qemu::MutParams';
+use Mojo::Base 'OpenQA::Qemu::MutParams', -signatures;
 
 use Scalar::Util 'weaken';
 use OpenQA::Qemu::SnapshotConf;
@@ -215,6 +215,8 @@ sub _from_map {
       ->implicit($this->{implicit})
       ->snapshot($snap_conf->get_snapshot(sequence => $this->{snapshot}));
 }
+
+sub deduce_driver ($self) { $self->driver($self->file =~ qr/\.qcow2$/ ? 'qcow2' : 'raw') }
 
 sub CARP_TRACE { 'OpenQA::Qemu::BlockDev(' . (shift->node_name || '') . ')' }
 

--- a/OpenQA/Qemu/BlockDevConf.pm
+++ b/OpenQA/Qemu/BlockDevConf.pm
@@ -131,7 +131,7 @@ new overlay is created so that the existing qcow2 image is not modified.
 sub add_existing_drive {
     my ($self, $id, $file_name, $model, $size, $num_queues) = @_;
 
-    my $base_drive = $self->add_existing_base($id, $file_name, $size)->implicit(1);
+    my $base_drive = $self->add_existing_base($id, $file_name, $size)->implicit(1)->deduce_driver;
     my $overlay    = $self->add_new_overlay($id . OVERLAY_POSTFIX . '0', $base_drive);
 
     return $self->_push_new_drive_dev($id, $overlay, $model, $num_queues);
@@ -164,11 +164,9 @@ variables. See the OpenQA::Qemu::PFlashDevice class.
 =cut
 sub add_pflash_drive {
     my ($self, $id, $file_name, $size) = @_;
-    my $base_drive = $self->add_existing_base($id, $file_name, $size)
-      ->implicit(1)
-      ->driver($file_name =~ qr/\.qcow2$/ ? 'qcow2' : 'raw');
-    my $overlay = $self->add_new_overlay($id . OVERLAY_POSTFIX . '0', $base_drive);
-    my $pflash  = OpenQA::Qemu::PFlashDevice->new()
+    my $base_drive = $self->add_existing_base($id, $file_name, $size)->implicit(1)->deduce_driver;
+    my $overlay    = $self->add_new_overlay($id . OVERLAY_POSTFIX . '0', $base_drive);
+    my $pflash     = OpenQA::Qemu::PFlashDevice->new()
       ->id($id)
       ->drive($overlay);
 


### PR DESCRIPTION
* So even if we assign an ISO as HDD_x we would use the correct parameter
  `-F raw` (and not `-F qcow2`)
* See https://github.com/os-autoinst/os-autoinst/pull/1764/files#r704549754
  and https://progress.opensuse.org/issues/98117