### PR TITLE
Fix missing subsecond display in video captions

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -516,7 +516,9 @@ sub enqueue_screenshot {
     $self->{min_video_similarity} -= 1;
     $self->{min_video_similarity} = $sim if $sim < $self->{min_video_similarity};
 
-    $self->{vtt_caption_file}->print($self->format_vtt_timestamp(gettimeofday));
+    # ensure gettimeofday returns float number, not a list of two entries
+    # where we would discard the second element
+    $self->{vtt_caption_file}->print($self->format_vtt_timestamp('' . gettimeofday));
 
     # we have two different similarity levels - one (slightly higher value, based
     # t/data/user-settings-*) to determine if it's worth it to recheck needles

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -32,17 +32,17 @@ bmwqemu::init_logger;
 my $baseclass = backend::baseclass->new();
 
 subtest 'format_vtt_timestamp' => sub {
-    my $timestamp = 1543917024;
-
+    my $timestamp = 1543917024.24791;
     $baseclass->{video_frame_number} = 0;
     is($baseclass->format_vtt_timestamp($timestamp),
-        "\n0\n00:00:00.000 --> 00:00:00.041\n[2018-12-04T09:50:24.000]\n",
+        "\n0\n00:00:00.000 --> 00:00:00.041\n[2018-12-04T09:50:24.247]\n",
         'frame number 0'
     );
 
+    $timestamp += .1;
     $baseclass->{video_frame_number} = 1;
     is($baseclass->format_vtt_timestamp($timestamp),
-        "\n1\n00:00:00.041 --> 00:00:00.083\n[2018-12-04T09:50:24.000]\n",
+        "\n1\n00:00:00.041 --> 00:00:00.083\n[2018-12-04T09:50:24.347]\n",
         'frame number 1'
     );
 };


### PR DESCRIPTION
https://github.com/os-autoinst/os-autoinst/pull/1059 introduced video
captions overlaying wallclock time over the video. The pull request even
had a discussion about the subsecond precision in the relative steps.
But for the actual absolute timestamp the calculation was always there
to correctly calculate subsecond precision and display as milliseconds.
However "gettimeofday()" only returns the expected float number when
used as a string. So far the code called gettimeofday as the argument
for the method "format_vtt_timestamp" meaning that gettimeofday yields a
list of two elements where we discard the second element including the
subsecond part meaning that the timestamp was always showing ".000"
instead of the real subsecond value. An example from a recent real-life
openQA job
https://openqa.opensuse.org/tests/1963236
shows

```
0
00:00:00.000 --> 00:00:00.041
[2021-10-11T12:24:23.000]

1
00:00:00.041 --> 00:00:00.083
[2021-10-11T12:24:23.000]

2
00:00:00.083 --> 00:00:00.125
[2021-10-11T12:24:23.000]

3
00:00:00.125 --> 00:00:00.166
[2021-10-11T12:24:24.000]
```

so multiple occurences of the same timestamp with the misleading and
wrong ".000" part included.

The problem was found when I was trying to introduce perl signatures
which failed because the second return value of gettimeofday was
unexpectedly discarded.

This commit adjusts the tests and changes the call to gettimeofday by
forcing it to return a string value, i.e. a float number.