### PR TITLE
loadtest: Retain original test path in error messages

### DIFF
--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -22,7 +22,7 @@ $bmwqemu::vars{CASEDIR} = File::Basename::dirname($0) . '/fake';
 
 like(exception { autotest::runalltests }, qr/ERROR: no tests loaded/, 'runalltests needs tests loaded first');
 like warning {
-    like(exception { autotest::loadtest 'does/not/match' }, qr/loadtest.*does not match required pattern/,
+    like(exception { autotest::loadtest 'does/not/match' }, qr@loadtest.+'does/not/match'.*does not match required pattern@,
         'loadtest catches incorrect test script paths')
 },
   qr/loadtest needs a script below.*is not/,

--- a/t/20-openqa-isotovideo-utils.t
+++ b/t/20-openqa-isotovideo-utils.t
@@ -43,7 +43,7 @@ subtest 'error handling when loading test schedule' => sub {
         my $state = decode_json($base_state->slurp);
         if (is(ref $state, 'HASH', 'state file contains object')) {
             is($state->{component}, 'tests', 'state file contains component');
-            like($state->{msg}, qr/unable to load foo\/bar\.pm/, 'state file contains error message');
+            like($state->{msg}, qr@unable to load foo/bar,@, 'state file contains error message');
         }
     };
     subtest 'invalid productdir' => sub {


### PR DESCRIPTION
The error handling refers to different paths than what was specified:

    SCHEDULE=console/rust
    tests died: unable to load console/rust.pm, check the log for the cause (e.g. syntax error)

    SCHEDULE=rust
    isotovideo died: loadtest: script path '../rust.pm' does not match required pattern \w.+/[^/]+.p[my]

XXX: No fix yet, I'm documenting the cases and adding unit tests first.