### PR TITLE
WIP Fix for Devel::Cover

### DIFF
--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -308,9 +308,9 @@ subtest 'load test successfully when CASEDIR is a relative path' => sub {
 stderr_like { autotest::loadtest('tests/test.py') } qr{scheduling test tests/test.py}, 'can load python test module at all';
 loadtest 'test.py', 'we can also parse python test modules';
 
-stderr_like {
-    throws_ok { autotest::loadtest 'tests/faulty.py' } qr/py_eval raised an exception/, 'dies on Python exception';
-} qr/Traceback.*No module named.*thismoduleshouldnotexist.*/s, 'Python traceback logged';
+#stderr_like {
+#    throws_ok { autotest::loadtest 'tests/faulty.py' } qr/py_eval raised an exception/, 'dies on Python exception';
+#} qr/Traceback.*No module named.*thismoduleshouldnotexist.*/s, 'Python traceback logged';
 
 done_testing();
 


### PR DESCRIPTION
    eval $code;

is called several times, and $code is different in each case, and as a result, has different number of statements.

This leads to a coverage report which looks wrong, reporting many many
statements for that line.

Let's see how codecov numbers change in contrast to Devel::Cover numbers