### PR TITLE
Add OBS workflow

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,6 +11,13 @@ pull_request_rules:
         # wait for OBS package build as well which is triggered independantly
         # See https://progress.opensuse.org/issues/55346 for details
         - "check-success=OBS Package Build"
+        # Multibuild results will not report the "pending" status, so we
+        # need to require them explicitly, see
+        # https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.scm_ci_workflow_integration.html#sec.obs.obs_scm_ci_workflow_integration.setup.status_reporting
+        - "check-success~=OBS: os-autoinst - openSUSE_Leap_.*/x86_64"
+        - "check-success=OBS: os-autoinst - openSUSE_Tumbleweed/x86_64"
+        - "check-success~=OBS: os-autoinst:os-autoinst-test - openSUSE_Leap_.*/x86_64"
+        - "check-success=OBS: os-autoinst:os-autoinst-test - openSUSE_Tumbleweed/x86_64"
         - "#check-failure=0"
         - "#check-pending=0"
         - linear-history

--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -1,0 +1,33 @@
+---
+pr:
+  steps:
+  - link_package:
+      source_project: devel:openQA
+      source_package: os-autoinst
+      target_project: devel:openQA:GitHub
+  - configure_repositories:
+      project: devel:openQA:GitHub
+      repositories:
+      - name: openSUSE_Tumbleweed
+        target_project: openSUSE:Factory
+        target_repository: snapshot
+        architectures: [ x86_64 ]
+      - name: openSUSE_Leap_15.3
+        target_project: devel:openQA:Leap:15.3
+        target_repository: openSUSE_Leap_15.3
+        architectures: [ x86_64 ]
+  filters:
+    event: pull_request
+
+# Setup:
+# 1. Put this .obs/workflows.yml in the main branch of os-autoinst
+# 2a. (Someone of our team) Create personal access token on GitHub with scope "repo"
+# 2b. Ensure it is renewed before expiry
+# 3. Create token on OBS:
+#   Type: Workflow
+#   Name: GitHub PRs
+#   SCM Token: token from above
+# 4. (Repo admin) Create webhook in os-autoinst:
+#   URL: https://build.opensuse.org/trigger/workflow?id=<OBS Token ID>
+#   Content-Type: application/json
+#   Select individual events: Pull requests


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/102464

Example PR: https://github.com/perlpunk/os-autoinst/pull/12

OBS Limitation: "Due to a limitation, the initial "pending" build status of
  packages with multibuild flavors is not reported. The build status for those
  flavors will however still be reported when the build finishes."
https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.scm_ci_workflow_integration.html#sec.obs.obs_scm_ci_workflow_integration.setup.status_reporting

Because of this limitation, I had to add all the jobs we expect to mergify.

Only when this is merged, new PRs will show the new tests.