### PR TITLE
Fix circular dependency

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -25,7 +25,6 @@ use Exporter 'import';
 our $VERSION;
 our @EXPORT_OK = qw(diag fctres fctinfo fctwarn modstate save_vars);
 
-use backend::driver;
 require IPC::System::Simple;
 
 sub mydie;
@@ -227,6 +226,7 @@ sub modstate {
 
 sub current_test {
     require autotest;
+    no warnings 'once';
     return $autotest::current_test;
 }
 

--- a/isotovideo
+++ b/isotovideo
@@ -53,6 +53,7 @@ BEGIN {
 }
 
 use bmwqemu;
+use backend::driver;
 use needle;
 use autotest ();
 use commands;

--- a/t/10-terminal.t
+++ b/t/10-terminal.t
@@ -22,6 +22,7 @@ my $main_pid = $$;
 
 use consoles::virtio_terminal;
 use testapi ();
+use myjsonrpc;
 use bmwqemu ();
 
 our $VERSION;


### PR DESCRIPTION
`bmwqemu -> backend::driver -> myjsonrpc -> bmwqemu`

However, the use of backend::driver was already thrown out of
bmwqemu in 2016 in 59ba44fa8e97db0be34c33b75be4265a59ea9feb, just the
use statement survived.

Now bmwqemu doesn't use any internal os-autoinst related module anymore.

The effects of the circular dependency can be watched when doing `perl -I. -c bwmqemu.pm`:
```
Subroutine result_dir redefined at bmwqemu.pm line 60.
Subroutine logger redefined at bmwqemu.pm line 62.
Subroutine init_logger redefined at bmwqemu.pm line 64.
Subroutine serialize_state redefined at bmwqemu.pm line 69.
...
```