### PR TITLE
mmapi: Allow for longer and more retries after observed failures

### DIFF
--- a/mmapi.pm
+++ b/mmapi.pm
@@ -30,8 +30,8 @@ require bmwqemu;
 use Mojo::UserAgent;
 use Mojo::URL;
 
-our $retry_count    = $ENV{OS_AUTOINST_MMAPI_RETRY_COUNT}    // 3;
-our $retry_interval = $ENV{OS_AUTOINST_MMAPI_RETRY_INTERVAL} // 3;
+our $retry_count    = $ENV{OS_AUTOINST_MMAPI_RETRY_COUNT}    // 30;
+our $retry_interval = $ENV{OS_AUTOINST_MMAPI_RETRY_INTERVAL} // 10;
 our $poll_interval  = $ENV{OS_AUTOINST_MMAPI_POLL_INTERVAL}  // 1;
 
 our $url;


### PR DESCRIPTION
The initial retry to mmapi calls as th the sleep periods introduced in
dee5d4cf seem to still run into temporary connection outages which we
should be able to pass with more and longer retries.

Related progress issue: https://progress.opensuse.org/issues/98940