### PR TITLE
Update deprecated 'short-form boolean' qemu args

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -895,7 +895,7 @@ sub start_qemu ($self) {
         }
 
         my $qmpid = 'qmp_socket';
-        sp('chardev', [qv "socket path=$qmpid server nowait id=$qmpid logfile=$qmpid.log logappend=on"]);
+        sp('chardev', [qv "socket path=$qmpid server=on wait=off id=$qmpid logfile=$qmpid.log logappend=on"]);
         sp('qmp', "chardev:$qmpid");
         sp('S');
     }


### PR DESCRIPTION
Running a qemu job on qemu 6.1.0 logs these warnings:

warning: short-form boolean option 'server' deprecated
QEMU: Please use server=on instead
warning: short-form boolean option 'nowait' deprecated
QEMU: Please use wait=off instead

So, this makes the recommended changes.

Signed-off-by: Adam Williamson <awilliam@redhat.com>