### PR TITLE
 osutils: Do not hide errors of exec call in run() and run_diag()

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -716,8 +716,6 @@ sub start_qemu ($self) {
     mkpath($basedir);
 
     # do not use autodie here, it can fail on tmpfs, xfs, ...
-    # potential endless loop on chattr call,
-    # see https://progress.opensuse.org/issues/81828
     run_diag('/usr/bin/chattr', '+C', $basedir);
 
     bmwqemu::diag('Configuring storage controllers and block devices');

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -716,9 +716,9 @@ sub start_qemu ($self) {
     mkpath($basedir);
 
     # do not use autodie here, it can fail on tmpfs, xfs, ...
-    # timeout with arbitrary value to catch a potential indefinite blocking
-    # chattr call, also see https://progress.opensuse.org/issues/81828
-    run_diag('timeout 30 /usr/bin/chattr', '-f', '+C', $basedir);
+    # potential endless loop on chattr call,
+    # see https://progress.opensuse.org/issues/81828
+    run_diag('/usr/bin/chattr', '+C', $basedir);
 
     bmwqemu::diag('Configuring storage controllers and block devices');
     my $keephdds = $vars->{KEEPHDDS} || $vars->{SKIPTO};


### PR DESCRIPTION
This change does actually 3 changes.
  * It fix the issue poo#81828 [1], as it bypass the race error of  `ReadWriteProcess(code => sub {})` (see: [2])
  * It show the output of the executed process.
  * run_diag() show a stacktrace if someone try to run a command which does not exists.
    
[1] https://progress.opensuse.org/issues/81828
[2] https://github.com/mudler/Mojo-IOLoop-ReadWriteProcess/pull/18

Example output of `run_diag()` looks like:
```
[2021-11-21T22:39:40.973951+01:00] [debug] Run command `/usr/bin/chattr +C /var/lib/openqa/pool/3/raid`
[2021-11-21T22:39:41.002731+01:00] [debug] Command `/usr/bin/chattr +C /var/lib/openqa/pool/3/raid` exit with 1
  /usr/bin/chattr: Operation not supported while setting flags on /var/lib/openqa/pool/3/raid
```

Example output of a command which doesn't exists:
```
[2021-11-21T22:39:41.002857+01:00] [debug] Run command `/I_do_not_exists +C /var/lib/openqa/pool/3/raid`
[2021-11-21T22:39:41.016686+01:00] [debug] Command `/I_do_not_exists +C /var/lib/openqa/pool/3/raid` failed fatal with: open3: exec of /I_do_not_exists +C /var/lib/openqa/pool/3/raid failed: No such file or directory at /usr/lib/perl5/5.26.1/IPC/Open3.pm line 283.
  	eval {...} called at /usr/lib/perl5/5.26.1/IPC/Open3.pm line 285
  	IPC::Open3::_open3("open3", GLOB(0x564903ecd848), GLOB(0x564903ecd860), undef, "/I_do_not_exists", "+C", Mojo::File=SCALAR(0x564903edbd48)) called at /usr/lib/perl5/5.26.1/IPC/Open3.pm line 359
  	IPC::Open3::open3(GLOB(0x564903ecd848), GLOB(0x564903ecd860), undef, "/I_do_not_exists", "+C", Mojo::File=SCALAR(0x564903edbd48)) called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 128
  	Mojo::IOLoop::ReadWriteProcess::_open(Mojo::IOLoop::ReadWriteProcess=HASH(0x564903e403c0), "/I_do_not_exists", "+C", Mojo::File=SCALAR(0x564903edbd48)) called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 477
  	Mojo::IOLoop::ReadWriteProcess::start(Mojo::IOLoop::ReadWriteProcess=HASH(0x564903e403c0)) called at /usr/lib/os-autoinst/osutils.pm line 85
  	osutils::run("/I_do_not_exists", "+C", Mojo::File=SCALAR(0x564903edbd48)) called at /usr/lib/os-autoinst/osutils.pm line 100
  	eval {...} called at /usr/lib/os-autoinst/osutils.pm line 98
  	osutils::run_diag("/I_do_not_exists", "+C", Mojo::File=SCALAR(0x564903edbd48)) called at /usr/lib/os-autoinst/backend/qemu.pm line 754
  	backend::qemu::start_qemu(backend::qemu=HASH(0x564905883930)) called at /usr/lib/os-autoinst/backend/qemu.pm line 116
  	backend::qemu::do_start_vm(backend::qemu=HASH(0x564905883930)) called at /usr/lib/os-autoinst/backend/baseclass.pm line 382
  	backend::baseclass::start_vm(backend::qemu=HASH(0x564905883930), undef) called at /usr/lib/os-autoinst/backend/baseclass.pm line 73
  	backend::baseclass::handle_command(backend::qemu=HASH(0x564905883930), HASH(0x564903edbdf0)) called at /usr/lib/os-autoinst/backend/baseclass.pm line 539
  	backend::baseclass::check_socket(backend::qemu=HASH(0x564905883930), IO::Handle=GLOB(0x56490574c7a0)) called at /usr/lib/os-autoinst/backend/qemu.pm line 1100
  	backend::qemu::check_socket(backend::qemu=HASH(0x564905883930), IO::Handle=GLOB(0x56490574c7a0), 0) called at /usr/lib/os-autoinst/backend/baseclass.pm line 229
  	backend::baseclass::do_capture(backend::qemu=HASH(0x564905883930), undef, 1637530780.91973) called at /usr/lib/os-autoinst/backend/baseclass.pm line 258
  	eval {...} called at /usr/lib/os-autoinst/backend/baseclass.pm line 258
  	backend::baseclass::run_capture_loop(backend::qemu=HASH(0x564905883930)) called at /usr/lib/os-autoinst/backend/baseclass.pm line 127
  	backend::baseclass::run(backend::qemu=HASH(0x564905883930), 13, 16) called at /usr/lib/os-autoinst/backend/driver.pm line 73
  	backend::driver::__ANON__(Mojo::IOLoop::ReadWriteProcess=HASH(0x5649057b6788)) called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 326
  	eval {...} called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 326
  	Mojo::IOLoop::ReadWriteProcess::_fork(Mojo::IOLoop::ReadWriteProcess=HASH(0x5649057b6788), CODE(0x564905f88588)) called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 477
  	Mojo::IOLoop::ReadWriteProcess::start(Mojo::IOLoop::ReadWriteProcess=HASH(0x5649057b6788)) called at /usr/lib/os-autoinst/backend/driver.pm line 74
  	backend::driver::start(backend::driver=HASH(0x5648ff091508)) called at /usr/lib/os-autoinst/backend/driver.pm line 39
  	backend::driver::new("backend::driver", "qemu") called at /usr/bin/isotovideo line 211
  	main::init_backend() called at /usr/bin/isotovideo line 262
```

## qemu: Don't call chattr with timeout and remove -f arg

The problem with chattr isn't about chattr it self, it seems to be
located in Mojo::IOLoop::ReadWriteProcess.
Also remove the `-f` argument, so we get error messages visible!