### PR TITLE
Use proper perl "signatures" in t/data

### DIFF
--- a/t/data/tests/bar/baz.pm
+++ b/t/data/tests/bar/baz.pm
@@ -1,3 +1,3 @@
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 use base 'basetest';
 1;

--- a/t/data/tests/foo.pm
+++ b/t/data/tests/foo.pm
@@ -1,3 +1,3 @@
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 use base 'basetest';
 1;

--- a/t/data/tests/lib/testdistribution.pm
+++ b/t/data/tests/lib/testdistribution.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 SUSE LLC
+# Copyright (C) 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,20 +15,16 @@
 
 package testdistribution;
 
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 
 use base 'distribution';
 
-sub init {
-    my ($self) = @_;
-
+sub init ($self) {
     $self->SUPER::init();
     $self->init_consoles();
 }
 
-sub init_consoles {
-    my ($self) = @_;
-
+sub init_consoles ($self) {
     $self->add_console(
         'brokenvnc',
         'vnc-base',
@@ -44,7 +40,6 @@ sub init_consoles {
             hostname => 'noIucvconn.nowhere',
             password => $testapi::password
         });
-
 }
 
 1;

--- a/t/data/tests/main.pm
+++ b/t/data/tests/main.pm
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 
 use Cwd 'abs_path';
 
@@ -22,8 +22,7 @@ use testdistribution;
 
 testapi::set_distribution(testdistribution->new());
 
-sub unregister_needle_tags {
-    my ($tag) = @_;
+sub unregister_needle_tags ($tag) {
     my @a = @{needle::tags($tag)};
     for my $n (@a) { $n->unregister($tag); }
 }

--- a/t/data/tests/tests/assert_screen.pm
+++ b/t/data/tests/tests/assert_screen.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2020 SUSE LLC
+# Copyright (C) 2016-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,8 +13,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
-
+use Mojo::Base -strict, -signatures;
 use base 'basetest';
 
 use testapi;

--- a/t/data/tests/tests/assert_screen_fail_test.pm
+++ b/t/data/tests/tests/assert_screen_fail_test.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 SUSE LLC
+# Copyright (C) 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,11 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use 5.018;
-use Mojo::Base -strict;
-
+use Mojo::Base -strict, -signatures;
 use base 'basetest';
-
 use testapi;
 
 sub run {

--- a/t/data/tests/tests/boot.pm
+++ b/t/data/tests/tests/boot.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2020 SUSE LLC
+# Copyright (C) 2016-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,10 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
-
+use Mojo::Base -strict, -signatures;
 use base "basetest";
-
 use testapi;
 
 sub run {

--- a/t/data/tests/tests/failing_module.pm
+++ b/t/data/tests/tests/failing_module.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,11 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use 5.018;
-use Mojo::Base -strict;
-
+use Mojo::Base -strict, -signatures;
 use base 'basetest';
-
 use testapi;
 
 sub run {

--- a/t/data/tests/tests/freeze.pm
+++ b/t/data/tests/tests/freeze.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2020 SUSE LLC
+# Copyright (C) 2016-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,10 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
-
+use Mojo::Base -strict, -signatures;
 use base 'basetest';
-
 use testapi;
 
 sub run {

--- a/t/data/tests/tests/modify_and_upload_file.pm
+++ b/t/data/tests/tests/modify_and_upload_file.pm
@@ -13,10 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
-
+use Mojo::Base -strict, -signatures;
 use base "basetest";
-
 use testapi;
 
 my $orig_file = <<'END';

--- a/t/data/tests/tests/noop.pm
+++ b/t/data/tests/tests/noop.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE LLC
+# Copyright (C) 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,10 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
-
+use Mojo::Base -strict, -signatures;
 use base "basetest";
-
 use testapi;
 
 sub run {

--- a/t/data/tests/tests/reload_needles.pm
+++ b/t/data/tests/tests/reload_needles.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 SUSE LLC
+# Copyright (C) 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,14 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use 5.018;
-use Mojo::Base -strict;
-
+use Mojo::Base -strict, -signatures;
 use base 'basetest';
-
 use testapi;
-
-use Data::Dumper;
 
 sub run {
     # this is the default, but to test set_var without argument

--- a/t/data/tests/tests/select_console_fail_test.pm
+++ b/t/data/tests/tests/select_console_fail_test.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 SUSE LLC
+# Copyright (C) 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,11 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use 5.018;
-use Mojo::Base -strict;
-
+use Mojo::Base -strict, -signatures;
 use base 'basetest';
-
 use testapi;
 
 sub run {

--- a/t/data/tests/tests/select_ssh_console_fail_test.pm
+++ b/t/data/tests/tests/select_ssh_console_fail_test.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,11 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use 5.018;
-use Mojo::Base -strict;
-
+use Mojo::Base -strict, -signatures;
 use base 'basetest';
-
 use testapi;
 
 sub run {

--- a/t/data/tests/tests/shutdown.pm
+++ b/t/data/tests/tests/shutdown.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2019 SUSE LLC
+# Copyright (C) 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,11 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use 5.018;
-use Mojo::Base -strict;
-
+use Mojo::Base -strict, -signatures;
 use base 'basetest';
-
 use testapi;
 
 sub run {

--- a/t/data/tests/tests/typing.pm
+++ b/t/data/tests/tests/typing.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2020 SUSE LLC
+# Copyright (C) 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,10 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict;
-
+use Mojo::Base -strict, -signatures;
 use base "basetest";
-
 use testapi;
 
 sub run {

--- a/t/fake/tests/fatal.pm
+++ b/t/fake/tests/fatal.pm
@@ -1,4 +1,4 @@
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 use base 'basetest';
 
 sub run { }

--- a/t/fake/tests/ignore_failure.pm
+++ b/t/fake/tests/ignore_failure.pm
@@ -1,4 +1,4 @@
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 use base 'basetest';
 
 sub run { }

--- a/t/fake/tests/run_args.pm
+++ b/t/fake/tests/run_args.pm
@@ -1,10 +1,9 @@
 use 5.018;
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 
 use base 'basetest';
 
-sub run {
-    my ($self, $rargs) = @_;
+sub run ($self, $rargs) {
 
     unless (defined $rargs) {
         die 'run_args not passed through';

--- a/t/fake/tests/scheduler.pm
+++ b/t/fake/tests/scheduler.pm
@@ -1,4 +1,4 @@
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 use base 'basetest';
 use autotest 'loadtest';
 

--- a/t/fake/tests/start.pm
+++ b/t/fake/tests/start.pm
@@ -1,4 +1,4 @@
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 use base 'basetest';
 
 sub run { }


### PR DESCRIPTION
Using a command like

```
sed -i "/^use strict;/ {N;s/use strict;/use Mojo::Base -strict, -signatures;/}" $(git ls-files)
for i in $(git grep -l 'use \(strict\|warnings\)'); do grep -q 'use Mojo::Base -strict' $i && sed -i '/use \(strict\|warnings\)/d' $i; done
tools/tidy --only-changed
```

and some manual fixes.