### PR TITLE
Show process (name[pid]) and UTC time in autoinst-log.txt

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -19,6 +19,7 @@ use Mojo::Log;
 use Mojo::File qw(path);
 use Time::Moment;
 use Term::ANSIColor;
+use File::Basename;
 
 use Exporter 'import';
 
@@ -180,7 +181,10 @@ sub log_format_callback {
     # ensure indentation for multi-line output
     $lines =~ s/(?<!\A)^/  /gm;
 
-    return '[' . Time::Moment->now . "] [$level] " . $lines;
+    my $idx = index($0, ': ');
+    my $proc = sprintf('%.10s[%d]', $idx != -1 ? substr($0, $idx + 2) : basename($0), $$);
+
+    return '[' . Time::Moment->now . "] $proc [$level] " . $lines;
 }
 
 sub diag {

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -184,7 +184,9 @@ sub log_format_callback {
     my $idx = index($0, ': ');
     my $proc = sprintf('%.10s[%d]', $idx != -1 ? substr($0, $idx + 2) : basename($0), $$);
 
-    return '[' . Time::Moment->now . "] $proc [$level] " . $lines;
+    return sprintf('%s %s [%s] %s',
+        Time::Moment->now_utc()->with_precision(3)->to_string(),
+        $proc, $level, $lines);
 }
 
 sub diag {

--- a/commands.pm
+++ b/commands.pm
@@ -285,15 +285,8 @@ sub run_daemon {
     }
     my $daemon = Mojo::Server::Daemon->new(app => app, listen => ["http://$address:$port"]);
     $daemon->silent;
-    # We need to override the default logging format
-    app->log->format(
-        sub {
-            my ($time, $level, @lines) = @_;
-            # Unfortunately $time doesn't have the precision we want. So we need to use Time::HiRes
-            $time = gettimeofday;
-            return sprintf(strftime("[%FT%T.%%03d %Z] [$level] ", localtime($time)), 1000 * ($time - int($time))) . join("\n", @lines, '');
-        });
-
+    # Use same log format as isotovideo
+    app->log->format(\&bmwqemu::log_format_callback);
     # process json messages from isotovideo
     Mojo::IOLoop->singleton->reactor->io($isotovideo => sub {
             my ($reactor, $writable) = @_;


### PR DESCRIPTION
This change the format of a log message from
```
[2021-11-25T09:42:21.088750+01:00] [debug] usingenv VIDEOMODE=text
[2021-11-25T14:06:38.778898+01:00] [debug] <<< testapi::type_string(text="export TERM=dumb; stty cols 2048; exec \$SHELL", lf=1)
[2021-11-25T14:06:38.779326+01:00] [debug] <<< consoles::serial_screen::type_string(json_cmd_token="HdanpIST", text="export TERM=dumb; stty cols 2048; exec \$SHELL\n", cmd="backend_type_string", lf=1)
```
to 
```
2021-11-25T13:17:45.792Z isotovideo[25043] [debug] usingenv VIDEOMODE=text
2021-11-25T13:18:27.453Z autotest[25066] [debug] <<< testapi::type_string(text="export TERM=dumb; stty cols 2048; exec \$SHELL", lf=1)
2021-11-25T13:18:27.453Z backend[25082] [debug] <<< consoles::serial_screen::type_string(cmd="backend_type_string", json_cmd_token="ZIqGcTSu", text="export TERM=dumb; stty cols 2048; exec \$SHELL\n", lf=1)
```

The disadvantage with the time change https://github.com/os-autoinst/os-autoinst/commit/369d6ed90cdb013ecae35be1ad0eb02716989241 is, that the worker also write into autoinst-log.txt, thus we have now two different styles at the beginning. 