### PR TITLE
Allow network cable to be unplugged

### DIFF
--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -9,7 +9,7 @@ use Mojo::Base -strict, -signatures;
 # -> increment on every change of such APIs
 # -> never move that variable to another place (when refactoring)
 #    because it may be accessed by the tests itself
-our $version = 24;
+our $version = 25;
 
 # major version of the (web socket) API relevant to the developer mode
 # -> increment when making non-backward compatible changes to that API

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -439,6 +439,8 @@ sub do_extract_assets ($self, $args) { $self->notimplemented }
 
 sub is_shutdown ($self, @) { -1 }
 
+sub switch_network ($self, $args) { $self->notimplemented }
+
 sub save_memory_dump ($self, $args) { $self->notimplemented }
 
 sub save_storage_drives ($self, $args) { $self->notimplemented }

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -279,6 +279,13 @@ sub _migrate_to_file ($self, %args) {
     return $self->_wait_for_migrate();
 }
 
+sub switch_network ($self, $args) {
+    $self->handle_qmp_command({execute => 'set_link', arguments => {
+                name => $args->{network_link_name} // "qanet0",
+                up => (!defined $args->{network_enabled} || $args->{network_enabled} ? Mojo::JSON->true : Mojo::JSON->false)
+    }}, fatal => 1);
+}
+
 sub save_memory_dump ($self, $args) {
     my $fdname = 'dumpfd';
     my $vars = \%bmwqemu::vars;

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -185,6 +185,16 @@ subtest 'eject_cd' => sub {
     $cmds = [];
 };
 
+subtest 'switch_network' => sub {
+    switch_network network_enabled => 0;
+    is_deeply $cmds, [{cmd => 'backend_switch_network', network_enabled => 0}] or diag explain $cmds;
+    $cmds = [];
+
+    switch_network network_enabled => 1, network_link_name => 'bingo';
+    is_deeply $cmds, [{cmd => 'backend_switch_network', network_enabled => 1, network_link_name => 'bingo'}] or diag explain $cmds;
+    $cmds = [];
+};
+
 subtest 'type_string with wait_still_screen' => sub {
     my $wait_still_screen_called = 0;
     my $module = Test::MockModule->new('testapi');

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -87,6 +87,23 @@ subtest 'eject cd' => sub {
     is_deeply $called{handle_qmp_command}[1], \%custom_remove_params, 'blockdev-remove-medium called with custom parameters';
 };
 
+subtest 'switch_network' => sub {
+    my %switch_network_params = (arguments => {name => 'qanet0', up => Mojo::JSON->false}, execute => 'set_link');
+    $called{handle_qmp_command} = undef;
+
+    $backend->switch_network({network_enabled => 0});
+    ok(exists $called{handle_qmp_command}, 'network must be disabled');
+    is_deeply($called{handle_qmp_command}[0], \%switch_network_params, 'qmp command for setlink is passed');
+
+    $called{handle_qmp_command} = undef;
+    $backend->switch_network({network_enabled => 1, network_link_name => 'bingo'});
+    %switch_network_params = (arguments => {name => 'bingo', up => Mojo::JSON->true}, execute => 'set_link');
+    ok(exists $called{handle_qmp_command}, 'a qmp command has been called');
+    is_deeply($called{handle_qmp_command}[0], \%switch_network_params, 'Network name can be specified, network can be enabled');
+
+    $called{handle_qmp_command} = undef;
+};
+
 subtest 'execute arbitrary QMP command' => sub {
     my %query = (execute => 'foo', arguments => {bar => 1});
     $called{handle_qmp_command} = undef;

--- a/testapi.pm
+++ b/testapi.pm
@@ -51,6 +51,7 @@ our @EXPORT = qw($realname $username $password $serialdev %cmd %vars
   record_soft_failure record_info force_soft_failure
   become_root x11_start_program ensure_installed eject_cd power
 
+  switch_network
   save_memory_dump save_storage_drives freeze_vm resume_vm
 
   diag hashed_string
@@ -1980,6 +1981,23 @@ sub eject_cd {
     my (%nargs) = @_;
     bmwqemu::log_call(%nargs);
     query_isotovideo(backend_eject_cd => \%nargs);
+}
+
+=head2 switch_network
+
+  switch_network network_enabled => $boolean, [network_link_name => $string];
+
+Changes network device's state akin to disconnecting the physical cable,
+default network is qanet0.
+
+This method is fatal in case the network device doesn't exist.
+
+=cut
+
+sub switch_network {
+    my (%nargs) = @_;
+    bmwqemu::log_call(%nargs);
+    query_isotovideo(backend_switch_network => \%nargs);
 }
 
 =head2 save_memory_dump


### PR DESCRIPTION
There are cases where during a test, we need to isolate the SUT from the network one way or the other, in the physical world we would unplug the network cable, so we can do the same for qemu via qmp commands.

For the time being, the network name is hardcoded to the default one, if system has two nics, code will have to be adjusted (if ever needed)

VR: http://phobos.qa.suse.de/tests/3857658#step/systemd_sapstart_check/45