### PR TITLE
mmapi: Add whoami() function

### DIFF
--- a/mmapi.pm
+++ b/mmapi.pm
@@ -22,7 +22,7 @@ use base 'Exporter';
 our @EXPORT = qw(get_children_by_state get_children get_parents
   get_job_info get_job_autoinst_url get_job_autoinst_vars
   wait_for_children wait_for_children_to_start api_call
-  api_call_2 handle_api_error
+  api_call_2 handle_api_error get_current_job_id
 );
 
 require bmwqemu;
@@ -287,6 +287,18 @@ sub wait_for_children_to_start {
         last unless $n;
         sleep $poll_interval;
     }
+}
+
+=head2 get_current_job_id
+
+    get_current_job_id();
+
+Query openQA's API to retrieve the current job ID 
+=cut
+sub get_current_job_id {
+    my $tx = api_call_2(get => 'whoami', undef, $CODES_EXPECTED_BY_MMAPI);
+    return undef if handle_api_error($tx, 'whoami', $CODES_EXPECTED_BY_MMAPI);
+    return $tx->res->json('/id');
 }
 
 1;

--- a/t/30-mmapi.t
+++ b/t/30-mmapi.t
@@ -222,4 +222,15 @@ subtest 'mmapi: wait functions' => sub {
     like exception { mmapi::wait_for_children }, qr/Failed to wait/, 'wait for children dies on error';
 };
 
+subtest 'mmapi: get_current_job_id function' => sub {
+    my $do_error = 0;
+    $fake_api->get('/whoami' => sub { return $do_error ? shift->render(status => 404, text => 'error') : shift->render(json => {id => 23}) });
+
+    is(get_current_job_id(), 23, 'Retrieve jobid');
+    $do_error = 1;
+    combined_like {
+        is(get_current_job_id(), undef, 'Retrieve undef on error');
+    } qr /404 response/, 'Error message has 404';
+};
+
 done_testing;


### PR DESCRIPTION
Add a function to get an easy way to retrieve the current jobID.
This jobID could be used later for external tools like pcw[1] to track
these jobs.

E.g. pcw track created public_cloud instances, these instances should
only live as long as the job is running. If a job get closed
unconditionally and the cleanup wasn't take place accordingly, pcw could
delete these instances right away. Currently we set a TTL and delete
these instances by age.

Ticked: https://progress.opensuse.org/issues/63604
VR: http://cfconrad-vm.qa.suse.de/tests/8292#step/clemix_job_id_tag/15