### PR TITLE
Adapt configure_repositories step in OBS workflow

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -9,12 +9,14 @@ pr:
       project: devel:openQA:GitHub
       repositories:
       - name: openSUSE_Tumbleweed
-        target_project: openSUSE:Factory
-        target_repository: snapshot
+        paths:
+          - target_project: openSUSE:Factory
+            target_repository: snapshot
         architectures: [ x86_64 ]
       - name: openSUSE_Leap_15.3
-        target_project: devel:openQA:Leap:15.3
-        target_repository: openSUSE_Leap_15.3
+        paths:
+          - target_project: devel:openQA:Leap:15.3
+            target_repository: openSUSE_Leap_15.3
         architectures: [ x86_64 ]
   filters:
     event: pull_request


### PR DESCRIPTION
The changes in this PR are needed due to a breaking change in the `configure_repositories` step. This breaking change isn't deployed yet. We plan this to go live on this Tuesday (01.02.2022). When it is live, I'll mark this PR as ready to review to allow a merge.