### PR TITLE
Log reason for stopping the test execution early

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -229,6 +229,12 @@ sub load_snapshot {
     query_isotovideo('backend_start_serial_grab');
 }
 
+sub _terminate () {
+    close $isotovideo;    # uncoverable statement
+    Devel::Cover::report() if Devel::Cover->can('report');    # uncoverable statement
+    _exit(0);    # uncoverable statement
+}
+
 sub run_all {
     my $died = 0;
     my $completed = 0;
@@ -242,9 +248,7 @@ sub run_all {
         bmwqemu::save_vars(no_secret => 1);
         myjsonrpc::send_json($isotovideo, {cmd => 'tests_done', died => $died, completed => $completed});
     };
-    close $isotovideo;
-    Devel::Cover::report() if Devel::Cover->can('report');
-    _exit(0);
+    _terminate;
 }
 
 sub handle_sigterm {

--- a/autotest.pm
+++ b/autotest.pm
@@ -379,6 +379,12 @@ sub runalltests {
                 query_isotovideo('backend_save_memory_dump', {filename => $fullname});
             }
             if ($t->{fatal_failure} || $flags->{fatal} || (!exists $flags->{fatal} && !$snapshots_supported) || $bmwqemu::vars{TESTDEBUG}) {
+                my $reason = ($t->{fatal_failure} || $flags->{fatal})
+                  ? 'after a fatal test failure'
+                  : ($bmwqemu::vars{TESTDEBUG}
+                    ? 'because TESTDEBUG has been set'
+                    : 'because snapshotting is disabled/unavailable and "fatal => 0" has NOT been set explicitly');
+                bmwqemu::diag "stopping overall test execution $reason";
                 bmwqemu::stop_vm();
                 return 0;
             }

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -19,9 +19,6 @@ use bmwqemu;
 use OpenQA::Test::RunArgs;
 
 $bmwqemu::vars{CASEDIR} = File::Basename::dirname($0) . '/fake';
-# array of messages sent with the fake json_send
-my @sent;
-
 
 like(exception { autotest::runalltests }, qr/ERROR: no tests loaded/, 'runalltests needs tests loaded first');
 like warning {
@@ -37,15 +34,14 @@ sub loadtest ($test, $msg = undef) {
     stderr_like { autotest::loadtest "tests/$filename" } qr@scheduling $test#?[0-9]* tests/$test|$test already scheduled@, $msg;
 }
 
-sub fake_send ($target, $msg) {
-    push @sent, $msg;
-}
+my @sent;    # array of messages sent with the fake json_send
+sub fake_send ($target, $msg) { push @sent, $msg }
 
 # find the (first) 'tests_done' message from the @sent array and
 # return the 'died' and 'completed' values
 sub get_tests_done() {
     for my $msg (@sent) {
-        if (ref($msg) eq "HASH" && $msg->{cmd} eq 'tests_done') {
+        if (ref $msg eq 'HASH' && $msg->{cmd} eq 'tests_done') {
             return ($msg->{died}, $msg->{completed});
         }
     }
@@ -56,13 +52,13 @@ $mock_jsonrpc->redefine(send_json => \&fake_send);
 $mock_jsonrpc->redefine(read_json => sub { });
 my $mock_bmwqemu = Test::MockModule->new('bmwqemu');
 my $vm_stopped = 0;
-$mock_bmwqemu->redefine(save_json_file => sub { });
+$mock_bmwqemu->noop('save_json_file');
 $mock_bmwqemu->redefine(stop_vm => sub { $vm_stopped = 1 });
 my $mock_basetest = Test::MockModule->new('basetest');
-$mock_basetest->redefine(_result_add_screenshot => sub { });
+$mock_basetest->noop('_result_add_screenshot');
 # stop run_all from quitting at the end
 my $mock_autotest = Test::MockModule->new('autotest', no_auto => 1);
-$mock_autotest->redefine(_exit => sub { });
+$mock_autotest->noop('_exit');
 
 my $died;
 my $completed;
@@ -73,7 +69,7 @@ like warning { autotest::run_all }, qr/ERROR: no tests loaded/, 'run_all outputs
 ($died, $completed) = get_tests_done;
 is($died, 1, 'run_all with no tests should catch runalltests dying');
 is($completed, 0, 'run_all with no tests should not complete');
-@sent = [];
+@sent = ();
 
 loadtest 'start';
 loadtest 'next';
@@ -88,94 +84,84 @@ stderr_like { autotest::run_all } qr/finished/, 'run_all outputs status on stder
 ($died, $completed) = get_tests_done;
 is($died, 0, 'start+next+start should not die');
 is($completed, 1, 'start+next+start should complete');
-@sent = [];
+@sent = ();
 
 # Test loading snapshots with always_rollback flag. Have to put it here, before loading
 # runargs test module, as it fails.
 subtest 'test always_rollback flag' => sub {
-    # Test that no rollback is triggered when flag is not explicitly set to true
-    $mock_basetest->redefine(test_flags => sub { return {milestone => 1}; });
-    $mock_autotest->redefine(query_isotovideo => sub { return 0; });
-    my $reverts_done = 0;
-    $mock_autotest->redefine(load_snapshot => sub { $reverts_done++; });
-    my $snapshots_made = 0;
-    $mock_autotest->redefine(make_snapshot => sub { $snapshots_made++; });
+    my ($reverts_done, $snapshots_made) = (0, 0);
+    $mock_autotest->redefine(load_snapshot => sub { $reverts_done++ });
+    $mock_autotest->redefine(make_snapshot => sub { $snapshots_made++ });
+    $mock_autotest->redefine(query_isotovideo => 0);
+    $mock_basetest->redefine(test_flags => {milestone => 1});
 
-    stderr_like { autotest::run_all } qr/finished/, 'run_all outputs status on stderr';
-    ($died, $completed) = get_tests_done;
-    is($died, 0, 'start+next+start should not die when always_rollback flag is set');
-    is($completed, 1, 'start+next+start should complete when always_rollback flag is set');
-    is($reverts_done, 0, "No snapshots loaded when flag is not explicitly set to true");
-    $reverts_done = 0;
-    is($snapshots_made, 0, 'No snapshots made if snapshots are not supported');
-    $snapshots_made = 0;
-    @sent = [];
+    subtest 'no rollback is triggered when flag is not explicitly set to true' => sub {
+        stderr_like { autotest::run_all } qr/finished/, 'run_all outputs status on stderr';
+        ($died, $completed) = get_tests_done;
+        is $died, 0, 'start+next+start should not die when always_rollback flag is set';
+        is $completed, 1, 'start+next+start should complete when always_rollback flag is set';
+        is $reverts_done, 0, 'no snapshots loaded when flag is not explicitly set to true';
+        is $snapshots_made, 0, 'no snapshots made if snapshots are not supported';
+        $reverts_done = $snapshots_made = 0;
+        @sent = ();
+    };
+    subtest 'no rollback is triggered if snapshots are not supported' => sub {
+        $mock_basetest->redefine(test_flags => {always_rollback => 1, milestone => 1});
+        $mock_autotest->redefine(query_isotovideo => 0);
+        $reverts_done = 0;
+        $mock_autotest->redefine(load_snapshot => sub { $reverts_done++; });
+        stderr_like { autotest::run_all } qr/finished/, 'run_all outputs status on stderr';
+        ($died, $completed) = get_tests_done;
+        is $died, 0, 'start+next+start should not die when always_rollback flag is set';
+        is $completed, 1, 'start+next+start should complete when always_rollback flag is set';
+        is $reverts_done, 0, 'no snapshots loaded if snapshots are not supported';
+        is $snapshots_made, 0, 'no snapshots made if snapshots are not supported';
+        $reverts_done = $snapshots_made = 0;
+        @sent = ();
+    };
+    subtest 'snapshot loading triggered even when tests successful' => sub {
+        $mock_basetest->redefine(test_flags => {always_rollback => 1});
+        $mock_autotest->redefine(query_isotovideo => 1);
+        stderr_like { autotest::run_all } qr/finished/, 'run_all outputs status on stderr';
+        ($died, $completed) = get_tests_done;
+        is $died, 0, 'start+next+start should not die when always_rollback flag is set';
+        is $completed, 1, 'start+next+start should complete when always_rollback flag is set';
+        is $reverts_done, 0, 'no snapshots loaded if not test with milestone flag';
+        is $snapshots_made, 0, 'no snapshots made if snapshots are not supported';
+        $reverts_done = $snapshots_made = 0;
+        @sent = ();
+    };
+    subtest 'snapshot loading with milestone flag' => sub {
+        $mock_basetest->redefine(test_flags => {always_rollback => 1, milestone => 1});
+        stderr_like { autotest::run_all } qr/finished/, 'run_all outputs status on stderr';
+        ($died, $completed) = get_tests_done;
+        is $died, 0, 'start+next+start should not die when always_rollback flag is set';
+        is $completed, 1, 'start+next+start should complete when always_rollback flag is set';
+        is $reverts_done, 2, 'snapshots are loaded even when tests succeed';
+        is $snapshots_made, 2, 'milestone snapshots are made for all except the last';
+        $reverts_done = $snapshots_made = 0;
+        @sent = ();
 
-    # Test that no rollback is triggered if snapshots are not supported
-    $mock_basetest->redefine(test_flags => sub { return {always_rollback => 1, milestone => 1}; });
-    $mock_autotest->redefine(query_isotovideo => sub { return 0; });
-    $reverts_done = 0;
-    $mock_autotest->redefine(load_snapshot => sub { $reverts_done++; });
-
-    stderr_like { autotest::run_all } qr/finished/, 'run_all outputs status on stderr';
-    ($died, $completed) = get_tests_done;
-    is($died, 0, 'start+next+start should not die when always_rollback flag is set');
-    is($completed, 1, 'start+next+start should complete when always_rollback flag is set');
-    is($reverts_done, 0, "No snapshots loaded if snapshots are not supported");
-    $reverts_done = 0;
-    is($snapshots_made, 0, 'No snapshots made if snapshots are not supported');
-    $snapshots_made = 0;
-    @sent = [];
-
-    # Test that snapshot loading is triggered even when tests are successful
-    $mock_basetest->redefine(test_flags => sub { return {always_rollback => 1}; });
-    $mock_autotest->redefine(query_isotovideo => sub { return 1; });
-    $reverts_done = 0;
-
-    stderr_like { autotest::run_all } qr/finished/, 'run_all outputs status on stderr';
-    ($died, $completed) = get_tests_done;
-    is($died, 0, 'start+next+start should not die when always_rollback flag is set');
-    is($completed, 1, 'start+next+start should complete when always_rollback flag is set');
-    is($reverts_done, 0, "No snapshots loaded if not test with milestone flag");
-    $reverts_done = 0;
-    is($snapshots_made, 0, 'No snapshots made if snapshots are not supported');
-    $snapshots_made = 0;
-    @sent = [];
-
-    # Test with snapshot available
-    $mock_basetest->redefine(test_flags => sub { return {always_rollback => 1, milestone => 1}; });
-    stderr_like { autotest::run_all } qr/finished/, 'run_all outputs status on stderr';
-    ($died, $completed) = get_tests_done;
-    is($died, 0, 'start+next+start should not die when always_rollback flag is set');
-    is($completed, 1, 'start+next+start should complete when always_rollback flag is set');
-    is($reverts_done, 2, "Snapshots are loaded even when tests succeed");
-    $reverts_done = 0;
-    is($snapshots_made, 2, 'Milestone snapshots are made for all except the last');
-    $snapshots_made = 0;
-    @sent = [];
-
-    $mock_basetest->redefine(test_flags => sub { return {milestone => 1, fatal => 1}; });
-    stderr_like { autotest::run_all } qr/finished/, 'run_all outputs status on stderr';
-    ($died, $completed) = get_tests_done;
-    is($died, 0, 'start+next+start should not die as fatal milestones');
-    is($completed, 1, 'start+next+start should complete as fatal milestones');
-    is($reverts_done, 0, 'No rollbacks done');
-    $reverts_done = 0;
-    is($snapshots_made, 0, 'No snapshots made as no test needed them');
-    $snapshots_made = 0;
-    @sent = [];
-
+        $mock_basetest->redefine(test_flags => {milestone => 1, fatal => 1});
+        stderr_like { autotest::run_all } qr/finished/, 'run_all outputs status on stderr';
+        ($died, $completed) = get_tests_done;
+        is $died, 0, 'start+next+start should not die as fatal milestones';
+        is $completed, 1, 'start+next+start should complete as fatal milestones';
+        is $reverts_done, 0, 'no rollbacks done';
+        is $snapshots_made, 0, 'no snapshots made as no test needed them';
+        $reverts_done = $snapshots_made = 0;
+        @sent = ();
+    };
     subtest 'stopping overall test execution early due to fatal test failure' => sub {
         $mock_basetest->redefine(runtest => sub { die "test died\n" });
         $vm_stopped = 0;
         stderr_like { autotest::run_all } qr/.*stopping overall test execution after a fatal test failure.*/, 'reason logged';
         ($died, $completed) = get_tests_done;
-        is($died, 0, 'tests still not considered died if only a test module failed');
-        is($completed, 0, 'tests not considered completed');
-        is($reverts_done, 0, 'no rollbacks done');
-        $reverts_done = 0;
-        is($snapshots_made, 0, 'no snapshots made');
-        $snapshots_made = 0;
+        is $died, 0, 'tests still not considered died if only a test module failed';
+        is $completed, 0, 'tests not considered completed';
+        is $reverts_done, 0, 'no rollbacks done';
+        is $snapshots_made, 0, 'no snapshots made';
+        $reverts_done = $snapshots_made = 0;
         @sent = ();
         ok $vm_stopped, 'VM has been stopped';
 
@@ -184,13 +170,8 @@ subtest 'test always_rollback flag' => sub {
         stderr_like { autotest::run_all } qr/.*stopping overall test execution because snapshotting is disabled.*/, 'reason logged (snapshotting not available';
         @sent = ();
     };
-
-    # # Revert mocks
-    $mock_basetest->unmock('runtest');
-    $mock_basetest->unmock('test_flags');
-    $mock_autotest->unmock('load_snapshot');
-    $mock_autotest->unmock('make_snapshot');
-    $mock_autotest->unmock('query_isotovideo');
+    $mock_basetest->unmock($_) for qw(runtest test_flags);
+    $mock_autotest->unmock($_) for qw(load_snapshot make_snapshot query_isotovideo);
 };
 
 my $targs = OpenQA::Test::RunArgs->new();
@@ -202,14 +183,14 @@ stderr_like { autotest::run_all } qr/finished alt_name tests/, 'dynamic schedule
 ($died, $completed) = get_tests_done;
 is($died, 0, 'run_args test should not die');
 is($completed, 1, 'run_args test should complete');
-@sent = [];
+@sent = ();
 
 stderr_like { autotest::loadtest("tests/run_args.pm", name => 'alt_name') } qr@scheduling alt_name tests/run_args.pm@;
 stderr_like { autotest::run_all } qr/Snapshots are not supported/, 'run_all outputs status on stderr';
 ($died, $completed) = get_tests_done;
 is($died, 0, 'run_args test should not die if there is no run_args');
 is($completed, 0, 'run_args test should not complete if there is no run_args');
-@sent = [];
+@sent = ();
 
 eval { autotest::loadtest("tests/run_args.pm", name => 'alt_name', run_args => {foo => 'bar'}); };
 like($@, qr/The run_args must be a sub-class of OpenQA::Test::RunArgs/, 'error message mentions RunArgs');
@@ -219,19 +200,17 @@ like($@, qr/The run_args must be a sub-class of OpenQA::Test::RunArgs/, 'error m
 # we cause the failure by mocking runtest rather than using a test
 # which dies, as runtest does a whole bunch of stuff when the test
 # dies that we may not want to run into here
-$mock_basetest->redefine(runtest => sub { die 'oh noes!'; });
+$mock_basetest->redefine(runtest => sub { die 'oh noes!' });
 my $enable_snapshots = 1;
-$mock_autotest->redefine(query_isotovideo => sub {
-        my ($command, $arguments) = @_;
-        return $enable_snapshots if $command eq 'backend_can_handle' && $arguments->{function} eq 'snapshots';
-        return 1;
+$mock_autotest->redefine(query_isotovideo => sub ($command, $arguments) {
+        $command eq 'backend_can_handle' && $arguments->{function} eq 'snapshots' ? $enable_snapshots : 1;
 });
 
 stderr_like { autotest::run_all } qr/oh noes/, 'run_all outputs status on stderr';
 ($died, $completed) = get_tests_done;
 is($died, 0, 'non-fatal test failure should not die');
 is($completed, 1, 'non-fatal test failure should complete');
-@sent = [];
+@sent = ();
 
 # now let's add an ignore_failure test
 loadtest 'ignore_failure';
@@ -239,13 +218,12 @@ stderr_like { autotest::run_all } qr/oh noes/, 'run_all outputs status on stderr
 ($died, $completed) = get_tests_done;
 is($died, 0, 'unimportant test failure should not die');
 is($completed, 1, 'unimportant test failure should complete');
-@sent = [];
+@sent = ();
 
 # unmock runtest, to fail in search_for_expected_serial_failures
 $mock_basetest->unmock('runtest');
 # mock reading of the serial output
-$mock_basetest->redefine(search_for_expected_serial_failures => sub {
-        my ($self) = @_;
+$mock_basetest->redefine(search_for_expected_serial_failures => sub ($self) {
         $self->{fatal_failure} = 1;
         die "Got serial hard failure";
 });
@@ -254,12 +232,11 @@ stderr_like { autotest::run_all } qr/Snapshots are supported/, 'run_all outputs 
 ($died, $completed) = get_tests_done;
 is($died, 0, 'fatal serial failure test should not die');
 is($completed, 0, 'fatal serial failure test should not complete');
-@sent = [];
+@sent = ();
 
 # make the serial failure non-fatal
 $mock_basetest->unmock('search_for_expected_serial_failures');
-$mock_basetest->redefine(search_for_expected_serial_failures => sub {
-        my ($self) = @_;
+$mock_basetest->redefine(search_for_expected_serial_failures => sub ($self) {
         $self->{fatal_failure} = 0;
         die "Got serial hard failure";
 });
@@ -268,7 +245,7 @@ stderr_like { autotest::run_all } qr/Snapshots are supported/, 'run_all outputs 
 ($died, $completed) = get_tests_done;
 is($died, 0, 'non-fatal serial failure test should not die');
 is($completed, 1, 'non-fatal serial failure test should complete');
-@sent = [];
+@sent = ();
 
 # disable snapshots and clean last milestone from previous testrun (with had snapshots enabled)
 $enable_snapshots = 0;
@@ -280,16 +257,16 @@ unlike($output, qr/Loading a VM snapshot/, 'no attempt to load VM snapshot');
 ($died, $completed) = get_tests_done;
 is($died, 0, 'non-fatal serial failure test should not die');
 is($completed, 0, 'non-fatal serial failure test should not complete by default without snapshot support');
-@sent = [];
+@sent = ();
 
-$mock_basetest->redefine(test_flags => sub { return {fatal => 0}; });
+$mock_basetest->redefine(test_flags => {fatal => 0});
 $output = combined_from(sub { autotest::run_all });
 like($output, qr/Snapshots are not supported/, 'snapshots actually disabled');
 unlike($output, qr/Loading a VM snapshot/, 'no attempt to load VM snapshot');
 ($died, $completed) = get_tests_done;
 is($died, 0, 'non-fatal serial failure test should not die');
 is($completed, 1, 'non-fatal serial failure test should complete with {fatal => 0} and not snapshot support');
-@sent = [];
+@sent = ();
 
 # Revert mock for runtest and remove mock for search_for_expected_serial_failures
 $mock_basetest->unmock('search_for_expected_serial_failures');
@@ -302,7 +279,7 @@ stderr_like { autotest::run_all } qr/oh noes/, 'run_all outputs status on stderr
 ($died, $completed) = get_tests_done;
 is($died, 0, 'fatal test failure should not die');
 is($completed, 0, 'fatal test failure should not complete');
-@sent = [];
+@sent = ();
 
 
 loadtest 'fatal', 'rescheduling same step later' for 1 .. 10;
@@ -318,37 +295,22 @@ subtest 'test scheduling test modules at test runtime' => sub {
 
     my %json_data;
     my $json_filename = bmwqemu::result_dir . '/test_order.json';
-    my $testorder = [
-        {
-            name => 'scheduler',
-            category => 'tests',
-            flags => {},
-            script => 'tests/scheduler.pm'
-        },
-        {
-            name => 'next',
-            category => 'tests',
-            flags => {},
-            script => 'tests/next.pm'
-        }
-    ];
+    my @testorder = (
+        {name => 'scheduler', category => 'tests', flags => {}, script => 'tests/scheduler.pm'},
+        {name => 'next', category => 'tests', flags => {}, script => 'tests/next.pm'}
+    );
 
     $mock_basetest->unmock('runtest');
-    $mock_bmwqemu->redefine(save_json_file => sub {
-            my ($data, $filename) = @_;
-            $json_data{$filename} = $data;
-    });
+    $mock_bmwqemu->redefine(save_json_file => sub ($data, $filename) { $json_data{$filename} = $data });
 
     loadtest 'scheduler';
-    ok(!defined($json_data{$json_filename}),
-        "loadtest shouldn't create test_order.json before tests started");
+    ok !defined $json_data{$json_filename}, 'loadtest should not create test_order.json before tests started';
 
     stderr_like { autotest::run_all } qr#scheduling next tests/next\.pm#, 'new test module gets scheduled at runtime';
-    is(scalar @autotest::testorder, 2, "loadtest adds new modules at runtime");
-    is_deeply($json_data{$json_filename}, $testorder,
-        "loadtest updates test_order.json at test runtime");
+    is scalar @autotest::testorder, 2, 'loadtest adds new modules at runtime';
+    is_deeply $json_data{$json_filename}, \@testorder, 'loadtest updates test_order.json at test runtime';
 
-    $mock_bmwqemu->redefine(save_json_file => sub { });
+    $mock_bmwqemu->noop('save_json_file');
 };
 
 my $sharedir = '/home/tux/.local/lib/openqa/share';

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -57,15 +57,13 @@ $mock_bmwqemu->noop('save_json_file');
 $mock_bmwqemu->redefine(stop_vm => sub { $vm_stopped = 1 });
 my $mock_basetest = Test::MockModule->new('basetest');
 $mock_basetest->noop('_result_add_screenshot');
-# stop run_all from quitting at the end
+# stop `run_all` from calling `Devel::Cover::report()` and quitting at the end
+# note: We are not calling `run_all` from a sub process here so the extra coverage collection must *not* run.
 my $mock_autotest = Test::MockModule->new('autotest', no_auto => 1);
-$mock_autotest->noop('_exit');
+$mock_autotest->noop('_terminate');
 
 my $died;
 my $completed;
-# we have to define this to *something* so the `close` in run_all
-# doesn't crash us
-$autotest::isotovideo = 'foo';
 like warning { autotest::run_all }, qr/ERROR: no tests loaded/, 'run_all outputs status on stderr';
 ($died, $completed) = get_tests_done;
 is($died, 1, 'run_all with no tests should catch runalltests dying');

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -169,7 +169,12 @@ subtest 'test always_rollback flag' => sub {
         $mock_autotest->redefine(query_isotovideo => 0);
         stderr_like { autotest::run_all } qr/.*stopping overall test execution because snapshotting is disabled.*/, 'reason logged (snapshotting not available';
         @sent = ();
+
+        $bmwqemu::vars{TESTDEBUG} = 1;
+        stderr_like { autotest::run_all } qr/.*stopping overall test execution because TESTDEBUG has been set.*/, 'reason logged (TESTDEBUG)';
+        @sent = ();
     };
+    delete $bmwqemu::vars{TESTDEBUG};
     $mock_basetest->unmock($_) for qw(runtest test_flags);
     $mock_autotest->unmock($_) for qw(load_snapshot make_snapshot query_isotovideo);
 };


### PR DESCRIPTION
This should make the behavior more obvious (which can otherwise not be
obvious at all, see https://progress.opensuse.org/issues/102539).

Note that the behavior is generally intended, see 9d81cdb8e. It is also
documented, see openQA commit 712f2db38f.