### PR TITLE
baseclass: Fix errors in some tests by increasing _CHKSEL_RATE_HITS

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -149,7 +149,7 @@ sub do_capture ($self, $timeout = undef, $starttime = undef) {
     # Time slot buckets
     my $buckets = {};
     my $wait_time_limit = $bmwqemu::vars{_CHKSEL_RATE_WAIT_TIME} // 30;
-    my $hits_limit = $bmwqemu::vars{_CHKSEL_RATE_HITS} // 15_000;
+    my $hits_limit = $bmwqemu::vars{_CHKSEL_RATE_HITS} // 30_000;
 
     while (1) {
         last unless $self->{cmdpipe};


### PR DESCRIPTION

Ticket: https://progress.opensuse.org/issues/60161

This just double the allowed read attempts in 30s to 30k. This is needed, as
faster workers can process more then 15k read attempts on one socket in
30s. In general idea of accounting reads per socket isn't a good. 
But we do, and the default was to low these days.
Of course all tests, which do heavy console interaction, can set this value
for it's own, but I think it's not obvious that a console error might be this
variable. So having a better default value makes sense.

We can easily trigger up to 55k by a simple valid testcode like this
```perl
while(1) { script_output('true', quiet => 1) };
```

http://openqa-3.wicked.suse.de/tests/31388 with _CHKSEL_RATE_HITS=15000 => FAILED
http://openqa-3.wicked.suse.de/tests/31387 with _CHKSEL_RATE_HITS=100000 => SUCCESSFUL