### PR TITLE
Fix 02-test_ocr.t after bmwqemu::vars change

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -55,7 +55,7 @@ our @ovmf_locations = (
 );
 
 our %vars;
-tie %vars, 'bmwqemu::tiedvars';
+tie %vars, 'bmwqemu::tiedvars', %vars;
 
 sub result_dir { 'testresults' }
 


### PR DESCRIPTION
Brokem since #1900 39b18520

The test writes to bmwqemu::vars before the `tie` happens.
Ideally any code should load the module before writing to %vars,
but we can solve it also by passing the current value of %vars to tie.