### PR TITLE
Regression in 'consoles::sshVirtsh::get_remote_vmm'

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -493,7 +493,7 @@ sub resume ($self) {
     bmwqemu::diag "VM " . $self->name . " resumed";
 }
 
-sub get_remote_vmm () { get_var('VMWARE_REMOTE_VMM', '') }
+sub get_remote_vmm ($self) { get_var('VMWARE_REMOTE_VMM', '') }
 
 sub define_and_start ($self) {
     my $remote_vmm = "";


### PR DESCRIPTION
`Too many arguments for subroutine 'consoles::sshVirtsh::get_remote_vmm'
at /usr/lib/os-autoinst/backend/baseclass.pm line 838, <$fh> line 45.`

- https://openqa.suse.de/tests/overview?arch=&flavor=&machine=svirt-vmware65&test=&modules=&module_re=&distri=sle&version=15-SP4&build=1.40&groupid=131#