### PR TITLE
Use consistent "Copyright" header without problematic characters

### DIFF
--- a/OpenQA/Benchmark/Stopwatch.pm
+++ b/OpenQA/Benchmark/Stopwatch.pm
@@ -262,7 +262,7 @@ Inspiration from my colleagues at L<http://www.nestoria.co.uk>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2006 Edmund von der Burg. All rights reserved.
+Copyright 2006 Edmund von der Burg. All rights reserved.
 
 This module is free software; you can redistribute it and/or modify it under
 the same terms as Perl itself. If it breaks you get to keep both pieces.

--- a/OpenQA/Commands.pm
+++ b/OpenQA/Commands.pm
@@ -1,4 +1,4 @@
-# Copyright © 2018-2019 SUSE LLC
+# Copyright 2018-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/OpenQA/Exceptions.pm
+++ b/OpenQA/Exceptions.pm
@@ -1,4 +1,4 @@
-# Copyright © 2016-2018 SUSE LLC
+# Copyright 2016-2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/OpenQA/Isotovideo/CommandHandler.pm
+++ b/OpenQA/Isotovideo/CommandHandler.pm
@@ -1,4 +1,4 @@
-# Copyright © 2018-2019 SUSE LLC
+# Copyright 2018-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -1,4 +1,4 @@
-# Copyright © 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/OpenQA/Isotovideo/NeedleDownloader.pm
+++ b/OpenQA/Isotovideo/NeedleDownloader.pm
@@ -1,4 +1,4 @@
-# Copyright © 2018 SUSE LLC
+# Copyright 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -1,4 +1,4 @@
-# Copyright © 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/OpenQA/Qemu/BlockDev.pm
+++ b/OpenQA/Qemu/BlockDev.pm
@@ -1,4 +1,4 @@
-# Copyright © 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/OpenQA/Qemu/BlockDevConf.pm
+++ b/OpenQA/Qemu/BlockDevConf.pm
@@ -1,4 +1,4 @@
-# Copyright © 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/OpenQA/Qemu/ControllerConf.pm
+++ b/OpenQA/Qemu/ControllerConf.pm
@@ -1,4 +1,4 @@
-# Copyright © 2018 SUSE LLC
+# Copyright 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/OpenQA/Qemu/DriveController.pm
+++ b/OpenQA/Qemu/DriveController.pm
@@ -1,4 +1,4 @@
-# Copyright © 2018 SUSE LLC
+# Copyright 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/OpenQA/Qemu/DriveDevice.pm
+++ b/OpenQA/Qemu/DriveDevice.pm
@@ -1,4 +1,4 @@
-# Copyright © 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/OpenQA/Qemu/DrivePath.pm
+++ b/OpenQA/Qemu/DrivePath.pm
@@ -1,4 +1,4 @@
-# Copyright © 2018 SUSE LLC
+# Copyright 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/OpenQA/Qemu/MutParams.pm
+++ b/OpenQA/Qemu/MutParams.pm
@@ -1,4 +1,4 @@
-# Copyright © 2018 SUSE LLC
+# Copyright 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/OpenQA/Qemu/PFlashDevice.pm
+++ b/OpenQA/Qemu/PFlashDevice.pm
@@ -1,4 +1,4 @@
-# Copyright © 2018 SUSE LLC
+# Copyright 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -1,4 +1,4 @@
-# Copyright © 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/OpenQA/Qemu/Snapshot.pm
+++ b/OpenQA/Qemu/Snapshot.pm
@@ -1,4 +1,4 @@
-# Copyright © 2018 SUSE LLC
+# Copyright 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/OpenQA/Qemu/SnapshotConf.pm
+++ b/OpenQA/Qemu/SnapshotConf.pm
@@ -1,4 +1,4 @@
-# Copyright © 2018 SUSE LLC
+# Copyright 2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/OpenQA/Test/RunArgs.pm
+++ b/OpenQA/Test/RunArgs.pm
@@ -1,4 +1,4 @@
-# Copyright © 2017 SUSE LLC
+# Copyright 2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/autotest.pm
+++ b/autotest.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2021 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/backend/amt.pm
+++ b/backend/amt.pm
@@ -1,4 +1,4 @@
-# Copyright © 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2021 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/backend/console_proxy.pm
+++ b/backend/console_proxy.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2020 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/backend/driver.pm
+++ b/backend/driver.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2021 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/backend/generalhw.pm
+++ b/backend/generalhw.pm
@@ -1,4 +1,4 @@
-# Copyright © 2016-2020 SUSE LLC
+# Copyright 2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/backend/ikvm.pm
+++ b/backend/ikvm.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2020 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2021 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/backend/null.pm
+++ b/backend/null.pm
@@ -1,4 +1,4 @@
-# Copyright © 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/backend/pvm.pm
+++ b/backend/pvm.pm
@@ -1,4 +1,4 @@
-# Copyright © 2016-2021 SUSE LLC
+# Copyright 2016-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/backend/pvm_hmc.pm
+++ b/backend/pvm_hmc.pm
@@ -1,4 +1,4 @@
-# Copyright © 2019-2020 SUSE LLC
+# Copyright 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2021 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/backend/s390x.pm
+++ b/backend/s390x.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2020 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/backend/spvm.pm
+++ b/backend/spvm.pm
@@ -1,4 +1,4 @@
-# Copyright © 2018-2020 SUSE LLC
+# Copyright 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2020 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/backend/vagrant.pm
+++ b/backend/vagrant.pm
@@ -1,4 +1,4 @@
-# Copyright © 2021 SUSE LLC
+# Copyright 2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/backend/virt.pm
+++ b/backend/virt.pm
@@ -1,4 +1,4 @@
-# Copyright © 2016 SUSE LLC
+# Copyright 2016 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/basetest.pm
+++ b/basetest.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2021 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2021 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/check_qemu_oom
+++ b/check_qemu_oom
@@ -1,5 +1,5 @@
 #!/usr/bin/perl -w
-# Copyright © 2021 SUSE LLC
+# Copyright 2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/commands.pm
+++ b/commands.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2021 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -1220,12 +1220,13 @@ Maurice Castro maurice@ipexchange.com.au
 Many thanks for Foxtons Ltd for giving Leon the opportunity to write
 the original version of this module.
 
-Copyright (C) 2006, Leon Brocard
+Copyright 2006, Leon Brocard
 
 This module is free software; you can redistribute it or modify it
 under the same terms as Perl itself.
 
-Copyright (C) 2014-2017 Stephan Kulow (coolo@suse.de)
+Copyright 2014-2017 Stephan Kulow (coolo@suse.de)
 adapted to be purely useful for qemu/openqa
 
-Copyright © 2017-2021 SUSE LLC
+Copyright 2017-2021 SUSE LLC
+

--- a/consoles/amtSol.pm
+++ b/consoles/amtSol.pm
@@ -1,4 +1,4 @@
-# Copyright © 2012-2020 SUSE LLC
+# Copyright 2012-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/consoles/console.pm
+++ b/consoles/console.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2020 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/consoles/ipmiSol.pm
+++ b/consoles/ipmiSol.pm
@@ -1,4 +1,4 @@
-# Copyright © 2012-2020 SUSE LLC
+# Copyright 2012-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/consoles/localXvnc.pm
+++ b/consoles/localXvnc.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2021 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/consoles/network_console.pm
+++ b/consoles/network_console.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2019-2020 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/consoles/remoteVnc.pm
+++ b/consoles/remoteVnc.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2020 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/consoles/s3270.pm
+++ b/consoles/s3270.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2020 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/consoles/serial_screen.pm
+++ b/consoles/serial_screen.pm
@@ -1,4 +1,4 @@
-# Copyright © 2016-2020 SUSE LLC
+# Copyright 2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/consoles/sshIucvconn.pm
+++ b/consoles/sshIucvconn.pm
@@ -1,4 +1,4 @@
-# Copyright © 2016-2020 SUSE LLC
+# Copyright 2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/consoles/sshSerial.pm
+++ b/consoles/sshSerial.pm
@@ -1,4 +1,4 @@
-# Copyright © 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2021 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/consoles/sshVirtshSUT.pm
+++ b/consoles/sshVirtshSUT.pm
@@ -1,4 +1,4 @@
-# Copyright © 2018-2019 SUSE LLC
+# Copyright 2018-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/consoles/sshX3270.pm
+++ b/consoles/sshX3270.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2015 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2015 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/consoles/sshXtermIPMI.pm
+++ b/consoles/sshXtermIPMI.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2015 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2015 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/consoles/sshXtermVt.pm
+++ b/consoles/sshXtermVt.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2015 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2015 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/consoles/ssh_screen.pm
+++ b/consoles/ssh_screen.pm
@@ -1,4 +1,4 @@
-# Copyright © 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/consoles/ttyConsole.pm
+++ b/consoles/ttyConsole.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2020 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -1,4 +1,4 @@
-# Copyright © 2016-2020 SUSE LLC
+# Copyright 2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/consoles/vnc_base.pm
+++ b/consoles/vnc_base.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2021 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/crop.py
+++ b/crop.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2013-2016 SUSE LLC
+# Copyright 2013-2016 SUSE LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/cv.pm
+++ b/cv.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2020 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package os-autoinst
 #
-# Copyright (c) 2018 SUSE LLC
+# Copyright 2018 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/distribution.pm
+++ b/distribution.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2015 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2015 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/isotovideo
+++ b/isotovideo
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2020 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lockapi.pm
+++ b/lockapi.pm
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/mmapi.pm
+++ b/mmapi.pm
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2021 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/myjsonrpc.pm
+++ b/myjsonrpc.pm
@@ -1,4 +1,4 @@
-# Copyright © 2012-2021 SUSE LLC
+# Copyright 2012-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/needle.pm
+++ b/needle.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2021 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/ocr.pm
+++ b/ocr.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2020 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/osutils.pm
+++ b/osutils.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2020 SUSE LLC
+# Copyright 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/ppmclibs/tinycv.h
+++ b/ppmclibs/tinycv.h
@@ -1,4 +1,4 @@
-// Copyright © 2012-2020 SUSE LLC
+// Copyright 2012-2020 SUSE LLC
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/ppmclibs/tinycv.pm
+++ b/ppmclibs/tinycv.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2020 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/ppmclibs/tinycv_ast2100.cc
+++ b/ppmclibs/tinycv_ast2100.cc
@@ -1,4 +1,4 @@
-// Copyright © 2012-2016 SUSE LLC
+// Copyright 2012-2016 SUSE LLC
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/ppmclibs/tinycv_impl.cc
+++ b/ppmclibs/tinycv_impl.cc
@@ -1,4 +1,4 @@
-// Copyright © 2012-2020 SUSE LLC
+// Copyright 2012-2020 SUSE LLC
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/signalblocker.pm
+++ b/signalblocker.pm
@@ -1,4 +1,4 @@
-# Copyright © 2021 SUSE LLC
+# Copyright 2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/00-compile-check-all.t
+++ b/t/00-compile-check-all.t
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-# Copyright (C) 2015-2020 SUSE LLC
+# Copyright 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/04-check_vars_docu.t
+++ b/t/04-check_vars_docu.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# Copyright (c) 2015 SUSE LLC
+# Copyright 2015 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 
-# Copyright (C) 2021 SUSE LLC
+# Copyright 2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/07-commands.t
+++ b/t/07-commands.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# Copyright (c) 2016-2021 SUSE LLC
+# Copyright 2016-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/10-terminal.t
+++ b/t/10-terminal.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 
-# Copyright (C) 2016-2020 SUSE LLC
+# Copyright 2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/10-virtio_terminal.t
+++ b/t/10-virtio_terminal.t
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-# Copyright © 2020-2021 SUSE LLC
+# Copyright 2020-2021 SUSE LLC
 
 use Test::Most;
 use Test::Warnings qw(:all :report_warnings);

--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 
-# Copyright (C) 2017-2021 SUSE LLC
+# Copyright 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/13-osutils.t
+++ b/t/13-osutils.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 
-# Copyright (C) 2017-2021 SUSE LLC
+# Copyright 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/15-logging.t
+++ b/t/15-logging.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 
-# Copyright (C) 2017-2020 SUSE LLC
+# Copyright 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -97,7 +97,7 @@ subtest 'execute arbitrary QMP command' => sub {
 subtest 'process_qemu_output' => sub {
     my $qemu_log = <<'EOF';
 QEMU emulator version 4.2.1 (openSUSE Leap 15.2)
-Copyright (c) 2003-2019 Fabrice Bellard and the QEMU Project developers
+Copyright 2003-2019 Fabrice Bellard and the QEMU Project developers
 qemu-system-x86_64: cannot set up guest memory 'pc.ram': Cannot allocate memory
 EOF
     my $expected = qr/\[debug\].*QEMU emulator version.*\[warn\].*Cannot allocate memory/s;

--- a/t/18-qemu-options.t
+++ b/t/18-qemu-options.t
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-# Copyright (C) 2018-2021 SUSE LLC
+# Copyright 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/24-myjsonrpc-debug.t
+++ b/t/24-myjsonrpc-debug.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# Copyright (c) 2019-2020 SUSE LLC
+# Copyright 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/24-myjsonrpc.t
+++ b/t/24-myjsonrpc.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# Copyright (c) 2019-2020 SUSE LLC
+# Copyright 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/26-serial_screen.t
+++ b/t/26-serial_screen.t
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-# Copyright © 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 
 use Test::Most;
 use FindBin '$Bin';

--- a/t/26-ssh_screen.t
+++ b/t/26-ssh_screen.t
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-# Copyright © 2019 SUSE LLC
+# Copyright 2019 SUSE LLC
 
 use Test::Most;
 use FindBin '$Bin';

--- a/t/28-signalblocker.t
+++ b/t/28-signalblocker.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright 2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/29-backend-generalhw.t
+++ b/t/29-backend-generalhw.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 
-# Copyright (c) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/30-mmapi.t
+++ b/t/30-mmapi.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# Copyright (c) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/34-git.t
+++ b/t/34-git.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright 2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-# Copyright (C) 2017-2021 SUSE LLC
+# Copyright 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/data/tests/lib/testdistribution.pm
+++ b/t/data/tests/lib/testdistribution.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2021 SUSE LLC
+# Copyright 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/data/tests/main.pm
+++ b/t/data/tests/main.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2020 SUSE LLC
+# Copyright 2016-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/data/tests/tests/assert_screen.pm
+++ b/t/data/tests/tests/assert_screen.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2021 SUSE LLC
+# Copyright 2016-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/data/tests/tests/assert_screen_fail_test.pm
+++ b/t/data/tests/tests/assert_screen_fail_test.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2021 SUSE LLC
+# Copyright 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/data/tests/tests/boot.pm
+++ b/t/data/tests/tests/boot.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2021 SUSE LLC
+# Copyright 2016-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/data/tests/tests/failing_module.pm
+++ b/t/data/tests/tests/failing_module.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/data/tests/tests/freeze.pm
+++ b/t/data/tests/tests/freeze.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2021 SUSE LLC
+# Copyright 2016-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/data/tests/tests/modify_and_upload_file.pm
+++ b/t/data/tests/tests/modify_and_upload_file.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2021 SUSE LLC
+# Copyright 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/data/tests/tests/noop.pm
+++ b/t/data/tests/tests/noop.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 SUSE LLC
+# Copyright 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/data/tests/tests/pre_boot.py
+++ b/t/data/tests/tests/pre_boot.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/data/tests/tests/reload_needles.pm
+++ b/t/data/tests/tests/reload_needles.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2021 SUSE LLC
+# Copyright 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/data/tests/tests/select_console_fail_test.pm
+++ b/t/data/tests/tests/select_console_fail_test.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2021 SUSE LLC
+# Copyright 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/data/tests/tests/shutdown.pm
+++ b/t/data/tests/tests/shutdown.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2021 SUSE LLC
+# Copyright 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/data/tests/tests/typing.pm
+++ b/t/data/tests/tests/typing.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2021 SUSE LLC
+# Copyright 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/testapi.pm
+++ b/testapi.pm
@@ -1,5 +1,5 @@
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2021 SUSE LLC
+# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2012-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/testapi.py
+++ b/testapi.py
@@ -1,4 +1,4 @@
-# Copyright © 2019-2021 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/xt/01-style.t
+++ b/xt/01-style.t
@@ -1,4 +1,5 @@
-# Copyright 2019-2021 SUSE LLC
+#!/usr/bin/perl
+# Copyright 2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,12 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-use Mojo::Base -strict, -signatures;
-use base 'basetest';
-use testapi;
+use Test::Most;
 
-sub run {
-    select_console 'brokeniucv';
-}
-
-1;
+ok system(qq{git grep -I -l 'Copyright \((C)\|(c)\|©\)' ':!COPYING' ':!external/'}) != 0, 'No redundant copyright character';
+done_testing;

--- a/xt/27-make-update-deps.t
+++ b/xt/27-make-update-deps.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright (C) 2020 SUSE LLC
+# Copyright 2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
* Use consistent "Copyright" header without problematic characters

If we accept these changes I plan to apply the same to other repositories
within the scope of https://github.com/os-autoinst

Previously this PR included another commit "Simplify Copyright entry for SUSE to not need to update recurringly
" https://github.com/os-autoinst/os-autoinst/commit/d0af9e9b143820311c0348383b54731c17701919 which I removed based on https://github.com/os-autoinst/os-autoinst/pull/1800#pullrequestreview-769896377

Related progress issue: https://progress.opensuse.org/issues/98616