### PR TITLE
Avoid running into TBB's soft limit for the max. number of threads

### DIFF
--- a/ppmclibs/tinycv.h
+++ b/ppmclibs/tinycv.h
@@ -6,6 +6,7 @@
 
 // opaque type to separate perl from opencv
 struct Image;
+int opencv_default_thread_count();
 void create_opencv_threads(int thread_count);
 void image_destroy(Image *s);
 Image *image_new(long width, long height);

--- a/ppmclibs/tinycv.xs
+++ b/ppmclibs/tinycv.xs
@@ -63,6 +63,13 @@ CODE:
 OUTPUT:
        RETVAL
 
+int
+default_thread_count()
+CODE:
+        RETVAL = opencv_default_thread_count();
+OUTPUT:
+        RETVAL
+
 void
 create_threads(int thread_count = -1)
 CODE:


### PR DESCRIPTION
When executing the signalblocker test in Factory builds (which use
`libtbb12-2021.4.0`) we currently see the warning
    
```
TBB Warning: The number of workers is currently limited to 5. The request for 7 workers is ignored. Further requests for more workers will be silently ignored until the limit changes.
```
    
and the test deadlocks.
    
This change should avoid it by staying below this limit.
    
See https://progress.opensuse.org/issues/103029