### PR TITLE
Switch from usb-ehci to qemu-xhci

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -113,7 +113,7 @@ sub configure_controllers ($self, $vars) {
     }
 
     if ($vars->{USBBOOT}) {
-        $cc->add_controller('usb-ehci', 'ehci0');
+        $cc->add_controller('qemu-xhci', 'xhci0');
     }
 
     return $self;

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -875,7 +875,7 @@ sub start_qemu {
         }
 
         unless ($vars->{QEMU_NO_TABLET}) {
-            sp('device', ($vars->{OFW} || $arch eq 'aarch64') ? 'nec-usb-xhci' : 'usb-ehci');
+            sp('device', ($vars->{OFW} || $arch eq 'aarch64') ? 'nec-usb-xhci' : 'qemu-xhci');
             sp('device', 'usb-tablet');
         }
 


### PR DESCRIPTION
XHCI is faster then EHCI and the official QEMU documentation recommends to use
this for all OSs which support it. It's more virtualization friendly and does
not need separate controllers for USB < 2.0 devices.

Verification run: http://10.160.67.86/tests/1092