### PR TITLE
dist: Bump up timeout scale due to recent OBS observed failures

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -191,7 +191,7 @@ export NO_BRP_STALE_LINK_ERROR=yes
 export CI=1
 # account for sporadic slowness in build environments
 # https://progress.opensuse.org/issues/89059
-export OPENQA_TEST_TIMEOUT_SCALE_CI=10
+export OPENQA_TEST_TIMEOUT_SCALE_CI=20
 cd %{__builddir}
 %cmake_build check-pkg-build
 


### PR DESCRIPTION
Locally with

```
count_fail_ratio prove -I. t/18-qemu.t
```

I could not observe any problems and a runtime of never above 2s but in
OBS in
https://build.opensuse.org/package/live_build_log/devel:openQA/os-autoinst/openSUSE_Leap_15.2/x86_64
t/18-qemu.t failed:

```
[  254s] 3: Bailout called.  Further testing stopped:  test './18-qemu.t' exceeds runtime limit of '50' seconds
[  254s] 3: FAILED--Further testing stopped: test './18-qemu.t' exceeds runtime limit of '50' seconds
[  254s] 3/3 Test #3: test-perl-testsuite ..............***Failed  163.17 sec
```