### PR TITLE
ci: Fix exit code of OpenQA::Test::CheckGitStatus

### DIFF
--- a/t/lib/OpenQA/Test/CheckGitStatus.pm
+++ b/t/lib/OpenQA/Test/CheckGitStatus.pm
@@ -16,6 +16,7 @@ if ($CHECK_GIT_STATUS) {
 }
 
 sub check_status {
+    local $?;
     chdir $cwd;
     my $git = File::Which::which('git');
     return unless $git;


### PR DESCRIPTION
Test failures haven't been recognized as such since
https://github.com/perlpunk/os-autoinst/commit/9ef54a85a901a3a2340da53a8d0699de782322a3

When getting to the END block, the exit code is already set.
Making system calls inside it will reset $?, so we localize it.

Issue: https://progress.opensuse.org/issues/103422

I tested it by adding a dummy `fail()` to 13-os-utils.t