### PR TITLE
Fix passing border_offset parameter to mouse_hide

### DIFF
--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -457,7 +457,7 @@ subtest 'assert_and_click' => sub {
     is_deeply($cmds->[-1], {cmd => 'backend_mouse_set', x => 100, y => 100}, 'assert_and_click succeeds and move to old mouse set');
 
     ok(assert_and_click('foo', mousehide => 1));
-    is_deeply($cmds->[-1], {cmd => 'backend_mouse_hide', offset => 0}, 'assert_and_click succeeds and hides mouse with mousehide => 1');
+    is_deeply($cmds->[-1], {cmd => 'backend_mouse_hide', border_offset => 0}, 'assert_and_click succeeds and hides mouse with mousehide => 1');
 
     ok(assert_and_click('foo', button => 'right'));
     is_deeply($cmds->[-2], {bstate => 0, button => 'right', cmd => 'backend_mouse_button'}, 'assert_and_click succeeds with right click');
@@ -474,7 +474,7 @@ subtest 'assert_and_dclick' => sub {
     for (-3, -5) {
         is_deeply($cmds->[$_], {bstate => 1, button => 'left', cmd => 'backend_mouse_button'}, 'assert_and_dclick succeeds with bstate => 1');
     }
-    is_deeply($cmds->[-1], {cmd => 'backend_mouse_hide', offset => 0}, 'assert_and_dclick succeeds and hides mouse with mousehide => 1');
+    is_deeply($cmds->[-1], {cmd => 'backend_mouse_hide', border_offset => 0}, 'assert_and_dclick succeeds and hides mouse with mousehide => 1');
 };
 
 subtest 'record_info' => sub {

--- a/testapi.pm
+++ b/testapi.pm
@@ -1602,7 +1602,7 @@ Hide mouse cursor by moving it out of screen area.
 sub mouse_hide(;$) {
     my $border_offset = shift || 0;
     bmwqemu::log_call(border_offset => $border_offset);
-    query_isotovideo('backend_mouse_hide', {offset => $border_offset});
+    query_isotovideo('backend_mouse_hide', {border_offset => $border_offset});
 }
 
 =head2 mouse_drag


### PR DESCRIPTION
The backend method expects the parameter to be called border_offset as well.

Verification run: http://10.160.67.86/tests/1100

I noticed this in an `autoinst-log.txt`:

```
[2021-11-02T08:18:17.653109+01:00] [debug] <<< testapi::mouse_hide(border_offset=1)
[2021-11-02T08:18:17.653997+01:00] [debug] send_pointer_event 0, 1018, 762, 1
[2021-11-02T08:18:17.654151+01:00] [debug] mouse_move 1023, 767
[2021-11-02T08:18:17.654224+01:00] [debug] send_pointer_event 0, 1023, 767, 1
...
[2021-11-02T08:18:22.031366+01:00] [debug] <<< testapi::mouse_hide(border_offset=200)
[2021-11-02T08:18:22.032341+01:00] [debug] send_pointer_event 0, 1018, 762, 1
[2021-11-02T08:18:22.032510+01:00] [debug] mouse_move 1023, 767
[2021-11-02T08:18:22.032595+01:00] [debug] send_pointer_event 0, 1023, 767, 1
```

The coordinates were the same, but with a vastly different offset.

with the fix:

```
[2021-11-02T12:17:00.483435+01:00] [debug] <<< testapi::mouse_hide(border_offset=1)
[2021-11-02T12:17:00.484225+01:00] [debug] mouse_move 1022, 766
[2021-11-02T12:17:00.484448+01:00] [debug] send_pointer_event 0, 1022, 766, 1
...
[2021-11-02T12:17:00.822135+01:00] [debug] <<< testapi::mouse_hide(border_offset=200)
[2021-11-02T12:17:00.823095+01:00] [debug] mouse_move 823, 567
[2021-11-02T12:17:00.823356+01:00] [debug] send_pointer_event 0, 823, 567, 1
```

I wonder whether it breaks anything that this parameter works now...