### PR TITLE
 testapi: Add die_on_timeout option to testapi::script::run()

### DIFF
--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -9,7 +9,7 @@ use Mojo::Base -strict, -signatures;
 # -> increment on every change of such APIs
 # -> never move that variable to another place (when refactoring)
 #    because it may be accessed by the tests itself
-our $version = 23;
+our $version = 24;
 
 # major version of the (web socket) API relevant to the developer mode
 # -> increment when making non-backward compatible changes to that API


### PR DESCRIPTION
The testapi function `script_run()` is widely used to execute one command 
after the other, without checking for exit code. But it could also
happen that the command timed out and in such situation the
test-developer need to handle it separately.
To solve this, introduce a new option `die_on_timeout`. The default is now like
we have it currently **don't die**. But we will see a log message like:
```
[2021-11-22T14:47:47.739305+01:00] [warn] !!! testapi::script_run: DEPRECATED call of script_run() in tests/clemix/script_run.pm:16 add `die_on_timeout => ?` to avoid this warning
```
if the user doesn't specified `die_on_timeout=>(0|1)` explicit.

==== Typical miss usage of script_run() ====

Example of possible miss usage of `script_run()`:
```perl
script_run('command_a');
script_run('command_b');
```
if the first call just times out, it is very likely that the shell is
_not_ at the prompt for command_b. Thus something unexpected happen,
even if we don't care of the exit value from `command_a`.

Also widely used is:
```perl
if (script_run(...) != 0) {
  some_sane_error_handling();
}
```
But in case of timeout, this error handling isn't triggered and the test
just continue.

With this change, we also need to increase the API version specified in
OpenQA::Isotovideo::Interface::version .

== testapi.t: Add test for script_run() timeout behavior ==

Changed other `script_run()` calls to avoid unexpected warnings.

We add `quiet => 1` to the script_run() calls, because otherwise the test
`result (to create a new needl from) has been added` failed, as the
detail picture has the next number.
