### PR TITLE
Select sensible default of 5 minutes for SSH command timeout

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -1238,7 +1238,7 @@ sub new_ssh_connection {
     }
 
     # timeout requires libssh2 >= 1.2.9 so not all versions might have it
-    my $ssh = Net::SSH2->new(timeout => ($bmwqemu::vars{SSH_COMMAND_TIMEOUT_S} // 0) * 1000);
+    my $ssh = Net::SSH2->new(timeout => ($bmwqemu::vars{SSH_COMMAND_TIMEOUT_S} // 5 * ONE_MINUTE) * 1000);
 
     # Retry multiple times, in case of the guest is not running yet
     my $counter    = $bmwqemu::vars{SSH_CONNECT_RETRY} // 5;

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -23,7 +23,7 @@ NOVIDEO;boolean;0;Whether the creation of the video should be disabled and also 
 NO_DEBUG_IO;boolean;0;Disable the I/O debug output in case of needle comparison times longer than expected
 OSUTILS_WAIT_ATTEMPT_INTERVAL;float;1;The interval in seconds between "attempts" in osutils, e.g. used for connections to qemu qmp backend
 SCREENSHOTINTERVAL;float;0.5;The interval in seconds at which screenshots are taken internally
-SSH_COMMAND_TIMEOUT_S;integer;0;Timeout for any SSH based command in SSH based consoles, disabled by default or for a value of 0. Time in seconds.
+SSH_COMMAND_TIMEOUT_S;integer;300;Timeout for any SSH based command in SSH based consoles, disabled for a value of 0. Time in seconds.
 SSH_CONNECT_RETRY;integer;5;Maximum retries to connect to SSH based console targets
 SSH_CONNECT_RETRY_INTERVAL;float;10;Interval in seconds between retries to connect to SSH based console targets. Related to SSH_CONNECT_RETRY
 VNC_STALL_THRESHOLD;integer;4;Time after which is VNC considered stalled


### PR DESCRIPTION
As shown by experiments with various openQA jobs we should be fine to
select a timeout of multiple minutes by default. My tests have shown
that a timeout of 1s is too low (as expected) and 30s or 3600s works
fine so a conservative selection of 5 minutes should be ok and helpful.

Related progress issue: https://progress.opensuse.org/issues/99123