### PR TITLE
Makefile: Fix initial call with test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
 # This is a convenience Makefile wrapping cmake calls
 # All targets should be defined in CMake
 
-build := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/build
+build := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))build
 .PHONY: all
 all: build/CMakeCache.txt
 	ninja -C ${build} symlinks
 
-.DEFAULT: build/CMakeCache.txt
+# empty default to ensure build dir is created when make called with arguments
+Makefile: ;
+%: build/CMakeCache.txt
 	ninja -C ${build} $@
 
 build/CMakeCache.txt:

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -175,6 +175,8 @@ sed  -i 's/ my $thisversion = qx{git.*rev-parse HEAD}.*;/ my $thisversion = "%{v
 for i in 07-commands 13-osutils 14-isotovideo 18-qemu-options 18-backend-qemu 99-full-stack; do
     rm t/$i.t
 done
+# Remove test relying on a git working copy
+rm xt/30-make.t
 
 %build
 %define __builder ninja

--- a/xt/30-make.t
+++ b/xt/30-make.t
@@ -1,0 +1,27 @@
+#!/usr/bin/env perl
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+use Test::Warnings ':report_warnings';
+use Test::Output 'stderr_like';
+use Mojo::File qw(path tempdir);
+use Mojo::Util 'scope_guard';
+use FindBin '$Bin';
+use lib "$Bin/../external/os-autoinst-common/lib";
+use OpenQA::Test::TimeLimit '20';
+
+my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
+my $srcdir = path("$Bin/..")->realpath;
+stderr_like { is qx{git -C $dir clone $srcdir os-autoinst}, '', 'prepare working copy with git' } qr/Cloning/, 'git clone';
+chdir "$dir/os-autoinst" or die "Failed to change directory to $dir/os-autoinst";
+my $cleanup = scope_guard sub { chdir $Bin; undef $dir };
+is $?, 0, 'prepare working copy with git (exit code)';
+like qx{make -n}, qr/ninja.*symlinks/, 'build default';
+is $?, 0, 'build default (exit code)';
+like qx{rm -rf build && make help}, qr/help: HELP/, 'call specific make target initially';
+chdir '..' or die 'Failed to change directory to ..';
+like qx{rm -rf os-autoinst/build && make -C os-autoinst help}, qr/help: HELP/, 'call make with target initially from outside';
+like qx{make -C os-autoinst help}, qr/help: HELP/, 'call make again with target from outside';
+like qx{make -C os-autoinst -n}, qr/ninja.*symlinks/, 'call make from outside without arguments';
+done_testing;


### PR DESCRIPTION
If the build directory does not yet exist but make is called with a
target initially then the previous default rule did not correctly ensure
that the CMake build directory is correctly initialized.

Tested with

```
rm -rf build/ && make coverage TESTS=t/03-testapi.t && make && rm -rf build && make && rm -rf os-autoinst/build/ && make -C os-autoinst coverage TESTS=t/03-testapi.t && make -C os-autoinst && rm -rf os-autoinst/build/ && make -C os-autoinst
```