### PR TITLE
Streamline the use of "|||" log marker with new "modstate" function

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -361,7 +361,7 @@ sub runalltests {
         }
 
         my $name = $t->{name};
-        bmwqemu::modstart "starting $name $t->{script}";
+        bmwqemu::modstate "starting $name $t->{script}";
         $t->start();
 
         # avoid erasing the good vm snapshot

--- a/basetest.pm
+++ b/basetest.pm
@@ -332,7 +332,7 @@ sub run_post_fail {
     $self->fail_if_running();
     $self->compute_test_execution_time();
     my $post_fail_hook_execution_time = execution_time($post_fail_hook_start_time);
-    bmwqemu::diag(sprintf("||| post fail hooks runtime: %d s", $post_fail_hook_execution_time));
+    bmwqemu::modstate("post fail hooks runtime: $post_fail_hook_execution_time s");
     die $msg . "\n";
 }
 
@@ -341,7 +341,7 @@ sub execution_time { time - shift }
 sub compute_test_execution_time ($self) {
     # Set the execution time for a general time spent
     $self->{execution_time} = execution_time($self->{test_start_time});
-    bmwqemu::diag(sprintf("||| finished %s %s (runtime: %d s)", $self->{name}, $self->{category}, $self->{execution_time}));
+    bmwqemu::modstate(sprintf("finished %s %s (runtime: %d s)", $self->{name}, $self->{category}, $self->{execution_time}));
 }
 
 sub runtest {

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -23,7 +23,7 @@ use Term::ANSIColor;
 use Exporter 'import';
 
 our $VERSION;
-our @EXPORT_OK = qw(diag fctres fctinfo fctwarn modstart save_vars);
+our @EXPORT_OK = qw(diag fctres fctinfo fctwarn modstate save_vars);
 
 use backend::driver;
 require IPC::System::Simple;
@@ -218,7 +218,7 @@ sub fctwarn {
     return;
 }
 
-sub modstart {
+sub modstate {
     logger->append(color('bold blue'));
     logger->debug("||| @{[join(' ', @_)]}")->append(color('reset'));
     return;

--- a/t/15-logging.t
+++ b/t/15-logging.t
@@ -20,7 +20,7 @@ sub output_once {
     bmwqemu::fctres('Via fctres function');
     bmwqemu::fctinfo('Via fctinfo function');
     bmwqemu::fctwarn('Via fctwarn function');
-    bmwqemu::modstart('Via modstart function');
+    bmwqemu::modstate('Via modstate function');
 }
 
 subtest 'Logging to STDERR' => sub {
@@ -29,7 +29,7 @@ subtest 'Logging to STDERR' => sub {
     my @matches = ($output =~ m/Via .*? function/gm);
     ok(@matches == 5, 'All messages logged to STDERR');
     my $i = 0;
-    ok($matches[$i++] =~ /$_/, "Logging $_ match!") for ('diag', 'fctres', 'fctinfo', 'fctwarn', 'modstart');
+    ok($matches[$i++] =~ /$_/, "Logging $_ match!") for ('diag', 'fctres', 'fctinfo', 'fctwarn', 'modstate');
 };
 
 subtest 'Logging to file' => sub {
@@ -39,7 +39,7 @@ subtest 'Logging to file' => sub {
     my @matches = (Mojo::File->new($log_file)->slurp =~ m/Via .*? function/gm);
     ok(@matches == 5, 'All messages logged to file');
     my $i = 0;
-    ok($matches[$i++] =~ /$_/, "Logging $_ match!") for ('diag', 'fctres', 'fctinfo', 'fctwarn', 'modstart');
+    ok($matches[$i++] =~ /$_/, "Logging $_ match!") for ('diag', 'fctres', 'fctinfo', 'fctwarn', 'modstate');
 };
 
 done_testing;


### PR DESCRIPTION
Previously we had a function "modstart" which was used only once to log
the start of a test module execution. A similar output but using custom
diag+sprintf was done at the end of a test module so the output looks
like

```
[2021-12-03T14:36:20.474509+01:00] [debug] ||| finished bootloader installation (runtime: 88 s)
[2021-12-03T14:36:20.475852+01:00] [debug] ||| starting rcshell_start tests/microos/rcshell_start.pm
```

of two consecutive test module lines but the second printed in bold and
blue font (not visible here).

This commit renames the "modstart" function with a more generic name
"modstate" and uses that in both above mentioned cases.

d5eb3309 motivated me to do this.