### PR TITLE
Use proper perl "signatures" in OpenQA::Isotovideo

### DIFF
--- a/OpenQA/Isotovideo/CommandHandler.pm
+++ b/OpenQA/Isotovideo/CommandHandler.pm
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::Isotovideo::CommandHandler;
-use Mojo::Base 'Mojo::EventEmitter';
+use Mojo::Base 'Mojo::EventEmitter', -signatures;
 
 use bmwqemu;
 use testapi 'diag';
@@ -53,16 +53,14 @@ has backend_requester => undef;
 # whether the test has already been completed and whether it has died
 has [qw(test_completed test_died)] => 0;
 
-sub clear_tags_and_timeout {
-    my ($self) = @_;
+sub clear_tags_and_timeout ($self) {
     $self->tags(undef);
     $self->timeout(undef);
 }
 
 # processes the $response and send the answer back via $answer_fd by invoking one of the subsequent handler methods
 # note: To add a new command, create a handler method called "_handle_command_<new_command_name>".
-sub process_command {
-    my ($self, $answer_fd, $command_to_process) = @_;
+sub process_command ($self, $answer_fd, $command_to_process) {
     my $cmd = $command_to_process->{cmd} or die 'isotovideo: no command specified';
     $self->answer_fd($answer_fd);
 
@@ -77,14 +75,9 @@ sub process_command {
     die 'isotovideo: unknown command ' . $cmd;
 }
 
-sub stop_command_processing {
-    my ($self) = @_;
+sub stop_command_processing ($self) { $self->_send_to_cmd_srv({stop_processing_isotovideo_commands => 1}) }
 
-    $self->_send_to_cmd_srv({stop_processing_isotovideo_commands => 1});
-}
-
-sub _postpone_backend_command_until_resumed {
-    my ($self, $response) = @_;
+sub _postpone_backend_command_until_resumed ($self, $response) {
     my $cmd              = $response->{cmd};
     my $reason_for_pause = $self->reason_for_pause;
 
@@ -108,34 +101,20 @@ sub _postpone_backend_command_until_resumed {
     return 1;
 }
 
-sub _send_to_cmd_srv {
-    my ($self, $data) = @_;
-    myjsonrpc::send_json($self->cmd_srv_fd, $data);
-}
+sub _send_to_cmd_srv ($self, $data) { myjsonrpc::send_json($self->cmd_srv_fd, $data) }
 
-sub _send_to_backend {
-    my ($self, $data) = @_;
-    myjsonrpc::send_json($self->backend_fd, $data);
-}
+sub _send_to_backend ($self, $data) { myjsonrpc::send_json($self->backend_fd, $data) }
 
-sub send_to_backend_requester {
-    my ($self, $data) = @_;
+sub send_to_backend_requester ($self, $data) {
     myjsonrpc::send_json($self->backend_requester, $data);
     $self->backend_requester(undef);
 }
 
-sub _respond {
-    my ($self, $data) = @_;
-    myjsonrpc::send_json($self->answer_fd, $data);
-}
+sub _respond ($self, $data) { myjsonrpc::send_json($self->answer_fd, $data) }
 
-sub _respond_ok {
-    my ($self) = @_;
-    $self->_respond({ret => 1});
-}
+sub _respond_ok ($self) { $self->_respond({ret => 1}) }
 
-sub _pass_command_to_backend_unless_paused {
-    my ($self, $response, $backend_cmd) = @_;
+sub _pass_command_to_backend_unless_paused ($self, $response, $backend_cmd) {
     return if $self->_postpone_backend_command_until_resumed($response);
 
     die 'isotovideo: we need to implement a backend queue' if $self->backend_requester;
@@ -149,8 +128,7 @@ sub _pass_command_to_backend_unless_paused {
     $self->current_api_function($backend_cmd);
 }
 
-sub _is_configured_to_pause_on_timeout {
-    my ($self, $response) = @_;
+sub _is_configured_to_pause_on_timeout ($self, $response) {
     return 0 unless my $pause_on_screen_mismatch = $self->pause_on_screen_mismatch;
 
     return 1                          if ($pause_on_screen_mismatch eq 'check_screen');
@@ -158,9 +136,7 @@ sub _is_configured_to_pause_on_timeout {
     return 0;
 }
 
-sub _handle_command_report_timeout {
-    my ($self, $response) = @_;
-
+sub _handle_command_report_timeout ($self, $response, @) {
     if (!$self->_is_configured_to_pause_on_timeout($response)) {
         $self->_respond({ret => 0});
         return;
@@ -177,18 +153,14 @@ sub _handle_command_report_timeout {
     $self->postponed_command(undef);
 }
 
-sub _handle_command_is_configured_to_pause_on_timeout {
-    my ($self, $response) = @_;
-
+sub _handle_command_is_configured_to_pause_on_timeout ($self, $response, @) {
     $self->_respond({
             ret => ($self->_is_configured_to_pause_on_timeout($response) ? 1 : 0)
     });
 }
 
-sub _handle_command_set_pause_at_test {
-    my ($self, $response) = @_;
+sub _handle_command_set_pause_at_test ($self, $response, @) {
     my $pause_test_name = $response->{name};
-
     if ($pause_test_name) {
         diag('isotovideo: test execution will be paused at test ' . $pause_test_name);
     }
@@ -200,26 +172,21 @@ sub _handle_command_set_pause_at_test {
     $self->_respond_ok();
 }
 
-sub _handle_command_set_pause_on_screen_mismatch {
-    my ($self, $response) = @_;
+sub _handle_command_set_pause_on_screen_mismatch ($self, $response, @) {
     my $pause_on_screen_mismatch = $response->{pause_on};
-
     $self->pause_on_screen_mismatch($pause_on_screen_mismatch);
     $self->_send_to_cmd_srv({set_pause_on_screen_mismatch => ($pause_on_screen_mismatch // Mojo::JSON->false)});
     $self->_respond_ok();
 }
 
-sub _handle_command_set_pause_on_next_command {
-    my ($self, $response) = @_;
+sub _handle_command_set_pause_on_next_command ($self, $response, @) {
     my $set_pause_on_next_command = ($response->{flag} ? 1 : 0);
-
     $self->pause_on_next_command($set_pause_on_next_command);
     $self->_send_to_cmd_srv({set_pause_on_next_command => $set_pause_on_next_command});
     $self->_respond_ok();
 }
 
-sub _handle_command_resume_test_execution {
-    my ($self, $response) = @_;
+sub _handle_command_resume_test_execution ($self, $response, @) {
     my $postponed_command   = $self->postponed_command;
     my $postponed_answer_fd = $self->postponed_answer_fd;
 
@@ -255,9 +222,7 @@ sub _handle_command_resume_test_execution {
     $self->process_command($postponed_answer_fd, $postponed_command);
 }
 
-sub _handle_command_set_current_test {
-    my ($self, $response) = @_;
-
+sub _handle_command_set_current_test ($self, $response, @) {
     # Note: It is unclear why we call set_serial_offset here
     $bmwqemu::backend->_send_json({cmd => 'clear_serial_buffer'});
 
@@ -283,9 +248,7 @@ sub _handle_command_set_current_test {
     $self->_respond_ok();
 }
 
-sub _handle_command_tests_done {
-    my ($self, $response) = @_;
-
+sub _handle_command_tests_done ($self, $response, @) {
     $self->test_died($response->{died});
     $self->test_completed($response->{completed});
     $self->emit(tests_done => $response);
@@ -294,8 +257,7 @@ sub _handle_command_tests_done {
     $self->update_status_file;
 }
 
-sub _handle_command_check_screen {
-    my ($self, $response) = @_;
+sub _handle_command_check_screen ($self, $response, @) {
     $self->no_wait($response->{no_wait} // 0);
     return if $self->_postpone_backend_command_until_resumed($response);
 
@@ -317,9 +279,7 @@ sub _handle_command_check_screen {
     $self->current_api_function($current_api_function);
 }
 
-sub _handle_command_set_assert_screen_timeout {
-    my ($self, $response) = @_;
-
+sub _handle_command_set_assert_screen_timeout ($self, $response, @) {
     my $timeout = $response->{timeout};
     $self->_send_to_cmd_srv({set_assert_screen_timeout => $timeout});
     $bmwqemu::backend->_send_json({
@@ -329,8 +289,7 @@ sub _handle_command_set_assert_screen_timeout {
     $self->_respond_ok();
 }
 
-sub _handle_command_status {
-    my ($self, $response) = @_;
+sub _handle_command_status ($self, $response, @) {
     $self->_respond({
             tags                     => $self->tags,
             running                  => $self->current_test_name,
@@ -345,8 +304,7 @@ sub _handle_command_status {
     });
 }
 
-sub _handle_command_version {
-    my ($self, $response) = @_;
+sub _handle_command_version ($self, $response, @) {
     $self->_respond({
             test_git_hash    => $bmwqemu::vars{TEST_GIT_HASH},
             needles_git_hash => $bmwqemu::vars{NEEDLES_GIT_HASH},
@@ -354,25 +312,20 @@ sub _handle_command_version {
     });
 }
 
-sub _handle_command_read_serial {
-    my ($self, $response) = @_;
-
+sub _handle_command_read_serial ($self, $response, @) {
     # This will stop to work if we change the serialfile after the initialization because of the fork
     my ($serial, $pos) = $bmwqemu::backend->{backend}->read_serial($response->{position});
     $self->_respond({serial => $serial, position => $pos});
 }
 
-sub _handle_command_send_clients {
-    my ($self, $response) = @_;
+sub _handle_command_send_clients ($self, $response, @) {
     delete $response->{cmd};
     delete $response->{json_cmd_token};
     $self->_send_to_cmd_srv($response);
     $self->_respond_ok();
 }
 
-sub update_status_file {
-    my ($self) = @_;
-
+sub update_status_file ($self) {
     my $coder = Cpanel::JSON::XS->new->pretty->canonical;
     my $data  = {
         test_execution_paused => $self->reason_for_pause,

--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -3,7 +3,7 @@
 
 package OpenQA::Isotovideo::Interface;
 
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 
 # version of the test API and the API relevant to the worker
 # -> increment on every change of such APIs

--- a/OpenQA/Isotovideo/NeedleDownloader.pm
+++ b/OpenQA/Isotovideo/NeedleDownloader.pm
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::Isotovideo::NeedleDownloader;
-use Mojo::Base -base;
+use Mojo::Base -base, -signatures;
 
 use Mojo::UserAgent;
 use Mojo::URL;
@@ -55,9 +55,7 @@ has openqa_url        => sub {
 has ua             => sub { Mojo::UserAgent->new };
 has download_limit => 150;
 
-sub _add_download {
-    my ($self, $needle, $extension, $path_param) = @_;
-
+sub _add_download ($self, $needle, $extension, $path_param) {
     my $needle_name     = $needle->{name};
     my $latest_update   = $needle->{t_updated};
     my $needles_dir     = needle::needles_dir();
@@ -79,9 +77,7 @@ sub _add_download {
     });
 }
 
-sub _download_file {
-    my ($self, $download) = @_;
-
+sub _download_file ($self, $download) {
     my $download_url    = $download->{url};
     my $download_target = $download->{target};
     bmwqemu::diag("download new needle: $download_url => $download_target");
@@ -112,9 +108,7 @@ sub _download_file {
 }
 
 # adds downloads for the specified $new_needles if those are missing/outdated locally
-sub add_relevant_downloads {
-    my ($self, $new_needles) = @_;
-
+sub add_relevant_downloads ($self, $new_needles) {
     my $download_limit  = $self->download_limit;
     my $added_downloads = $self->files_to_download;
     for my $needle (@$new_needles) {
@@ -125,16 +119,11 @@ sub add_relevant_downloads {
 }
 
 # downloads previously added downloads
-sub download {
-    my ($self) = @_;
-    $self->_download_file($_) for (@{$self->files_to_download});
-}
+sub download ($self) { $self->_download_file($_) for (@{$self->files_to_download}) }
 
 # downloads missing needles considering $new_needles
 # (see t/21-needle-downloader.t for an example of $new_needles)
-sub download_missing_needles {
-    my ($self, $new_needles) = @_;
-
+sub download_missing_needles ($self, $new_needles) {
     $self->add_relevant_downloads($new_needles);
     $self->download();
 }

--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::Isotovideo::Utils;
-use Mojo::Base -base;
+use Mojo::Base -base, -signatures;
 use Mojo::URL;
 use Mojo::File qw(path);
 
@@ -14,8 +14,7 @@ use Try::Tiny;
 our @EXPORT_OK = qw(checkout_git_repo_and_branch checkout_git_refspec
   handle_generated_assets load_test_schedule);
 
-sub calculate_git_hash {
-    my ($git_repo_dir) = @_;
+sub calculate_git_hash ($git_repo_dir) {
     my $dir = getcwd();
     chdir($git_repo_dir);
     chomp(my $git_hash = qx{git rev-parse HEAD ||:});
@@ -35,8 +34,7 @@ optional git refspec to checkout. The git clone depth can be specified in the
 argument C<clone_depth> which defaults to 1.
 
 =cut
-sub checkout_git_repo_and_branch {
-    my ($dir_variable, %args) = @_;
+sub checkout_git_repo_and_branch ($dir_variable, %args) {
     my $dir = $bmwqemu::vars{$dir_variable};
     return undef unless defined $dir;
 
@@ -109,8 +107,7 @@ Example:
     checkout_git_refspec('/path/to/casedir', 'TEST_GIT_REFSPEC');
 
 =cut
-sub checkout_git_refspec {
-    my ($dir, $refspec_variable) = @_;
+sub checkout_git_refspec ($dir, $refspec_variable) {
     return undef unless defined $dir;
     if (my $refspec = $bmwqemu::vars{$refspec_variable}) {
         bmwqemu::diag "Checking out local git refspec '$refspec' in '$dir'";
@@ -127,8 +124,7 @@ configuration variables.
 
 =cut
 
-sub handle_generated_assets {
-    my ($command_handler, $clean_shutdown) = @_;
+sub handle_generated_assets ($command_handler, $clean_shutdown) {
     my $return_code = 0;
     # mark hard disks for upload if test finished
     return unless $bmwqemu::vars{BACKEND} eq 'qemu';
@@ -219,8 +215,7 @@ sub load_test_schedule {
     }
 }
 
-sub _store_asset {
-    my ($index, $name, $dir) = @_;
+sub _store_asset ($index, $name, $dir) {
     $name =~ /\.([[:alnum:]]+)$/;
     my $format = $1;
     return {hdd_num => $index, name => $name, dir => $dir, format => $format};


### PR DESCRIPTION
Using a command like

```
sed -i "/^use strict;/ {N;s/use strict;/use Mojo::Base -strict, -signatures;/}" $(git ls-files)
for i in $(git grep -l 'use \(strict\|warnings\)'); do grep -q 'use Mojo::Base -strict' $i && sed -i '/use \(strict\|warnings\)/d' $i; done
tools/tidy --only-changed
```

and some manual fixes.