### PR TITLE
Prevent the use of external facing API commands in backend consistently

### DIFF
--- a/backend/amt.pm
+++ b/backend/amt.pm
@@ -12,7 +12,6 @@ use Time::HiRes qw(sleep gettimeofday);
 use Data::Dumper;
 require Carp;
 use bmwqemu ();
-use testapi 'get_required_var';
 use IPC::Run ();
 require IPC::System::Simple;
 
@@ -28,8 +27,8 @@ my $ADR = "http://schemas.xmlsoap.org/ws/2004/08/addressing";
 my $vnc_password = 'we4kP@ss';
 
 sub new ($class) {
-    get_required_var('AMT_HOSTNAME');
-    get_required_var('AMT_PASSWORD');
+    defined $bmwqemu::vars{AMT_HOSTNAME} or die 'Need variable AMT_HOSTNAME';
+    defined $bmwqemu::vars{AMT_PASSWORD} or die 'Need variable AMT_PASSWORD';
 
     # use env to avoid leaking password to logs
     $ENV{'WSMAN_USER'} = 'admin';

--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -11,17 +11,16 @@ use base 'backend::baseclass';
 
 use Time::HiRes qw(sleep);
 use Time::Seconds;
-use testapi 'get_required_var';
 use IPC::Run ();
 require IPC::System::Simple;
 
 sub new ($class) {
-    get_required_var('WORKER_HOSTNAME');
+    $bmwqemu::vars{WORKER_HOSTNAME} or die 'Need variable WORKER_HOSTNAME';
     return $class->SUPER::new;
 }
 
 sub ipmi_cmdline ($self) {
-    get_required_var("IPMI_$_") foreach qw(HOSTNAME USER PASSWORD);
+    $bmwqemu::vars{"IPMI_$_"} or die 'Need variable IPMI_$_' foreach qw(HOSTNAME USER PASSWORD);
     return ('ipmitool', '-I', 'lanplus', '-H', $bmwqemu::vars{IPMI_HOSTNAME}, '-U', $bmwqemu::vars{IPMI_USER}, '-P', $bmwqemu::vars{IPMI_PASSWORD});
 }
 

--- a/backend/s390x.pm
+++ b/backend/s390x.pm
@@ -12,11 +12,10 @@ use base 'backend::baseclass';
 use English;
 require IPC::System::Simple;
 use Carp qw(confess cluck carp croak);
-use testapi 'get_required_var';
 
 sub new ($class) {
     my $self = $class->SUPER::new;
-    get_required_var('WORKER_HOSTNAME');
+    defined $bmwqemu::vars{WORKER_HOSTNAME} or die 'Need variable WORKER_HOSTNAME';
     return $self;
 }
 

--- a/backend/spvm.pm
+++ b/backend/spvm.pm
@@ -7,8 +7,6 @@ use Mojo::Base -strict, -signatures;
 
 use base 'backend::virt';
 
-use testapi qw(get_var get_required_var);
-
 # supporting the minimal command set of NovaLink through a ssh tunnel
 
 sub new ($class) {

--- a/backend/vagrant.pm
+++ b/backend/vagrant.pm
@@ -5,7 +5,6 @@ package backend::vagrant;
 
 use base 'backend::virt';
 use bmwqemu;
-use testapi ();
 
 use Mojo::Base -strict, -signatures;
 use Mojo::File;

--- a/backend/virt.pm
+++ b/backend/virt.pm
@@ -7,7 +7,6 @@ use Mojo::Base -strict, -signatures;
 
 use base 'backend::baseclass';
 
-use testapi 'get_var';
 use bmwqemu;
 
 sub new ($class) {

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -10,7 +10,6 @@ use IO::Socket::INET;
 use bmwqemu qw(diag fctwarn);
 use Time::HiRes qw( sleep gettimeofday time );
 use List::Util 'min';
-use testapi 'get_var';
 use Crypt::DES;
 use Compress::Raw::Zlib;
 use Carp qw(confess cluck carp croak);
@@ -819,7 +818,7 @@ sub _send_frame_buffer {
 sub send_update_request {
     my ($self) = @_;
 
-    my $time_after_vnc_is_considered_stalled = get_var('VNC_STALL_THRESHOLD', 4);
+    my $time_after_vnc_is_considered_stalled = $bmwqemu::vars{VNC_STALL_THRESHOLD} // 4;
     # after 2 seconds: send forced update
     # after 4 seconds: turn off screen
     my $time_since_last_update = time - $self->_last_update_received;

--- a/consoles/console.pm
+++ b/consoles/console.pm
@@ -18,7 +18,6 @@ package consoles::console;
 
 use Mojo::Base -strict, -signatures;
 use autodie ':all';
-use testapi 'check_var';
 
 require IPC::System::Simple;
 use Class::Accessor 'antlers';
@@ -37,7 +36,7 @@ sub new ($class, $testapi_console, $args) {
 sub init ($self) {
     # Special keys like Ctrl-Alt-Fx are not passed to the VM by xfreerdp.
     # That means switch from graphical to console is not possible on Hyper-V.
-    $self->{console_hotkey} = check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 'alt-f' : 'ctrl-alt-f';
+    $self->{console_hotkey} = ($bmwqemu::vars{VIRSH_VMM_FAMILY} // '') eq 'hyperv' ? 'alt-f' : 'ctrl-alt-f';
 }
 
 # SUT was e.g. rebooted

--- a/consoles/localXvnc.pm
+++ b/consoles/localXvnc.pm
@@ -15,7 +15,6 @@ use Socket;
 use File::Path 'mkpath';
 use File::Which;
 use Time::Seconds;
-use testapi qw(get_var);
 
 # helper function
 # Keep ssh session for the maximum of ServerAliveCountMax x ServerAliveInterval seconds
@@ -24,8 +23,8 @@ use testapi qw(get_var);
 # long-time run test without these options. TCPKeepAlive ensures that if network goes down
 # or the remote host dies, machines will be properly noticed
 sub sshCommand ($self, $username, $host, $gui = undef) {
-    my $server_alive_count_max = get_var('_SSH_SERVER_ALIVE_COUNT_MAX', 480);
-    my $server_alive_interval = get_var('_SSH_SERVER_ALIVE_INTERVAL', ONE_MINUTE);
+    my $server_alive_count_max = $bmwqemu::vars{_SSH_SERVER_ALIVE_COUNT_MAX} // 480;
+    my $server_alive_interval = $bmwqemu::vars{_SSH_SERVER_ALIVE_INTERVAL} // ONE_MINUTE;
     my $sshopts = "-o TCPKeepAlive=yes -o ServerAliveCountMax=$server_alive_count_max -o ServerAliveInterval=$server_alive_interval -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no $username\@$host";
     $sshopts = "-X $sshopts" if $gui;
     return "ssh $sshopts; read";

--- a/consoles/s3270.pm
+++ b/consoles/s3270.pm
@@ -12,7 +12,6 @@ use base 'consoles::localXvnc';
 use Class::Accessor 'antlers';
 use Data::Dumper 'Dumper';
 use Carp qw(confess cluck carp croak);
-use testapi 'get_required_var';
 require IPC::Run;
 use IPC::Run::Debug;    # set IPCRUNDEBUG=data in shell environment for trace
 use Thread::Queue;
@@ -423,9 +422,9 @@ sub new_3270_console ($self) {
 sub activate ($self) {
     $self->SUPER::activate;
 
-    $self->zVM_host(get_required_var("ZVM_HOST"));
-    $self->guest_user(get_required_var("ZVM_GUEST"));
-    $self->guest_login(get_required_var("ZVM_PASSWORD"));
+    $self->zVM_host($bmwqemu::vars{ZVM_HOST} or die 'Need variable ZVM_HOST');
+    $self->guest_user($bmwqemu::vars{ZVM_GUEST} or die 'Need variable ZVM_GUEST');
+    $self->guest_login($bmwqemu::vars{ZVM_PASSWORD} or die 'Need variable ZVM_PASSWORD');
     $self->new_3270_console;
     $self->connect_and_login;
     return;

--- a/consoles/sshIucvconn.pm
+++ b/consoles/sshIucvconn.pm
@@ -11,11 +11,10 @@ use autodie ':all';
 
 use base 'consoles::network_console';
 
-use testapi 'get_var';
 
 sub connect_remote ($self, $args) {
     my $hostname = $args->{hostname};
-    my $zvmguest = get_var('ZVM_GUEST');
+    my $zvmguest = $bmwqemu::vars{ZVM_GUEST};
 
     # ssh connection to SUT for agetty
     my $ttyconn = $self->backend->new_ssh_connection(hostname => $hostname, password => $args->{password}, username => 'root');

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -14,7 +14,6 @@ use Class::Accessor 'antlers';
 use Mojo::JSON qw(decode_json);
 
 use backend::svirt;
-use testapi qw(get_var get_required_var check_var set_var);
 
 has instance => (is => "rw", isa => "Num");
 has name => (is => "rw", isa => "Str");
@@ -24,11 +23,11 @@ has vmm_type => (is => "rw", isa => "Str");
 sub new ($class, $testapi_console = undef, $args = {}) {
     my $self = $class->SUPER::new($testapi_console, $args);
 
-    $self->instance(get_var('VIRSH_INSTANCE', 1));
+    $self->instance($bmwqemu::vars{VIRSH_INSTANCE} // 1);
     # default name
     $self->name("openQA-SUT-" . $self->instance);
-    $self->vmm_family(get_var('VIRSH_VMM_FAMILY', 'kvm'));
-    $self->vmm_type(get_var('VIRSH_VMM_TYPE', 'hvm'));
+    $self->vmm_family($bmwqemu::vars{VIRSH_VMM_FAMILY} // 'kvm');
+    $self->vmm_type($bmwqemu::vars{VIRSH_VMM_TYPE} // 'hvm');
 
     return $self;
 }
@@ -58,8 +57,8 @@ sub _init_ssh ($self, $args) {
     if ($self->vmm_family eq 'vmware') {
         $self->{ssh_credentials}->{sshVMwareServer} =
           {
-            hostname => get_required_var('VMWARE_HOST'),
-            password => get_required_var('VMWARE_PASSWORD'),
+            hostname => $bmwqemu::vars{VMWARE_HOST} || die('Need variable VMWARE_HOST'),
+            password => $bmwqemu::vars{VMWARE_PASSWORD} || die('Need variable VMWARE_PASSWORD'),
             username => 'root',
           };
     }
@@ -85,19 +84,19 @@ sub _init_xml ($self, $args = {}) {
     $elem->appendTextNode($self->name);
     $root->appendChild($elem);
 
-    my $openqa_hostname = get_var('OPENQA_HOSTNAME', 'no-webui-set');
+    my $openqa_hostname = $bmwqemu::vars{OPENQA_HOSTNAME} // 'no-webui-set';
     $elem = $doc->createElement('description');
     $elem->appendTextNode("openQA WebUI: $openqa_hostname ($instance): ");
-    $elem->appendTextNode(get_var('NAME', '0-no-scenario'));
+    $elem->appendTextNode($bmwqemu::vars{NAME} // '0-no-scenario');
     $root->appendChild($elem);
 
     $elem = $doc->createElement('memory');
-    $elem->appendTextNode(get_required_var('QEMURAM'));
+    $elem->appendTextNode($bmwqemu::vars{QEMURAM} or die 'Need variable QEMURAM');
     $elem->setAttribute(unit => 'MiB');
     $root->appendChild($elem);
 
     $elem = $doc->createElement('vcpu');
-    $elem->appendTextNode(get_required_var('QEMUCPUS'));
+    $elem->appendTextNode($bmwqemu::vars{QEMUCPUS} or die 'Need variable QEMUCPUS');
     $root->appendChild($elem);
 
     my $os = $doc->createElement('os');
@@ -134,19 +133,19 @@ sub _init_xml ($self, $args = {}) {
         $root->appendChild($elem);
     }
 
-    if (get_var('UEFI') and check_var('ARCH', 'x86_64') and !get_var('BIOS') and !check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
+    if ($bmwqemu::vars{UEFI} and $bmwqemu::vars{ARCH} eq 'x86_64' and !$bmwqemu::vars{BIOS} and !$bmwqemu::vars{VIRSH_VMM_FAMILY} eq 'hyperv') {
         foreach my $firmware (@bmwqemu::ovmf_locations) {
             if (!$self->run_cmd("test -e $firmware")) {
-                set_var('BIOS', $firmware);
+                $bmwqemu::vars{BIOS} = $firmware;
                 $elem = $doc->createElement('loader');
                 $elem->appendTextNode($firmware);
                 $os->appendChild($elem);
                 last;
             }
         }
-        if (!get_var('BIOS')) {
+        if (!$bmwqemu::vars{BIOS}) {
             # We know this won't go well.
-            my $virsh_hostname = get_var('VIRSH_HOSTNAME', '');
+            my $virsh_hostname = $bmwqemu::vars{VIRSH_HOSTNAME} // '';
             die "No UEFI firmware can be found on hypervisor '$virsh_hostname'. Please specify BIOS or UEFI_BIOS or install an appropriate package.";
         }
     }
@@ -224,7 +223,7 @@ sub add_pty ($self, $args) {
         my $elem = $doc->createElement('source');
         $elem->setAttribute(mode => 'bind');
         $elem->setAttribute(host => '0.0.0.0');
-        $elem->setAttribute(service => get_var('VMWARE_SERIAL_PORT'));
+        $elem->setAttribute(service => $bmwqemu::vars{VMWARE_SERIAL_PORT});
         $console->appendChild($elem);
     }
 
@@ -330,7 +329,7 @@ sub _copy_image_vmware ($self, $name, $backingfile, $file_basename, $vmware_open
     # If the file exists, make sure someone else is not copying it there right now,
     # otherwise copy image from NFS datastore.
     my $nfs_dir = $backingfile ? 'hdd' : 'iso';
-    my $vmware_nfs_datastore = get_required_var('VMWARE_NFS_DATASTORE');
+    my $vmware_nfs_datastore = $bmwqemu::vars{VMWARE_NFS_DATASTORE} or die 'Need variable VMWARE_NFS_DATASTORE';
     my $cmd =
       "if test -e $vmware_openqa_datastore$file_basename; then " .
       "while lsof | grep 'cp.*$file_basename'; do " .
@@ -432,7 +431,7 @@ sub add_disk ($self, $args) {
     my $name = $self->name;
     my $file = $name . $args->{dev_id} . ($self->vmm_family eq 'vmware' ? '.vmdk' : '.img');
     my $basedir = '/var/lib/libvirt/images/';
-    my $vmware_datastore = get_var('VMWARE_DATASTORE', '');
+    my $vmware_datastore = $bmwqemu::vars{VMWARE_DATASTORE} // '';
     my $vmware_openqa_datastore = "/vmfs/volumes/$vmware_datastore/openQA/";
     if ($args->{create}) {
         $file = $self->_create_disk($args, $vmware_openqa_datastore, $file, $name, $basedir);
@@ -468,7 +467,7 @@ sub add_disk ($self, $args) {
 
 sub virsh () {
     my $virsh = 'virsh';
-    $virsh .= ' ' . get_var('VMWARE_REMOTE_VMM') if get_var('VMWARE_REMOTE_VMM');
+    $virsh .= ' ' . $bmwqemu::vars{VMWARE_REMOTE_VMM} if $bmwqemu::vars{VMWARE_REMOTE_VMM};
     return $virsh;
 }
 
@@ -482,7 +481,7 @@ sub resume ($self) {
     bmwqemu::diag "VM " . $self->name . " resumed";
 }
 
-sub get_remote_vmm ($self) { get_var('VMWARE_REMOTE_VMM', '') }
+sub get_remote_vmm ($self) { $bmwqemu::vars{VMWARE_REMOTE_VMM} // '' }
 
 sub define_and_start ($self) {
     my $remote_vmm = "";
@@ -494,16 +493,16 @@ sub define_and_start ($self) {
         $self->run_cmd(
             "cat > $libvirtauthfilename <<__END
 [credentials-vmware]
-username=" . get_required_var('VMWARE_USERNAME') . "
-password=" . get_required_var('VMWARE_PASSWORD') . "
-[auth-esx-" . get_required_var('VMWARE_HOST') . "]
+username=" . $bmwqemu::vars{VMWARE_USERNAME} or die 'Need variable VMWARE_USERNAME' . "
+password=" . $bmwqemu::vars{VMWARE_PASSWORD} or die 'Need variable VMWARE_PASSWORD' . "
+[auth-esx-" . $bmwqemu::vars{VMWARE_HOST} or die 'Need variable VMWARE_HOST' . "]
 credentials=vmware
 __END"
         );
-        my $user = get_required_var('VMWARE_USERNAME');
-        my $host = get_required_var('VMWARE_HOST');
+        my $user = $bmwqemu::vars{VMWARE_USERNAME} or die 'Need variable VMWARE_USERNAME';
+        my $host = $bmwqemu::vars{VMWARE_HOST} or die 'Need variable VMWARE_HOST';
         $remote_vmm = "-c esx://$user\@$host/?no_verify=1\\&authfile=$libvirtauthfilename ";
-        set_var('VMWARE_REMOTE_VMM', $remote_vmm);
+        $bmwqemu::vars{VMWARE_REMOTE_VMM} = $remote_vmm;
     }
 
     my $instance = $self->instance;
@@ -548,7 +547,7 @@ sub attach_to_running ($self, $args = undef) {
 
     # Setting SVIRT_KEEP_VM_RUNNING variable prevents destruction of a perhaps valuable VM
     # outside of openQA. Set 'stop_vm' argument should the VM be destroyed at the end.
-    set_var('SVIRT_KEEP_VM_RUNNING', 1) unless $args->{stop_vm};
+    $bmwqemu::vars{SVIRT_KEEP_VM_RUNNING} = 1 unless $args->{stop_vm};
 }
 
 sub start_serial_grab ($self) { $self->backend->start_serial_grab($self->name) }

--- a/consoles/sshVirtshSUT.pm
+++ b/consoles/sshVirtshSUT.pm
@@ -7,7 +7,6 @@ use Mojo::Base -strict, -signatures;
 
 use base 'consoles::console';
 
-use testapi 'get_var';
 use backend::svirt qw(SERIAL_TERMINAL_DEFAULT_PORT SERIAL_TERMINAL_DEFAULT_DEVICE);
 use consoles::ssh_screen;
 
@@ -15,7 +14,7 @@ sub new ($class, $testapi_console, $args) {
     my $self = $class->SUPER::new($testapi_console, $args);
 
     # TODO: inherit from consoles::sshVirtsh
-    my $instance = get_var('VIRSH_INSTANCE', 1);
+    my $instance = $bmwqemu::vars{VIRSH_INSTANCE} // 1;
     $self->{libvirt_domain} = $args->{libvirt_domain} // "openQA-SUT-$instance";
     $self->{serial_port_no} = $args->{serial_port_no} // SERIAL_TERMINAL_DEFAULT_PORT;
 

--- a/consoles/sshX3270.pm
+++ b/consoles/sshX3270.pm
@@ -8,10 +8,9 @@ use Mojo::Base -strict, -signatures;
 
 use base 'consoles::localXvnc';
 
-use testapi 'get_var';
 
 sub activate ($self) {
-    my $sshcommand = $self->sshCommand('root', get_var("PARMFILE")->{Hostname});
+    my $sshcommand = $self->sshCommand('root', $bmwqemu::vars{PARMFILE}->{Hostname});
     my $display = $self->{backend}->{consoles}->{worker}->{DISPLAY};
     my $sshpassword = $testapi::password;
 

--- a/consoles/sshXtermIPMI.pm
+++ b/consoles/sshXtermIPMI.pm
@@ -9,7 +9,6 @@ use autodie ':all';
 
 use base 'consoles::localXvnc';
 
-use testapi 'get_required_var';
 require IPC::System::Simple;
 use File::Which;
 

--- a/consoles/sshXtermVt.pm
+++ b/consoles/sshXtermVt.pm
@@ -10,7 +10,6 @@ use autodie ':all';
 use base 'consoles::localXvnc';
 
 use IO::Socket::INET;
-use testapi 'get_var';
 require IPC::System::Simple;
 
 sub activate ($self) {
@@ -28,7 +27,7 @@ sub activate ($self) {
     my $serial = $self->{args}->{serial};
 
     # Wait that ssh server on SUT is live on network
-    if (!$self->wait_for_ssh_port($hostname, timeout => (get_var('SSH_XTERM_WAIT_SUT_ALIVE_TIMEOUT') // 120))) {
+    if (!$self->wait_for_ssh_port($hostname, timeout => ($bmwqemu::vars{SSH_XTERM_WAIT_SUT_ALIVE_TIMEOUT} // 120))) {
         bmwqemu::diag("$hostname does not seems to have an active SSH server. Continuing anyway.");
     }
     $self->callxterm($sshcommand, "ssh:$testapi_console");

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -43,6 +43,16 @@ UPLOAD_INACTIVITY_TIMEOUT;integer;300;Specifies the inactivity timeout in second
 
 |====================
 
+.ZVM backend
+[grid="rows",format="csv"]
+[options="header",cols="^m,^m,^m,v",separator=";"]
+|====================
+Variable;Values allowed;Default value;Explanation
+ZVM_HOST;string;;Sets the remote hostname.
+ZVM_GUEST;string;;Sets the remote username.
+ZVM_PASSWORD;string;;Sets the remote password.
+|====================
+
 .SSH backend
 [grid="rows",format="csv"]
 [options="header",cols="^m,^m,^m,v",separator=";"]

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -182,7 +182,7 @@ VDE_USE_SLIRP;integer;1;whether to start slirpvde
 VNC;integer;worker instance + 90;Display on which VNC server is running. Actual port is 5900 + VNC
 VNCKB;;;Set the keyboard layout if you are not using en-us
 WORKER_CLASS;string;undef;qemu system types
-WORKER_HOSTNAME;string;undef;Worker host name
+WORKER_HOSTNAME;string;undef;Worker hostname
 |====================
 
 .SVIRT backend
@@ -304,7 +304,7 @@ AMT_PASSWORD;string;;Password for admin AMT user on target host
 [options="header",cols="^m,^m,^m,v",separator=";"]
 |====================
 Variable;Values allowed;Default value;Explanation
-WORKER_HOSTNAME;string;undef;Worker host name
+WORKER_HOSTNAME;string;undef;Worker hostname
 |====================
 
 .SPVM backend
@@ -313,7 +313,7 @@ WORKER_HOSTNAME;string;undef;Worker host name
 |====================
 Variable;Values allowed;Default value;Explanation
 HARDWARE_CONSOLE_LOG;boolean;undef;Enable direct log capture of mkvterm console, disabled by default
-WORKER_HOSTNAME;string;undef;Worker host name
+WORKER_HOSTNAME;string;undef;Worker hostname
 NOVALINK_HOSTNAME;string;undef;Novalink target host to connect to
 NOVALINK_USERNAME;string;root;Username to authenticate on Novalink host
 NOVALINK_PASSWORD;string;undef;Password to authenticate on Novalink host

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -82,6 +82,8 @@ IPMI_MC_RESET_TIMEOUT;integer;60;Counts to try to reach IPMI interface after mc 
 IPMI_MC_RESET_PING_COUNT;integer;1;Ping counts that must be successful after mc reset
 IPMI_MC_RESET_IPMI_TRIES;integer;3;Maximum number of IPMI command tries that are conducted after mc reset
 IPMI_SOL_PERSISTENT_CONSOLE;boolean;1;Make SOL console persistent and don't reset it, enabled by default
+IPMI_$_;;;Internal iterator variable
+WORKER_HOSTNAME;string;undef;Worker hostname
 |====================
 
 .QEMU backend
@@ -194,7 +196,8 @@ HDDSIZEGB;integer;15;Disk size in GB
 QEMUCPUS;integer;1;Number of CPUs to assign to VM
 QEMURAM;integer;1024;Size of RAM of VM in MiB
 VIRSH_HOSTNAME;string;;SSH Host with virsh
-VIRSH_PASSWORD;string;;Password for root account on above host
+VIRSH_USERNAME;string;;Username on above host, defaults to root
+VIRSH_PASSWORD;string;;Password for user account on above host
 VIRSH_VMM_FAMILY;string;;Host's hypervisor ('kvm', 'xen')
 VIRSH_VMM_TYPE;string;;Host's hypervisor type ('hvm' for full virtualization on 'kvm' and 'xen' families, 'linux' for paravirtualization on 'xen' family)
 VIRSH_GUEST;string;;Where to look for VNC server (SUT or VM)
@@ -215,6 +218,9 @@ HYPERV_SERIAL_PORT;integer;;TCP port where is VM's serial port stream to be expe
 HYPERV_VIRTUAL_SWITCH;string;;ExternalVirtualSwitch;Name of Hyper-V's External Virtual Switch
 NUMDISKS;integer;1;Number of disks
 RAIDLEVEL;integer;undef;Sets the raid level
+HDDFORMAT;;;HDD format
+SVIRT_KEEP_VM_RUNNING;boolean;undef;Keep VM running after execution, disabled by default
+WORKER_HOSTNAME;string;undef;Worker hostname
 |====================
 
 .VAGRANT backend
@@ -267,13 +273,14 @@ WORKER_ID;string;undef;osauto id
 |====================
 Variable;Values allowed;Default value;Explanation
 HARDWARE_CONSOLE_LOG;boolean;undef;Enable direct log capture of mkvterm console, disabled by default
-HMC_MACHINE_NAME;;Sets the public name of the host
-HMC_HOSTNAME;;Sets the remote host to connect tp
-HMC_USERNAME;string;;Username for the remote host
+HMC_MACHINE_NAME;string;;Sets the public name of the host
+HMC_HOSTNAME;string;;Sets the remote host to connect tp
+HMC_USERNAME;string;;Username for the remote host, defaults to hscroot
 HMC_PASSWORD;string;;Password for the remote host
+LPAR_ID;string;udef;LPAR id
 |====================
 
-.GENERAL_HW backend
+.GENERALHW backend
 [grid="rows",format="csv"]
 [options="header",cols="^m,^m,^m,v",separator=";"]
 |====================
@@ -288,6 +295,11 @@ GENERAL_HW_POWEROFF_CMD;string;;Shell Command to power off the SUT (in CMD_DIR)
 GENERAL_HW_POWEROFF_ARGS;string;;Arguments to pass GENERAL_HW_POWEROFF_CMD Shell script
 GENERAL_HW_FLASH_CMD;string;;Shell Command to flash a disk image on SUT (in CMD_DIR), optional
 GENERAL_HW_FLASH_ARGS;string;;Arguments to pass GENERAL_HW_FLASH_CMD Shell script
+HDDSIZEGB;integer;10;Creates HDD with specified size in GiB
+HDD_$i;filename;;Filename of HDD image to be used for machine.
+HDDSIZEGB_$i;integer;;Creates HDD with specified size in GiB for corresponding HDD
+NUMDISKS;integer;1;Number of disks attached to machine
+WORKER_HOSTNAME;string;undef;Worker hostname
 |====================
 
 .AMT backend

--- a/t/04-check_vars_docu.t
+++ b/t/04-check_vars_docu.t
@@ -22,7 +22,12 @@ use constant VARS_DOC => DOC_DIR . '/backend_vars.asciidoc';
 # array of ignored "backends"
 my @backend_blocklist = qw();
 # blocklist of vars per backend. These vars will be ignored during vars exploration
-my %var_blocklist = (QEMU => ['WORKER_ID', 'WORKER_INSTANCE'], VAGRANT => ['QEMUCPUS', 'QEMURAM']);
+my %var_blocklist = (
+    QEMU => ['WORKER_ID', 'WORKER_INSTANCE'],
+    VAGRANT => ['QEMUCPUS', 'QEMURAM'],
+    GENERALHW => ['HDD_1'],
+    SVIRT => ['JOBTOKEN'],
+);
 # in case we want to present backend under different name, place it here
 my %backend_renames = (BASECLASS => 'Common', IKVM => 'IPMI');
 

--- a/xt/01-style.t
+++ b/xt/01-style.t
@@ -12,5 +12,5 @@ ok system(qq{git grep -I -l 'This program is free software.*if not, see <http://
 ok system(qq{git grep -I -l '[#/ ]*SPDX-License-Identifier ' ':!COPYING' ':!external/' ':!xt/01-style.t'}) != 0, 'SPDX-License-Identifier correctly terminated';
 is qx{git grep -I -L '^use Test::Most' t/**.t}, '', 'All tests use Test::Most';
 is qx{git grep -I -L '^use Test::Warnings' t/**.t}, '', 'All tests use Test::Warnings';
-is qx{git grep -I -l '^use testapi' backend/}, '', 'No backend files use external facing testapi';
+is qx{git grep -I -l '^use testapi' backend/ consoles/}, '', 'No backend or console files use external facing testapi';
 done_testing;

--- a/xt/01-style.t
+++ b/xt/01-style.t
@@ -12,4 +12,5 @@ ok system(qq{git grep -I -l 'This program is free software.*if not, see <http://
 ok system(qq{git grep -I -l '[#/ ]*SPDX-License-Identifier ' ':!COPYING' ':!external/' ':!xt/01-style.t'}) != 0, 'SPDX-License-Identifier correctly terminated';
 is qx{git grep -I -L '^use Test::Most' t/**.t}, '', 'All tests use Test::Most';
 is qx{git grep -I -L '^use Test::Warnings' t/**.t}, '', 'All tests use Test::Warnings';
+is qx{git grep -I -l '^use testapi' backend/}, '', 'No backend files use external facing testapi';
 done_testing;


### PR DESCRIPTION
Some backend code (mis-)used the testapi "get_var" and other functions when
we should use the bmwqemu variable directly. This also fixes the check for
documentation of backend variables which relies on the variable use.

Used the following command for automatic replacement and some manual corrections:

```
sed -i -e "s/get_required_var([\"\']\([A-Za-z0-9_\$]*\)[\"\'])/\$bmwqemu::vars{\1} or die 'Need variable \1'/g" -e "s/get_var([\"\']\([A-Za-z0-9_\$]*\)[\"\'])/\$bmwqemu::vars{\1}/g" -e "s/get_var([\"\']\([A-Za-z0-9_\$]*\)[\"\'], [\"\']\([A-Za-z_0-9]*\)[\"\'])/\$bmwqemu::vars{\1} \/\/ \'\2\'/g" -e "s/check_var([\"\']\([A-Za-z0-9_\$]*\)[\"\'], [\"\']\([A-Za-z_0-9]*\)[\"\'])/\$bmwqemu::vars{\1} eq \'\2\'/g" $(git grep -l '_var' backend/)
```