### PR TITLE
t: Fix "Useless use of a constant"

### DIFF
--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -339,7 +339,7 @@ subtest 'load test successfully when CASEDIR is a relative path' => sub {
     loadtest 'start';
 };
 
-pass autotest::loadtest('tests/test.py'), 'can load python test module at all';
+stderr_like { autotest::loadtest('tests/test.py') } qr{scheduling test tests/test.py}, 'can load python test module at all';
 loadtest 'test.py', 'we can also parse python test modules';
 
 stderr_like {


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/99675