### PR TITLE
Mark backend::amt as deprecated as it seems to be unused

### DIFF
--- a/backend/amt.pm
+++ b/backend/amt.pm
@@ -31,6 +31,7 @@ sub new ($class) {
     $ENV{'WSMAN_USER'} = 'admin';
     $ENV{'WSMAN_PASS'} = $bmwqemu::vars{AMT_PASSWORD};
 
+    bmwqemu::fctwarn 'DEPRECATED: backend::amt is unsupported and planned to be removed from os-autoinst eventually';
     return $class->SUPER::new;
 }
 

--- a/backend/amt.pm
+++ b/backend/amt.pm
@@ -38,7 +38,7 @@ sub wsman_cmdline ($self) {
     return ('wsman', '-h', $bmwqemu::vars{AMT_HOSTNAME}, '-P', '16992');
 }
 
-sub wsman ($self, $cmd, $stdin) {
+sub wsman ($self, $cmd, $stdin = undef) {
     my @cmd = $self->wsman_cmdline();
     push(@cmd, split(/ /, $cmd));
 
@@ -95,19 +95,11 @@ sub set_power_state ($self, $power_state) {
 }
 
 sub select_next_boot ($self, $bootdev) {
-    my $amt_bootdev;
-    if ($bootdev eq 'cddvd') {
-        $amt_bootdev = 'Intel(r) AMT: Force CD/DVD Boot';
-    }
-    elsif ($bootdev eq 'hdd') {
-        $amt_bootdev = 'Intel(r) AMT: Force Hard-drive Boot';
-    }
-    elsif ($bootdev eq 'pxe') {
-        $amt_bootdev = 'Intel(r) AMT: Force PXE Boot';
-    }
-    else {
-        die "Unsupported boot device $bootdev";
-    }
+    my $amt_bootdev = 'Intel(r) AMT: Force ' . ({
+            cddvd => 'CD/DVD Boot',
+            hdd => 'Hard-drive Boot',
+            pxe => 'PXE Boot',
+    }->{$bootdev} or die "Unsupported boot device $bootdev");
 
     # reset boot configuration to known state
     my $keys = "-k BIOSPause=false -k BootMediaIndex=0";
@@ -158,11 +150,7 @@ sub select_next_boot ($self, $bootdev) {
 </p:SetBootConfigRole_INPUT>";
 
     $stdout = $self->wsman("-J - invoke -a SetBootConfigRole $CIM/CIM_BootService", $cmd_stdin);
-
-    if (!($stdout =~ m/:ReturnValue>0</)) {
-        die "SetBootConfigRole failed";
-    }
-
+    die 'SetBootConfigRole failed' unless $stdout =~ m/:ReturnValue>0</;
 }
 
 sub restart_host ($self) {

--- a/backend/amt.pm
+++ b/backend/amt.pm
@@ -176,9 +176,6 @@ sub do_start_vm ($self, @) {
     #   $self->{configured} = 1;
     #}
     $self->select_next_boot('pxe');
-
-    # remove backend.crashed
-    $self->unlink_crash_file;
     $self->restart_host;
     sleep(5);
     $self->truncate_serial_file;

--- a/t/29-backend-amt.t
+++ b/t/29-backend-amt.t
@@ -33,7 +33,8 @@ sub redefine_ipc_run_cmd ($expected_stdout = ':ReturnValue>0<') {
 
 $bmwqemu::vars{AMT_HOSTNAME} = 'localhost';
 $bmwqemu::vars{AMT_PASSWORD} = 'password';
-my $backend = backend::amt->new;
+my $backend;
+stderr_like { $backend = backend::amt->new } qr/DEPRECATED/, 'backend can be created but is deprecated';
 is $backend->wsman_cmdline, 16992, 'wsman_cmdline generated';
 my $bmwqemu_mock = Test::MockModule->new('bmwqemu');
 # silence some log output for cleaner tests

--- a/t/29-backend-amt.t
+++ b/t/29-backend-amt.t
@@ -1,0 +1,58 @@
+#!/usr/bin/perl
+
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+use Mojo::Base -strict, -signatures;
+use Test::Warnings qw(:all :report_warnings);
+use Test::Fatal;
+use Test::MockModule;
+use Test::Mock::Time;
+use Test::Output qw(stderr_like);
+use Mojo::File qw(tempdir);
+use Mojo::Util qw(scope_guard);
+use FindBin '$Bin';
+use lib "$Bin/../external/os-autoinst-common/lib";
+use OpenQA::Test::TimeLimit '5';
+use backend::amt;
+
+my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
+chdir $dir;
+my $cleanup = scope_guard sub { chdir $Bin; undef $dir };
+
+my $ipc_run_mock = Test::MockModule->new('IPC::Run');
+
+sub redefine_ipc_run_cmd ($expected_stdout = ':ReturnValue>0<') {
+    $ipc_run_mock->redefine(run => sub ($args, $stdin, $stdout, $stderr) {
+            $$stdin = 'stdin';
+            $$stdout = $expected_stdout;
+            $$stderr = 'stderr';
+    });
+}
+
+$bmwqemu::vars{AMT_HOSTNAME} = 'localhost';
+$bmwqemu::vars{AMT_PASSWORD} = 'password';
+my $backend = backend::amt->new;
+is $backend->wsman_cmdline, 16992, 'wsman_cmdline generated';
+my $bmwqemu_mock = Test::MockModule->new('bmwqemu');
+# silence some log output for cleaner tests
+$bmwqemu_mock->noop('diag');
+redefine_ipc_run_cmd;
+ok $backend->wsman('', undef), 'can call wsman';
+ok $backend->enable_solider, 'can call enable_solider';
+ok $backend->configure_vnc, 'can call configure_vnc';
+redefine_ipc_run_cmd(':PowerState>0<');
+is $backend->get_power_state, 0, 'can call get_power_state';
+is $backend->is_shutdown, '', 'can call is_shutdown';
+is $backend->set_power_state('foo'), '', 'can call set_power_state';
+like exception { $backend->select_next_boot('hdd') }, qr/ChangeBootOrder failed/, 'select_next_boot evaluates wsman command';
+redefine_ipc_run_cmd;
+my $backend_mock = Test::MockModule->new('backend::amt');
+$backend_mock->redefine(is_shutdown => 1);
+my $distri = Test::MockModule->new('distribution');
+$testapi::distri = distribution->new;
+stderr_like { $backend->do_start_vm } qr/Error connecting to VNC/, 'can call do_start_vm';
+ok $backend->do_stop_vm, 'can call do_stop_vm';
+
+done_testing;


### PR DESCRIPTION
As the commit "backend::amt: Remove unsupported call to remove crash
file" showed backend::amt had an error since 4 years so it is likely
completely unused. Also on openqa.suse.de and openqa.opensuse.org I
called SQL `select * from machines where backend ~ 'amt';` and found no
matches.

Related progress issue: https://progress.opensuse.org/issues/105217