### PR TITLE
baseclass: Improve error message on "half-open socket"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ set(PERL_FILES
     OpenQA/Isotovideo/Interface.pm
     OpenQA/Isotovideo/NeedleDownloader.pm
     OpenQA/Isotovideo/Utils.pm
+    OpenQA/NamedIOSelect.pm
     OpenQA/Qemu/BlockDevConf.pm
     OpenQA/Qemu/BlockDev.pm
     OpenQA/Qemu/ControllerConf.pm

--- a/OpenQA/NamedIOSelect.pm
+++ b/OpenQA/NamedIOSelect.pm
@@ -1,0 +1,36 @@
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Helper class to use descriptive names for file descriptors within IO::Select
+
+package OpenQA::NamedIOSelect;
+use Mojo::Base -base, -signatures;
+use IO::Select;
+use Carp;
+
+sub select ($self) { $self->{select_obj} //= IO::Select->new() }
+
+sub names ($self) { $self->{names_hash} //= {} }
+
+sub add ($self, $fd, $name = undef) {
+    my $fd_nr = fileno $fd // $fd;
+    if (!defined($name)) {
+        my ($package, $filename, $line) = caller;
+        $name = sprintf('NamedIOSelect::add(%d) called at %s:%d', $fd_nr, $filename, $line);
+    }
+
+    $self->names->{$fd_nr} = $name;
+    $self->select->add($fd);
+}
+
+sub get_name ($self, $fd) {
+    my $fd_nr = fileno $fd // $fd;
+    return $self->names->{$fd_nr} // "Unknown fd($fd_nr)";
+}
+
+sub remove ($self, $fd) {
+    delete $self->names->{fileno $fd // $fd};
+    $self->select->remove($fd);
+}
+
+1;

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -220,7 +220,7 @@ sub do_capture ($self, $timeout = undef, $starttime = undef) {
             if (fileno $fh && fileno $fh != -1) {
                 # Very high limits! On a working socket, the maximum hits per 10 seconds will be around 60.
                 # The maximum hits per 10 seconds saw on a half open socket was >100k
-                if (check_select_rate($buckets, $wait_time_limit, $hits_limit, fileno $fh)) {
+                if (check_select_rate($buckets, $wait_time_limit, $hits_limit, fileno $fh, time())) {
                     my $console = $self->{current_console}->{testapi_console};
                     my $fd_nr = fileno $fh;
                     my $cnt = $buckets->{BUCKET}{$fd_nr};
@@ -270,8 +270,7 @@ sub run_capture_loop ($self, $timeout = undef) {
 
 # wait_time_limit = seconds
 # This is not sliding buckets. All the IDs inside the bucket must be over the limit!
-sub check_select_rate ($buckets, $wait_time_limit, $hits_limit, $id) {
-    my $time = gettimeofday;
+sub check_select_rate ($buckets, $wait_time_limit, $hits_limit, $id, $time) {
     my $lower_limit = $buckets->{TIME} //= $time;
     my $upper_limit = $lower_limit + $wait_time_limit;
     if ($time > $upper_limit) {

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -437,8 +437,8 @@ sub load_snapshot ($self, $args) {
     $self->{qmpsocket} = $self->{proc}->connect_qmp();
     my $init = myjsonrpc::read_json($self->{qmpsocket});
     my $hash = $self->handle_qmp_command({execute => 'qmp_capabilities'});
-    $self->{select_read}->add($qemu_pipe);
-    $self->{select_write}->add($qemu_pipe);
+    $self->{select_read}->add($qemu_pipe, 'qemu::load_snapshot::qemu_pipe');
+    $self->{select_write}->add($qemu_pipe, 'qemu::load_snapshot::qemu_pipe');
 
     # Ideally we want to send a file descriptor to QEMU, but it doesn't seem
     # to work for incoming migrations, so we are forced to use exec:cat instead.
@@ -960,8 +960,8 @@ sub start_qemu ($self) {
         $self->handle_qmp_command({execute => 'cont'});
     }
 
-    $self->{select_read}->add($qemu_pipe);
-    $self->{select_write}->add($qemu_pipe);
+    $self->{select_read}->add($qemu_pipe, 'qemu::start_qemu::qemu_pipe');
+    $self->{select_write}->add($qemu_pipe, 'qemu::start_qemu::qemu_pipe');
 }
 
 =head2 handle_qmp_command

--- a/t/36-openqa-namedioselect.t
+++ b/t/36-openqa-namedioselect.t
@@ -1,0 +1,26 @@
+#!/usr/bin/perl
+
+use Test::Most;
+use Mojo::Base -strict, -signatures;
+use OpenQA::NamedIOSelect;
+
+subtest NamedIOSelect => sub {
+
+    my $io = OpenQA::NamedIOSelect->new;
+
+    $io->add(*STDIN);
+    $io->add(*STDOUT, 'STDOUT');
+
+    like($io->get_name(*STDIN), qr/called at/, 'No name give, fallback to caller');
+    is($io->get_name(*STDOUT), 'STDOUT', 'Filedescriptor got name');
+    is($io->get_name(666), 'Unknown fd(666)', 'Unknown fd return formatted string');
+
+    is(ref($io->select), 'IO::Select', 'Get the IO::Select object');
+
+    $io->remove(*STDOUT);
+    is($io->names->{fileno *STDOUT}, undef, 'File descriptor was removed');
+    $io->remove(*STDIN);
+    is(scalar(keys %{$io->names}), 0, 'All file descriptors are removed');
+};
+
+done_testing;


### PR DESCRIPTION
## baseclass: Improve error message on "half-open socket"
Ticket: https://progress.opensuse.org/issues/60161

The current error message is miss leading. As we die here because of
some read attempts threshold. And it must not be correlated to the
current active console.

This try to improve the error message and point to the actual fd which
hit the limit. Also we can name the fd's so it is more easy to identify
them on debugging.

## baseclass: Add test for check_select_rate() function