### PR TITLE
Warn about backend errors more prominently in log

### DIFF
--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -149,7 +149,7 @@ sub handle_generated_assets ($command_handler, $clean_shutdown) {
                     format => 'qcow2'});
         }
         if (@toextract && !$clean_shutdown) {
-            bmwqemu::serialize_state(component => 'isotovideo', msg => 'unable to handle generated assets: machine not shut down when uploading disks', log => 1);
+            bmwqemu::serialize_state(component => 'isotovideo', msg => 'unable to handle generated assets: machine not shut down when uploading disks', error => 1);
             return 1;
         }
     }
@@ -162,7 +162,7 @@ sub handle_generated_assets ($command_handler, $clean_shutdown) {
         local $@;
         eval { $bmwqemu::backend->extract_assets($asset); };
         if ($@) {
-            bmwqemu::serialize_state(component => 'backend', msg => "unable to extract assets: $@", log => 1);
+            bmwqemu::serialize_state(component => 'backend', msg => "unable to extract assets: $@", error => 1);
             $return_code = 1;
         }
     }

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -67,6 +67,7 @@ use constant STATE_FILE => 'base_state.json';
 # Write a JSON representation of the process termination to disk
 sub serialize_state {
     my $state = {@_};
+    bmwqemu::fctwarn($state->{msg}) if delete $state->{error};
     bmwqemu::diag($state->{msg}) if delete $state->{log};
     return undef if -e STATE_FILE;
     eval { Mojo::File->new(STATE_FILE)->spurt(encode_json($state)); };

--- a/isotovideo
+++ b/isotovideo
@@ -397,7 +397,7 @@ if (!$return_code) {
     # don't rely on the backend in a sane state if we failed - just stop it later
     eval { bmwqemu::stop_vm(); };
     if ($@) {
-        bmwqemu::serialize_state(component => 'backend', msg => "unable to stop VM: $@", log => 1);
+        bmwqemu::serialize_state(component => 'backend', msg => "unable to stop VM: $@", error => 1);
         $return_code = 1;
     }
 }


### PR DESCRIPTION
Example output:

```
[2021-10-28T09:10:34.398262+02:00] [debug] ||| starting failing_module tests/failing_module.pm
[2021-10-28T09:10:34.515257+02:00] [info] ::: basetest::runtest: # Test died: fail at /home/okurz/local/os-autoinst/os-autoinst/t/data/tests/tests/failing_module.pm line 9.

[2021-10-28T09:10:34.521643+02:00] [debug] stopping autotest process 32476
[2021-10-28T09:10:34.524441+02:00] [debug] [autotest] process exited: 0

[2021-10-28T09:10:34.743729+02:00] [debug] QEMU status is not 'shutdown', it is 'running'
[2021-10-28T09:10:34.744010+02:00] [debug] backend shutdown state:
[2021-10-28T09:10:34.744309+02:00] [warn] !!! bmwqemu::serialize_state: unable to stop VM: Too few arguments for subroutine 'backend::driver::stop' at /home/okurz/local/os-autoinst/os-autoinst/bmwqemu.pm line 284.
```

using a line with `[warn] !!!` instead of just `[debug]`.