### PR TITLE
testapi: Allow distri class provide default for die_on_timeout

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -15,6 +15,7 @@ sub new {
     $self->{consoles} = {};
     $self->{serial_failures} = [];
     $self->{autoinst_failures} = [];
+    $self->{script_run_die_on_timeout} = -1;
 
 =head2 serial_term_prompt
 

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -287,6 +287,9 @@ subtest 'script_run' => sub {
     is(script_run('false', 0, die_on_timeout => 1), undef, 'script_run with no check of success, returns undef when not waiting');
     $fake_matched = 0;
     throws_ok { script_run('sleep 13', timeout => 10, die_on_timeout => 1, quiet => 1) } qr/command.*timed out/, 'exception occured on script_run() timeout';
+    $testapi::distri->{script_run_die_on_timeout} = 1;
+    throws_ok { script_run('sleep 13', timeout => 10, quiet => 1) } qr/command.*timed out/, 'exception occured on script_run() timeout';
+    $testapi::distri->{script_run_die_on_timeout} = -1;
     $fake_matched = 1;
 
     stderr_like { script_run('true', quiet => 1) } qr/DEPRECATED/, 'DEPRECATED message appear if `die_on_timeout` is not given.';

--- a/testapi.pm
+++ b/testapi.pm
@@ -1028,7 +1028,7 @@ sub script_run {
             timeout => $bmwqemu::default_timeout,
             output => '',
             quiet => testapi::get_var('_QUIET_SCRIPT_CALLS'),
-            die_on_timeout => -1,
+            die_on_timeout => $distri->{script_run_die_on_timeout},
         }, ['timeout'], @_);
 
     bmwqemu::log_call(cmd => $cmd, %args);
@@ -1045,7 +1045,9 @@ sub script_run {
                 my $casedir = testapi::get_var(CASEDIR => '');
                 $filename =~ s%^\Q$casedir\E/%%;
                 bmwqemu::fctwarn("DEPRECATED call of script_run() in $filename:$line " .
-                      'add `die_on_timeout => ?` to avoid this warning');
+                      'add `die_on_timeout => ?` to the call or set
+                      $distri->{script_run_die_on_timeout} to avoid this
+                      warning');
             }
         }
     }


### PR DESCRIPTION
script_run warns if die_on_timeout is not provided (regardless if is 0
or 1). Adjusting all the usages to always use the argument is
unnecessary boilerplate, so let the distri class provide the default.
This way, test developers can set it everywhere without actually
changing every single call. It is still possible to override it
per-call.