### PR TITLE
Fix sporadic failures in openQA's fullstack test

### DIFF
--- a/t/data/tests/main.pm
+++ b/t/data/tests/main.pm
@@ -34,8 +34,8 @@ unless ($integration_tests) {
 }
 
 autotest::loadtest "tests/boot.pm";
+autotest::loadtest "tests/assert_screen.pm";
 unless ($integration_tests) {
-    autotest::loadtest "tests/assert_screen.pm";
     autotest::loadtest "tests/typing.pm";
     autotest::loadtest "tests/select_console_fail_test.pm";
     autotest::loadtest "tests/select_ssh_console_fail_test.pm";


### PR DESCRIPTION
I assume these failures happen when trying to type the `poweroff` command
in the `shutdown` module and the system hasn't finished booting yet. We do
not see this problem in os-autoinst's fullstack test because it also runs
the `assert_screen` module which waits until the prompt is shown. It makes
most sense to simply run this module in openQA's fullstack test as well.

I've also tried `power 'off'` but it doesn't work as it terminates QEMU
completely and therefore further queries for the VM's state don't work.
`power 'acpi'` does not work as well as the TinyCore system doesn't seem to
handle it.

See https://progress.opensuse.org/issues/105429