### PR TITLE
validate_script_output: Fix static timeout when typing command

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -281,7 +281,7 @@ sub script_output {
     elsif ($args{type_command}) {
         my $cat = "cat - > $script_path;\n";
         testapi::type_string($cat);
-        testapi::type_string($script . "\n");
+        testapi::type_string($script . "\n", timeout => $args{timeout});
         testapi::send_key('ctrl-d');
     }
     else {


### PR DESCRIPTION
Timeout is 180 but script_output is using 30

Fail: https://openqa.suse.de/tests/7378199#step/yast_keyboard/15
VR: http://dzedro.suse.cz/tests/19588
```
42      validate_script_output("yast keyboard summary 2>&1", sub { m/korean/ }, timeout => 180);                                                                                                                                              
43      validate_script_output("yast keyboard summary 2>&1", sub { m/korean/ }); 
```

```
[2021-10-12T15:10:00.086066+02:00] [debug] tests/yast2_cmd/yast_keyboard.pm:42 called testapi::validate_script_output
[2021-10-12T15:10:00.086234+02:00] [debug] <<< testapi::type_string(string="cat - > /tmp/script5xau2.sh;\n", max_interval=250, wait_screen_changes=0, wait_still_screen=0, timeout=30, similarity_level=47)
[2021-10-12T15:10:01.088829+02:00] [debug] tests/yast2_cmd/yast_keyboard.pm:42 called testapi::validate_script_output
[2021-10-12T15:10:01.089227+02:00] [debug] <<< testapi::type_string(string="yast keyboard summary 2>&1\n", max_interval=250, wait_screen_changes=0, wait_still_screen=0, timeout=180, similarity_level=47)
[2021-10-12T15:10:02.039226+02:00] [debug] tests/yast2_cmd/yast_keyboard.pm:42 called testapi::validate_script_output
[2021-10-12T15:10:02.039461+02:00] [debug] <<< testapi::send_key(key="ctrl-d", do_wait=0, wait_screen_change=0)
[2021-10-12T15:10:02.375110+02:00] [debug] tests/yast2_cmd/yast_keyboard.pm:42 called testapi::validate_script_output
[2021-10-12T15:10:02.375573+02:00] [debug] <<< testapi::type_string(string="(echo 5xau2; bash -eox pipefail /tmp/script5xau2.sh ; echo SCRIPT_FINISHED5xau2-\$?-) | tee /dev/ttyS0\n", max_interval=250, wait_screen_changes=0, wait_still_screen=0, timeout=30, similarity_level=47)
[2021-10-12T15:10:06.192257+02:00] [debug] tests/yast2_cmd/yast_keyboard.pm:42 called testapi::validate_script_output
[2021-10-12T15:10:06.192558+02:00] [debug] <<< testapi::wait_serial(timeout=180, regexp="SCRIPT_FINISHED5xau2-\\d+-", record_output=1, buffer_size=undef, expect_not_found=0, quiet=undef, no_regex=0)
[2021-10-12T15:10:08.252304+02:00] [debug] >>> testapi::wait_serial: SCRIPT_FINISHED5xau2-\d+-: ok
[2021-10-12T15:10:08.254206+02:00] [debug] tests/yast2_cmd/yast_keyboard.pm:43 called testapi::validate_script_output
[2021-10-12T15:10:08.254393+02:00] [debug] <<< testapi::type_string(string="cat - > /tmp/script5xau2.sh;\n", max_interval=250, wait_screen_changes=0, wait_still_screen=0, timeout=30, similarity_level=47)
[2021-10-12T15:10:09.270658+02:00] [debug] tests/yast2_cmd/yast_keyboard.pm:43 called testapi::validate_script_output
[2021-10-12T15:10:09.270898+02:00] [debug] <<< testapi::type_string(string="yast keyboard summary 2>&1\n", max_interval=250, wait_screen_changes=0, wait_still_screen=0, timeout=30, similarity_level=47)
[2021-10-12T15:10:10.221886+02:00] [debug] tests/yast2_cmd/yast_keyboard.pm:43 called testapi::validate_script_output
[2021-10-12T15:10:10.222071+02:00] [debug] <<< testapi::send_key(key="ctrl-d", wait_screen_change=0, do_wait=0)
[2021-10-12T15:10:10.557446+02:00] [debug] tests/yast2_cmd/yast_keyboard.pm:43 called testapi::validate_script_output
[2021-10-12T15:10:10.557695+02:00] [debug] <<< testapi::type_string(string="(echo 5xau2; bash -eox pipefail /tmp/script5xau2.sh ; echo SCRIPT_FINISHED5xau2-\$?-) | tee /dev/ttyS0\n", max_interval=250, wait_screen_changes=0, wait_still_screen=0, timeout=30, similarity_level=47)
[2021-10-12T15:10:14.375095+02:00] [debug] tests/yast2_cmd/yast_keyboard.pm:43 called testapi::validate_script_output
[2021-10-12T15:10:14.375444+02:00] [debug] <<< testapi::wait_serial(expect_not_found=0, no_regex=0, quiet=undef, timeout=30, buffer_size=undef, record_output=1, regexp="SCRIPT_FINISHED5xau2-\\d+-")
[2021-10-12T15:10:16.434342+02:00] [debug] >>> testapi::wait_serial: SCRIPT_FINISHED5xau2-\d+-: ok
```