### PR TITLE
t: More tests, especially consoles

### DIFF
--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -8,7 +8,7 @@ use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use Test::Mock::Time;
 use File::Temp;
-use Test::Output qw(combined_like stderr_like stderr_unlike);
+use Test::Output qw(stderr_like stderr_unlike);
 use Test::Fatal;
 use Test::Warnings qw(:all :report_warnings);
 use Test::Exception;

--- a/t/26-serial_screen.t
+++ b/t/26-serial_screen.t
@@ -4,6 +4,7 @@
 use Test::Most;
 use Mojo::Base -strict, -signatures;
 use Test::Warnings ':report_warnings';
+use Test::Fatal;
 use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
@@ -17,5 +18,10 @@ is($screen->{carry_buffer}, '', 'Check if channel was set for read fd');
 $screen = consoles::serial_screen->new('same', 'same');
 is($screen->{fd_read}, 'same', 'Fd read member was set.');
 is($screen->{fd_read}, $screen->{fd_write}, 'If only one fd give, read and write are equal');
+
+dies_ok { $screen->hold_key } 'hold_key dies with error';
+dies_ok { $screen->release_key } 'release_key dies with error';
+dies_ok { $screen->send_key({key => 'space'}) } 'send_key dies for most keys';
+is $screen->current_screen, 0, 'no current screen';
 
 done_testing;

--- a/t/27-consoles-vnc.t
+++ b/t/27-consoles-vnc.t
@@ -1,0 +1,26 @@
+#!/usr/bin/perl
+
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+use Mojo::Base -strict, -signatures;
+use Test::Warnings qw(:all :report_warnings);
+use Test::MockModule;
+use Test::MockObject;
+use FindBin '$Bin';
+use lib "$Bin/../external/os-autoinst-common/lib";
+use OpenQA::Test::TimeLimit '5';
+use consoles::VNC;
+
+my $c = consoles::VNC->new;
+my $inet_mock = Test::MockModule->new('IO::Socket::INET');
+my $s = Test::MockObject->new->set_true('sockopt', 'print', 'connected');
+$s->set_series('mocked_read', 'RFB 003.006', pack('N', 1));
+$s->mock('read', sub { $_[1] = $s->mocked_read; 1 });
+$inet_mock->redefine(new => $s);
+my $vnc_mock = Test::MockModule->new('consoles::VNC');
+$vnc_mock->noop('_server_initialization');
+is $c->login, '', 'can call login';
+
+done_testing;

--- a/t/27-consoles-vnc_base.t
+++ b/t/27-consoles-vnc_base.t
@@ -1,0 +1,71 @@
+#!/usr/bin/perl
+
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+use Mojo::Base -strict, -signatures;
+use Test::Warnings qw(:all :report_warnings);
+use Test::Fatal;
+use Test::MockModule;
+use Test::MockObject;
+use Test::Output qw(stderr_like);
+use FindBin '$Bin';
+use lib "$Bin/../external/os-autoinst-common/lib";
+use OpenQA::Test::TimeLimit '5';
+use consoles::vnc_base;
+
+my $c = consoles::vnc_base->new('sut', {});
+is $c->screen, $c, 'screen returns self';
+my $vnc = Test::MockObject->new->set_true('map_and_send_key');
+$c->{vnc} = $vnc;
+$vnc->set_always('socket', 0);
+$c->disable;
+is $c->{vnc}, undef, 'VNC removed by disable';
+
+is $c->get_last_mouse_set, undef, 'can call get_last_mouse_set';
+$vnc->set_true('check_vnc_stalls');
+is $c->disable_vnc_stalls, undef, 'can call disable_vnc_stalls without VNC';
+ok !$vnc->called('check_vnc_stalls'), 'check_vnc_stalls not called without VNC';
+$c->{vnc} = $vnc;
+is $c->disable_vnc_stalls, 1, 'can call disable_vnc_stalls with VNC';
+ok $vnc->called('check_vnc_stalls'), 'check_vnc_stalls called with VNC';
+my $vnc_mock = Test::MockModule->new('consoles::VNC');
+$vnc_mock->redefine(new => $vnc);
+$vnc->set_true('login');
+stderr_like { $c->connect_remote({hostname => 'localhost', port => 42}) } qr/Establishing VNC connection to localhost:42/, 'can call connect_remote';
+$vnc->set_true('update_framebuffer', 'send_update_request');
+is $c->request_screen_update, undef, 'can call request_screen_update';
+$vnc->set_always('_framebuffer', 0);
+$vnc->clear('update_framebuffer');
+is $c->current_screen, undef, 'can call current_screen without framebuffer';
+$vnc->called_ok('update_framebuffer', 'update_framebuffer called when framebuffer is initialized');
+$vnc->set_true('_framebuffer');
+ok $c->current_screen, 'can call current_screen with framebuffer';
+$c->{backend} = Test::MockObject->new->set_true('run_capture_loop');
+ok $c->type_string({max_interval => 1, text => 'foo'}), 'type_string with small max_interval';
+my ($name, $args) = $c->{backend}->next_call;
+ok 0.5 < (@$args)[-1] && (@$args)[-1] < 0.6, 'seconds per keypress somewhere below 1';
+ok $c->send_key({}), 'send_key can be called';
+ok $c->hold_key({}), 'hold_key can be called';
+ok $c->release_key({}), 'release_key can be called';
+$c->{mouse} = Test::MockObject->new;
+$c->{mouse}->{x} = $c->{mouse}->{y} = 0;
+$vnc->set_always('width', 0);
+$vnc->set_true('mouse_move_to');
+$vnc->set_always('height', 0);
+$vnc->set_always('absolute', 0);
+stderr_like { $c->mouse_hide({}) } qr/mouse_move -1, -1/, 'mouse_hide goes to offscreen position';
+dies_ok { $c->mouse_set({}) } 'mouse_set needs x/y parameters';
+stderr_like { $c->mouse_set({x => 0, y => 0}) } qr/mouse_move 0, 0/, 'mouse_set outputs new mouse position';
+ok $vnc->called('mouse_move_to'), 'actually moved to default 0/0 position';
+$vnc->clear('mouse_move_to');
+ok !$vnc->called('mouse_move_to'), 'mouse_move_to not called for same position';
+stderr_like { $c->mouse_set({x => 0, y => 0}) } qr/mouse_move 0, 0/, 'second mouse_set keeps mouse';
+ok $vnc->called_ok('mouse_move_to'), 'mouse is moved again';
+$vnc->set_true('send_pointer_event');
+stderr_like { $c->mouse_button({button => 'left', bstate => 0}) } qr/pointer_event.*0, 0/, 'mouse_button can be called';
+stderr_like { $c->mouse_button({button => 'right', bstate => 0}) } qr/0, 0/, 'mouse_button right can be called';
+stderr_like { $c->mouse_button({button => 'middle', bstate => 0}) } qr/0, 0/, 'mouse_button middle can be called';
+
+done_testing;


### PR DESCRIPTION
* t: Add missing coverage for consoles::serial_screen
* t: Simplify file read/write with Mojo::File in 99-full-stack.t
* t: Add test for consoles::VNC
* t: Add consoles::vnc_base unit test
* t: Remove unnecessary method import in 03-testapi.t

Low-risk part pulled out from https://github.com/os-autoinst/os-autoinst/pull/1789