### PR TITLE
Fix `consoles::VNC::new does not exist! at t/27-consoles-vnc_base.t`

### DIFF
--- a/t/27-consoles-vnc_base.t
+++ b/t/27-consoles-vnc_base.t
@@ -31,7 +31,7 @@ $c->{vnc} = $vnc;
 is $c->disable_vnc_stalls, 1, 'can call disable_vnc_stalls with VNC';
 ok $vnc->called('check_vnc_stalls'), 'check_vnc_stalls called with VNC';
 my $vnc_mock = Test::MockModule->new('consoles::VNC');
-$vnc_mock->redefine(new => $vnc);
+$vnc_mock->mock(new => $vnc);
 $vnc->set_true('login');
 stderr_like { $c->connect_remote({hostname => 'localhost', port => 42}) } qr/Establishing VNC connection to localhost:42/, 'can call connect_remote';
 $vnc->set_true('update_framebuffer', 'send_update_request');


### PR DESCRIPTION
This test failure happens on Leap 15.2 / SLE15-SP3. The function really
does not exist. Likely the newer version of `perl-Test-MockModule` we
provide for Leap 15.3 can cope with that so we only see the problem in
Leap 15.2 / SLE15-SP3 builds.

---

Btw, I've tested this via a Leap 15.2 container image.