### PR TITLE
Set offset in serial output buffer

### DIFF
--- a/OpenQA/Isotovideo/CommandHandler.pm
+++ b/OpenQA/Isotovideo/CommandHandler.pm
@@ -259,7 +259,7 @@ sub _handle_command_set_current_test {
     my ($self, $response) = @_;
 
     # Note: It is unclear why we call set_serial_offset here
-    $bmwqemu::backend->_send_json({cmd => 'set_serial_offset'});
+    $bmwqemu::backend->_send_json({cmd => 'clear_serial_buffer'});
 
     my ($test_name, $full_test_name) = ($response->{name}, $response->{full_name});
     my $pause_test_name = $self->pause_test_name;

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -29,6 +29,7 @@ use Scalar::Util 'looks_like_number';
 use Mojo::File 'path';
 use OpenQA::Exceptions;
 use Time::Seconds;
+use English -no_match_vars;
 
 # should be a singleton - and only useful in backend process
 our $backend;
@@ -838,7 +839,7 @@ previous test's serial output. Call this before you start doing something new
 =cut
 
 sub set_serial_offset {
-    my ($self, $args) = @_;
+    my ($self, $keep) = @_;
 
     $self->{serial_offset} = -s $self->{serialfile};
     return $self->{serial_offset};
@@ -889,20 +890,27 @@ sub wait_serial {
     }
 
     $regexp = [$regexp] if ref $regexp ne 'ARRAY';
-    my $initial_time = time;
+    my $initial_time   = time;
+    my $current_offset = $self->{serial_offset};
     while (time < $initial_time + $timeout) {
         $str = $self->serial_text();
         for my $r (@$regexp) {
-            $matched = ref $r eq 'Regexp' ? $str =~ $r : $str =~ m/$r/;
-            if ($matched) {
-                $regexp = "$r";
+            if (!$args->{no_regex} && $str =~ m/$r/) {
+                $current_offset += $LAST_MATCH_END[0];
+                $str     = substr($str, 0, $LAST_MATCH_END[0]);
+                $matched = 1;
+                last;
+            } elsif ($args->{no_regex} && (my $i = index($str, $r)) >= 0) {
+                $current_offset += length($r) + $i;
+                $str     = substr($str, 0, $i + length($r));
+                $matched = 1;
                 last;
             }
         }
         last if ($matched);
         $self->run_capture_loop(1);
     }
-    $self->set_serial_offset();
+    $self->{serial_offset} = $current_offset;
     return {matched => $matched, string => $str};
 }
 

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -831,15 +831,15 @@ sub proxy_console_call {
     return $wrapped_result;
 }
 
-=head2 set_serial_offset
+=head2 clear_serial_buffer
 
 Determines the starting offset within the serial file - so that we do not check the
 previous test's serial output. Call this before you start doing something new
 
 =cut
 
-sub set_serial_offset {
-    my ($self, $keep) = @_;
+sub clear_serial_buffer {
+    my ($self) = @_;
 
     $self->{serial_offset} = -s $self->{serialfile};
     return $self->{serial_offset};
@@ -848,7 +848,7 @@ sub set_serial_offset {
 
 =head2 serial_text
 
-Returns the output on the serial device since the last call to set_serial_offset
+Returns the output on the serial device since the last call to clear_serial_buffer
 
 =cut
 


### PR DESCRIPTION
Test case [gdb](https://progress.opensuse.org/issues/93901) fails regularly outside serial console.
The issue happens only when 2 consequent `wait_serial` calls appear and
the first call contains also the string that should have been match by
the following one.

This should be handled by setting offset on the serial file after each
match.

- VRs:
    - [sle-15-SP3-JeOS-for-kvm-and-xen-QR-x86_64-Build3.3.5-jeos-base+sdk+desktop@svirt-xen-hvm](http://kepler.suse.cz/tests/7282#step/gdb/1)
    - [sle-15-SP3-JeOS-for-VMware-QR-x86_64-Build3.3.5-jeos-base+sdk+desktop@svirt-vmware65](http://kepler.suse.cz/tests/7281#step/gdb/1)
    - [sle-15-SP3-JeOS-for-MS-HyperV-QR-x86_64-Build3.3.5-jeos-base+sdk+desktop@svirt-hyperv-uefi](http://kepler.suse.cz/tests/7284#step/gdb/1)