### PR TITLE
Ensure to import os-autoinst-common in all tests consistently

### DIFF
--- a/t/34-git.t
+++ b/t/34-git.t
@@ -8,6 +8,7 @@ use File::Path qw(rmtree);
 use FindBin '$Bin';
 use Test::Output qw(combined_from);
 use OpenQA::Isotovideo::Utils qw(checkout_git_repo_and_branch);
+use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use Test::Warnings ':report_warnings';
 

--- a/t/35-imgsearch.t
+++ b/t/35-imgsearch.t
@@ -5,7 +5,7 @@
 
 use Test::Most;
 use FindBin '$Bin';
-
+use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use Mojo::Base -strict, -signatures;
 use Mojo::File qw(path);

--- a/tools/invoke-tests
+++ b/tools/invoke-tests
@@ -40,7 +40,7 @@ db="$build_directory/cover_db"
 [[ $SKIP_IF_COVER_DB_EXISTS ]] && [[ -d $db ]] && exit 0
 
 # set Perl module include path and coverage options
-export PERL5LIB="$source_directory:$source_directory/external/os-autoinst-common/lib:$source_directory/ppmclibs:$source_directory/ppmclibs/blib/arch/auto/tinycv:$PERL5LIB"
+export PERL5LIB="$source_directory:$source_directory/ppmclibs:$source_directory/ppmclibs/blib/arch/auto/tinycv:$PERL5LIB"
 if [[ $WITH_COVER_OPTIONS ]]; then
     path_regex="^|$source_directory/|\\.\\./"
     select="($path_regex)(OpenQA|backend|consoles|ppmclibs)/|($path_regex)isotovideo|($path_regex)[^/]+\.pm,-ignore,\.t|data/tests/|fake/tests/|/CheckGitStatus.pm|$prove_path"


### PR DESCRIPTION
Instead of adding "os-autoinst-common" to the include path we can simply
include the corresponding paths within all tests which we already did in
most.