### PR TITLE
Allow running tidy on single files

### DIFF
--- a/tools/tidy
+++ b/tools/tidy
@@ -94,7 +94,16 @@ test -e tools/tidy || exit 1
 
 cleanup
 
-[[ -f $filename ]] && perltidy --pro=.../.perltidyrc $filename || find-files | xargs perltidy --pro=.../.perltidyrc
+if [[ -n "$filename" ]]; then
+   if [[ -f "$filename" ]]; then
+       perltidy --pro=.../.perltidyrc "$filename"
+   else
+       echo "\"$filename\" is not a valid file, please provide only one file"
+       exit 22
+   fi
+else
+    find-files | xargs perltidy --pro=.../.perltidyrc
+fi
 
 find . -name "*.tdy" | while read -r file
 do

--- a/tools/tidy
+++ b/tools/tidy
@@ -6,7 +6,7 @@
 usage() {
     cat << EOF
 Usage:
- tidy [-c|--check] [-f|--force] [-o|--only-changed]
+ tidy [-c|--check] [-f|--force] [-o|--only-changed] [path/to/file]
 
 Options:
  -h, -?, --help       display this help
@@ -14,6 +14,9 @@ Options:
  -f, --force          Force check even if tidy version mismatches
  -o --only-changed    Only tidy files with uncommitted changes in git. This can
                       speed up execution a lot.
+ path/to/file         When passing a file as argument, tidy will run perltidy
+                      wether it is added to the git tree or not
+
 
 perltidy rules can be found in .perltidyrc
 EOF
@@ -40,6 +43,9 @@ while true; do
     * ) break ;;
   esac
 done
+
+shift $((OPTIND - 1))
+filename=$*
 
 trap cleanup EXIT
 
@@ -88,7 +94,7 @@ test -e tools/tidy || exit 1
 
 cleanup
 
-find-files | xargs perltidy --pro=.../.perltidyrc
+[[ -f $filename ]] && perltidy --pro=.../.perltidyrc $filename || find-files | xargs perltidy --pro=.../.perltidyrc
 
 find . -name "*.tdy" | while read -r file
 do


### PR DESCRIPTION
As a follow up to 3b277957a and os-autoinst/openQA/4216 add more
information to the xml metadata to avoid guessing where a remote worker
is running