### PR TITLE
testapi: Return name of saved file in save_tmp_file

### DIFF
--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -8,6 +8,7 @@ use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use Test::Mock::Time;
 use File::Temp;
+use Mojo::File qw(path);
 use Test::Output qw(stderr_like stderr_unlike);
 use Test::Fatal;
 use Test::Warnings qw(:all :report_warnings);
@@ -583,6 +584,14 @@ subtest 'validate_script_output' => sub {
         my $joined_args = join(',', @$exp_args);
         lives_ok { validate_script_output('script', qr/^$joined_args$/, @$exp_args) } "Arguments passed to script_output($joined_args)";
     }
+};
+
+subtest save_tmp_file => sub {
+    my $expected = '<profile>Test</profile>';
+    my $filename = save_tmp_file('autoyast/autoinst.xml', $expected);
+    my $xml = path($filename);
+    is($xml->slurp, $expected, 'Expected file contents written');
+    $xml->remove;
 };
 
 subtest 'wait_still_screen & assert_still_screen' => sub {

--- a/testapi.pm
+++ b/testapi.pm
@@ -1177,6 +1177,8 @@ including file, so it can be fetched via http later on using
 Can be used to modify files for specific test needs, e.g. autoinst profiles.
 Dies if cannot open file for writing.
 
+Returns filename of saved file (filename hashed).
+
 Example:
   save_tmp_file('autoyast/autoinst.xml', '<profile>Test</profile>')
 Then the file can be fetched using url:
@@ -1192,6 +1194,8 @@ sub save_tmp_file {
     open my $fh, ">", $path;
     print $fh $content;
     close $fh;
+
+    return $path;
 }
 
 =head2 get_test_data


### PR DESCRIPTION
So that tests do not have to call hashed_string() themselves.