### PR TITLE
dist: Move swtpm "files" out of unnecessary ifarch

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -257,8 +257,8 @@ cd %{__builddir}
 %ifarch x86_64
 %files qemu-kvm
 %files qemu-x86
-%files swtpm
 %endif
+%files swtpm
 %files s390-deps
 
 %changelog


### PR DESCRIPTION
The swtpm package is built for all architectures. Yet the "files" is
not.

Fixes: https://progress.opensuse.org/issues/103683