### PR TITLE
Simplify base inheritance statement with Mojo::Base everywhere

### DIFF
--- a/backend/amt.pm
+++ b/backend/amt.pm
@@ -3,11 +3,8 @@
 
 package backend::amt;
 
-use Mojo::Base -strict, -signatures;
+use Mojo::Base 'backend::baseclass', -signatures;
 use autodie ':all';
-
-use base 'backend::baseclass';
-
 use Time::HiRes qw(sleep gettimeofday);
 use Data::Dumper;
 require Carp;

--- a/backend/generalhw.pm
+++ b/backend/generalhw.pm
@@ -6,11 +6,8 @@
 
 package backend::generalhw;
 
-use Mojo::Base -strict, -signatures;
+use Mojo::Base 'backend::baseclass', -signatures;
 use autodie ':all';
-
-use base 'backend::baseclass';
-
 use bmwqemu;
 use IPC::Run ();
 require IPC::System::Simple;

--- a/backend/ikvm.pm
+++ b/backend/ikvm.pm
@@ -4,10 +4,8 @@
 
 package backend::ikvm;
 
-use Mojo::Base -strict, -signatures;
+use Mojo::Base 'backend::ipmi', -signatures;
 use autodie ':all';
-
-use base 'backend::ipmi';
 
 sub new ($class) { $class->SUPER::new }
 

--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -3,12 +3,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package backend::ipmi;
-
-use Mojo::Base -strict, -signatures;
+use Mojo::Base 'backend::baseclass', -signatures;
 use autodie ':all';
-
-use base 'backend::baseclass';
-
 use Time::HiRes qw(sleep);
 use Time::Seconds;
 use IPC::Run ();

--- a/backend/null.pm
+++ b/backend/null.pm
@@ -2,10 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package backend::null;
-
-use Mojo::Base -strict, -signatures;
-
-use base 'backend::baseclass';
+use Mojo::Base 'backend::baseclass', -signatures;
 
 sub new ($self) { $self->SUPER::new }
 

--- a/backend/pvm.pm
+++ b/backend/pvm.pm
@@ -2,12 +2,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package backend::pvm;
-
-use Mojo::Base -strict, -signatures;
+use Mojo::Base 'backend::baseclass', -signatures;
 use autodie ':all';
-
-use base 'backend::baseclass';
-
 use bmwqemu qw(diag fctwarn);
 use File::Path 'mkpath';
 require IPC::System::Simple;

--- a/backend/pvm_hmc.pm
+++ b/backend/pvm_hmc.pm
@@ -2,10 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package backend::pvm_hmc;
-
-use Mojo::Base -strict, -signatures;
-
-use base 'backend::virt';
+use Mojo::Base 'backend::virt', -signatures;
 
 # supporting the minimal command set of the HMC through a ssh tunnel
 

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -3,12 +3,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package backend::qemu;
-
-use Mojo::Base -strict, -signatures;
+use Mojo::Base 'backend::virt', -signatures;
 use autodie ':all';
-
-use base 'backend::virt';
-
 use File::Basename 'dirname';
 use File::Path 'mkpath';
 use File::Which;

--- a/backend/s390x.pm
+++ b/backend/s390x.pm
@@ -3,12 +3,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package backend::s390x;
-
-use Mojo::Base -strict, -signatures;
+use Mojo::Base 'backend::baseclass', -signatures;
 use autodie ':all';
-
-use base 'backend::baseclass';
-
 use English;
 require IPC::System::Simple;
 use Carp qw(confess cluck carp croak);

--- a/backend/spvm.pm
+++ b/backend/spvm.pm
@@ -2,10 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package backend::spvm;
-
-use Mojo::Base -strict, -signatures;
-
-use base 'backend::virt';
+use Mojo::Base 'backend::virt', -signatures;
 
 # supporting the minimal command set of NovaLink through a ssh tunnel
 

--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -3,11 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package backend::svirt;
-
-use Mojo::Base -strict, -signatures;
-
-use base 'backend::virt';
-
+use Mojo::Base 'backend::virt', -signatures;
 use File::Basename;
 use IO::Scalar;
 use Time::HiRes 'usleep';

--- a/backend/vagrant.pm
+++ b/backend/vagrant.pm
@@ -3,10 +3,8 @@
 
 package backend::vagrant;
 
-use base 'backend::virt';
+use Mojo::Base 'backend::virt', -signatures;
 use bmwqemu;
-
-use Mojo::Base -strict, -signatures;
 use Mojo::File;
 use Cwd qw(abs_path);
 use File::Temp;

--- a/backend/virt.pm
+++ b/backend/virt.pm
@@ -3,10 +3,7 @@
 
 package backend::virt;
 
-use Mojo::Base -strict, -signatures;
-
-use base 'backend::baseclass';
-
+use Mojo::Base 'backend::baseclass', -signatures;
 use bmwqemu;
 
 sub new ($class) {

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -1,11 +1,7 @@
 package consoles::VNC;
 
-use Mojo::Base -strict;
+use Mojo::Base 'Class::Accessor::Fast', -signatures;
 use bytes;
-use feature 'say';
-
-use base 'Class::Accessor::Fast';
-
 use IO::Socket::INET;
 use bmwqemu qw(diag fctwarn);
 use Time::HiRes qw( sleep gettimeofday time );

--- a/consoles/amtSol.pm
+++ b/consoles/amtSol.pm
@@ -3,11 +3,8 @@
 
 package consoles::amtSol;
 
-use Mojo::Base -strict, -signatures;
+use Mojo::Base 'consoles::console', -signatures;
 use autodie ':all';
-
-use base 'consoles::console';
-
 require IPC::System::Simple;
 use POSIX '_exit';
 use bmwqemu;

--- a/consoles/ipmiSol.pm
+++ b/consoles/ipmiSol.pm
@@ -3,11 +3,8 @@
 
 package consoles::ipmiSol;
 
-use Mojo::Base -strict, -signatures;
+use Mojo::Base 'consoles::console', -signatures;
 use autodie ':all';
-
-use base 'consoles::console';
-
 require IPC::System::Simple;
 use POSIX '_exit';
 use bmwqemu;

--- a/consoles/localXvnc.pm
+++ b/consoles/localXvnc.pm
@@ -4,11 +4,8 @@
 
 package consoles::localXvnc;
 
-use Mojo::Base -strict, -signatures;
+use Mojo::Base 'consoles::vnc_base', -signatures;
 use autodie ':all';
-
-use base 'consoles::vnc_base';
-
 use IPC::Run ();
 require IPC::System::Simple;
 use Socket;

--- a/consoles/network_console.pm
+++ b/consoles/network_console.pm
@@ -4,10 +4,7 @@
 
 package consoles::network_console;
 
-use Mojo::Base -strict, -signatures;
-
-use base 'consoles::console';
-
+use Mojo::Base 'consoles::console', -signatures;
 use Try::Tiny;
 use Scalar::Util 'blessed';
 

--- a/consoles/s3270.pm
+++ b/consoles/s3270.pm
@@ -4,11 +4,8 @@
 
 package consoles::s3270;
 
-use Mojo::Base -strict, -signatures;
+use Mojo::Base 'consoles::localXvnc', -signatures;
 use feature 'say';
-
-use base 'consoles::localXvnc';
-
 use Class::Accessor 'antlers';
 use Data::Dumper 'Dumper';
 use Carp qw(confess cluck carp croak);

--- a/consoles/sshIucvconn.pm
+++ b/consoles/sshIucvconn.pm
@@ -6,11 +6,8 @@
 
 package consoles::sshIucvconn;
 
-use Mojo::Base -strict, -signatures;
+use Mojo::Base 'consoles::network_console', -signatures;
 use autodie ':all';
-
-use base 'consoles::network_console';
-
 
 sub connect_remote ($self, $args) {
     my $hostname = $args->{hostname};

--- a/consoles/sshSerial.pm
+++ b/consoles/sshSerial.pm
@@ -6,10 +6,7 @@
 
 package consoles::sshSerial;
 
-use Mojo::Base -strict, -signatures;
-
-use base 'consoles::console';
-
+use Mojo::Base 'consoles::console', -signatures;
 use consoles::ssh_screen;
 
 sub new ($class, $testapi_console, $args) {

--- a/consoles/sshVirtshSUT.pm
+++ b/consoles/sshVirtshSUT.pm
@@ -3,10 +3,7 @@
 
 package consoles::sshVirtshSUT;
 
-use Mojo::Base -strict, -signatures;
-
-use base 'consoles::console';
-
+use Mojo::Base 'consoles::console', -signatures;
 use backend::svirt qw(SERIAL_TERMINAL_DEFAULT_PORT SERIAL_TERMINAL_DEFAULT_DEVICE);
 use consoles::ssh_screen;
 

--- a/consoles/sshX3270.pm
+++ b/consoles/sshX3270.pm
@@ -4,10 +4,7 @@
 
 package consoles::sshX3270;
 
-use Mojo::Base -strict, -signatures;
-
-use base 'consoles::localXvnc';
-
+use Mojo::Base 'consoles::localXvnc', -signatures;
 
 sub activate ($self) {
     my $sshcommand = $self->sshCommand('root', $bmwqemu::vars{PARMFILE}->{Hostname});

--- a/consoles/sshXtermIPMI.pm
+++ b/consoles/sshXtermIPMI.pm
@@ -4,11 +4,8 @@
 
 package consoles::sshXtermIPMI;
 
-use Mojo::Base -strict, -signatures;
+use Mojo::Base 'consoles::localXvnc', -signatures;
 use autodie ':all';
-
-use base 'consoles::localXvnc';
-
 require IPC::System::Simple;
 use File::Which;
 

--- a/consoles/sshXtermVt.pm
+++ b/consoles/sshXtermVt.pm
@@ -4,11 +4,8 @@
 
 package consoles::sshXtermVt;
 
-use Mojo::Base -strict, -signatures;
+use Mojo::Base 'consoles::localXvnc', -signatures;
 use autodie ':all';
-
-use base 'consoles::localXvnc';
-
 use IO::Socket::INET;
 require IPC::System::Simple;
 

--- a/consoles/ttyConsole.pm
+++ b/consoles/ttyConsole.pm
@@ -4,11 +4,8 @@
 
 package consoles::ttyConsole;
 
-use Mojo::Base -strict, -signatures;
+use Mojo::Base 'consoles::console', -signatures;
 use autodie ':all';
-
-use base 'consoles::console';
-
 require IPC::System::Simple;
 
 sub trigger_select ($self) {

--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -2,11 +2,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 package consoles::virtio_terminal;
 
-use Mojo::Base -strict, -signatures;
+use Mojo::Base 'consoles::console', -signatures;
 use autodie;
-
-use base 'consoles::console';
-
 use Mojo::File 'path';
 use Socket qw(SOCK_NONBLOCK PF_UNIX SOCK_STREAM sockaddr_un);
 use Errno qw(EAGAIN EWOULDBLOCK);

--- a/consoles/vnc_base.pm
+++ b/consoles/vnc_base.pm
@@ -4,10 +4,7 @@
 
 package consoles::vnc_base;
 
-use Mojo::Base -strict, -signatures;
-
-use base 'consoles::network_console';
-
+use Mojo::Base 'consoles::network_console', -signatures;
 use consoles::VNC;
 use Time::HiRes qw(usleep);
 

--- a/lockapi.pm
+++ b/lockapi.pm
@@ -4,10 +4,9 @@
 ## synchronization API
 package lockapi;
 
-use Mojo::Base -strict;
+use Mojo::Base 'Exporter';
 use Scalar::Util 'looks_like_number';
 use Time::Seconds;
-use base 'Exporter';
 our @EXPORT = qw(mutex_create mutex_lock mutex_unlock mutex_try_lock mutex_wait
   barrier_create barrier_wait barrier_try_wait barrier_destroy);
 

--- a/mmapi.pm
+++ b/mmapi.pm
@@ -4,9 +4,7 @@
 ## Multi-Machine API
 package mmapi;
 
-use Mojo::Base -strict;
-
-use base 'Exporter';
+use Mojo::Base 'Exporter';
 our @EXPORT = qw(get_children_by_state get_children get_parents
   get_job_info get_job_autoinst_url get_job_autoinst_vars
   wait_for_children wait_for_children_to_start api_call

--- a/os-autoinst-openvswitch
+++ b/os-autoinst-openvswitch
@@ -1,11 +1,8 @@
 #!/usr/bin/perl
 package OVS;
 
-use Mojo::Base -strict;
+use Mojo::Base 'Net::DBus::Object';
 use autodie ':all';
-
-use base 'Net::DBus::Object';
-
 use Net::DBus::Exporter 'org.opensuse.os_autoinst.switch';
 require IPC::System::Simple;
 use IPC::Open3;

--- a/osutils.pm
+++ b/osutils.pm
@@ -3,11 +3,8 @@
 
 package osutils;
 
-require 5.002;
-use Mojo::Base -strict;
-
+use Mojo::Base 'Exporter';
 use Carp;
-use base 'Exporter';
 use Mojo::File 'path';
 use bmwqemu;
 use Mojo::IOLoop::ReadWriteProcess 'process';

--- a/t/data/tests/bar/baz.pm
+++ b/t/data/tests/bar/baz.pm
@@ -1,3 +1,2 @@
-use Mojo::Base -strict, -signatures;
-use base 'basetest';
+use Mojo::Base 'basetest', -signatures;
 1;

--- a/t/data/tests/foo.pm
+++ b/t/data/tests/foo.pm
@@ -1,3 +1,2 @@
-use Mojo::Base -strict, -signatures;
-use base 'basetest';
+use Mojo::Base 'basetest', -signatures;
 1;

--- a/t/data/tests/lib/testdistribution.pm
+++ b/t/data/tests/lib/testdistribution.pm
@@ -3,9 +3,7 @@
 
 package testdistribution;
 
-use Mojo::Base -strict, -signatures;
-
-use base 'distribution';
+use Mojo::Base 'distribution', -signatures;
 
 sub init ($self) {
     $self->SUPER::init();

--- a/t/data/tests/tests/assert_screen.pm
+++ b/t/data/tests/tests/assert_screen.pm
@@ -1,9 +1,7 @@
 # Copyright 2016-2021 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-use Mojo::Base -strict, -signatures;
-use base 'basetest';
-
+use Mojo::Base 'basetest', -signatures;
 use testapi;
 
 sub run {

--- a/t/data/tests/tests/assert_screen_fail_test.pm
+++ b/t/data/tests/tests/assert_screen_fail_test.pm
@@ -1,8 +1,7 @@
 # Copyright 2017-2021 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-use Mojo::Base -strict, -signatures;
-use base 'basetest';
+use Mojo::Base 'basetest', -signatures;
 use testapi;
 
 sub run {

--- a/t/data/tests/tests/boot.pm
+++ b/t/data/tests/tests/boot.pm
@@ -1,8 +1,7 @@
 # Copyright 2016-2021 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-use Mojo::Base -strict, -signatures;
-use base "basetest";
+use Mojo::Base 'basetest', -signatures;
 use testapi;
 
 sub run {

--- a/t/data/tests/tests/failing_module.pm
+++ b/t/data/tests/tests/failing_module.pm
@@ -1,8 +1,7 @@
 # Copyright 2019-2021 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-use Mojo::Base -strict, -signatures;
-use base 'basetest';
+use Mojo::Base 'basetest', -signatures;
 use testapi;
 
 sub run {

--- a/t/data/tests/tests/freeze.pm
+++ b/t/data/tests/tests/freeze.pm
@@ -1,8 +1,7 @@
 # Copyright 2016-2021 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-use Mojo::Base -strict, -signatures;
-use base 'basetest';
+use Mojo::Base 'basetest', -signatures;
 use testapi;
 
 sub run {

--- a/t/data/tests/tests/modify_and_upload_file.pm
+++ b/t/data/tests/tests/modify_and_upload_file.pm
@@ -1,8 +1,7 @@
 # Copyright 2017-2021 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-use Mojo::Base -strict, -signatures;
-use base "basetest";
+use Mojo::Base 'basetest', -signatures;
 use testapi;
 
 my $orig_file = <<'END';

--- a/t/data/tests/tests/noop.pm
+++ b/t/data/tests/tests/noop.pm
@@ -1,8 +1,7 @@
 # Copyright 2020-2021 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-use Mojo::Base -strict, -signatures;
-use base "basetest";
+use Mojo::Base 'basetest', -signatures;
 use testapi;
 
 sub run {

--- a/t/data/tests/tests/reload_needles.pm
+++ b/t/data/tests/tests/reload_needles.pm
@@ -1,8 +1,7 @@
 # Copyright 2017-2021 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-use Mojo::Base -strict, -signatures;
-use base 'basetest';
+use Mojo::Base 'basetest', -signatures;
 use testapi;
 
 sub run {

--- a/t/data/tests/tests/select_console_fail_test.pm
+++ b/t/data/tests/tests/select_console_fail_test.pm
@@ -1,8 +1,7 @@
 # Copyright 2017-2021 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-use Mojo::Base -strict, -signatures;
-use base 'basetest';
+use Mojo::Base 'basetest', -signatures;
 use testapi;
 
 sub run {

--- a/t/data/tests/tests/select_ssh_console_fail_test.pm
+++ b/t/data/tests/tests/select_ssh_console_fail_test.pm
@@ -1,8 +1,7 @@
 # Copyright 2019-2021 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-use Mojo::Base -strict, -signatures;
-use base 'basetest';
+use Mojo::Base 'basetest', -signatures;
 use testapi;
 
 sub run {

--- a/t/data/tests/tests/shutdown.pm
+++ b/t/data/tests/tests/shutdown.pm
@@ -1,8 +1,7 @@
 # Copyright 2017-2021 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-use Mojo::Base -strict, -signatures;
-use base 'basetest';
+use Mojo::Base 'basetest', -signatures;
 use testapi;
 
 sub run {

--- a/t/data/tests/tests/typing.pm
+++ b/t/data/tests/tests/typing.pm
@@ -1,8 +1,7 @@
 # Copyright 2017-2021 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-use Mojo::Base -strict, -signatures;
-use base "basetest";
+use Mojo::Base 'basetest', -signatures;
 use testapi;
 
 sub run {

--- a/t/fake/tests/fatal.pm
+++ b/t/fake/tests/fatal.pm
@@ -1,5 +1,4 @@
-use Mojo::Base -strict, -signatures;
-use base 'basetest';
+use Mojo::Base 'basetest', -signatures;
 
 sub run { }
 

--- a/t/fake/tests/ignore_failure.pm
+++ b/t/fake/tests/ignore_failure.pm
@@ -1,5 +1,4 @@
-use Mojo::Base -strict, -signatures;
-use base 'basetest';
+use Mojo::Base 'basetest', -signatures;
 
 sub run { }
 

--- a/t/fake/tests/run_args.pm
+++ b/t/fake/tests/run_args.pm
@@ -1,6 +1,4 @@
-use Mojo::Base -strict, -signatures;
-
-use base 'basetest';
+use Mojo::Base 'basetest', -signatures;
 
 sub run ($self, $rargs) {
 

--- a/t/fake/tests/scheduler.pm
+++ b/t/fake/tests/scheduler.pm
@@ -1,5 +1,4 @@
-use Mojo::Base -strict, -signatures;
-use base 'basetest';
+use Mojo::Base 'basetest', -signatures;
 use autotest 'loadtest';
 
 sub run {

--- a/t/fake/tests/start.pm
+++ b/t/fake/tests/start.pm
@@ -1,5 +1,4 @@
-use Mojo::Base -strict, -signatures;
-use base 'basetest';
+use Mojo::Base 'basetest', -signatures;
 
 sub run { }
 1;

--- a/testapi.pm
+++ b/testapi.pm
@@ -4,10 +4,9 @@
 
 package testapi;
 
-use base Exporter;
 use Carp;
 use Exporter;
-use Mojo::Base -strict;
+use Mojo::Base 'Exporter';
 use File::Basename qw(basename dirname);
 use File::Path 'make_path';
 use Time::HiRes qw(sleep gettimeofday tv_interval);

--- a/tools/lib/perlcritic/Perl/Critic/Policy/HashKeyQuotes.pm
+++ b/tools/lib/perlcritic/Perl/Critic/Policy/HashKeyQuotes.pm
@@ -1,9 +1,7 @@
 package Perl::Critic::Policy::HashKeyQuotes;
 
-use Mojo::Base -strict, -signatures;
-
+use Mojo::Base 'Perl::Critic::Policy', -signatures;
 use Perl::Critic::Utils qw( :severities :classification :ppi );
-use base 'Perl::Critic::Policy';
 
 our $VERSION = '0.0.1';
 


### PR DESCRIPTION
Based on
* #1913
* #1926
* #1789


The patch coverage will be still be our automatic acceptance threshold due to background processes not collecting coverage properly. If you can approve in the current state please approve which I will see as implicit approval of the other three PRs, otherwise please review the PRs above in the stated order.

EDIT: I managed to exclude the consoles::VNC changes which cause the codecov patch coverage check to fail so this PR now only includes the one commit about "base inheritance using Mojo::Base"