### PR TITLE
mergify: Add more useful checks

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,11 +6,11 @@ pull_request_rules:
         - -label~=^acceptance-tests-needed|not-ready
         # wait explicitly for one of the final checks to show up to be on the
         # safe side even in case of checks not reporting back at all
-        - "status-success=codecov/project"
-        - "status-success=codecov/patch"
+        - "check-success=codecov/project"
+        - "check-success=codecov/patch"
         # wait for OBS package build as well which is triggered independantly
         # See https://progress.opensuse.org/issues/55346 for details
-        - "status-success=OBS Package Build"
+        - "check-success=OBS Package Build"
       - and:
         - "#approved-reviews-by>=2"
         - "#changes-requested-reviews-by=0"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,33 +1,33 @@
 pull_request_rules:
   - name: automatic merge
     conditions:
-      - "#approved-reviews-by>=2"
-      - "#changes-requested-reviews-by=0"
-      # https://doc.mergify.io/examples.html#require-all-requested-reviews-to-be-approved
-      - "#review-requested=0"
-      - -label~=^acceptance-tests-needed|not-ready
-      - base=master
-      # wait explicitly for one of the final checks to show up to be on the
-      # safe side even in case of checks not reporting back at all
-      - "status-success=codecov/project"
-      - "status-success=codecov/patch"
-      # wait for OBS package build as well which is triggered independantly
-      # See https://progress.opensuse.org/issues/55346 for details
-      - "status-success=OBS Package Build"
-    actions:
+      - and: &base_checks
+        - base=master
+        - -label~=^acceptance-tests-needed|not-ready
+        # wait explicitly for one of the final checks to show up to be on the
+        # safe side even in case of checks not reporting back at all
+        - "status-success=codecov/project"
+        - "status-success=codecov/patch"
+        # wait for OBS package build as well which is triggered independantly
+        # See https://progress.opensuse.org/issues/55346 for details
+        - "status-success=OBS Package Build"
+      - and:
+        - "#approved-reviews-by>=2"
+        - "#changes-requested-reviews-by=0"
+        # https://doc.mergify.io/examples.html#require-all-requested-reviews-to-be-approved
+        - "#review-requested=0"
+    actions: &merge
       merge:
         method: merge
   - name: automatic merge on special label
     conditions:
-      - -label~=^acceptance-tests-needed|not-ready
-      - "label=merge-fast"
-      - base=master
-      - "status-success=OBS Package Build"
-      - "status-success=codecov/project"
-      - "status-success=codecov/patch"
-    actions:
-      merge:
-        method: merge
+      - and: *base_checks
+      - and:
+        # mergify config checks needs at least two rules in "and" so we repeat
+        # one from the base checks
+        - base=master
+        - "label=merge-fast"
+    actions: *merge
   - name: ask to resolve conflict
     conditions:
       - conflict

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,6 +11,9 @@ pull_request_rules:
         # wait for OBS package build as well which is triggered independantly
         # See https://progress.opensuse.org/issues/55346 for details
         - "check-success=OBS Package Build"
+        - "#check-failure=0"
+        - "#check-pending=0"
+        - linear-history
       - and:
         - "#approved-reviews-by>=2"
         - "#changes-requested-reviews-by=0"


### PR DESCRIPTION
While we still need to check explicitly for the success of checks (see
https://docs.mergify.com/conditions/#validating-all-status-checks) we
can specify to additionally not merge on any failures or pending checks.
This should cover any potential new checks which we introduce but not
mention in the mergify config explicitly.