### PR TITLE
Fix sporadic error in t/10-virtio_terminal.t

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -172,8 +172,7 @@ sed  -i 's/ my $thisversion = qx{git.*rev-parse HEAD}.*;/ my $thisversion = "%{v
 # and exclude known flaky tests in OBS check
 # https://progress.opensuse.org/issues/52652
 # 07-commands: https://progress.opensuse.org/issues/60755
-# 10-virtio_terminal: https://progress.opensuse.org/issues/94991
-for i in 07-commands 10-virtio_terminal 13-osutils 14-isotovideo 18-qemu-options 18-backend-qemu 99-full-stack; do
+for i in 07-commands 13-osutils 14-isotovideo 18-qemu-options 18-backend-qemu 99-full-stack; do
     rm t/$i.t
 done
 


### PR DESCRIPTION
I wasn't able to reproce the problem, but this is what I guess.
We call `$console->peak()` before we wrote the data into the other side of
the pipe.
Now we use USR2 signal to sync between "sender" and "receiver".
Also calling `flush()` explicit, so we ensure data is not buffered by
perl.

Ticked: https://progress.opensuse.org/issues/94991
Issue: https://github.com/os-autoinst/os-autoinst/issues/1686