### PR TITLE
Include descriptive name of unresponsive VNC server in connection error

### DIFF
--- a/backend/pvm.pm
+++ b/backend/pvm.pm
@@ -210,7 +210,8 @@ sub start_lpar ($self) {
         'vnc-base',
         {
             hostname => 'localhost',
-            port => $vars->{VNC}});
+            port => $vars->{VNC},
+            description => 'mkvtermutil VNC'});
     $vnc->backend($self);
     $self->select_console({testapi_console => 'sut'});
 }

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -924,7 +924,8 @@ sub start_qemu ($self) {
         {
             hostname => 'localhost',
             connect_timeout => 3,
-            port => 5900 + $bmwqemu::vars{VNC}});
+            port => 5900 + $bmwqemu::vars{VNC},
+            description => "QEMU's VNC"});
 
     $vnc->backend($self);
     $self->select_console({testapi_console => 'sut'});

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -15,7 +15,7 @@ use Scalar::Util 'blessed';
 use OpenQA::Exceptions;
 
 __PACKAGE__->mk_accessors(
-    qw(hostname port username password socket name width height depth
+    qw(description hostname port username password socket name width height depth
       no_endian_conversion  _pixinfo _colourmap _framebuffer _rfb_version screen_on
       _bpp _true_colour _do_endian_conversion absolute ikvm keymap _last_update_received
       _last_update_requested check_vnc_stalls _vnc_stalled vncinfo old_ikvm dell
@@ -134,6 +134,7 @@ sub login ($self, $connect_timeout = undef) {
 
     my $hostname = $self->hostname || 'localhost';
     my $port = $self->port || 5900;
+    my $description = $self->description || 'VNC server';
 
     my $endtime = time + $connect_timeout;
 
@@ -147,7 +148,7 @@ sub login ($self, $connect_timeout = undef) {
         );
         if (!$socket) {
             $err_cnt++;
-            my $error_message = "Error connecting to VNC server <$hostname:$port>: $@";
+            my $error_message = "Error connecting to $description <$hostname:$port>: $@";
             if (time > $endtime) {
                 OpenQA::Exception::VNCSetupError->throw(error => $error_message);
             }

--- a/consoles/localXvnc.pm
+++ b/consoles/localXvnc.pm
@@ -89,7 +89,7 @@ sub activate ($self) {
     start_xvnc($s, $display) unless $pid;
     close($s);
 
-    my $vnc = $self->connect_remote({hostname => 'localhost', port => $port, ikvm => 0});
+    my $vnc = $self->connect_remote({hostname => 'localhost', port => $port, ikvm => 0, description => 'local Xvnc'});
     # disable checking VNC stalls as this setup would not survive re-connects triggered by the VNC stall
     # detection anyways (as Xvnc terminates itself when the connection is closed)
     # note: Otherwise jobs are failing with "Error connecting to VNC server localhost … Connection refused"


### PR DESCRIPTION
So it is clear which kind of VNC server was supposed to respond in the
concrete test setup. That should help distinguishing different kinds of VNC
issues. See https://progress.opensuse.org/issues/105882#note-5.