### PR TITLE
Avoid non-incremental screen updates in `localXvnc` console

### DIFF
--- a/consoles/localXvnc.pm
+++ b/consoles/localXvnc.pm
@@ -43,6 +43,13 @@ sub callxterm ($self, $command, $window_name) {
     die "cant' start xterm on $display (err: $! retval: $?)" if $@;
 }
 
+sub request_screen_update ($self, $args = undef) {
+    # avoid non-incremental screen updates, see poo#106017
+    # note: It apparently breaks some cases causing the stale VNC detection to force a re-connect which then
+    #       fails with "Connection refused".
+    $self->SUPER::request_screen_update($args) if !(exists $args->{incremental}) || $args->{incremental};
+}
+
 sub fullscreen ($self, $args) {
     my $display = $self->{DISPLAY};
     my $window_name = $args->{window_name};

--- a/t/27-consoles-local_xvnc.t
+++ b/t/27-consoles-local_xvnc.t
@@ -45,4 +45,11 @@ is $c->callxterm('true', 'window1'), '', 'can call callxterm';
 is $c->fullscreen({window_name => 'foo'}), 1, 'can call fullscreen';
 is $c->disable, undef, 'can call disable';
 
+my $base_screen_update_called;
+$vnc_base_mock->redefine(request_screen_update => sub { ++$base_screen_update_called });
+is $c->request_screen_update({incremental => 0}), 0, 'non-incremental screen updated prevented';
+is $base_screen_update_called, undef, 'non-incremental screen update not passed to vnc_base';
+is $c->request_screen_update(), 1, 'incremental screen updated done as usual';
+is $c->request_screen_update({incremental => 1}), 2, 'explicit incremental screen updated done as usual';
+
 done_testing;


### PR DESCRIPTION
It apparently breaks in some cases, see
https://progress.opensuse.org/issues/106017 where the VNC connection is
attempted to be re-established as it is considered stale (but it fails).
The additional non-incremental update requests have maybe an impact on the
stale VNC detection making it more aggressive. Note that when watching the
test referenced in the ticket with the non-incremental screen update
requests commented out it passes but the screen is not updated for a while.

This is basically a revert of 944b3626c89b47baf7162013a85f2d54b7858131 for
localXvnc.