### PR TITLE
Fix missing parameter for consoles::vnc_base::get_last_mouse_set

### DIFF
--- a/consoles/vnc_base.pm
+++ b/consoles/vnc_base.pm
@@ -23,7 +23,7 @@ sub disable ($self) {
     $self->{vnc} = undef;
 }
 
-sub get_last_mouse_set ($self) { $self->{mouse} }
+sub get_last_mouse_set ($self, $args) { $self->{mouse} }
 
 sub disable_vnc_stalls ($self) {
     return unless $self->{vnc};

--- a/t/27-consoles-vnc_base.t
+++ b/t/27-consoles-vnc_base.t
@@ -23,7 +23,7 @@ $vnc->set_always('socket', 0);
 $c->disable;
 is $c->{vnc}, undef, 'VNC removed by disable';
 
-is $c->get_last_mouse_set, undef, 'can call get_last_mouse_set';
+is $c->get_last_mouse_set({}), undef, 'can call get_last_mouse_set';
 $vnc->set_true('check_vnc_stalls');
 is $c->disable_vnc_stalls, undef, 'can call disable_vnc_stalls without VNC';
 ok !$vnc->called('check_vnc_stalls'), 'check_vnc_stalls not called without VNC';


### PR DESCRIPTION
Related progress issues:
* https://progress.opensuse.org/issues/99663
* https://progress.opensuse.org/issues/104986