### PR TITLE
t: Check git status at the end of every test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+doc/backend_vars.asciidoc.newvars
 videoencoder
 debugviewer/debugviewer
 snd2png/snd2png

--- a/t/lib/OpenQA/Test/CheckGitStatus.pm
+++ b/t/lib/OpenQA/Test/CheckGitStatus.pm
@@ -1,0 +1,39 @@
+package OpenQA::Test::CheckGitStatus;
+use Mojo::Base -strict;
+my $CHECK_GIT_STATUS = $ENV{CHECK_GIT_STATUS};
+# prevent subsequent perl processes to check the status
+$ENV{CHECK_GIT_STATUS} = 0;
+
+my $cwd;
+# Get the PID when loading the module to check later
+my $pid = $$;
+
+if ($CHECK_GIT_STATUS) {
+    require Test::More;
+    require File::Which;
+    require Cwd;
+    $cwd = Cwd::cwd();
+}
+
+sub check_status {
+    chdir $cwd;
+    my $git = File::Which::which('git');
+    return unless $git;
+    my $cmd = 'git rev-parse --git-dir';
+    my $out = qx{$cmd};
+    return if $? != 0;
+    $cmd = 'git status --porcelain=v1 2>&1';
+    my @lines = qx{$cmd};
+    die "Problem running git:\n" . join '', @lines if $? != 0;
+    if (@lines > 0) {
+        Test::More::diag("Error: modified or untracked files\n" . join '', @lines);
+        exit 1;
+    }
+}
+
+END {
+    # Check $pid - don't run this in forked processes
+    check_status() if $$ == $pid and $CHECK_GIT_STATUS;
+}
+
+1;

--- a/tools/container_run_ci
+++ b/tools/container_run_ci
@@ -58,7 +58,7 @@ fi
 [[ \"$target\" == \"coverage-codecovbash\" ]] && zypper -n in perl-App-cpanminus && cpanm -nq 'Devel::Cover::Report::Codecovbash'
 cd /opt
 ./tools/install-new-deps.sh
-export CI=1 WITH_COVER_OPTIONS=1
+export CI=1 WITH_COVER_OPTIONS=1 CHECK_GIT_STATUS=1
 cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -S . -B \"$build_dir\"
 cmake --build \"$build_dir\" --verbose --target check
 cmake --build \"$build_dir\" --verbose --target $target"

--- a/tools/invoke-tests
+++ b/tools/invoke-tests
@@ -43,8 +43,8 @@ db="$build_directory/cover_db"
 export PERL5LIB="$source_directory:$source_directory/external/os-autoinst-common/lib:$source_directory/ppmclibs:$source_directory/ppmclibs/blib/arch/auto/tinycv:$PERL5LIB"
 if [[ $WITH_COVER_OPTIONS ]]; then
     path_regex="^|$source_directory/|\\.\\./"
-    select="($path_regex)(OpenQA|backend|consoles|ppmclibs)/|($path_regex)isotovideo|($path_regex)[^/]+\.pm,-ignore,\.t|data/tests/|fake/tests/|$prove_path"
-    export PERL5OPT="-MDevel::Cover=-db,$db,-select,$select,-coverage,statement"
+    select="($path_regex)(OpenQA|backend|consoles|ppmclibs)/|($path_regex)isotovideo|($path_regex)[^/]+\.pm,-ignore,\.t|data/tests/|fake/tests/|/CheckGitStatus.pm|$prove_path"
+    export PERL5OPT="-I$source_directory/t/lib -MOpenQA::Test::CheckGitStatus -MDevel::Cover=-db,$db,-select,$select,-coverage,statement"
 fi
 
 # set variables for tests which need to invoke the make tool


### PR DESCRIPTION
...to make sure we have a clean status - no modified and no untracked
files were added by the tests.

This check must be explicitly enabled by setting CHECK_GIT_STATUS to 1.

~~Tests are failing, cleanup pr #1823 is currently blocked.~~

For now the module is in t/lib and could be moved to os-autoinst-common when it works out ok.