### PR TITLE
Automatically detect KVM in qemu if available

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -876,7 +876,7 @@ sub start_qemu ($self) {
             }
         }
 
-        sp('enable-kvm') unless $vars->{QEMU_NO_KVM};
+        sp('enable-kvm') if -r '/dev/kvm' && !$vars->{QEMU_NO_KVM};
         sp('no-shutdown');
 
         if ($vars->{VNC}) {

--- a/t/18-qemu-options.t
+++ b/t/18-qemu-options.t
@@ -35,7 +35,6 @@ my @common_options = (
     ARCH => 'i386',
     BACKEND => 'qemu',
     QEMU => 'i386',
-    QEMU_NO_KVM => 1,
     QEMU_NO_TABLET => 1,
     QEMU_NO_FDC_SET => 1,
     CASEDIR => "$data_dir/tests",

--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -35,7 +35,6 @@ print $var <<EOV;
    "ARCH" : "i386",
    "BACKEND" : "qemu",
    "QEMU" : "i386",
-   "QEMU_NO_KVM" : "1",
    "QEMU_NO_TABLET" : "1",
    "QEMU_NO_FDC_SET" : "1",
    "CASEDIR" : "$data_dir/tests",


### PR DESCRIPTION
Previously KVM was expected to be present when running QEMU based tests
unless the test variable "QEMU_NO_KVM" was set. Any jobs running in an
environment where KVM is not available would fail. This commit now
automatically looks up the KVM device file while keeping the
configuration option to disable the use of KVM. Also changing the two
test modules t/18-qemu-options.t and t/99-full-stack.t to not hardcore
QEMU_NO_KVM as they can benefit from faster runtimes in KVM-enabled
environments as well. This additionally helps to actually test
KVM-accelerated virtualization environments directly.

Related progress issue: https://progress.opensuse.org/issues/101262