### PR TITLE
Also hide common password test variables from vars.json

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -99,7 +99,7 @@ sub save_vars {
     my $write_vars = \%vars;
     if ($args{no_secret}) {
         $write_vars = {};
-        $write_vars->{$_} = $vars{$_} for (grep !/^_SECRET_/, keys(%vars));
+        $write_vars->{$_} = $vars{$_} for (grep !/(^_SECRET_|_PASSWORD)/, keys(%vars));
     }
 
     # make sure the JSON is sorted

--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -106,7 +106,7 @@ subtest 'save_vars' => sub {
 
 subtest 'save_vars no_secret' => sub {
     my $dir = "$data_dir/tests";
-    create_vars({CASEDIR => $dir, _SECRET_TEST => 'my_credentials'});
+    create_vars({CASEDIR => $dir, _SECRET_TEST => 'my_credentials', MY_PASSWORD => 'secret'});
     $bmwqemu::openqa_default_share = $data_dir;
 
     eval {
@@ -118,6 +118,7 @@ subtest 'save_vars no_secret' => sub {
 
     my %vars = %{read_vars()};
     ok(!$vars{_SECRET_TEST}, '_SECRET_TEST not written to vars.json');
+    ok(!$vars{MY_PASSWORD}, 'MY_PASSWORD not written to vars.json');
     is($vars{CASEDIR}, $dir, 'CASEDIR unchanged');
 };
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -767,7 +767,9 @@ sub get_required_var {
   set_var($variable, $value [, reload_needles => 1] );
 
 Set test variable C<$variable> to value C<$value>.
-Variables starting with C<_SECRET_> will not appear in the C<vars.json> file.
+
+Variables starting with C<_SECRET_> or including C<_PASSWORD> will not appear
+in the C<vars.json> file.
 
 Specify a true value for the C<reload_needles> flag to trigger a reloading
 of needles in the backend and call the cleanup handler with the new variables


### PR DESCRIPTION
We already don't write any variable with "_SECRET_" in the name to vars.json
for security reasons. Within os-autoinst we have some security relevant data,
e.g. passwords within backends that we should likely treat the same. Cloning
openQA tests would mean that the passwords are not taken over however most
likely they are filled by worker settings when jobs are started anywhere.

Related progress issue: https://progress.opensuse.org/issues/104751