### PR TITLE
Adapt container path in README in accordance with 16d2b42e0960

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -38,7 +38,7 @@ virtualization acceleration:
 
 [source,sh]
 ----
-podman run --rm -it -v .:/tests registry.opensuse.org/devel/openqa/containers/isotovideo:qemu-kvm casedir=/tests
+podman run --rm -it -v .:/tests registry.opensuse.org/devel/openqa/containers15.3/isotovideo:qemu-kvm casedir=/tests
 ----
 
 Use the image variant ending with `qemu-x86` on x86_64 if no KVM support is


### PR DESCRIPTION
Not strictly required because e.g. on a Tumbleweed host the Tumbleweed
container should work as well and `podman` is also not affected anyways.