### PR TITLE
tools: Properly call tests from root dir

### DIFF
--- a/cmake/test-targets.cmake
+++ b/cmake/test-targets.cmake
@@ -84,7 +84,6 @@ if (PROVE_PATH)
     add_test(
         NAME test-perl-testsuite
         COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tools/invoke-tests" ${INVOKE_TEST_ARGS}
-        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
 else ()
     message(STATUS "Set PROVE_PATH to the path of the prove executable to enable running the Perl testsuite.")
@@ -114,11 +113,10 @@ if (COVER_PATH AND PROVE_PATH)
         COMMENT "Run Perl testsuite with coverage instrumentation if no coverage data has been collected so far"
         COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tools/invoke-tests" --coverage --skip-if-cover-db-exists ${INVOKE_TEST_ARGS}
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cover_db"
-        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
     add_custom_command(
         COMMENT "Generate coverage report (HTML)"
-        COMMAND "${COVER_PATH}" -report html_basic "${CMAKE_CURRENT_BINARY_DIR}/cover_db"
+        COMMAND "${COVER_PATH}" -report html "${CMAKE_CURRENT_BINARY_DIR}/cover_db"
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/cover_db"
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/coverage.html"
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
@@ -139,6 +137,7 @@ if (COVER_PATH AND PROVE_PATH)
         COMMENT "Perl test suite coverage (codecov, if direct report uploading possible, e.g. within travis CI)"
         COMMAND "${COVER_PATH}" -report codecov "${CMAKE_CURRENT_BINARY_DIR}/cover_db"
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/cover_db"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
     add_dependencies(coverage-codecov symlinks)
     add_custom_target(

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -26,6 +26,14 @@ my $pool_dir = "$dir/pool";
 chdir $dir;
 my $cleanup = scope_guard sub { chdir $Bin; undef $dir };
 mkdir $pool_dir;
+# TODO if we stay in the root dir of os-autoinst coverage will not
+# output files with absolute paths but keep using relative paths
+# of course with exception of the subtest that gets the version number where
+# we change to the root dir /
+# I think this means that any chdir in tests is harmful, also see
+# https://stackoverflow.com/a/22733744
+#$pool_dir = $toplevel_dir;
+#chdir $toplevel_dir;
 
 sub isotovideo (%args) {
     $args{default_opts} //= 'backend=null';

--- a/tools/invoke-tests
+++ b/tools/invoke-tests
@@ -42,7 +42,17 @@ db="$build_directory/cover_db"
 # set Perl module include path and coverage options
 export PERL5LIB="$source_directory:$source_directory/ppmclibs/blib/lib:$source_directory/ppmclibs/blib/arch/auto/tinycv:$PERL5LIB"
 if [[ $WITH_COVER_OPTIONS ]]; then
-    select="-ignore,^/|^external/|/tmp|CheckGitStatus.pm"
+    # As described on
+    # https://stackoverflow.com/a/22733744
+    # whenever you put coverage into a coverage DB you should ensure that you
+    # are doing it from the same directory, so that Devel::Cover can match and
+    # locate the files in the coverage DB.
+    # Meaning that chdir in tests is harmful. We either try to run everything
+    # from the root source folder or everything from another folder,
+    # previously from within t/ but of course we could also run everything
+    # from the build folder or a temporary directory
+
+    select="-select,$source_directory,-ignore,^/|external|/tmp|/CheckGitStatus.pm"
     # add ' -MOpenQA::Test::PatchDeparse' for older OS versions to avoid warnings
     export PERL5OPT="-I$source_directory/t/lib -I$source_directory/external/os-autoinst-common/lib -MOpenQA::Test::CheckGitStatus -MDevel::Cover=-db,$db,-select,$select,-coverage,statement"
 fi

--- a/tools/invoke-tests
+++ b/tools/invoke-tests
@@ -43,7 +43,7 @@ db="$build_directory/cover_db"
 export PERL5LIB="$source_directory:$source_directory/ppmclibs/blib/lib:$source_directory/ppmclibs/blib/arch/auto/tinycv:$PERL5LIB"
 if [[ $WITH_COVER_OPTIONS ]]; then
     path_regex="^|$source_directory/|\\.\\./"
-    select="($path_regex)(OpenQA|backend|consoles|ppmclibs)/|($path_regex)isotovideo|($path_regex)[^/]+\.pm,-ignore,external/|/tmp|/CheckGitStatus.pm|$prove_path"
+    select="(OpenQA|backend|consoles|ppmclibs)/|isotovideo|[^/]+\.pm,-ignore,external/|/tmp|/CheckGitStatus.pm|$prove_path"
     # add ' -MOpenQA::Test::PatchDeparse' for older OS versions to avoid warnings
     export PERL5OPT="-I$source_directory/t/lib -I$source_directory/external/os-autoinst-common/lib -MOpenQA::Test::CheckGitStatus -MDevel::Cover=-db,$db,-select,$select,-coverage,statement"
 fi

--- a/tools/invoke-tests
+++ b/tools/invoke-tests
@@ -42,8 +42,7 @@ db="$build_directory/cover_db"
 # set Perl module include path and coverage options
 export PERL5LIB="$source_directory:$source_directory/ppmclibs/blib/lib:$source_directory/ppmclibs/blib/arch/auto/tinycv:$PERL5LIB"
 if [[ $WITH_COVER_OPTIONS ]]; then
-    path_regex="^|$source_directory/|\\.\\./"
-    select="(OpenQA|backend|consoles|ppmclibs)/|isotovideo|[^/]+\.pm,-ignore,external/|/tmp|/CheckGitStatus.pm|$prove_path"
+    select="-ignore,^/|^external/|/tmp|CheckGitStatus.pm"
     # add ' -MOpenQA::Test::PatchDeparse' for older OS versions to avoid warnings
     export PERL5OPT="-I$source_directory/t/lib -I$source_directory/external/os-autoinst-common/lib -MOpenQA::Test::CheckGitStatus -MDevel::Cover=-db,$db,-select,$select,-coverage,statement"
 fi


### PR DESCRIPTION
I think for a long time tests have been called from the t/ (or xt/)
directory because some tests relied on that but by now we should have
fixed all tests to be able to be called from the root folder of the
project (or any folder). With this change we call prove from the root
dir which should help us to get rid of some special workarounds as well
as allow to collect coverage information consistently from test code as
well.