### PR TITLE
Fix wrong condition in SSH virsh console introduced by 54d514df79fa1

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -133,7 +133,7 @@ sub _init_xml ($self, $args = {}) {
         $root->appendChild($elem);
     }
 
-    if ($bmwqemu::vars{UEFI} and $bmwqemu::vars{ARCH} eq 'x86_64' and !$bmwqemu::vars{BIOS} and !$bmwqemu::vars{VIRSH_VMM_FAMILY} eq 'hyperv') {
+    if ($bmwqemu::vars{UEFI} and $bmwqemu::vars{ARCH} eq 'x86_64' and !$bmwqemu::vars{BIOS} and $bmwqemu::vars{VIRSH_VMM_FAMILY} ne 'hyperv') {
         foreach my $firmware (@bmwqemu::ovmf_locations) {
             if (!$self->run_cmd("test -e $firmware")) {
                 $bmwqemu::vars{BIOS} = $firmware;

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -493,9 +493,9 @@ sub define_and_start ($self) {
         $self->run_cmd(
             "cat > $libvirtauthfilename <<__END
 [credentials-vmware]
-username=" . $bmwqemu::vars{VMWARE_USERNAME} or die 'Need variable VMWARE_USERNAME' . "
-password=" . $bmwqemu::vars{VMWARE_PASSWORD} or die 'Need variable VMWARE_PASSWORD' . "
-[auth-esx-" . $bmwqemu::vars{VMWARE_HOST} or die 'Need variable VMWARE_HOST' . "]
+username=" . ($bmwqemu::vars{VMWARE_USERNAME} or die 'Need variable VMWARE_USERNAME') . "
+password=" . ($bmwqemu::vars{VMWARE_PASSWORD} or die 'Need variable VMWARE_PASSWORD') . "
+[auth-esx-" . ($bmwqemu::vars{VMWARE_HOST} or die 'Need variable VMWARE_HOST') . "]
 credentials=vmware
 __END"
         );


### PR DESCRIPTION
* It was originally `!check_var('VIRSH_VMM_FAMILY', 'hyperv')`
* The code from 54d514df79fa1 negates the variable fist and does the
  comparison second (which is different)
* See https://progress.opensuse.org/issues/104992