### PR TITLE
Fix default VNC connect timeout

### DIFF
--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -117,7 +117,8 @@ my @encodings = (
     },
 );
 
-sub login ($self, $connect_timeout = 10) {
+sub login ($self, $connect_timeout = undef) {
+    $connect_timeout //= 10;
     # arbitrary
     my $connect_failure_limit = 2;
 


### PR DESCRIPTION
Fix

```
Use of uninitialized value $connect_timeout in addition (+) at /usr/lib/os-autoinst/consoles/VNC.pm line 137.
```

See https://progress.opensuse.org/issues/106654