### PR TITLE
Control access to %bmwqemu::vars and warn about invalid keys

### DIFF
--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -16,7 +16,7 @@ use Cwd 'abs_path';
 use Mojo::File qw(path);
 use Mojo::JSON qw(decode_json);
 use Cpanel::JSON::XS ();
-use Test::Warnings qw(:report_warnings);
+use Test::Warnings qw(warning :report_warnings);
 
 my $toplevel_dir = abs_path(dirname(__FILE__) . '/..');
 my $data_dir = "$toplevel_dir/t/data";
@@ -127,6 +127,14 @@ subtest 'HDD variables sanity check' => sub {
     ok(bmwqemu::_check_publish_vars, 'one HDD for reading, one for publishing is ok');
     $bmwqemu::vars{PUBLISH_HDD_1} = 'foo.qcow2';
     throws_ok { bmwqemu::_check_publish_vars } qr/HDD_1 also specified in PUBLISH/, 'overwriting source HDD is prevented';
+};
+
+subtest 'invalid vars characters' => sub {
+    my $num = scalar %bmwqemu::vars;
+    like warning { $bmwqemu::vars{lowercase_not_accepted} = 23 }, qr{Settings key 'lowercase_not_accepted' is invalid.*12-bmwqemu.t}s, 'Warning is issued for invalid setting keys';
+    my $new_num = %bmwqemu::vars;
+    is $new_num, $num + 1, '%vars in scalar context works';
+    is exists $bmwqemu::vars{lowercase_not_accepted}, 1, 'exists $vars{...} works';
 };
 
 my %new_json = (foo => 'bar', baz => 42);


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/98577

%bmwqemu::vars is writeable from everywhere, and we can't change that
for backwards compatibility.

But by making it a tied hash, we can control access to it.