### PR TITLE
Avoid warning because of missing second argument

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -233,6 +233,7 @@ sub record_info {
     my ($title, $output, %nargs) = @_;
     $nargs{result} //= 'ok';
     die 'unsupported $result \'' . $nargs{result} . '\'' unless _is_valid_result($nargs{result});
+    $output //= '';
     bmwqemu::log_call(title => $title, output => $output, %nargs);
     $autotest::current_test->record_resultfile($title, $output, %nargs);
 }


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/106684

The second argument is not required, but when it is undef, it will
create a warning further down the road.