### PR TITLE
Use proper perl "signatures" in some consoles

### DIFF
--- a/consoles/ssh_screen.pm
+++ b/consoles/ssh_screen.pm
@@ -3,7 +3,7 @@
 
 package consoles::ssh_screen;
 
-use Mojo::Base 'consoles::serial_screen';
+use Mojo::Base 'consoles::serial_screen', -signatures;
 use Carp 'croak';
 use Net::SSH2 'LIBSSH2_ERROR_EAGAIN';
 use Time::Seconds;
@@ -13,9 +13,8 @@ has ssh_channel => undef;
 
 use constant TYPE_STRING_TIMEOUT => ONE_MINUTE;
 
-sub new {
-    my $class = shift;
-    my $self = bless @_ ? @_ > 1 ? {@_} : {%{$_[0]}} : {}, ref $class || $class;
+sub new ($class, @args) {
+    my $self = bless @args ? @args > 1 ? {@args} : {%{$args[0]}} : {}, ref $class || $class;
 
     croak('Missing parameter ssh_connection') unless $self->ssh_connection;
     croak('Missing parameter ssh_channel') unless $self->ssh_channel;
@@ -28,9 +27,7 @@ sub new {
     return $self->SUPER::new($self->ssh_channel);
 }
 
-sub do_read
-{
-    my ($self, undef, %args) = @_;
+sub do_read ($self, $, %args) {
     my $buffer = '';
     $args{timeout} //= undef;    # wait till data is available
     $args{max_size} //= 2048;
@@ -51,9 +48,7 @@ sub do_read
     return undef;
 }
 
-sub type_string {
-    my ($self, $nargs) = @_;
-
+sub type_string ($self, $nargs) {
     bmwqemu::log_call(%$nargs);
 
     my $text = $nargs->{text};


### PR DESCRIPTION
Using a command like

```
sed -i "/^use strict;/ {N;s/use strict;/use Mojo::Base -strict, -signatures;/}" $(git ls-files)
for i in $(git grep -l 'use \(strict\|warnings\)'); do grep -q 'use Mojo::Base -strict' $i && sed -i '/use \(strict\|warnings\)/d' $i; done
tools/tidy --only-changed
```

and some manual fixes.