### PR TITLE
Force full screen update shortly before check screen would fail

### DIFF
--- a/OpenQA/Benchmark/Stopwatch.pm
+++ b/OpenQA/Benchmark/Stopwatch.pm
@@ -228,7 +228,7 @@ sub as_data ($self) {
 
         $running_total += $lapcopy{time};
         $lapcopy{cumulative} = $running_total;
-        $lapcopy{fraction} = $lapcopy{time} / $data{total_time};
+        $lapcopy{fraction} = $lapcopy{time} / $data{total_time} if $data{total_time};
 
         push @{$data{laps}}, \%lapcopy;
     }

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -33,6 +33,7 @@ use English -no_match_vars;
 use OpenQA::NamedIOSelect;
 
 use constant FULL_SCREEN_SEARCH_FREQUENCY => $ENV{OS_AUTOINST_FULL_SCREEN_SEARCH_FREQUENCY} // 5;
+use constant FULL_UPDATE_REQUEST_FREQUENCY => $ENV{OS_AUTOINST_FULL_UPDATE_REQUEST_FREQUENCY} // 5;
 
 # should be a singleton - and only useful in backend process
 our $backend;
@@ -1030,6 +1031,9 @@ sub check_asserted_screen ($self, $args) {
         # as we're nearing the deadline
         $self->request_screen_update({incremental => 0});
         $self->{_final_full_update_requested} = 1;
+    }
+    elsif ($n % FULL_UPDATE_REQUEST_FREQUENCY == 0) {
+        $self->request_screen_update({incremental => 0});
     }
 
     if ($search_ratio == 1) {

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -800,9 +800,7 @@ sub _send_frame_buffer {
 }
 
 # frame buffer update request
-sub send_update_request {
-    my ($self) = @_;
-
+sub send_update_request ($self, $incremental = undef) {
     my $time_after_vnc_is_considered_stalled = $bmwqemu::vars{VNC_STALL_THRESHOLD} // 4;
     # after 2 seconds: send forced update
     # after 4 seconds: turn off screen
@@ -825,9 +823,8 @@ sub send_update_request {
         }
     }
 
-    my $incremental = $self->_framebuffer ? 1 : 0;
     # if we have a black screen, we need a full update
-    $incremental = 0 unless $self->_last_update_received;
+    $incremental = $self->_framebuffer && $self->_last_update_received ? 1 : 0 unless defined $incremental;
     return $self->_send_frame_buffer(
         {
             incremental => $incremental,

--- a/consoles/vnc_base.pm
+++ b/consoles/vnc_base.pm
@@ -37,11 +37,11 @@ sub connect_remote ($self, $args) {
     return $self->{vnc};
 }
 
-sub request_screen_update ($self, @) {
+sub request_screen_update ($self, $args = undef) {
     return unless $self->{vnc};
     # drain the VNC socket before polling for a new update
     $self->{vnc}->update_framebuffer();
-    $self->{vnc}->send_update_request();
+    $self->{vnc}->send_update_request($args ? $args->{incremental} : undef);
     return;
 }
 

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -5,6 +5,7 @@ use Mojo::Base -strict, -signatures;
 use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
+use Test::Mock::Time;
 use Test::MockModule;
 use Test::MockObject;
 use Test::Output;
@@ -29,6 +30,11 @@ tzset;
 
 bmwqemu::init_logger;
 
+my $baseclass_mock = Test::MockModule->new('backend::baseclass');
+$baseclass_mock->redefine(run_capture_loop => sub {
+        sleep 5;    # simulate that time passes (mocked via Test::Mock::Time)
+        $baseclass_mock->original('run_capture_loop')->(@_);
+});
 my $baseclass = backend::baseclass->new();
 
 subtest 'format_vtt_timestamp' => sub {

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -31,10 +31,16 @@ tzset;
 bmwqemu::init_logger;
 
 my $baseclass_mock = Test::MockModule->new('backend::baseclass');
+my @requested_screen_updates;
 $baseclass_mock->redefine(run_capture_loop => sub {
         sleep 5;    # simulate that time passes (mocked via Test::Mock::Time)
         $baseclass_mock->original('run_capture_loop')->(@_);
 });
+$baseclass_mock->redefine(request_screen_update => sub ($self, $args) {
+        is $args->{incremental}, 0, 'screen update is always expected to be non-incremental within this test';
+        push @requested_screen_updates, [$args];
+});
+
 my $baseclass = backend::baseclass->new();
 
 subtest 'format_vtt_timestamp' => sub {
@@ -380,6 +386,24 @@ subtest check_select_rate => sub {
         }
         is(backend::baseclass::check_select_rate($buckets, $time_limit, $hit_limit, 42, $time_limit + 1), 1, "Hit the limit, as all fds hit it!");
     };
+};
+
+subtest 'requesting full screen update' => sub {
+    is scalar @requested_screen_updates, 0, 'no screen update requested so far';
+    $baseclass->last_image(Test::MockObject->new->set_list(search => 0, []));
+    $baseclass->assert_screen_tags(['foo']);
+    $baseclass->assert_screen_needles([{}]);
+    $baseclass_mock->redefine(_time_to_assert_screen_deadline => 41);
+    $baseclass->screenshot_interval(20);
+    $baseclass->check_asserted_screen({});
+    is scalar @requested_screen_updates, 0, 'no screen update requested';
+    $baseclass_mock->redefine(_time_to_assert_screen_deadline => 40);
+    $baseclass->check_asserted_screen({});
+    is scalar @requested_screen_updates, 1, 'screen update requested as deadline nearing end';
+    is scalar @requested_screen_updates, 1, 'no further screen update requested';
+    $baseclass_mock->redefine(_time_to_assert_screen_deadline => 2 * backend::baseclass::FULL_UPDATE_REQUEST_FREQUENCY);
+    $baseclass->check_asserted_screen({});
+    is scalar @requested_screen_updates, 2, 'screen update triggered periodically';
 };
 
 is($baseclass->get_wait_still_screen_on_here_doc_input({}), 0, 'wait_still_screen on here doc is off by default!');


### PR DESCRIPTION
Sometimes we are left with a distorted VNC screen despite no stall is
detected. This problem is sometimes even reproducible when running the
fullstack test (fail rate is 5 % on my system), see
https://progress.opensuse.org/issues/104971.

This change forces a full (non-incremental) update of the VNC screen
shortly before a check screen would fail to workaround the issue.

---

I'm currently still running the fullstack test in a loop locally to see whether
it makes a difference. (So far it looks good.)