### PR TITLE
Use proper perl "signatures" in tools

### DIFF
--- a/tools/absolutize
+++ b/tools/absolutize
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 
 $_ = shift;
 unless (m{^/}) {

--- a/tools/check_coverage
+++ b/tools/check_coverage
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 use autodie;
 
 

--- a/tools/lib/perlcritic/Perl/Critic/Policy/HashKeyQuotes.pm
+++ b/tools/lib/perlcritic/Perl/Critic/Policy/HashKeyQuotes.pm
@@ -1,6 +1,6 @@
 package Perl::Critic::Policy::HashKeyQuotes;
 
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 
 use Perl::Critic::Utils qw( :severities :classification :ppi );
 use base 'Perl::Critic::Policy';
@@ -14,9 +14,7 @@ sub applies_to       { return qw(PPI::Token::Quote::Single PPI::Token::Quote::Do
 # check that hashes are not overly using quotes
 # (os-autoinst coding style)
 
-sub violates {
-    my ($self, $elem) = @_;
-
+sub violates ($self, $elem, $) {
     #we only want the check hash keys
     return if !is_hash_key($elem);
 


### PR DESCRIPTION
Using a command like

```
sed -i "/^use strict;/ {N;s/use strict;/use Mojo::Base -strict, -signatures;/}" $(git ls-files)
for i in $(git grep -l 'use \(strict\|warnings\)'); do grep -q 'use Mojo::Base -strict' $i && sed -i '/use \(strict\|warnings\)/d' $i; done
tools/tidy --only-changed
```

and some manual fixes.