### PR TITLE
Guess vmdk driver for vmdk files

### DIFF
--- a/OpenQA/Qemu/BlockDev.pm
+++ b/OpenQA/Qemu/BlockDev.pm
@@ -194,7 +194,7 @@ sub _from_map ($self, $drives, $snap_conf) {
       ->snapshot($snap_conf->get_snapshot(sequence => $this->{snapshot}));
 }
 
-sub deduce_driver ($self) { $self->driver($self->file =~ qr/\.qcow2$/ ? 'qcow2' : 'raw') }
+sub deduce_driver ($self) { $self->driver($self->file =~ qr/\.(qcow2|vmdk)/ ? "$1" : 'raw') }
 
 sub CARP_TRACE { 'OpenQA::Qemu::BlockDev(' . (shift->node_name || '') . ')' }
 

--- a/t/18-qemu.t
+++ b/t/18-qemu.t
@@ -55,6 +55,21 @@ $compress = 0;
 @gcmdl = $bdc->gen_qemu_img_convert(qr/^hd/, 'images', 'hd1.qcow2', $compress);
 is_deeply(\@gcmdl, \@cmdl, 'Generate qemu-img convert for single new drive, without compression');
 
+my %vars;
+my $proc;
+
+%vars = (
+    NUMDISKS => 1,
+    HDDMODEL => 'virtio-blk',
+    CDMODEL => 'virtio-cd',
+    HDDSIZEGB_1 => 42,
+    HDD_1 => "$Bin/data/test-image-disk.vmdk"
+);
+$proc = qemu_proc('-foo', \%vars);
+@cmdl = ([qw(create -f qcow2 -F vmdk -b), "$Bin/data/test-image-disk.vmdk", qw(raid/hd0-overlay0 42G)]);
+@gcmdl = $proc->blockdev_conf->gen_qemu_img_cmdlines();
+is_deeply(\@gcmdl, \@cmdl, 'qemu-img create call for a vmdk disk image');
+
 @cmdl = ('-blockdev', 'driver=file,node-name=hd1-file,filename=raid/hd1,cache.no-flush=on',
     '-blockdev', 'driver=qcow2,node-name=hd1,file=hd1-file,cache.no-flush=on',
     '-device', 'virtio-blk,id=hd1-device,drive=hd1',
@@ -96,9 +111,6 @@ $compress = 1;
 @cmdl = (['convert', '-c', '-O', 'qcow2', 'raid/hd1-overlay0', 'images/hd1.qcow2']);
 @gcmdl = $bdc->gen_qemu_img_convert(qr/^hd1/, 'images', 'hd1.qcow2', $compress);
 is_deeply(\@gcmdl, \@cmdl, 'Generate qemu-img convert for single existing drive');
-
-my %vars;
-my $proc;
 
 @cmdl = ('qemu-kvm', '-foo',
     '-blockdev', 'driver=file,node-name=hd0-overlay0-file,filename=raid/hd0-overlay0,cache.no-flush=on',


### PR DESCRIPTION
os-autoinst is creating a new qcow2 disk image from a backing file when a disk
drive is passed via `HDD_N`. However, this does not work correctly for vmdk disk
images, here os-autoinst calls:
qemu-img create -f qcow2 -F raw -b /path/to.vmdk raid/hd0-overlay0 20G
which creates a disfunctional disk image.
The correct call is with `-F vmdk`.

We solve this issue by extending deduce_driver, which instructs os-autoinst to
use the correct driver for vmdk disk images instead.

This commit also adds a regression test which verifies the desired behavior.