### PR TITLE
ipmi: Make persistent SOL console enabled by default

### DIFF
--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -93,7 +93,7 @@ sub do_start_vm ($self, @) {
     $self->get_mc_status;
     $self->restart_host unless $bmwqemu::vars{IPMI_DO_NOT_RESTART_HOST};
     $self->truncate_serial_file;
-    my $sol = $testapi::distri->add_console('sol', 'ipmi-xterm', {persistent => $bmwqemu::vars{IPMI_SOL_PERSISTENT_CONSOLE} // 0});
+    my $sol = $testapi::distri->add_console('sol', 'ipmi-xterm', {persistent => $bmwqemu::vars{IPMI_SOL_PERSISTENT_CONSOLE} // 1});
     $sol->backend($self);
     return {};
 }

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -69,7 +69,7 @@ IPMI_MC_RESET_SLEEP_TIME_S;integer;10;Time to sleep after sending mc reset comma
 IPMI_MC_RESET_TIMEOUT;integer;60;Counts to try to reach IPMI interface after mc reset
 IPMI_MC_RESET_PING_COUNT;integer;1;Ping counts that must be successful after mc reset
 IPMI_MC_RESET_IPMI_TRIES;integer;3;Maximum number of IPMI command tries that are conducted after mc reset
-IPMI_SOL_PERSISTENT_CONSOLE;boolean;0;Make SOL console persistent and don't reset it, disabled by default
+IPMI_SOL_PERSISTENT_CONSOLE;boolean;1;Make SOL console persistent and don't reset it, enabled by default
 |====================
 
 .QEMU backend


### PR DESCRIPTION
Follow of  https://progress.opensuse.org/issues/60437 and https://github.com/os-autoinst/os-autoinst/pull/1654 where we agreed that this behavior should be enabled by default.

Verification runs:
* old default: http://10.100.12.105/tests/1377#step/kdump/42
* new default:  http://10.100.12.105/tests/1387
