### PR TITLE
qemu: Use wait=off instead of the deprecated nowait

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -885,7 +885,7 @@ sub start_qemu ($self) {
         }
 
         my $qmpid = 'qmp_socket';
-        sp('chardev', [qv "socket path=$qmpid server nowait id=$qmpid logfile=$qmpid.log logappend=on"]);
+        sp('chardev', [qv "socket path=$qmpid server wait=off id=$qmpid logfile=$qmpid.log logappend=on"]);
         sp('qmp', "chardev:$qmpid");
         sp('S');
     }


### PR DESCRIPTION
Otherwise the tests fail because of a deprecation message:

    warning: short-form boolean option 'server' deprecated
    Please use wait=off instead