### PR TITLE
Add hardware console log to IPMI and PowerVM backends

### DIFF
--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -93,7 +93,11 @@ sub do_start_vm ($self, @) {
     $self->get_mc_status;
     $self->restart_host unless $bmwqemu::vars{IPMI_DO_NOT_RESTART_HOST};
     $self->truncate_serial_file;
-    my $sol = $testapi::distri->add_console('sol', 'ipmi-xterm', {persistent => $bmwqemu::vars{IPMI_SOL_PERSISTENT_CONSOLE} // 1});
+    my $sol = $testapi::distri->add_console(
+        'sol', 'ipmi-xterm',
+        {
+            persistent => $bmwqemu::vars{IPMI_SOL_PERSISTENT_CONSOLE} // 1,
+            log => $bmwqemu::vars{HARDWARE_CONSOLE_LOG} // 0});
     $sol->backend($self);
     return {};
 }

--- a/backend/pvm_hmc.pm
+++ b/backend/pvm_hmc.pm
@@ -32,7 +32,8 @@ sub do_start_vm ($self, @) {
             hostname => get_required_var('HMC_HOSTNAME'),
             password => get_required_var('HMC_PASSWORD'),
             username => get_var('HMC_USERNAME', 'hscroot'),
-            persistent => 1});
+            persistent => 1,
+            log => $bmwqemu::vars{HARDWARE_CONSOLE_LOG} // 0});
     $ssh->backend($self);
 
     return {};

--- a/backend/spvm.pm
+++ b/backend/spvm.pm
@@ -30,7 +30,8 @@ sub do_start_vm ($self, @) {
             hostname => $bmwqemu::vars{NOVALINK_HOSTNAME},
             password => $bmwqemu::vars{NOVALINK_PASSWORD},
             username => $bmwqemu::vars{NOVALINK_USERNAME} // 'root',
-            persistent => 1});
+            persistent => 1,
+            log => $bmwqemu::vars{HARDWARE_CONSOLE_LOG} // 0});
     $ssh->backend($self);
 
     return {};

--- a/consoles/localXvnc.pm
+++ b/consoles/localXvnc.pm
@@ -12,6 +12,7 @@ use base 'consoles::vnc_base';
 use IPC::Run ();
 require IPC::System::Simple;
 use Socket;
+use File::Path 'mkpath';
 use File::Which;
 use Time::Seconds;
 use testapi qw(get_var);
@@ -38,6 +39,10 @@ sub callxterm ($self, $command, $window_name) {
     die('Missing "Xvnc"') unless which('Xvnc');
     die('Missing "icewm"') unless which('icewm');
     die('Missing "xterm"') unless which('xterm');
+    if ($self->{args}->{log}) {
+        mkpath 'ulogs';
+        $command = "script -f ulogs/hardware-console-log.txt -c \"$command\"";
+    }
     eval { system("DISPLAY=$display $xterm_vt_cmd -title $window_name -e bash -c '$command' & echo \"xterm PID is \$!\""); };
     die "cant' start xterm on $display (err: $! retval: $?)" if $@;
 }

--- a/container/os-autoinst_dev/Dockerfile
+++ b/container/os-autoinst_dev/Dockerfile
@@ -26,6 +26,7 @@ RUN zypper in -y -C \
        cpio \
        gcc-c++ \
        git-core \
+       icewm \
        ninja \
        perl-base \
        pkg-config \
@@ -38,6 +39,9 @@ RUN zypper in -y -C \
        qemu-x86 \
        sudo \
        which \
+       xorg-x11-Xvnc \
+       xterm \
+       xterm-console \
        'perl(B::Deparse)' \
        'perl(Benchmark)' \
        'perl(Carp)' \

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -89,6 +89,10 @@ test_base_requires:
   qemu-x86:
   procps:
   python3-setuptools:
+  xterm-console:
+  xorg-x11-Xvnc:
+  icewm:
+  xterm:
 
 test_version_only_requires:
   perl(Mojo::IOLoop::ReadWriteProcess): '>= 0.28'

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -74,7 +74,7 @@ Source0:        %{name}-%{version}.tar.xz
 %define python_style_requires %{nil}
 %endif
 # The following line is generated from dependencies.yaml
-%define test_base_requires %main_requires cpio perl(Benchmark) perl(Devel::Cover) perl(FindBin) perl(Pod::Coverage) perl(Test::Fatal) perl(Test::Mock::Time) perl(Test::MockModule) perl(Test::MockObject) perl(Test::MockRandom) perl(Test::Mojo) perl(Test::Most) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 procps python3-setuptools qemu >= 4.0 qemu-tools qemu-x86
+%define test_base_requires %main_requires cpio icewm perl(Benchmark) perl(Devel::Cover) perl(FindBin) perl(Pod::Coverage) perl(Test::Fatal) perl(Test::Mock::Time) perl(Test::MockModule) perl(Test::MockObject) perl(Test::MockRandom) perl(Test::Mojo) perl(Test::Most) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 procps python3-setuptools qemu >= 4.0 qemu-tools qemu-x86 xorg-x11-Xvnc xterm xterm-console
 # The following line is generated from dependencies.yaml
 %define test_version_only_requires perl(Mojo::IOLoop::ReadWriteProcess) >= 0.28
 # The following line is generated from dependencies.yaml

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -56,6 +56,7 @@ _SSH_SERVER_ALIVE_INTERVAL;integer;60;Sets a timeout interval in seconds after w
 [options="header",cols="^m,^m,^m,v",separator=";"]
 |====================
 Variable;Values allowed;Default value;Explanation
+HARDWARE_CONSOLE_LOG;boolean;undef;Enable direct log capture of sol console, disabled by default
 IPMI_HOSTNAME;string;undef;Hostname/IP for IPMI interface
 IPMI_PASSWORD;string;undef;Password for the IPMI interface
 IPMI_USER;string;undef;Username for the IPMI interface
@@ -254,6 +255,7 @@ WORKER_ID;string;undef;osauto id
 [options="header",cols="^m,^m,^m,v",separator=";"]
 |====================
 Variable;Values allowed;Default value;Explanation
+HARDWARE_CONSOLE_LOG;boolean;undef;Enable direct log capture of mkvterm console, disabled by default
 HMC_USERNAME;string;;Username for HMC
 |====================
 
@@ -296,6 +298,7 @@ WORKER_HOSTNAME;string;undef;Worker host name
 [options="header",cols="^m,^m,^m,v",separator=";"]
 |====================
 Variable;Values allowed;Default value;Explanation
+HARDWARE_CONSOLE_LOG;boolean;undef;Enable direct log capture of mkvterm console, disabled by default
 WORKER_HOSTNAME;string;undef;Worker host name
 NOVALINK_HOSTNAME;string;undef;Novalink target host to connect to
 NOVALINK_USERNAME;string;root;Username to authenticate on Novalink host


### PR DESCRIPTION
Enhancement poo#103903: IPMI and PowerVM backends miss log from system
boot/shutdown or kernel crash. This feature enables direct capture of
ipmi/mkvterm sessions on IPMI and PowerVM backends. It is disabled by
default, managed by variable HARDWARE_CONSOLE_LOG. New log file is
hardware-console-log.txt.

Progress: https://progress.opensuse.org/issues/103903
Needles: none

Verification:
ipmi: http://10.100.12.105/tests/1536/logfile?filename=hardware-console-log.txt
spvm: http://10.100.12.105/tests/1530/logfile?filename=hardware-console-log.txt
hmc: http://10.100.12.105/tests/1537/logfile?filename=hardware-console-log.txt
