### PR TITLE
dist: Fix missing package build for swtpm

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -257,6 +257,7 @@ cd %{__builddir}
 %ifarch x86_64
 %files qemu-kvm
 %files qemu-x86
+%files swtpm
 %endif
 %files s390-deps
 


### PR DESCRIPTION
AFAIR packages in OBS do not appear unless a files section is included.

https://build.opensuse.org/package/live_build_log/devel:openQA:TestGithub:OPR-1888/os-autoinst/openSUSE_15.3/x86_64 shows that the swtpm package is now included in the build

Related progress issue: https://progress.opensuse.org/issues/103683