### PR TITLE
ci: Fix OpenQA::Test::CheckGitStatus exit status

### DIFF
--- a/t/lib/OpenQA/Test/CheckGitStatus.pm
+++ b/t/lib/OpenQA/Test/CheckGitStatus.pm
@@ -16,19 +16,22 @@ if ($CHECK_GIT_STATUS) {
 }
 
 sub check_status {
-    local $?;
-    chdir $cwd;
-    my $git = File::Which::which('git');
-    return unless $git;
-    my $cmd = 'git rev-parse --git-dir';
-    my $out = qx{$cmd};
-    return if $? != 0;
-    $cmd = 'git status --porcelain=v1 2>&1';
-    my @lines = qx{$cmd};
-    die "Problem running git:\n" . join '', @lines if $? != 0;
+    my @lines;
+    {
+        local $?;
+        chdir $cwd;
+        my $git = File::Which::which('git');
+        return unless $git;
+        my $cmd = 'git rev-parse --git-dir';
+        my $out = qx{$cmd};
+        return if $? != 0;
+        $cmd = 'git status --porcelain=v1 2>&1';
+        @lines = qx{$cmd};
+        die "Problem running git:\n" . join '', @lines if $? != 0;
+    }
     if (@lines > 0) {
         Test::More::diag("Error: modified or untracked files\n" . join '', @lines);
-        exit 1;
+        $? = 1;
     }
 }
 


### PR DESCRIPTION
In the previous commit #1873  the `exit 1` was happening when $? was localized,
so the actual purpose of the module wasn't working anymore.

Now we just set the value of $?, I think that's the right way to do it.

Issue: https://progress.opensuse.org/issues/103422