### PR TITLE
[RFC] workflows/commit_message_checker.yml: Fix file based prefix

### DIFF
--- a/.github/workflows/commit_message_checker.yml
+++ b/.github/workflows/commit_message_checker.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Check Subject Begining
         uses: gsactions/commit-message-checker@v1
         with:
-          pattern: '^([A-Z]|\w+:)'
+          pattern: '^([A-Z]|[A-Za-z0-9_/.]+:)'
           flags: 'g'
           error: 'The subject does not start with a capital or tag.'
           excludeDescription: 'true'


### PR DESCRIPTION
Subjects like "tools/tidy: Disable aligning assignments" [failed](https://github.com/os-autoinst/os-autoinst/pull/1787/checks?check_run_id=3753638396), because `\w` (word character) contains `[A-Za-z0-9_]`. Adding dot (`.`) and slash (`/`) allows to add file based prefix.

Subject of this commit actually checks the change.