### PR TITLE
Add execution time for failed test modules

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -4,7 +4,7 @@
 
 package basetest;
 
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 use autodie ':all';
 
 use bmwqemu ();
@@ -338,8 +338,7 @@ sub run_post_fail {
 
 sub execution_time { time - shift }
 
-sub compute_test_execution_time {
-    my ($self) = @_;
+sub compute_test_execution_time ($self) {
     # Set the execution time for a general time spent
     $self->{execution_time} = execution_time($self->{test_start_time});
     bmwqemu::diag(sprintf("||| finished %s %s (runtime: %d s)", $self->{name}, $self->{category}, $self->{execution_time}));

--- a/basetest.pm
+++ b/basetest.pm
@@ -46,6 +46,7 @@ sub new {
     $self->{autoinst_failures} = [];
     $self->{fatal_failure} = 0;
     $self->{execution_time} = 0;
+    $self->{test_start_time} = 0;
     return bless $self, $class;
 }
 
@@ -315,6 +316,8 @@ sub post_run_hook {
 
 sub run_post_fail {
     my ($self, $msg) = @_;
+    my $post_fail_hook_start_time = time;
+
     unless ($bmwqemu::vars{_SKIP_POST_FAIL_HOOKS}) {
         $self->{post_fail_hook_running} = 1;
         eval { $self->post_fail_hook; };
@@ -325,15 +328,26 @@ sub run_post_fail {
         # Read them now to not stumble upon them in the next module.
         $self->get_new_serial_output();
     }
+
     $self->fail_if_running();
+    $self->compute_test_execution_time();
+    my $post_fail_hook_execution_time = execution_time($post_fail_hook_start_time);
+    bmwqemu::diag(sprintf("||| post fail hooks runtime: %d s", $post_fail_hook_execution_time));
     die $msg . "\n";
 }
 
 sub execution_time { time - shift }
 
+sub compute_test_execution_time {
+    my ($self) = @_;
+    # Set the execution time for a general time spent
+    $self->{execution_time} = execution_time($self->{test_start_time});
+    bmwqemu::diag(sprintf("||| finished %s %s (runtime: %d s)", $self->{name}, $self->{category}, $self->{execution_time}));
+}
+
 sub runtest {
     my ($self) = @_;
-    my $starttime = time;
+    $self->{test_start_time} = time;
 
     my $died;
     my $name = $self->{name};
@@ -382,9 +396,8 @@ sub runtest {
         $self->run_post_fail("test $name failed");
     }
 
+    $self->compute_test_execution_time();
     $self->done();
-    $self->{execution_time} = execution_time($starttime);
-    bmwqemu::diag(sprintf("||| finished %s %s (runtime: %d s)", $name, $self->{category}, $self->{execution_time}));
     return;
 }
 

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -63,6 +63,9 @@ subtest run_post_fail_test => sub {
             execute_time => 42,
     }, $basetest_class);
     combined_like { dies_ok { $basetest->runtest } 'run_post_fail end up with die' } qr/Test died/, 'test died';
+    combined_like { dies_ok { $basetest->runtest } 'post fail hooks runtime' } qr/post fail hooks runtime:/,
+      'Post fail hooks runtime present';
+
     $bmwqemu::vars{_SKIP_POST_FAIL_HOOKS} = 1;
     combined_like { dies_ok { $basetest->runtest } 'behavior persists regardless of _SKIP_POST_FAIL_HOOKS setting' }
     qr/Test died/, 'test died';


### PR DESCRIPTION
Currently when a test fails, we don't know how long did it take, or how long did the post fail hooks took, unless we look at the timestamps on the logs, displaying total execution fixes the first problem and printing a message in the logs for the post fail hooks, fixes the second.

VR: http://phobos.qa.suse.de/tests/3857623

```
[2021-12-02T18:15:47.191256+01:00] [debug] ||| finished gpg console (runtime: 527 s)
[2021-12-02T18:15:47.191297+01:00] [debug] ||| post fail hooks runtime: 474 s
```