### PR TITLE
Fix handling resume command (of developer mode) when not paused

### DIFF
--- a/OpenQA/Isotovideo/CommandHandler.pm
+++ b/OpenQA/Isotovideo/CommandHandler.pm
@@ -203,6 +203,11 @@ sub _handle_command_resume_test_execution ($self, $response, @) {
     my $downloader = OpenQA::Isotovideo::NeedleDownloader->new();
     $downloader->download_missing_needles($response->{new_needles} // []);
 
+    # skip resuming last command if receiving a resume command without having previously postponed an answer
+    # note: This should normally not be the case. However, the JavaScript client can technically send the command
+    #       to resume at any time and that apparently also happens sometimes in the fullstack test (see poo#101734).
+    return undef unless defined $postponed_answer_fd;
+
     # if no command has been postponed (because paused due to timeout) just return 1
     if (!$postponed_command) {
         myjsonrpc::send_json($postponed_answer_fd, {

--- a/t/19-isotovideo-command-processing.t
+++ b/t/19-isotovideo-command-processing.t
@@ -262,6 +262,13 @@ subtest 'set_pause_on_next_command, postponing command, resuming' => sub {
     is($command_handler->postponed_command, undef, 'no command postponed anymore');
     is($command_handler->postponed_answer_fd, undef, 'postponed answer_fd cleared');
     is($command_handler->reason_for_pause, 0, 'test no longer paused');
+
+    # resume without previously postponed command
+    # note: The check for relevant early return is provided by mock function of send_json which is defined
+    #       at the top of this file.
+    stderr_like {
+        $command_handler->process_command($answer_fd, {cmd => 'resume_test_execution'});
+    } qr/resuming.*not paused anyways/, 'resuming test execution without previously pausing';
 };
 
 subtest 'assert_screen' => sub {


### PR DESCRIPTION
This fixes errors we observe in the fullstack test logs, see
https://progress.opensuse.org/issues/101734.

Note that the problem can also be reproduced manually by sending
`{"cmd": "resume_test_execution"}` via the developer mode console while the
test is *not* paused. This leads to the exact same error message than we
see in the fullstack test (and the job ends up incomplete).