### PR TITLE
Don't include the previous tests fail hook output in the search for issues

### DIFF
--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -61,11 +61,8 @@ subtest modules_test => sub {
 subtest parse_serial_output => sub {
     my $mock_basetest = Test::MockModule->new('basetest');
     # Mock reading of the serial output
-    $mock_basetest->redefine(get_serial_output_json => sub {
-            return {
-                serial => "Serial to match\n1q2w333\nMore text",
-                position => '100'
-            };
+    $mock_basetest->redefine(get_new_serial_output => sub {
+            return "Serial to match\n1q2w333\nMore text";
     });
     my $basetest = basetest->new('installation');
     my $message;
@@ -133,7 +130,6 @@ subtest parse_serial_output => sub {
     eval { $basetest->parse_serial_output_qemu() };
     like($@, qr(Message not defined for serial failure for the pattern.*), 'test died because of missing message');
     is($basetest->{result}, 'fail', 'test result set to hard failure');
-
 };
 
 subtest record_testresult => sub {


### PR DESCRIPTION
After the main test code runs, search_for_expected_serial_failures looks
through the generated serial output for certain patterns. In the case that the
test failed, the post_fail_hook runs after that, which might also produce output
on the serial console. Before this commit, this was not skipped and so the call
to search_for_expected_serial_failures on the next module sees it.

This can even have a cascading effect if there's a OOM message in the log files,
if it was missed in an earlier module. Then the post_fail_hook would print that
to the serial console and thus cause the next module to fail, which in turn
prints the message again and the cycle repeats.

See also https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13610
Related ticket: https://progress.opensuse.org/issues/81382

Before: http://10.160.67.86/tests/1122
After: http://10.160.67.86/tests/1127