### PR TITLE
t: Prevent unnecessary diag output in 28-signalblocker.t

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -203,6 +203,9 @@ export CI=1
 # account for sporadic slowness in build environments
 # https://progress.opensuse.org/issues/89059
 export OPENQA_TEST_TIMEOUT_SCALE_CI=20
+# Enable verbose test output as we can not store test artifacts within package
+# build environments in case of needing to investigate failures
+export PROVE_ARGS="--timer -v"
 cd %{__builddir}
 %cmake_build check-pkg-build
 

--- a/t/28-signalblocker.t
+++ b/t/28-signalblocker.t
@@ -48,7 +48,7 @@ $SIG{CHLD} = sub { $received_sigchld += 1; note "received SIGCHLD $received_sigc
     # make the number of threads to spawn configurable
     my $thread_count = tinycv::default_thread_count();
     my $thread_count_for_testing = $ENV{OS_AUTOINST_TEST_THREAD_COUNT} || $thread_count;
-    diag "threads used: $thread_count_for_testing of $thread_count";
+    note "threads used: $thread_count_for_testing of $thread_count";
 
     tinycv::create_threads($thread_count_for_testing);
     $last_thread_count = thread_count;

--- a/tools/invoke-tests
+++ b/tools/invoke-tests
@@ -55,8 +55,10 @@ export OS_AUTOINST_MAKE_TOOL=$make_path
 if [[ $TESTS = *[!\ ]* ]]; then
     # split TESTS on white-spaces to allow specifying multiple tests as documented
     # shellcheck disable=SC2086
-    "$prove_path" "$PROVE_ARGS" $TESTS
+    "$prove_path" $PROVE_ARGS $TESTS
 else
-    cd t && "$prove_path" "$PROVE_ARGS" -r
-    cd ../xt && "$prove_path" "$PROVE_ARGS" -r
+    # shellcheck disable=SC2086
+    cd t && "$prove_path" $PROVE_ARGS -r
+    # shellcheck disable=SC2086
+    cd ../xt && "$prove_path" $PROVE_ARGS -r
 fi


### PR DESCRIPTION
8363ce36 introduced a change with a "diag" for something that is just
informative and not an error and hence should not be output in normal
terse test output.