### PR TITLE
git subrepo pull (merge) --force external/os-autoinst-common

### DIFF
--- a/external/os-autoinst-common/.github/workflows/commit_message_checker.yml
+++ b/external/os-autoinst-common/.github/workflows/commit_message_checker.yml
@@ -1,0 +1,41 @@
+---
+# https://github.com/marketplace/actions/gs-commit-message-checker
+name: 'Commit Message Check'
+# yamllint disable-line rule:truthy
+on: [push, pull_request]
+
+jobs:
+  check-commit-message:
+    name: Check Commit Message
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Subject Begining
+        uses: gsactions/commit-message-checker@v1
+        with:
+          pattern: '^([A-Z]|[A-Za-z0-9_/.]+:)'
+          flags: 'g'
+          error: 'The subject does not start with a capital or tag.'
+          excludeDescription: 'true'
+          excludeTitle: 'true'
+          checkAllCommitMessages: 'true'
+          accessToken: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check Subject Line Length
+        uses: gsactions/commit-message-checker@v1
+        with:
+          pattern: '^.{1,72}(\n|$)'
+          flags: 'g'
+          error: 'The maximum subject line length of 72 characters is exceeded.'
+          excludeDescription: 'true'    # excludes the description body of a pull request
+          excludeTitle: 'true'    # excludes the title of a pull request
+          checkAllCommitMessages: 'true'    # checks all commits associated with a pull request
+          accessToken: ${{ secrets.GITHUB_TOKEN }}    # only required if checkAllCommitMessages is true
+      - name: Check Empty Line
+        uses: gsactions/commit-message-checker@v1
+        with:
+          pattern: '^.*(\n\n|$)'
+          flags: 'g'
+          error: 'No newline between title and description.'
+          excludeDescription: 'true'
+          excludeTitle: 'true'
+          checkAllCommitMessages: 'true'
+          accessToken: ${{ secrets.GITHUB_TOKEN }}

--- a/external/os-autoinst-common/.gitrepo
+++ b/external/os-autoinst-common/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = git@github.com:os-autoinst/os-autoinst-common.git
 	branch = master
-	commit = bbab8951e82f2fa1a462be2c2af105e832c32225
-	parent = c54b90f220b7c1c08e6fda4e2702691d6c760685
+	commit = 08fd08b0ac809d90af3840942fbdfbafa98b112e
+	parent = 9b31e8770b86dfbb479e325f494d0b7cdbf56d66
 	method = merge
 	cmdver = 0.4.3

--- a/external/os-autoinst-common/lib/OpenQA/Test/TimeLimit.pm
+++ b/external/os-autoinst-common/lib/OpenQA/Test/TimeLimit.pm
@@ -1,17 +1,5 @@
-# Copyright (C) 2020-2021 SUSE LLC
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, see <http://www.gnu.org/licenses/>.
+# Copyright 2020-2021 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::Test::TimeLimit;
 use Test::Most;

--- a/external/os-autoinst-common/tools/update-deps
+++ b/external/os-autoinst-common/tools/update-deps
@@ -1,4 +1,6 @@
 #!/usr/bin/env perl
+# Copyright 2020 SUSE LLC
+# SPDX-License-Identifier: MIT
 use strict;
 use warnings;
 use 5.010;


### PR DESCRIPTION
subrepo:
  subdir:   "external/os-autoinst-common"
  merged:   "08fd08b0"
upstream:
  origin:   "git@github.com:os-autoinst/os-autoinst-common.git"
  branch:   "master"
  commit:   "08fd08b0"
git-subrepo:
  version:  "0.4.3"
  origin:   "???"
  commit:   "???"

I tried to update with the "--force" parameter but with no luck:

```
$ git subrepo clean --all
Removed branch 'subrepo/external/os-autoinst-common'.
$ git subrepo pull external/os-autoinst-common
git-subrepo: There is already a worktree with branch subrepo/external/os-autoinst-common.
Use the --force flag to override this check or perform a subrepo clean
to remove the worktree.
$ git subrepo clean --ALL --force
$ git subrepo pull external/os-autoinst-common
git-subrepo: There is already a worktree with branch subrepo/external/os-autoinst-common.
Use the --force flag to override this check or perform a subrepo clean
to remove the worktree.
```