### PR TITLE
mergify: Rely on more reviewers

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,7 @@
 pull_request_rules:
   - name: automatic merge
     conditions:
-      - "#approved-reviews-by>=1"
+      - "#approved-reviews-by>=2"
       - "#changes-requested-reviews-by=0"
       # https://doc.mergify.io/examples.html#require-all-requested-reviews-to-be-approved
       - "#review-requested=0"


### PR DESCRIPTION
We currently have more active contributors and reviewers so we should be
fine to only merge when there are at least two approved reviews.