### PR TITLE
Add support for timeout on SSH based commands if possible

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -1,5 +1,5 @@
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2020 SUSE LLC
+# Copyright © 2012-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -40,6 +40,7 @@ use List::MoreUtils 'uniq';
 use Scalar::Util 'looks_like_number';
 use Mojo::File 'path';
 use OpenQA::Exceptions;
+use Time::Seconds;
 
 # should be a singleton - and only useful in backend process
 our $backend;
@@ -1240,7 +1241,8 @@ sub new_ssh_connection {
         }
     }
 
-    my $ssh = Net::SSH2->new;
+    # timeout requires libssh2 >= 1.2.9 so not all versions might have it
+    my $ssh = Net::SSH2->new(timeout => ($bmwqemu::vars{SSH_COMMAND_TIMEOUT_S} // 0) * 1000);
 
     # Retry multiple times, in case of the guest is not running yet
     my $counter    = $bmwqemu::vars{SSH_CONNECT_RETRY} // 5;

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -23,6 +23,7 @@ NOVIDEO;boolean;0;Whether the creation of the video should be disabled and also 
 NO_DEBUG_IO;boolean;0;Disable the I/O debug output in case of needle comparison times longer than expected
 OSUTILS_WAIT_ATTEMPT_INTERVAL;float;1;The interval in seconds between "attempts" in osutils, e.g. used for connections to qemu qmp backend
 SCREENSHOTINTERVAL;float;0.5;The interval in seconds at which screenshots are taken internally
+SSH_COMMAND_TIMEOUT_S;integer;0;Timeout for any SSH based command in SSH based consoles, disabled by default or for a value of 0. Time in seconds.
 SSH_CONNECT_RETRY;integer;5;Maximum retries to connect to SSH based console targets
 SSH_CONNECT_RETRY_INTERVAL;float;10;Interval in seconds between retries to connect to SSH based console targets. Related to SSH_CONNECT_RETRY
 VNC_STALL_THRESHOLD;integer;4;Time after which is VNC considered stalled


### PR DESCRIPTION
Net::SSH2 supports a timeout command which so far was not used by us.
The command is available since libssh2 >= 1.2.9 which we commonly have
by now. For example in openSUSE Leap 15.2 there is libssh2-1-1.9.0.
Applying a timeout on individual SSH commands should prevent openQA jobs
hitting "timeout_exceeded" with the additional benefit that jobs can
fail earlier than the default 2h openQA job timeout.

To be backward compatible here we do not apply any timeout. To configure
the value the new test variable SSH_COMMAND_TIMEOUT_S can be set to a
different value.

Tested with `t/23-baseclass.t t/26-ssh_screen.t t/31-sshSerial.t` as
regression tests and manual experimentation with the parameter in `perl
-de1`.

Related progress issue: https://progress.opensuse.org/issues/99123