### PR TITLE
distribution: Fix sporadic here-script input failure

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -723,6 +723,8 @@ sub is_serial_terminal ($self, $args) {
     return {yesorno => $self->{current_console}->is_serial_terminal};
 }
 
+sub get_wait_still_screen_on_here_doc_input ($self, $args) { 0 }
+
 sub capture_screenshot ($self) {
     return unless $self->{current_screen};
 

--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -309,4 +309,17 @@ sub stop_serial_grab ($self, @) {
     return;
 }
 
+sub get_wait_still_screen_on_here_doc_input ($self, $args) {
+    # We encountered a sporadic error when type into the here-document in the
+    # distribution::script_output() function (poo#60566). This issue was only
+    # seen by svirt backends from VMM_FAMILY hyperv or vmware.
+    #
+    # With wait_still_screen we actually do a sleep, but the given duration is
+    # the minimum and will be extended till there is no change on the screen.
+    # by comparing the screen and checking that nothing else will write on it.
+    # So if the here-document input is really slow, we hope the wait_still_screen
+    # takes even longer.
+    ($bmwqemu::vars{VIRSH_VMM_FAMILY} // '') =~ qr/^hyperv|vmware$/ ? 1 : 0;
+}
+
 1;

--- a/distribution.pm
+++ b/distribution.pm
@@ -279,8 +279,9 @@ sub script_output {
         testapi::wait_serial("$marker-0-", quiet => $args{quiet});
     }
     elsif ($args{type_command}) {
-        my $cat = "cat - > $script_path;\n";
+        my $cat = "cat - > $script_path;";
         testapi::type_string($cat);
+        testapi::type_string("\n", wait_still_screen => testapi::backend_get_wait_still_screen_on_here_doc_input());
         testapi::type_string($script . "\n", timeout => $args{timeout});
         testapi::send_key('ctrl-d');
     }

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -35,6 +35,7 @@ PAUSE_AT;string;;Test module (name or fullname) to pause test execution at. To b
 PAUSE_ON_SCREEN_MISMATCH;boolean;0;Pause test execution on the next screen mismatch. Same notes as for `PAUSE_AT` apply.
 PAUSE_ON_NEXT_COMMAND;boolean;0;Pause test execution on the next test API command. Same notes as for `PAUSE_AT` apply.
 _QUIET_SCRIPT_CALLS;boolean;0;Add quiet flag to all the calls to script_run, script_output and validate_script_output. It will omit all the squares "wait_serial expected" on the Details view of the test case. This option might be useful for serial terminal tests.
+_WAIT_STILL_SCREEN_ON_HERE_DOC_INPUT;float;0;If this value is greater then 0, it is used by `wait_still_screen` before starting to write the script into the here document used in `testapi::script_output()` function (see: poo#60566). By default this depends on the backend.
 AUTOINST_URL_HOSTNAME;string;;hostname or IP address of host running the autoinst webserver endpoint, defaults to the local IP address within the qemu network for the qemu backend or the `WORKER_HOSTNAME` otherwise.
 UPLOAD_METER;boolean;0;Display curl progress meter in `upload_logs()` and `upload_assets()` test API functions.
 UPLOAD_MAX_MESSAGE_SIZE_GB;integer;20;Specifies the max. upload size in GiB for the test API functions `upload_logs()` and `upload_assets()` and the underlying command server API.

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -83,7 +83,9 @@ sub fake_read_json ($fd) {
     elsif ($cmd eq 'backend_mouse_set') {
         return {ret => {x => 100, y => 100}};
     }
-    else {
+    elsif ($cmd eq 'backend_get_wait_still_screen_on_here_doc_input') {
+        return {ret => 0};
+    } else {
         note "mock method not implemented \$cmd: $cmd\n";
     }
     return {};
@@ -857,6 +859,12 @@ subtest 'show_curl_progress_meter' => sub {
     is(testapi::show_curl_progress_meter(), '-o /dev/ttyS0 ', 'show_curl_progress_meter returns curl output parameter pointing to /dev/ttyS0');
     $bmwqemu::vars{UPLOAD_METER} = 0;
     is(testapi::show_curl_progress_meter(), '', 'show_curl_progress_meter returns "0" when UPLOAD_METER is not set');
+};
+
+subtest 'get_wait_still_screen_on_here_doc_input' => sub {
+    is(testapi::backend_get_wait_still_screen_on_here_doc_input({}) != 42, 1, 'Sanity check, that wait_still_screen_on_here_doc_input returns not 42!');
+    testapi::set_var(_WAIT_STILL_SCREEN_ON_HERE_DOC_INPUT => 42);
+    is(testapi::backend_get_wait_still_screen_on_here_doc_input({}), 42, 'The variable `_WAIT_STILL_SCREEN_ON_HERE_DOC_INPUT` has precedence over backend value!');
 };
 
 done_testing;

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -689,4 +689,14 @@ subtest 'Method consoles::sshVirtsh::add_disk()' => sub {
         }
     };
 };
+
+subtest 'get_wait_still_screen_on_here_doc_input' => sub {
+    set_var(VIRSH_VMM_FAMILY => 'hyperv');
+    is($svirt->get_wait_still_screen_on_here_doc_input({}) > 0, 1, 'wait_still_screen on here doc is set for hyperv');
+    set_var(VIRSH_VMM_FAMILY => 'vmware');
+    is($svirt->get_wait_still_screen_on_here_doc_input({}) > 0, 1, 'wait_still_screen on here doc is set for vmware');
+    set_var(VIRSH_VMM_FAMILY => 'kvm');
+    is($svirt->get_wait_still_screen_on_here_doc_input({}), 0, 'wait_still_screen on here doc is not set for kvm');
+};
+
 done_testing;

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -350,4 +350,6 @@ subtest check_select_rate => sub {
     };
 };
 
+is($baseclass->get_wait_still_screen_on_here_doc_input({}), 0, 'wait_still_screen on here doc is off by default!');
+
 done_testing;

--- a/testapi.pm
+++ b/testapi.pm
@@ -2335,4 +2335,17 @@ A typical call would look like:
 
 sub show_curl_progress_meter { get_var('UPLOAD_METER') ? "-o /dev/$serialdev " : '' }
 
+=head2 backend_get_wait_still_screen_on_here_doc_input 
+
+Function to query the backend if it has the known bug from
+https://progress.opensuse.org/issues/60566 which is that typing too fast into
+the here-document input can yield invalid script content.
+This function returns the value to be used by C<wait_still_screen> before 
+starting to write the script into the here document.
+=cut
+sub backend_get_wait_still_screen_on_here_doc_input {
+    state $ret;
+    $ret = query_isotovideo('backend_get_wait_still_screen_on_here_doc_input', {}) unless defined($ret);
+    return get_var(_WAIT_STILL_SCREEN_ON_HERE_DOC_INPUT => $ret);
+}
 1;


### PR DESCRIPTION
We encounter a stability problem with simple `script_output('w')` call.
1 out of ~50 calls failed, because the content of the script is
```
w\r
```
instead of
```
w\n
```

The actual root cause is unknown. But it seems that we encounter similar
problems as fixed with 87f895f3. The problem is, that a `wait_screen_change()`
call around the `type_string("\n")` didn't solve the problem, as the
changed screen where sometimes detected to early. During tests, we
encountered a minimal sleep of 800ms.
To not use a native `sleep` the decision was made to use
`wait_still_screen` functionality of `type_string`. This is a minimum
sleep, but guarded that the screen did not change within this
period.

The behavior was only seen on hyperv and vmware hosts. Thus we added a
`testapi::backend_get_wait_still_screen_on_here_doc_input()` function which
return the amount of seconds to wait for still screen, before start
typing the script.

The openqa variable `_WAIT_STILL_SCREEN_ON_HERE_DOC_INPUT` can be used to
overwrite this value.

Ticked: https://progress.opensuse.org/issues/60566
