### PR TITLE
Continue further checks in fullstack test after one fails

### DIFF
--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -65,12 +65,12 @@ unlike $log, qr/warn.*qemu-system.*terminating/, 'No warning about expected term
 my $ignore_results_re = qr/fail/;
 for my $result (grep { $_ !~ $ignore_results_re } glob("testresults/result*.json")) {
     my $json = decode_json(path($result)->slurp);
-    is($json->{result}, 'ok', "Result in $result is ok") or BAIL_OUT("$result failed");
+    is($json->{result}, 'ok', "Result in $result is ok");
 }
 
 for my $result (glob("testresults/result*fail*.json")) {
     my $json = decode_json(path($result)->slurp);
-    is($json->{result}, 'fail', "Result in $result is fail") or BAIL_OUT("$result failed");
+    is($json->{result}, 'fail', "Result in $result is fail");
 }
 
 subtest 'Assert screen failure' => sub {


### PR DESCRIPTION
This eases debugging as in the failure case all check results will be
available.

Note that this is basically a revert of 90f5eadd1 which does not state why
it was needed/useful.

Related ticket: https://progress.opensuse.org/issues/104971