### PR TITLE
dist: Do not build for i586

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -93,6 +93,7 @@ Recommends:     perl(Inline::Python)
 Requires(pre):  %{_bindir}/getent
 Requires(pre):  %{_sbindir}/useradd
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+ExcludeArch:    %{ix86}
 
 %description
 The OS-autoinst project aims at providing a means to run fully


### PR DESCRIPTION
The resulting binaries are not installable, as some dependencies
(e.g. ShellCheck) are not being built for i586.
