### PR TITLE
Add quirk for QEMU >= 5 on PPC

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -672,6 +672,8 @@ sub start_qemu {
         # https://progress.opensuse.org/issues/75259
         my $caps = ',cap-cfpc=broken,cap-sbbc=broken,cap-ibs=broken';
         $vars->{QEMUMACHINE} .= $caps if $vars->{QEMUMACHINE} !~ /$caps/;
+        $caps = ',cap-ccf-assist=off';
+        $vars->{QEMUMACHINE} .= $caps if $self->{qemu_version} >= 5 && $vars->{QEMUMACHINE} !~ /$caps/;
     }
     sp('vga', $vars->{QEMUVGA}) if $vars->{QEMUVGA};
 


### PR DESCRIPTION
Add cap-ccf-assist=off to QEMUMACHINE on QEMU >= 5 to fix

[warn] !!! : qemu-system-ppc64: Requested count cache flush assist capability level not supported by KVM
[debug] QEMU: Try appending -machine cap-ccf-assist=off

VR of using that setting manually: https://openqa.opensuse.org/tests/1993838

No VR of this code directly because I don't have a host to test it on. I could monkeypatch power8 if desired...