### PR TITLE
utils: Extract asset regardless of backend

### DIFF
--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -128,7 +128,6 @@ configuration variables.
 sub handle_generated_assets ($command_handler, $clean_shutdown) {
     my $return_code = 0;
     # mark hard disks for upload if test finished
-    return unless $bmwqemu::vars{BACKEND} eq 'qemu';
     my @toextract;
     my $nd = $bmwqemu::vars{NUMDISKS};
     if ($command_handler->test_completed) {

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -184,6 +184,20 @@ subtest 'upload the asset even in an incomplete job' => sub {
     ok(!-e $pool_dir . '/assets_public/publish_test.qcow2', 'the asset defined by PUBLISH_HDD_X would not be generated in an incomplete job');
 };
 
+subtest 'asset handling in unsupported backends' => sub {
+    my $command_handler = OpenQA::Isotovideo::CommandHandler->new();
+    $bmwqemu::vars{BACKEND} = 'vagrant';
+    $bmwqemu::vars{NUMDISKS} = 1;
+    $bmwqemu::vars{VAGRANT_PROVIDER} = 'libvirt';
+    $bmwqemu::vars{VAGRANT_BOX} = 'foobar';
+    $bmwqemu::backend = FakeBackendDriver->new('vagrant');
+    combined_like { handle_generated_assets($command_handler, 1) } qr/unable to extract assets: backend method '.*' not implemented for class/, 'Fails with not implemented error';
+
+    delete $bmwqemu::vars{FORCE_PUBLISH_HDD_1};
+    delete $bmwqemu::vars{PUBLISH_HDD_1};
+    is(handle_generated_assets($command_handler, 1), 0, 'No extraction called');
+};
+
 done_testing();
 
 END {


### PR DESCRIPTION
We don't need to check the backend if it's implemented correctly. And we can test that extraction is only called when requested.

See: https://progress.opensuse.org/issues/104499