### PR TITLE
Include "t/" in coverage analysis as well to prevent never called tests

### DIFF
--- a/tools/invoke-tests
+++ b/tools/invoke-tests
@@ -43,7 +43,7 @@ db="$build_directory/cover_db"
 export PERL5LIB="$source_directory:$source_directory/ppmclibs/blib/lib:$source_directory/ppmclibs/blib/arch/auto/tinycv:$PERL5LIB"
 if [[ $WITH_COVER_OPTIONS ]]; then
     path_regex="^|$source_directory/|\\.\\./"
-    select="($path_regex)(OpenQA|backend|consoles|ppmclibs)/|($path_regex)isotovideo|($path_regex)[^/]+\.pm,-ignore,external/|\.t|data/tests/|fake/tests/|/CheckGitStatus.pm|$prove_path"
+    select="($path_regex)(OpenQA|backend|consoles|ppmclibs)/|($path_regex)isotovideo|($path_regex)[^/]+\.pm,-ignore,external/|/CheckGitStatus.pm|$prove_path"
     # add ' -MOpenQA::Test::PatchDeparse' for older OS versions to avoid warnings
     export PERL5OPT="-I$source_directory/t/lib -I$source_directory/external/os-autoinst-common/lib -MOpenQA::Test::CheckGitStatus -MDevel::Cover=-db,$db,-select,$select,-coverage,statement"
 fi


### PR DESCRIPTION
Yet another try with including t/ in coverage analysis but not tinkering with the working directory due to how Devel::Cover tries to resolve paths, see https://github.com/os-autoinst/os-autoinst/pull/1536#issuecomment-996187939 why