### PR TITLE
Use proper perl "signatures" in backend

### DIFF
--- a/backend/amt.pm
+++ b/backend/amt.pm
@@ -173,7 +173,7 @@ sub restart_host ($self) {
     $self->set_power_state($self->is_shutdown() ? 2 : 5);
 }
 
-sub do_start_vm ($self) {
+sub do_start_vm ($self, @) {
     #if (!$self->{configured}) {
     #   $self->enable_solider();
     #   $self->configure_vnc();
@@ -207,7 +207,7 @@ sub do_start_vm ($self) {
     return {};
 }
 
-sub do_stop_vm ($self) {
+sub do_stop_vm ($self, @) {
     # need to terminate both VNC and console first, otherwise AMT will refuse
     # to shutdown
     $self->deactivate_console({testapi_console => 'sol'});
@@ -216,7 +216,7 @@ sub do_stop_vm ($self) {
     return {};
 }
 
-sub is_shutdown ($self) {
+sub is_shutdown ($self, @) {
     my $ret = $self->get_power_state();
     return $ret == 8;
 }

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -382,7 +382,7 @@ sub start_vm ($self, @) {
     return $self->do_start_vm();
 }
 
-sub stop_vm ($self) {
+sub stop_vm ($self, @) {
     if ($self->{started}) {
         # backend.run might have disappeared already in case of failed builds
         no autodie 'unlink';
@@ -412,18 +412,18 @@ sub notimplemented ($self) { confess "backend method not implemented" }
 sub power ($self, $args) { notimplemented }
 sub insert_cd ($self) { notimplemented }
 sub eject_cd ($self, $args = {}) { notimplemented }
-sub do_start_vm ($self) { notimplemented }
-sub do_stop_vm ($self) { notimplemented }
+sub do_start_vm ($self, @) { notimplemented }
+sub do_stop_vm ($self, @) { notimplemented }
 sub stop ($self) { notimplemented }
 sub cont ($self) { notimplemented }
 
-sub can_handle ($self, $args) {
+sub can_handle ($self, @) {
     return;    # sorry, no
 }
 
 sub do_extract_assets ($self) { notimplemented }
 
-sub is_shutdown ($self) { -1 }
+sub is_shutdown ($self, @) { -1 }
 
 sub save_memory_dump ($self) { notimplemented }
 
@@ -725,7 +725,7 @@ sub capture_screenshot ($self) {
     return;
 }
 
-sub reload_needles () {
+sub reload_needles (@) {
     # called from testapi::set_var, so read the vars
     bmwqemu::load_vars();
 
@@ -1058,12 +1058,12 @@ sub _reduce_to_biggest_changes ($imglist, $limit) {
     return;
 }
 
-sub freeze_vm ($self) {
+sub freeze_vm ($self, @) {
     bmwqemu::diag "ignored freeze_vm";
     return;
 }
 
-sub cont_vm ($self) {
+sub cont_vm ($self, @) {
     bmwqemu::diag "ignored cont_vm";
     return;
 }

--- a/backend/console_proxy.pm
+++ b/backend/console_proxy.pm
@@ -10,39 +10,34 @@
 
 package backend::console_proxy;
 
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 use feature 'say';
 
-sub new {
-    my ($class, $console) = @_;
+sub new ($class, $console) {
 
     my $self = bless({class => $class, console => $console}, $class);
 
     return $self;
 }
 
-sub DESTROY {
-    # nothing to destroy but avoid AUTOLOAD
-}
+# nothing to destroy but avoid AUTOLOAD
+sub DESTROY () { }
 
 # handles the attempt to invoke an undefined method on the proxy console object
 # using query_isotovideo() to invoke the method on the actual console object in
 # the right process
-sub AUTOLOAD {
-
+sub AUTOLOAD ($self, @args) {
     my $function = our $AUTOLOAD;
 
     $function =~ s,.*::,,;
 
     # allow symbolic references
     no strict 'refs';
-    *$AUTOLOAD = sub {
-        my $self = shift;
-        my $args = \@_;
+    *$AUTOLOAD = sub ($self, @args) {
         my $wrapped_call = {
             console => $self->{console},
             function => $function,
-            args => $args,
+            args => \@args,
             wantarray => wantarray,
         };
 

--- a/backend/driver.pm
+++ b/backend/driver.pm
@@ -77,11 +77,9 @@ sub start ($self) {
     $self->{backend_process} = $backend_process;
 }
 
-sub extract_assets ($self) {
-    $self->{backend}->do_extract_assets(@_);
-}
+sub extract_assets ($self, @args) { $self->{backend}->do_extract_assets(@args) }
 
-sub stop ($self, $cmd) {
+sub stop ($self) {
     return unless $self->{backend_process}->is_running;
 
     $self->stop_backend() if $self->{backend_process}->channel_out;
@@ -117,11 +115,7 @@ sub stop_backend ($self) {
 
 # new api end
 
-sub mouse_hide ($self, $border_offset) {
-    $border_offset ||= 0;
-
-    return $self->_send_json({cmd => 'mouse_hide', arguments => {border_offset => $border_offset}});
-}
+sub mouse_hide ($self, $border_offset = 0) { $self->_send_json({cmd => 'mouse_hide', arguments => {border_offset => $border_offset}}) }
 
 # virtual methods end
 

--- a/backend/generalhw.pm
+++ b/backend/generalhw.pm
@@ -6,7 +6,7 @@
 
 package backend::generalhw;
 
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 use autodie ':all';
 
 use base 'backend::baseclass';
@@ -17,16 +17,13 @@ use IPC::Run ();
 require IPC::System::Simple;
 use File::Basename 'basename';
 
-sub new {
-    my $class = shift;
+sub new ($class) {
     # required for the tests to access our HTTP port
     get_required_var('WORKER_HOSTNAME');
     return $class->SUPER::new;
 }
 
-sub get_cmd {
-    my ($self, $cmd) = @_;
-
+sub get_cmd ($self, $cmd) {
     my $dir = get_required_var('GENERAL_HW_CMD_DIR');
     die 'GENERAL_HW_CMD_DIR is not pointing to a directory' unless -d $dir;
 
@@ -52,8 +49,7 @@ sub get_cmd {
     return $cmd;
 }
 
-sub run_cmd {
-    my ($self, $cmd) = @_;
+sub run_cmd ($self, $cmd) {
     my @full_cmd = split / /, $self->get_cmd($cmd);
 
     my ($stdin, $stdout, $stderr, $ret);
@@ -67,24 +63,19 @@ sub run_cmd {
     return $stdout;
 }
 
-sub poweroff_host {
-    my ($self) = @_;
+sub poweroff_host ($self) {
     $self->run_cmd('GENERAL_HW_POWEROFF_CMD');
     return;
 }
 
-sub restart_host {
-    my ($self) = @_;
-
+sub restart_host ($self) {
     $self->poweroff_host;
     sleep(3);
     $self->run_cmd('GENERAL_HW_POWERON_CMD');
     return;
 }
 
-sub relogin_vnc {
-    my ($self) = @_;
-
+sub relogin_vnc ($self) {
     if ($self->{vnc}) {
         close($self->{vnc}->socket);
         sleep(1);
@@ -105,9 +96,7 @@ sub relogin_vnc {
     return 1;
 }
 
-sub do_start_vm {
-    my ($self) = @_;
-
+sub do_start_vm ($self) {
     $self->truncate_serial_file;
     if (get_var('GENERAL_HW_FLASH_CMD')) {
         $self->poweroff_host;    # Ensure system is off, before flashing
@@ -119,25 +108,19 @@ sub do_start_vm {
     return {};
 }
 
-sub do_stop_vm {
-    my ($self) = @_;
-
+sub do_stop_vm ($self) {
     $self->poweroff_host;
     $self->stop_serial_grab() if (get_var('GENERAL_HW_VNC_IP') || get_var('GENERAL_HW_SOL_CMD'));
     return {};
 }
 
-sub check_socket {
-    my ($self, $fh, $write) = @_;
-
+sub check_socket ($self, $fh, $write = undef) {
     return $self->check_ssh_serial($fh) || $self->SUPER::check_socket($fh, $write);
 }
 
 # serial grab
 
-sub start_serial_grab {
-    my ($self) = @_;
-
+sub start_serial_grab ($self) {
     $self->{serialpid} = fork();
     return unless $self->{serialpid} == 0;
     setpgrp 0, 0;
@@ -148,8 +131,7 @@ sub start_serial_grab {
     die "exec failed $!";
 }
 
-sub stop_serial_grab {
-    my ($self) = @_;
+sub stop_serial_grab ($self) {
     return unless $self->{serialpid};
     kill("-TERM", $self->{serialpid});
     return waitpid($self->{serialpid}, 0);

--- a/backend/generalhw.pm
+++ b/backend/generalhw.pm
@@ -49,16 +49,16 @@ sub get_cmd ($self, $cmd) {
     return $cmd;
 }
 
-sub run_cmd ($self, $cmd) {
-    my @full_cmd = split / /, $self->get_cmd($cmd);
+sub run_cmd ($self, @args) {
+    my @full_cmd = split / /, $self->get_cmd($args[0]);
 
     my ($stdin, $stdout, $stderr, $ret);
     eval { $ret = IPC::Run::run([@full_cmd], \$stdin, \$stdout, \$stderr) };
-    die "Unable to run command '@full_cmd' (deduced from test variable $cmd): $@\n" if $@;
+    die "Unable to run command '@full_cmd' (deduced from test variable $args[0]): $@\n" if $@;
     chomp $stdout;
     chomp $stderr;
 
-    die "$cmd: $stderr" unless $ret;
+    die "$args[0]: $stderr" unless $ret;
     bmwqemu::diag("IPMI: $stdout");
     return $stdout;
 }
@@ -96,7 +96,7 @@ sub relogin_vnc ($self) {
     return 1;
 }
 
-sub do_start_vm ($self) {
+sub do_start_vm ($self, @) {
     $self->truncate_serial_file;
     if (get_var('GENERAL_HW_FLASH_CMD')) {
         $self->poweroff_host;    # Ensure system is off, before flashing
@@ -108,7 +108,7 @@ sub do_start_vm ($self) {
     return {};
 }
 
-sub do_stop_vm ($self) {
+sub do_stop_vm ($self, @) {
     $self->poweroff_host;
     $self->stop_serial_grab() if (get_var('GENERAL_HW_VNC_IP') || get_var('GENERAL_HW_SOL_CMD'));
     return {};
@@ -131,7 +131,7 @@ sub start_serial_grab ($self) {
     die "exec failed $!";
 }
 
-sub stop_serial_grab ($self) {
+sub stop_serial_grab ($self, @) {
     return unless $self->{serialpid};
     kill("-TERM", $self->{serialpid});
     return waitpid($self->{serialpid}, 0);

--- a/backend/ikvm.pm
+++ b/backend/ikvm.pm
@@ -4,19 +4,14 @@
 
 package backend::ikvm;
 
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 use autodie ':all';
 
 use base 'backend::ipmi';
 
-sub new {
-    my $class = shift;
-    return $class->SUPER::new;
-}
+sub new ($class) { $class->SUPER::new }
 
-sub relogin_vnc {
-    my ($self) = @_;
-
+sub relogin_vnc ($self) {
     my $vncopts = {
         hostname => $bmwqemu::vars{IPMI_HOSTNAME},
         port => 5900,
@@ -36,9 +31,7 @@ sub relogin_vnc {
     return 1;
 }
 
-sub do_start_vm {
-    my ($self) = @_;
-
+sub do_start_vm ($self) {
     $self->get_mc_status;
     $self->restart_host;
     $self->relogin_vnc;
@@ -48,9 +41,7 @@ sub do_start_vm {
     return {};
 }
 
-sub do_stop_vm {
-    my ($self) = @_;
-
+sub do_stop_vm ($self) {
     $self->ipmitool("chassis power off");
     $self->deactivate_console({testapi_console => 'sol'});
     return {};

--- a/backend/ikvm.pm
+++ b/backend/ikvm.pm
@@ -31,7 +31,7 @@ sub relogin_vnc ($self) {
     return 1;
 }
 
-sub do_start_vm ($self) {
+sub do_start_vm ($self, @) {
     $self->get_mc_status;
     $self->restart_host;
     $self->relogin_vnc;
@@ -41,7 +41,7 @@ sub do_start_vm ($self) {
     return {};
 }
 
-sub do_stop_vm ($self) {
+sub do_stop_vm ($self, @) {
     $self->ipmitool("chassis power off");
     $self->deactivate_console({testapi_console => 'sol'});
     return {};

--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -82,7 +82,7 @@ sub restart_host ($self) {
     1;
 }
 
-sub do_start_vm ($self) {
+sub do_start_vm ($self, @) {
     # reset ipmi main board if switch on
     # We may need this IPMI_BACKEND_MC_RESET setting to tune differently
     # on different ipmi workers according to different ipmi machines' behavior.
@@ -98,13 +98,13 @@ sub do_start_vm ($self) {
     return {};
 }
 
-sub do_stop_vm ($self) {
+sub do_stop_vm ($self, @) {
     $self->ipmitool("chassis power off") unless $bmwqemu::vars{IPMI_DO_NOT_POWER_OFF};
     $self->deactivate_console({testapi_console => 'sol'}) if defined $testapi::distri->{consoles}->{sol};
     return {};
 }
 
-sub is_shutdown ($self) {
+sub is_shutdown ($self, @) {
     my $ret = $self->ipmitool('chassis power status', tries => 3);
     return $ret =~ m/is off/;
 }

--- a/backend/null.pm
+++ b/backend/null.pm
@@ -9,18 +9,18 @@ use base 'backend::baseclass';
 
 sub new ($self) { $self->SUPER::new }
 
-sub do_start_vm ($self) { {} }
+sub do_start_vm ($self, @) { {} }
 
-sub do_stop_vm ($self) { }
+sub do_stop_vm ($self, @) { }
 
 sub do_extract_assets ($self, @) { }
 
-sub run_cmd ($self) { }
+sub run_cmd ($self, @) { }
 
-sub can_handle ($self) { }
+sub can_handle ($self, @) { }
 
-sub is_shutdown ($self) { 1 }
+sub is_shutdown ($self, @) { 1 }
 
-sub stop_serial_grab ($self) { }
+sub stop_serial_grab ($self, @) { }
 
 1;

--- a/backend/null.pm
+++ b/backend/null.pm
@@ -3,24 +3,24 @@
 
 package backend::null;
 
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 
 use base 'backend::baseclass';
 
-sub new { shift->SUPER::new }
+sub new ($self) { $self->SUPER::new }
 
-sub do_start_vm { {} }
+sub do_start_vm ($self) { {} }
 
-sub do_stop_vm { }
+sub do_stop_vm ($self) { }
 
-sub do_extract_assets { }
+sub do_extract_assets ($self, @) { }
 
-sub run_cmd { }
+sub run_cmd ($self) { }
 
-sub can_handle { }
+sub can_handle ($self) { }
 
-sub is_shutdown { 1 }
+sub is_shutdown ($self) { 1 }
 
-sub stop_serial_grab { }
+sub stop_serial_grab ($self) { }
 
 1;

--- a/backend/pvm.pm
+++ b/backend/pvm.pm
@@ -3,7 +3,7 @@
 
 package backend::pvm;
 
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 use autodie ':all';
 
 use base 'backend::baseclass';
@@ -22,10 +22,9 @@ use osutils qw(dd_gen_params gen_params runcmd);
 # ssh to a novalink installation (so you only need ssh and terminal on worker)
 
 # uncoverable statement
-sub _masterlpar { qx{cat /proc/device-tree/ibm,partition-name} }
+sub _masterlpar () { qx{cat /proc/device-tree/ibm,partition-name} }
 
-sub new {
-    my $class = shift;
+sub new ($class) {
     my $self = $class->SUPER::new;
     $self->{pid} = undef;
     $self->{children} = [];
@@ -37,14 +36,12 @@ sub new {
     return $self;
 }
 
-sub do_start_vm {
-    my $self = shift;
+sub do_start_vm ($self) {
     $self->start_lpar();
     return {};
 }
 
-sub do_extract_assets {
-    my ($self, $args) = @_;
+sub do_extract_assets ($self, $args) {
     my $vars = \%bmwqemu::vars;
     my $hdd_num = $args->{hdd_num};
     my $name = $args->{name};
@@ -82,10 +79,7 @@ sub do_extract_assets {
     qx/sudo rescan-scsi-bus.sh -r/;
 }
 
-sub pvmctl {
-    my $self = shift @_;
-    my $type = shift @_;
-    my $action = shift @_;
+sub pvmctl ($self, $type, $action, @args) {
     my $vars = \%bmwqemu::vars;
 
     die "pvmctl: Not enough arguments (at least you should supply a type and an action)" unless ($type && $action);
@@ -96,7 +90,7 @@ sub pvmctl {
     if ($type =~ /lpar/) {
         gen_params @cmd, "i", "name=$lpar" if ($lpar && $action =~ /power|restart|delete/);
         if ($action =~ /create/) {
-            my ($cpu, $memory) = @_;
+            my ($cpu, $memory) = @args;
             dd_gen_params @cmd, "proc-type", "shared";
             dd_gen_params @cmd, "sharing-mode", "uncapped";
             dd_gen_params @cmd, "type", "AIX/Linux";
@@ -107,7 +101,7 @@ sub pvmctl {
         }
     }
     elsif ($type =~ /scsi/) {
-        my ($kind, $file, $target) = @_;
+        my ($kind, $file, $target) = @args;
         die "pvmctl: scsi type needs at least both kind and file" unless ($kind && $file);
 
         #so far only disks are reatachable to the master LPAR
@@ -119,12 +113,12 @@ sub pvmctl {
         dd_gen_params @cmd, "vg", "name=rootvg" if ($type =~ /lv/);
     }
     elsif ($type =~ /lv/) {
-        my ($name, $size) = @_;
+        my ($name, $size) = @args;
         dd_gen_params @cmd, "name", $name if $name;
         dd_gen_params @cmd, "size", $size if $size;
     }
     elsif ($type =~ /eth/) {
-        my ($vlan, $vswitch) = @_;
+        my ($vlan, $vswitch) = @args;
         dd_gen_params @cmd, "pvid", $vlan if $vlan;
         dd_gen_params @cmd, "vswitch", $vswitch if $vswitch;
         gen_params @cmd, "p", "name=$lpar" if $lpar;
@@ -134,8 +128,7 @@ sub pvmctl {
     }
     runcmd(@cmd);
 }
-sub attach_console {
-    my $vars = \%bmwqemu::vars;
+sub attach_console ($vars) {
     my $vncport = qx{sudo /usr/sbin/mkvtermutil --id $vars->{LPARID} --vnc --local --log serial0 2>/dev/null};
     $vncport =~ /([0-9]+)/;
     chomp($vncport);
@@ -143,8 +136,7 @@ sub attach_console {
     diag "VNC is $vars->{VNC}";
 }
 
-sub image_exists {
-    my ($img, $size) = @_;
+sub image_exists ($img, $size) {
     #lv already exists?
     my @cmd;
     my $pvmctlcmd = "pvmctl lv list -w LogicalVolume.name=$img -d LogicalVolume.name LogicalVolume.capacity -f , --hide-label";
@@ -158,8 +150,7 @@ sub image_exists {
     }
     runcmd(@cmd);
 }
-sub start_lpar {
-    my $self = shift;
+sub start_lpar ($self) {
     my $vars = \%bmwqemu::vars;
     #general settiings
     $vars->{LPAR} = "osauto" . $vars->{WORKER_ID};
@@ -228,19 +219,14 @@ sub start_lpar {
     $self->select_console({testapi_console => 'sut'});
 }
 
-sub _status {
-    my ($self) = @_;
+sub _status ($self) {
     my $id = $bmwqemu::vars{LPARID};
     return qx{pvmctl lpar list -i id=$id -d LogicalPartition.state --hide-label};
 }
 
-sub is_shutdown {
-    my ($self) = @_;
-    return $self->_status =~ /running/;
-}
+sub is_shutdown ($self) { $self->_status =~ /running/ }
 
-sub do_stop_vm {
-    my $self = shift;
+sub do_stop_vm ($self) {
     my $vars = \%bmwqemu::vars;
     $self->pvmctl("lpar", "power-off") if (!$self->is_shutdown);
     runcmd("rmvterm", "--id", $vars->{LPARID});

--- a/backend/pvm.pm
+++ b/backend/pvm.pm
@@ -36,7 +36,7 @@ sub new ($class) {
     return $self;
 }
 
-sub do_start_vm ($self) {
+sub do_start_vm ($self, @) {
     $self->start_lpar();
     return {};
 }
@@ -224,9 +224,9 @@ sub _status ($self) {
     return qx{pvmctl lpar list -i id=$id -d LogicalPartition.state --hide-label};
 }
 
-sub is_shutdown ($self) { $self->_status =~ /running/ }
+sub is_shutdown ($self, @) { $self->_status =~ /running/ }
 
-sub do_stop_vm ($self) {
+sub do_stop_vm ($self, @) {
     my $vars = \%bmwqemu::vars;
     $self->pvmctl("lpar", "power-off") if (!$self->is_shutdown);
     runcmd("rmvterm", "--id", $vars->{LPARID});

--- a/backend/pvm_hmc.pm
+++ b/backend/pvm_hmc.pm
@@ -3,7 +3,7 @@
 
 package backend::pvm_hmc;
 
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 
 use base 'backend::virt';
 
@@ -11,8 +11,7 @@ use testapi qw(get_var get_required_var);
 
 # supporting the minimal command set of the HMC through a ssh tunnel
 
-sub new {
-    my $class = shift;
+sub new ($class) {
     my $self = $class->SUPER::new;
     get_required_var('HMC_MACHINE_NAME');
 
@@ -21,9 +20,7 @@ sub new {
 
 # only define the HMC console - we leave the actual
 # poweron to the test
-sub do_start_vm {
-    my ($self) = @_;
-
+sub do_start_vm ($self) {
     # truncate the serial file
     open(my $sf, '>', $self->{serialfile});
     close($sf);
@@ -41,16 +38,13 @@ sub do_start_vm {
     return {};
 }
 
-sub do_stop_vm {
-    my ($self) = @_;
-
+sub do_stop_vm ($self) {
     $self->stop_serial_grab;
     $self->deactivate_console({testapi_console => 'powerhmc-ssh'});
     return {};
 }
 
-sub run_cmd {
-    my ($self, $cmd, $hostname, $password) = @_;
+sub run_cmd ($self, $cmd, $hostname, $password) {
     $hostname ||= get_required_var('HMC_HOSTNAME');
     $password ||= get_required_var('HMC_PASSWORD');
     my $username = get_var('HMC_USERNAME', 'hscroot');
@@ -58,27 +52,19 @@ sub run_cmd {
     return $self->run_ssh_cmd($cmd, username => $username, password => $password, hostname => $hostname, keep_open => 0);
 }
 
-sub can_handle {
-    my ($self, $args) = @_;
-    return undef;
-}
+sub can_handle ($self, $args) { undef }
 
-sub is_shutdown {
-    my ($self) = @_;
+sub is_shutdown ($self) {
     my $lpar_id = get_required_var('LPAR_ID');
     my $hmc_machine_name = get_required_var('HMC_MACHINE_NAME');
     return $self->run_cmd("! lssyscfg -m ${hmc_machine_name} -r lpar --filter 'lpar_ids=${lpar_id}' -F state | grep -i 'not activated' -q");
 }
 
-sub check_socket {
-    my ($self, $fh, $write) = @_;
-
+sub check_socket ($self, $fh, $write = undef) {
     return $self->check_ssh_serial($fh) || $self->SUPER::check_socket($fh, $write);
 }
 
-sub stop_serial_grab {
-    my ($self) = @_;
-
+sub stop_serial_grab ($self) {
     $self->stop_ssh_serial;
     return undef;
 }

--- a/backend/pvm_hmc.pm
+++ b/backend/pvm_hmc.pm
@@ -20,7 +20,7 @@ sub new ($class) {
 
 # only define the HMC console - we leave the actual
 # poweron to the test
-sub do_start_vm ($self) {
+sub do_start_vm ($self, @) {
     # truncate the serial file
     open(my $sf, '>', $self->{serialfile});
     close($sf);
@@ -38,23 +38,20 @@ sub do_start_vm ($self) {
     return {};
 }
 
-sub do_stop_vm ($self) {
+sub do_stop_vm ($self, @) {
     $self->stop_serial_grab;
     $self->deactivate_console({testapi_console => 'powerhmc-ssh'});
     return {};
 }
 
-sub run_cmd ($self, $cmd, $hostname, $password) {
-    $hostname ||= get_required_var('HMC_HOSTNAME');
-    $password ||= get_required_var('HMC_PASSWORD');
+sub run_cmd ($self, $cmd, $hostname = get_required_var('HMC_HOSTNAME'), $password = get_required_var('HMC_PASSWORD'), @) {
     my $username = get_var('HMC_USERNAME', 'hscroot');
-
     return $self->run_ssh_cmd($cmd, username => $username, password => $password, hostname => $hostname, keep_open => 0);
 }
 
-sub can_handle ($self, $args) { undef }
+sub can_handle ($self, @) { undef }
 
-sub is_shutdown ($self) {
+sub is_shutdown ($self, @) {
     my $lpar_id = get_required_var('LPAR_ID');
     my $hmc_machine_name = get_required_var('HMC_MACHINE_NAME');
     return $self->run_cmd("! lssyscfg -m ${hmc_machine_name} -r lpar --filter 'lpar_ids=${lpar_id}' -F state | grep -i 'not activated' -q");
@@ -64,7 +61,7 @@ sub check_socket ($self, $fh, $write = undef) {
     return $self->check_ssh_serial($fh) || $self->SUPER::check_socket($fh, $write);
 }
 
-sub stop_serial_grab ($self) {
+sub stop_serial_grab ($self, @) {
     $self->stop_ssh_serial;
     return undef;
 }

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -4,7 +4,7 @@
 
 package backend::qemu;
 
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 use autodie ':all';
 
 use base 'backend::virt';
@@ -37,8 +37,7 @@ use constant LONG_MAX => (~0 >> 1);
 # in a separate dir.
 use constant VM_SNAPSHOTS_DIR => 'vm-snapshots';
 
-sub new {
-    my $class = shift;
+sub new ($class) {
     my $self = $class->SUPER::new;
     $self->{pidfilename} = 'qemu.pid';
     $self->{proc} = OpenQA::Qemu::Proc->new();
@@ -48,37 +47,31 @@ sub new {
 
 # baseclass virt method overwrite
 
-sub raw_alive { shift->{proc}->_process->is_running }
+sub raw_alive ($self) { $self->{proc}->_process->is_running }
 
-sub _wrap_hmc {
-    my $cmdline = shift;
-    return {
+sub _wrap_hmc ($cmdline) { {
         execute => 'human-monitor-command',
-        arguments => {'command-line' => $cmdline}};
+        arguments => {'command-line' => $cmdline}}
 }
 
 # poo#66667: Since qemu 4.2, -audiodev is required to record sounds, as we need an audiodev id for 'wavcapture'
-sub requires_audiodev {
-    my ($self) = @_;
+sub requires_audiodev ($self) {
     return (version->declare($self->{qemu_version}) ge version->declare(4.2));
 }
 
-sub start_audiocapture {
-    my ($self, $args) = @_;
+sub start_audiocapture ($self, $args) {
 
     # poo#66667: an audiodev id is required by wavcapture when audiodev is used
     my $audiodev_id = $self->requires_audiodev ? 'snd0' : '';
     $self->handle_qmp_command(_wrap_hmc("wavcapture $args->{filename} $audiodev_id 44100 16 1"));
 }
 
-sub stop_audiocapture {
-    my ($self, $args) = @_;
+sub stop_audiocapture ($self, $args) {
     $self->handle_qmp_command(_wrap_hmc("stopcapture 0"));
 }
 
-sub power {
-    # parameters: acpi, reset, (on), off
-    my ($self, $args) = @_;
+# parameters: acpi, reset, (on), off
+sub power ($self, $args) {
     my %action_to_cmd = (
         acpi => 'system_powerdown',
         reset => 'system_reset',
@@ -87,8 +80,7 @@ sub power {
     $self->handle_qmp_command({execute => $action_to_cmd{$args->{action}}});
 }
 
-sub eject_cd {
-    my ($self, $args) = @_;
+sub eject_cd ($self, $args = {}) {
     die "'device' parameter is not supported anymore, use 'id'" if defined $args->{device};
     my $id = $args->{id} // 'cd0-device';
     $self->handle_qmp_command({execute => 'eject', arguments => {
@@ -98,33 +90,26 @@ sub eject_cd {
     $self->handle_qmp_command({execute => 'blockdev-remove-medium', arguments => {id => $id}});
 }
 
-sub execute_qmp_command {
-    my ($self, $args) = @_;
-    $self->handle_qmp_command($args->{query});
-}
+sub execute_qmp_command ($self, $args) { $self->handle_qmp_command($args->{query}) }
 
-sub cpu_stat {
-    my $self = shift;
+sub cpu_stat ($self) {
     my $stat = path("/proc/" . $self->{proc}->_process->pid . "/stat")->slurp;
     my @a = split(" ", $stat);
     return [@a[13, 14]];
 }
 
-sub do_start_vm {
-    my $self = shift;
+sub do_start_vm ($self) {
     $self->start_qemu();
     return {};
 }
 
-sub stop_qemu {
-    my ($self) = (@_);
+sub stop_qemu ($self) {
     $self->{proc}->stop_qemu;
-    $self->delete_virtio_console_fifo();
+    delete_virtio_console_fifo();
     $self->_stop_children_processes;
 }
 
-sub _dbus_do_call {
-    my ($self, $fn, @args) = @_;
+sub _dbus_do_call ($self, $fn, @args) {
     # we intentionally do not persist the dbus connection to avoid
     # queueing up signals we are not interested in handling:
     # https://progress.opensuse.org/issues/90872
@@ -136,8 +121,7 @@ sub _dbus_do_call {
     return @result;
 }
 
-sub _dbus_call {
-    my ($self, $fn, @args) = @_;
+sub _dbus_call ($self, $fn, @args) {
     my ($rt, $message);
     eval {
         # do not die on unconfigured service
@@ -155,8 +139,7 @@ sub _dbus_call {
     return ($rt, $message, ($error) x !!($error));
 }
 
-sub do_stop_vm {
-    my $self = shift;
+sub do_stop_vm ($self) {
 
     my $proc = $self->{proc};
     if ($bmwqemu::vars{QEMU_WAIT_FINISH}) {
@@ -169,8 +152,7 @@ sub do_stop_vm {
     $self->stop_qemu;
 }
 
-sub can_handle {
-    my ($self, $args) = @_;
+sub can_handle ($self, $args) {
     my $vars = \%bmwqemu::vars;
 
     return unless $args->{function} eq 'snapshots';
@@ -183,8 +165,7 @@ sub can_handle {
     return undef;
 }
 
-sub open_file_and_send_fd_to_qemu {
-    my ($self, $path, $fdname) = @_;
+sub open_file_and_send_fd_to_qemu ($self, $path, $fdname) {
 
     mkpath(dirname($path));
     my $fd = POSIX::open($path, POSIX::O_CREAT() | POSIX::O_RDWR()) or die "Failed to open $path: $!";
@@ -196,8 +177,7 @@ sub open_file_and_send_fd_to_qemu {
     POSIX::close($fd);
 }
 
-sub set_migrate_capability {
-    my ($self, $name, $state) = @_;
+sub set_migrate_capability ($self, $name, $state) {
 
     $self->handle_qmp_command(
         {
@@ -213,8 +193,7 @@ sub set_migrate_capability {
     );
 }
 
-sub _wait_while_status_is {
-    my ($self, $status, $timeout, $fail_msg) = @_;
+sub _wait_while_status_is ($self, $status, $timeout, $fail_msg) {
 
     my $rsp = $self->handle_qmp_command({execute => 'query-status'}, fatal => 1);
     my $i = 0;
@@ -226,8 +205,7 @@ sub _wait_while_status_is {
     }
 }
 
-sub _wait_for_migrate {
-    my ($self) = @_;
+sub _wait_for_migrate ($self) {
     my $migration_starttime = gettimeofday;
     my $execution_time = gettimeofday;
     # We need to wait for qemu, since it will not honor timeouts
@@ -262,8 +240,7 @@ sub _wait_for_migrate {
         'Timed out waiting for migration to finalize');
 }
 
-sub _migrate_to_file {
-    my ($self, %args) = @_;
+sub _migrate_to_file ($self, %args) {
     my $fdname = 'dumpfd';
     my $compress_level = $args{compress_level} || 0;
     my $compress_threads = $args{compress_threads} // 2;
@@ -306,8 +283,7 @@ sub _migrate_to_file {
     return $self->_wait_for_migrate();
 }
 
-sub save_memory_dump {
-    my ($self, $args) = @_;
+sub save_memory_dump ($self, $args) {
     my $fdname = 'dumpfd';
     my $vars = \%bmwqemu::vars;
     my $compress_method = $vars->{QEMU_DUMP_COMPRESS_METHOD} || 'xz';
@@ -344,8 +320,7 @@ sub save_memory_dump {
     }
 }
 
-sub save_storage_drives {
-    my ($self, $args) = @_;
+sub save_storage_drives ($self, $args) {
     diag "Attempting to extract disk #%d.", $args->{disk};
     $self->do_extract_assets(
         {
@@ -359,8 +334,7 @@ sub save_storage_drives {
     return;
 }
 
-sub inflate_balloon {
-    my $self = shift;
+sub inflate_balloon ($self) {
     my $vars = \%bmwqemu::vars;
     return unless $vars->{QEMU_BALLOON_TARGET};
     my $target_bytes = $vars->{QEMU_BALLOON_TARGET} * 1048576;
@@ -377,16 +351,14 @@ sub inflate_balloon {
     }
 }
 
-sub deflate_balloon {
-    my $self = shift;
+sub deflate_balloon ($self) {
     my $vars = \%bmwqemu::vars;
     return unless $vars->{QEMU_BALLOON_TARGET};
     my $ram_bytes = $vars->{QEMURAM} * 1048576;
     $self->handle_qmp_command({execute => 'balloon', arguments => {value => $ram_bytes}}, fatal => 1);
 }
 
-sub save_snapshot {
-    my ($self, $args) = @_;
+sub save_snapshot ($self, $args) {
     my $vars = \%bmwqemu::vars;
     my $vmname = $args->{name};
     my $bdc = $self->{proc}->blockdev_conf;
@@ -442,8 +414,7 @@ sub save_snapshot {
     return;
 }
 
-sub load_snapshot {
-    my ($self, $args) = @_;
+sub load_snapshot ($self, $args) {
     my $vmname = $args->{name};
 
     my $rsp = $self->handle_qmp_command({execute => 'query-status'}, fatal => 1);
@@ -461,7 +432,7 @@ sub load_snapshot {
 
     my $snapshot = $self->{proc}->revert_to_snapshot($vmname);
 
-    $self->create_virtio_console_fifo();
+    create_virtio_console_fifo();
     my $qemu_pipe = $self->{qemupipe} = $self->{proc}->exec_qemu();
     $self->{qmpsocket} = $self->{proc}->connect_qmp();
     my $init = myjsonrpc::read_json($self->{qmpsocket});
@@ -494,8 +465,7 @@ sub load_snapshot {
     $self->deflate_balloon();
 }
 
-sub do_extract_assets {
-    my ($self, $args) = @_;
+sub do_extract_assets ($self, $args) {
     my $name = $args->{name};
     my $img_dir = $args->{dir};
     my $hdd_num = $args->{hdd_num} - 1;
@@ -510,27 +480,25 @@ sub do_extract_assets {
 
 # baseclass virt method overwrite end
 
-sub find_ovmf { first { -e } @bmwqemu::ovmf_locations }
+sub find_ovmf () { first { -e } @bmwqemu::ovmf_locations }
 
-sub virtio_console_names {
+sub virtio_console_names () {
     return () unless $bmwqemu::vars{VIRTIO_CONSOLE};
     return map { 'virtio_console' . ($_ || '') } (0 .. ($bmwqemu::vars{VIRTIO_CONSOLE_NUM} // 1));
 }
 
-sub virtio_console_fifo_names { map { $_ . '.in', $_ . '.out' } virtio_console_names }
+sub virtio_console_fifo_names () { map { $_ . '.in', $_ . '.out' } virtio_console_names }
 
-sub console_fifo {
-    my ($name) = @_;
+sub console_fifo ($name) {
     return bmwqemu::fctwarn("Fifo pipe '$name' already exists!") if -e $name;
     mkfifo($name, 0666) or bmwqemu::fctwarn("Failed to create pipe $name: $!");
 }
 
-sub create_virtio_console_fifo { console_fifo($_) for virtio_console_fifo_names }
+sub create_virtio_console_fifo() { console_fifo($_) for virtio_console_fifo_names }
 
-sub delete_virtio_console_fifo { unlink $_ or bmwqemu::fctwarn("Could not unlink $_ $!") for grep { -e } virtio_console_fifo_names }
+sub delete_virtio_console_fifo() { unlink $_ or bmwqemu::fctwarn("Could not unlink $_ $!") for grep { -e } virtio_console_fifo_names }
 
-sub qemu_params_ofw {
-    my $self = shift;
+sub qemu_params_ofw ($self) {
     my $vars = \%bmwqemu::vars;
     $vars->{QEMUVGA} ||= "std";
     $vars->{QEMUMACHINE} //= "usb=off";
@@ -544,8 +512,7 @@ sub qemu_params_ofw {
     return 1;
 }
 
-sub start_qemu {
-    my $self = shift;
+sub start_qemu ($self) {
     my $vars = \%bmwqemu::vars;
 
     my $basedir = path('raid')->to_abs;
@@ -931,7 +898,7 @@ sub start_qemu {
         sp(split(' ', $_)) for @spl;
     }
 
-    $self->create_virtio_console_fifo();
+    create_virtio_console_fifo();
     my $qemu_pipe = $self->{qemupipe} = $self->{proc}->exec_qemu();
     return bmwqemu::fctinfo('Not connecting to QEMU as requested by QEMU_ONLY_EXEC') if $vars->{QEMU_ONLY_EXEC};
     $self->{qmpsocket} = $self->{proc}->connect_qmp();
@@ -996,9 +963,7 @@ Pass send_fd => $fd to send $fd to QEMU using SCM rights. Probably only useful
 with the getfd command.
 
 =cut
-sub handle_qmp_command {
-    my ($self, $cmd) = @_[0, 1];
-    my %optargs = @_[2 .. $#_];
+sub handle_qmp_command ($self, $cmd, %optargs) {
     $optargs{fatal} ||= 0;
     my $sk = $self->{qmpsocket};
 
@@ -1024,8 +989,7 @@ sub handle_qmp_command {
     return $hash;
 }
 
-sub process_qemu_output {
-    my ($buffer) = @_;
+sub process_qemu_output ($buffer) {
     for my $line (split(/\n/, $buffer)) {
         die "QEMU: Shutting down the job" if $line =~ m/key event queue full/;
         if ($line =~ /^\s*qemu-system-[^:]+: (?!terminating on signal)/) {
@@ -1037,8 +1001,7 @@ sub process_qemu_output {
     }
 }
 
-sub read_qemupipe {
-    my ($self) = @_;
+sub read_qemupipe ($self) {
     my $buffer;
     my $bytes = sysread($self->{qemupipe}, $buffer, 1000);
     chomp $buffer;
@@ -1046,8 +1009,7 @@ sub read_qemupipe {
     return $bytes;
 }
 
-sub close_pipes {
-    my ($self) = @_;
+sub close_pipes ($self) {
     $self->do_stop_vm() if $self->{started};
 
     if (my $qemu_pipe = $self->{qemupipe}) {
@@ -1068,8 +1030,7 @@ sub close_pipes {
     $self->SUPER::close_pipes() unless exists $self->{stop_only_qemu} && $self->{stop_only_qemu};
 }
 
-sub is_shutdown {
-    my ($self) = @_;
+sub is_shutdown ($self) {
     my $ret = $self->handle_qmp_command({execute => 'query-status'})->{return}->{status}
       || 'unknown';
 
@@ -1080,8 +1041,7 @@ sub is_shutdown {
 
 # this is called for all sockets ready to read from. return 1 if socket
 # detected and -1 if there was an error
-sub check_socket {
-    my ($self, $fh, $write) = @_;
+sub check_socket ($self, $fh, $write = undef) {
 
     if ($self->{qemupipe} && $fh == $self->{qemupipe}) {
         $self->close_pipes() if !$write && !$self->read_qemupipe();
@@ -1090,8 +1050,7 @@ sub check_socket {
     return $self->SUPER::check_socket($fh);
 }
 
-sub freeze_vm {
-    my ($self) = @_;
+sub freeze_vm ($self, @) {
     # qemu specific - all other backends will crash
     my $ret = $self->handle_qmp_command({execute => 'stop'}, fatal => 1);
     # once we stopped, there is no point in querying VNC
@@ -1102,8 +1061,7 @@ sub freeze_vm {
     return $ret;
 }
 
-sub cont_vm {
-    my ($self) = @_;
+sub cont_vm ($self) {
     $self->update_request_interval(delete $self->{_qemu_saved_request_interval}) if $self->{_qemu_saved_request_interval};
     return $self->handle_qmp_command({execute => 'cont'});
 }

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -98,7 +98,7 @@ sub cpu_stat ($self) {
     return [@a[13, 14]];
 }
 
-sub do_start_vm ($self) {
+sub do_start_vm ($self, @) {
     $self->start_qemu();
     return {};
 }
@@ -139,7 +139,7 @@ sub _dbus_call ($self, $fn, @args) {
     return ($rt, $message, ($error) x !!($error));
 }
 
-sub do_stop_vm ($self) {
+sub do_stop_vm ($self, @) {
 
     my $proc = $self->{proc};
     if ($bmwqemu::vars{QEMU_WAIT_FINISH}) {
@@ -1030,7 +1030,7 @@ sub close_pipes ($self) {
     $self->SUPER::close_pipes() unless exists $self->{stop_only_qemu} && $self->{stop_only_qemu};
 }
 
-sub is_shutdown ($self) {
+sub is_shutdown ($self, @) {
     my $ret = $self->handle_qmp_command({execute => 'query-status'})->{return}->{status}
       || 'unknown';
 
@@ -1061,7 +1061,7 @@ sub freeze_vm ($self, @) {
     return $ret;
 }
 
-sub cont_vm ($self) {
+sub cont_vm ($self, @) {
     $self->update_request_interval(delete $self->{_qemu_saved_request_interval}) if $self->{_qemu_saved_request_interval};
     return $self->handle_qmp_command({execute => 'cont'});
 }

--- a/backend/s390x.pm
+++ b/backend/s390x.pm
@@ -4,7 +4,7 @@
 
 package backend::s390x;
 
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 use autodie ':all';
 
 use base 'backend::baseclass';
@@ -14,16 +14,14 @@ require IPC::System::Simple;
 use Carp qw(confess cluck carp croak);
 use testapi 'get_required_var';
 
-sub new {
-    my $class = shift;
+sub new ($class) {
     my $self = $class->SUPER::new;
     get_required_var('WORKER_HOSTNAME');
     return $self;
 }
 
 ###################################################################
-sub do_start_vm {
-    my ($self) = @_;
+sub do_start_vm ($self) {
     $self->truncate_serial_file;
     my $console = $testapi::distri->add_console('x3270', 's3270');
     $console->backend($self);
@@ -32,9 +30,7 @@ sub do_start_vm {
     return 1;
 }
 
-sub do_stop_vm {
-    my ($self) = @_;
-
+sub do_stop_vm ($self) {
     # first kill all _remote_ consoles except for the remote zVM
     # console (which would stop the vm guest)
     my @consoles = keys %{$self->{consoles}};
@@ -46,9 +42,7 @@ sub do_stop_vm {
     return;
 }
 
-sub check_socket {
-    my ($self, $fh, $write) = @_;
-
+sub check_socket ($self, $fh, $write = undef) {
     return $self->check_ssh_serial($fh) || $self->SUPER::check_socket($fh, $write);
 }
 

--- a/backend/s390x.pm
+++ b/backend/s390x.pm
@@ -21,7 +21,7 @@ sub new ($class) {
 }
 
 ###################################################################
-sub do_start_vm ($self) {
+sub do_start_vm ($self, @) {
     $self->truncate_serial_file;
     my $console = $testapi::distri->add_console('x3270', 's3270');
     $console->backend($self);
@@ -30,7 +30,7 @@ sub do_start_vm ($self) {
     return 1;
 }
 
-sub do_stop_vm ($self) {
+sub do_stop_vm ($self, @) {
     # first kill all _remote_ consoles except for the remote zVM
     # console (which would stop the vm guest)
     my @consoles = keys %{$self->{consoles}};

--- a/backend/spvm.pm
+++ b/backend/spvm.pm
@@ -19,7 +19,7 @@ sub new ($class) {
 
 # only define the novalink console - we leave the actual
 # poweron to the test
-sub do_start_vm ($self) {
+sub do_start_vm ($self, @) {
     $self->truncate_serial_file;
     $bmwqemu::vars{NOVALINK_HOSTNAME} // die 'Need variable \'NOVALINK_HOSTNAME\'';
     $bmwqemu::vars{NOVALINK_PASSWORD} // die 'Need variable \'NOVALINK_PASSWORD\'';
@@ -36,7 +36,7 @@ sub do_start_vm ($self) {
     return {};
 }
 
-sub do_stop_vm ($self) {
+sub do_stop_vm ($self, @) {
     $self->stop_serial_grab;
     $self->deactivate_console({testapi_console => 'novalink-ssh'});
     return {};
@@ -48,11 +48,9 @@ sub run_cmd ($self, $cmd, $hostname = $bmwqemu::vars{NOVALINK_HOSTNAME}, $passwo
     return $self->run_ssh_cmd($cmd, username => $username, password => $password, hostname => $hostname, keep_open => 0);
 }
 
-sub can_handle ($self, $args) {
-    return;
-}
+sub can_handle ($self, @) { }
 
-sub is_shutdown ($self) {
+sub is_shutdown ($self, @) {
     my $lpar_id = $bmwqemu::vars{NOVALINK_LPAR_ID} // die 'Need variable \'NOVALINK_LPAR_ID\'';
     return $self->run_cmd("! pvmctl  lpar list -i id=${lpar_id} | grep  'not a'");
 }
@@ -61,7 +59,7 @@ sub check_socket ($self, $fh, $write = undef) {
     return $self->check_ssh_serial($fh) || $self->SUPER::check_socket($fh, $write);
 }
 
-sub stop_serial_grab ($self) {
+sub stop_serial_grab ($self, @) {
     $self->stop_ssh_serial;
     return;
 }

--- a/backend/spvm.pm
+++ b/backend/spvm.pm
@@ -3,7 +3,7 @@
 
 package backend::spvm;
 
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 
 use base 'backend::virt';
 
@@ -11,78 +11,65 @@ use testapi qw(get_var get_required_var);
 
 # supporting the minimal command set of NovaLink through a ssh tunnel
 
-sub new {
-    my $class = shift;
+sub new ($class) {
     my $self = $class->SUPER::new;
-    get_required_var('WORKER_HOSTNAME');
-
+    $bmwqemu::vars{WORKER_HOSTNAME} // die 'Need variable \'WORKER_HOSTNAME\'';
     return $self;
 }
 
 # only define the novalink console - we leave the actual
 # poweron to the test
-sub do_start_vm {
-    my ($self) = @_;
+sub do_start_vm ($self) {
     $self->truncate_serial_file;
+    $bmwqemu::vars{NOVALINK_HOSTNAME} // die 'Need variable \'NOVALINK_HOSTNAME\'';
+    $bmwqemu::vars{NOVALINK_PASSWORD} // die 'Need variable \'NOVALINK_PASSWORD\'';
     my $ssh = $testapi::distri->add_console(
         'novalink-ssh',
         'ssh-xterm',
         {
-            hostname => get_required_var('NOVALINK_HOSTNAME'),
-            password => get_required_var('NOVALINK_PASSWORD'),
-            username => get_var('NOVALINK_USERNAME', 'root'),
+            hostname => $bmwqemu::vars{NOVALINK_HOSTNAME},
+            password => $bmwqemu::vars{NOVALINK_PASSWORD},
+            username => $bmwqemu::vars{NOVALINK_USERNAME} // 'root',
             persistent => 1});
     $ssh->backend($self);
 
     return {};
 }
 
-sub do_stop_vm {
-    my ($self) = @_;
-
+sub do_stop_vm ($self) {
     $self->stop_serial_grab;
     $self->deactivate_console({testapi_console => 'novalink-ssh'});
     return {};
 }
 
-sub run_cmd {
-    my ($self, $cmd, $hostname, $password) = @_;
-    $hostname ||= get_required_var('NOVALINK_HOSTNAME');
-    $password ||= get_required_var('NOVALINK_PASSWORD');
-    my $username = get_var('NOVALINK_USERNAME', 'root');
+sub run_cmd ($self, $cmd, $hostname = $bmwqemu::vars{NOVALINK_HOSTNAME}, $password = $bmwqemu::vars{NOVALINK_PASSWORD}) {
+    my $username = $bmwqemu::vars{NOVALINK_USERNAME} // 'root';
 
     return $self->run_ssh_cmd($cmd, username => $username, password => $password, hostname => $hostname, keep_open => 0);
 }
 
-sub can_handle {
-    my ($self, $args) = @_;
+sub can_handle ($self, $args) {
     return;
 }
 
-sub is_shutdown {
-    my ($self) = @_;
-    my $lpar_id = get_required_var('NOVALINK_LPAR_ID');
+sub is_shutdown ($self) {
+    my $lpar_id = $bmwqemu::vars{NOVALINK_LPAR_ID} // die 'Need variable \'NOVALINK_LPAR_ID\'';
     return $self->run_cmd("! pvmctl  lpar list -i id=${lpar_id} | grep  'not a'");
 }
 
-sub check_socket {
-    my ($self, $fh, $write) = @_;
-
+sub check_socket ($self, $fh, $write = undef) {
     return $self->check_ssh_serial($fh) || $self->SUPER::check_socket($fh, $write);
 }
 
-sub stop_serial_grab {
-    my ($self) = @_;
-
+sub stop_serial_grab ($self) {
     $self->stop_ssh_serial;
     return;
 }
 
-sub power {
-    # parameters: on, off, reset
-    my ($self, $args) = @_;
+# parameters: on, off, reset
+sub power ($self, $args) {
     my $action = $args->{action};
-    my $lpar_id = get_required_var('NOVALINK_LPAR_ID');
+    my $lpar_id = $bmwqemu::vars{NOVALINK_LPAR_ID} // die 'Need variable \'NOVALINK_LPAR_ID\'';
 
     my %cmds = (
         on => "pvmctl lpar power-on -i id=${lpar_id} --bootmode norm",

--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -36,7 +36,7 @@ sub new ($class) {
 }
 
 # we don't do anything actually
-sub do_start_vm ($self) {
+sub do_start_vm ($self, @) {
     my $vars = \%bmwqemu::vars;
     my $n = $vars->{NUMDISKS} // 1;
     $vars->{NUMDISKS} //= defined($vars->{RAIDLEVEL}) ? 4 : $n;
@@ -56,7 +56,7 @@ sub do_start_vm ($self) {
     return {};
 }
 
-sub do_stop_vm ($self) {
+sub do_stop_vm ($self, @) {
     $self->stop_serial_grab;
 
     unless (get_var('SVIRT_KEEP_VM_RUNNING')) {
@@ -111,7 +111,7 @@ sub can_handle ($self, $args) {
     return;
 }
 
-sub is_shutdown ($self) {
+sub is_shutdown ($self, @) {
     my $vmname = $self->console('svirt')->name;
     my $rsp;
     if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
@@ -304,7 +304,7 @@ sub check_socket ($self, $fh, $write = undef) {
     return $self->check_ssh_serial($fh, $write) || $self->SUPER::check_socket($fh, $write);
 }
 
-sub stop_serial_grab ($self) {
+sub stop_serial_grab ($self, @) {
     $self->stop_ssh_serial;
     return;
 }

--- a/backend/vagrant.pm
+++ b/backend/vagrant.pm
@@ -130,7 +130,7 @@ sub get_ssh_credentials ($self) {
     return %con_creds;
 }
 
-sub do_start_vm ($self) {
+sub do_start_vm ($self, @) {
     if (defined($self->{libvirt_pool_name})) {
         my ($stdout, $stderr, $virsh_res);
 
@@ -160,7 +160,7 @@ sub do_start_vm ($self) {
     return {};
 }
 
-sub do_stop_vm ($self) {
+sub do_stop_vm ($self, @) {
     my $res = $self->run_vagrant_command({cmd => "halt"});
     if ($res->{retval} != 0) {
         bmwqemu::fctwarn("vagrant: failed to execute vagrant halt, got $res->{retval},\n$res->{stdout}\n$res->{stderr}");
@@ -200,11 +200,9 @@ sub run_cmd ($self, $cmd) {
     return $res->{stdout};
 }
 
-sub can_handle ($self) { }
+sub can_handle ($self, @) { }
 
-# don't use signatures here, as is_shutdown also receives some additional args
-# that are not really used anywhere
-sub is_shutdown ($self) {
+sub is_shutdown ($self, @) {
     my $res = $self->run_vagrant_command({cmd => "status", timeout => 5});
     chomp($res->{stdout});
     return $res->{stdout} =~ /default,state,(shutoff|not_created|poweroff)/;
@@ -212,6 +210,6 @@ sub is_shutdown ($self) {
 
 sub check_socket ($self, $fh, $write = undef) { $self->SUPER::check_socket($fh, $write) }
 
-sub stop_serial_grab ($self) { }
+sub stop_serial_grab ($self, @) { }
 
 1;

--- a/backend/vagrant.pm
+++ b/backend/vagrant.pm
@@ -200,21 +200,18 @@ sub run_cmd ($self, $cmd) {
     return $res->{stdout};
 }
 
-sub can_handle { }
+sub can_handle ($self) { }
 
 # don't use signatures here, as is_shutdown also receives some additional args
 # that are not really used anywhere
-sub is_shutdown {
-    my ($self) = @_;
+sub is_shutdown ($self) {
     my $res = $self->run_vagrant_command({cmd => "status", timeout => 5});
     chomp($res->{stdout});
     return $res->{stdout} =~ /default,state,(shutoff|not_created|poweroff)/;
 }
 
-sub check_socket ($self, $fh, $write) {
-    return $self->SUPER::check_socket($fh, $write);
-}
+sub check_socket ($self, $fh, $write = undef) { $self->SUPER::check_socket($fh, $write) }
 
-sub stop_serial_grab { }
+sub stop_serial_grab ($self) { }
 
 1;

--- a/backend/virt.pm
+++ b/backend/virt.pm
@@ -3,20 +3,18 @@
 
 package backend::virt;
 
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 
 use base 'backend::baseclass';
 
 use testapi 'get_var';
 use bmwqemu;
 
-sub new {
-    my ($class) = @_;
+sub new ($class) {
     my $self = $class->SUPER::new;
     $bmwqemu::vars{QEMURAM} //= 1024;
     $bmwqemu::vars{QEMUCPUS} //= 1;
     return $self;
 }
-
 
 1;

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -553,7 +553,7 @@ sub attach_to_running ($self, $args = undef) {
 
 sub start_serial_grab ($self) { $self->backend->start_serial_grab($self->name) }
 
-sub stop_serial_grab ($self) { $self->backend->stop_serial_grab($self->name) }
+sub stop_serial_grab ($self, @) { $self->backend->stop_serial_grab($self->name) }
 
 
 =head2 run_cmd

--- a/t/29-backend-ipmi.t
+++ b/t/29-backend-ipmi.t
@@ -45,7 +45,7 @@ $testapi::distri = distribution->new;
 
 ok $backend->do_start_vm, 'can call do_start_vm';
 ok $backend->do_stop_vm, 'can call do_stop_vm';
-ok !$backend->check_socket, 'check_socket not returning true by default';
+ok !$backend->check_socket(undef), 'check_socket not returning true by default';
 ok $backend->get_mc_status, 'can call get_mc_status';
 
 # reduce retries for testing

--- a/t/29-backend-s390x.t
+++ b/t/29-backend-s390x.t
@@ -12,7 +12,7 @@ use backend::s390x;    # SUT
 
 $bmwqemu::vars{WORKER_HOSTNAME} = 'localhost';
 ok my $backend = backend::s390x->new(), 'can instantiate backend';
-ok !$backend->check_socket, 'check_socket returns false by default';
+ok !$backend->check_socket(undef), 'check_socket returns false by default';
 
 done_testing;
 


### PR DESCRIPTION
Using a command like

```
sed -i "/^use strict;/ {N;s/use strict;/use Mojo::Base -strict, -signatures;/}" $(git ls-files)
for i in $(git grep -l 'use \(strict\|warnings\)'); do grep -q 'use Mojo::Base -strict' $i && sed -i '/use \(strict\|warnings\)/d' $i; done
tools/tidy --only-changed
```

and some manual fixes.