### PR TITLE
Flush Python's `stderr` to ensure error messages end up in logs

### DIFF
--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -6,6 +6,7 @@ use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use Test::Output qw(stderr_like combined_from);
+use Test::Exception;
 use Test::Fatal;
 use Test::MockModule;
 use File::Basename ();
@@ -340,6 +341,10 @@ subtest 'load test successfully when CASEDIR is a relative path' => sub {
 
 pass autotest::loadtest('tests/test.py'), 'can load python test module at all';
 loadtest 'test.py', 'we can also parse python test modules';
+
+stderr_like {
+    throws_ok { autotest::loadtest 'tests/faulty.py' } qr/py_eval raised an exception/, 'dies on Python exception';
+} qr/Traceback.*No module named.*thismoduleshouldnotexist.*/s, 'Python traceback logged';
 
 done_testing();
 

--- a/t/fake/tests/faulty.py
+++ b/t/fake/tests/faulty.py
@@ -1,0 +1,1 @@
+import thismoduleshouldnotexist


### PR DESCRIPTION
I could only reproduce the problem of missing error messages under Leap
15.2 but there it helps to flush Python's `stderr`. Note that flushing
Perls `STDERR` did not help.

See https://progress.opensuse.org/issues/91653