### PR TITLE
Fix working directory for generating HTML coverage report

### DIFF
--- a/cmake/test-targets.cmake
+++ b/cmake/test-targets.cmake
@@ -128,6 +128,7 @@ if (COVER_PATH AND PROVE_PATH)
         COMMAND "${COVER_PATH}" -report html_basic "${CMAKE_CURRENT_BINARY_DIR}/cover_db"
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/cover_db"
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/coverage.html"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
     add_custom_target(
         coverage-reset


### PR DESCRIPTION
Otherwise one gets errors like:
```
Devel::Cover: Warning: can't open basetest.pm for MD5 digest: No such file or directory
```

This is in accordance with 328ce0117d.