### PR TITLE
Deprecate likely unused backend::ikvm

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -199,6 +199,31 @@ implications and how we can help each other to improve
 If this is too much hassle for you feel free to provide incomplete pull
 requests for consideration or create an issue with a code change proposal.
 
+=== Deprecation approach
+
+In case you want to deprecate functionality consider putting in a die-message
+stopping execution with a notice about the deprecation and a way to
+temporarily continue execution by specifying an according variable like in the
+following example:
+
+----
+my $deprecation_message = <<"EOF";
+DEPRECATED: 'backend::$backend' is unsupported and planned to be
+removed from os-autoinst eventually. If the backend is still needed please
+report an issue on https://github.com/os-autoinst/os-autoinst . This message
+can be temporarily turned into a warning by setting the environment variable
+'OS_AUTOINST_NO_DEPRECATE_BACKEND_$backend' or the os-autoinst variable
+'NO_DEPRECATE_BACKEND_$backend'
+EOF
+if ($bmwqemu::vars{"NO_DEPRECATE_BACKEND_$backend"} ||
+    $ENV{"OS_AUTOINST_NO_DEPRECATE_BACKEND_$backend"}) {
+    log::fctwarn $deprecation_message;
+}
+else {
+    die $deprecation_message;
+}
+----
+
 == Build instructions
 
 === Installing dependencies

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -201,28 +201,8 @@ requests for consideration or create an issue with a code change proposal.
 
 === Deprecation approach
 
-In case you want to deprecate functionality consider putting in a die-message
-stopping execution with a notice about the deprecation and a way to
-temporarily continue execution by specifying an according variable like in the
-following example:
-
-----
-my $deprecation_message = <<"EOF";
-DEPRECATED: 'backend::$backend' is unsupported and planned to be
-removed from os-autoinst eventually. If the backend is still needed please
-report an issue on https://github.com/os-autoinst/os-autoinst . This message
-can be temporarily turned into a warning by setting the environment variable
-'OS_AUTOINST_NO_DEPRECATE_BACKEND_$backend' or the os-autoinst variable
-'NO_DEPRECATE_BACKEND_$backend'
-EOF
-if ($bmwqemu::vars{"NO_DEPRECATE_BACKEND_$backend"} ||
-    $ENV{"OS_AUTOINST_NO_DEPRECATE_BACKEND_$backend"}) {
-    log::fctwarn $deprecation_message;
-}
-else {
-    die $deprecation_message;
-}
-----
+In case you want to deprecate functionality consider the use of the function
+`backend::baseclass::handle_deprecate_backend`.
 
 == Build instructions
 

--- a/backend/amt.pm
+++ b/backend/amt.pm
@@ -31,7 +31,22 @@ sub new ($class) {
     $ENV{'WSMAN_USER'} = 'admin';
     $ENV{'WSMAN_PASS'} = $bmwqemu::vars{AMT_PASSWORD};
 
-    bmwqemu::fctwarn 'DEPRECATED: backend::amt is unsupported and planned to be removed from os-autoinst eventually';
+    my $backend = 'AMT';
+    my $deprecation_message = <<"EOF";
+DEPRECATED: 'backend::$backend' is unsupported and planned to be
+removed from os-autoinst eventually. If the backend is still needed please
+report an issue on https://github.com/os-autoinst/os-autoinst . This message
+can be temporarily turned into a warning by setting the environment variable
+'OS_AUTOINST_NO_DEPRECATE_BACKEND_$backend' or the os-autoinst variable
+'NO_DEPRECATE_BACKEND_$backend'
+EOF
+    if ($bmwqemu::vars{"NO_DEPRECATE_BACKEND_$backend"} ||
+        $ENV{"OS_AUTOINST_NO_DEPRECATE_BACKEND_$backend"}) {
+        log::fctwarn $deprecation_message;
+    }
+    else {
+        die $deprecation_message;
+    }
     return $class->SUPER::new;
 }
 

--- a/backend/amt.pm
+++ b/backend/amt.pm
@@ -31,22 +31,7 @@ sub new ($class) {
     $ENV{'WSMAN_USER'} = 'admin';
     $ENV{'WSMAN_PASS'} = $bmwqemu::vars{AMT_PASSWORD};
 
-    my $backend = 'AMT';
-    my $deprecation_message = <<"EOF";
-DEPRECATED: 'backend::$backend' is unsupported and planned to be
-removed from os-autoinst eventually. If the backend is still needed please
-report an issue on https://github.com/os-autoinst/os-autoinst . This message
-can be temporarily turned into a warning by setting the environment variable
-'OS_AUTOINST_NO_DEPRECATE_BACKEND_$backend' or the os-autoinst variable
-'NO_DEPRECATE_BACKEND_$backend'
-EOF
-    if ($bmwqemu::vars{"NO_DEPRECATE_BACKEND_$backend"} ||
-        $ENV{"OS_AUTOINST_NO_DEPRECATE_BACKEND_$backend"}) {
-        log::fctwarn $deprecation_message;
-    }
-    else {
-        die $deprecation_message;
-    }
+    backend::baseclass::handle_deprecate_backend('AMT');
     return $class->SUPER::new;
 }
 

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -1302,6 +1302,19 @@ sub hide_password ($self, %args) {
     return \%args;
 }
 
+sub handle_deprecate_backend ($backend) {
+    my $deprecation_message = <<"EOF";
+DEPRECATED: 'backend::$backend' is unsupported and planned to be
+removed from os-autoinst eventually. If the backend is still needed please
+report an issue on https://github.com/os-autoinst/os-autoinst . This message
+can be temporarily turned into a warning by setting the environment variable
+'OS_AUTOINST_NO_DEPRECATE_BACKEND_$backend' or the os-autoinst variable
+'NO_DEPRECATE_BACKEND_$backend'
+EOF
+    die $deprecation_message unless $bmwqemu::vars{"NO_DEPRECATE_BACKEND_$backend"} || $ENV{"OS_AUTOINST_NO_DEPRECATE_BACKEND_$backend"};
+    log::fctwarn $deprecation_message;
+}
+
 # Send TERM signal to any child process
 sub _stop_children_processes ($self) {
     my $ret;

--- a/backend/ikvm.pm
+++ b/backend/ikvm.pm
@@ -7,6 +7,26 @@ package backend::ikvm;
 use Mojo::Base 'backend::ipmi', -signatures;
 use autodie ':all';
 
+sub new ($class) {
+    my $backend = 'IKVM';
+    my $deprecation_message = <<"EOF";
+DEPRECATED: 'backend::$backend' is unsupported and planned to be
+removed from os-autoinst eventually. If the backend is still needed please
+report an issue on https://github.com/os-autoinst/os-autoinst . This message
+can be temporarily turned into a warning by setting the environment variable
+'OS_AUTOINST_NO_DEPRECATE_BACKEND_$backend' or the os-autoinst variable
+'NO_DEPRECATE_BACKEND_$backend'
+EOF
+    if ($bmwqemu::vars{"NO_DEPRECATE_BACKEND_$backend"} ||
+        $ENV{"OS_AUTOINST_NO_DEPRECATE_BACKEND_$backend"}) {
+        log::fctwarn $deprecation_message;
+    }
+    else {
+        die $deprecation_message;
+    }
+    return $class->SUPER::new;
+}
+
 sub relogin_vnc ($self) {
     my $vncopts = {
         hostname => $bmwqemu::vars{IPMI_HOSTNAME},

--- a/backend/ikvm.pm
+++ b/backend/ikvm.pm
@@ -8,22 +8,7 @@ use Mojo::Base 'backend::ipmi', -signatures;
 use autodie ':all';
 
 sub new ($class) {
-    my $backend = 'IKVM';
-    my $deprecation_message = <<"EOF";
-DEPRECATED: 'backend::$backend' is unsupported and planned to be
-removed from os-autoinst eventually. If the backend is still needed please
-report an issue on https://github.com/os-autoinst/os-autoinst . This message
-can be temporarily turned into a warning by setting the environment variable
-'OS_AUTOINST_NO_DEPRECATE_BACKEND_$backend' or the os-autoinst variable
-'NO_DEPRECATE_BACKEND_$backend'
-EOF
-    if ($bmwqemu::vars{"NO_DEPRECATE_BACKEND_$backend"} ||
-        $ENV{"OS_AUTOINST_NO_DEPRECATE_BACKEND_$backend"}) {
-        log::fctwarn $deprecation_message;
-    }
-    else {
-        die $deprecation_message;
-    }
+    backend::baseclass::handle_deprecate_backend('IKVM');
     return $class->SUPER::new;
 }
 

--- a/backend/pvm.pm
+++ b/backend/pvm.pm
@@ -28,22 +28,7 @@ sub new ($class) {
     $self->{pvmctl} = $ENV{PVMCTL} // '/usr/bin/pvmctl';
     $self->{masterlpar} = substr(_masterlpar, 0, -1);
     die "pvmctl not found" unless -x $self->{pvmctl};
-    my $backend = 'PVM';
-    my $deprecation_message = <<"EOF";
-DEPRECATED: 'backend::$backend' is unsupported and planned to be
-removed from os-autoinst eventually. If the backend is still needed please
-report an issue on https://github.com/os-autoinst/os-autoinst . This message
-can be temporarily turned into a warning by setting the environment variable
-'OS_AUTOINST_NO_DEPRECATE_BACKEND_$backend' or the os-autoinst variable
-'NO_DEPRECATE_BACKEND_$backend'
-EOF
-    if ($bmwqemu::vars{"NO_DEPRECATE_BACKEND_$backend"} ||
-        $ENV{"OS_AUTOINST_NO_DEPRECATE_BACKEND_$backend"}) {
-        log::fctwarn $deprecation_message;
-    }
-    else {
-        die $deprecation_message;
-    }
+    backend::baseclass::handle_deprecate_backend('PVM');
     return $self;
 }
 

--- a/backend/pvm.pm
+++ b/backend/pvm.pm
@@ -28,7 +28,22 @@ sub new ($class) {
     $self->{pvmctl} = $ENV{PVMCTL} // '/usr/bin/pvmctl';
     $self->{masterlpar} = substr(_masterlpar, 0, -1);
     die "pvmctl not found" unless -x $self->{pvmctl};
-    bmwqemu::fctwarn 'DEPRECATED: backend::pvm is unsupported and planned to be removed from os-autoinst eventually';
+    my $backend = 'PVM';
+    my $deprecation_message = <<"EOF";
+DEPRECATED: 'backend::$backend' is unsupported and planned to be
+removed from os-autoinst eventually. If the backend is still needed please
+report an issue on https://github.com/os-autoinst/os-autoinst . This message
+can be temporarily turned into a warning by setting the environment variable
+'OS_AUTOINST_NO_DEPRECATE_BACKEND_$backend' or the os-autoinst variable
+'NO_DEPRECATE_BACKEND_$backend'
+EOF
+    if ($bmwqemu::vars{"NO_DEPRECATE_BACKEND_$backend"} ||
+        $ENV{"OS_AUTOINST_NO_DEPRECATE_BACKEND_$backend"}) {
+        log::fctwarn $deprecation_message;
+    }
+    else {
+        die $deprecation_message;
+    }
     return $self;
 }
 

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -40,6 +40,7 @@ AUTOINST_URL_HOSTNAME;string;;hostname or IP address of host running the autoins
 UPLOAD_METER;boolean;0;Display curl progress meter in `upload_logs()` and `upload_assets()` test API functions.
 UPLOAD_MAX_MESSAGE_SIZE_GB;integer;20;Specifies the max. upload size in GiB for the test API functions `upload_logs()` and `upload_assets()` and the underlying command server API.
 UPLOAD_INACTIVITY_TIMEOUT;integer;300;Specifies the inactivity timeout in seconds for the test API functions `upload_logs()` and `upload_assets()` and underlying the command server API.
+NO_DEPRECATE_BACKEND_$backend;boolean;0;Only warn about deprecated backends instead of aborting
 
 |====================
 

--- a/t/04-check_vars_docu.t
+++ b/t/04-check_vars_docu.t
@@ -20,7 +20,7 @@ use constant {
 use constant VARS_DOC => DOC_DIR . '/backend_vars.asciidoc';
 
 # array of ignored "backends"
-my @backend_blocklist = qw(amt ikvm pvm);
+my @backend_blocklist = qw();
 # blocklist of vars per backend. These vars will be ignored during vars exploration
 my %var_blocklist = (
     QEMU => ['WORKER_ID', 'WORKER_INSTANCE'],

--- a/t/04-check_vars_docu.t
+++ b/t/04-check_vars_docu.t
@@ -20,7 +20,7 @@ use constant {
 use constant VARS_DOC => DOC_DIR . '/backend_vars.asciidoc';
 
 # array of ignored "backends"
-my @backend_blocklist = qw(amt);
+my @backend_blocklist = qw(amt pvm);
 # blocklist of vars per backend. These vars will be ignored during vars exploration
 my %var_blocklist = (
     QEMU => ['WORKER_ID', 'WORKER_INSTANCE'],

--- a/t/04-check_vars_docu.t
+++ b/t/04-check_vars_docu.t
@@ -20,7 +20,7 @@ use constant {
 use constant VARS_DOC => DOC_DIR . '/backend_vars.asciidoc';
 
 # array of ignored "backends"
-my @backend_blocklist = qw(amt pvm);
+my @backend_blocklist = qw(amt ikvm pvm);
 # blocklist of vars per backend. These vars will be ignored during vars exploration
 my %var_blocklist = (
     QEMU => ['WORKER_ID', 'WORKER_INSTANCE'],

--- a/t/04-check_vars_docu.t
+++ b/t/04-check_vars_docu.t
@@ -20,7 +20,7 @@ use constant {
 use constant VARS_DOC => DOC_DIR . '/backend_vars.asciidoc';
 
 # array of ignored "backends"
-my @backend_blocklist = qw();
+my @backend_blocklist = qw(amt);
 # blocklist of vars per backend. These vars will be ignored during vars exploration
 my %var_blocklist = (
     QEMU => ['WORKER_ID', 'WORKER_INSTANCE'],

--- a/t/29-backend-amt.t
+++ b/t/29-backend-amt.t
@@ -33,6 +33,7 @@ sub redefine_ipc_run_cmd ($expected_stdout = ':ReturnValue>0<') {
 
 $bmwqemu::vars{AMT_HOSTNAME} = 'localhost';
 $bmwqemu::vars{AMT_PASSWORD} = 'password';
+$bmwqemu::vars{"NO_DEPRECATE_BACKEND_AMT"} = 1;
 my $backend;
 stderr_like { $backend = backend::amt->new } qr/DEPRECATED/, 'backend can be created but is deprecated';
 is $backend->wsman_cmdline, 16992, 'wsman_cmdline generated';

--- a/t/29-backend-ikvm.t
+++ b/t/29-backend-ikvm.t
@@ -4,6 +4,7 @@ use Test::Most;
 use Mojo::Base -strict, -signatures;
 
 use Test::MockModule;
+use Test::Output qw(stderr_like);
 use Test::Warnings qw(:report_warnings);
 use Test::Fatal;
 use FindBin '$Bin';
@@ -13,7 +14,9 @@ use OpenQA::Test::TimeLimit '5';
 use backend::ikvm;    # SUT
 
 $bmwqemu::vars{WORKER_HOSTNAME} = 'localhost';
-ok my $backend = backend::ikvm->new(), 'backend can be created';
+$bmwqemu::vars{"NO_DEPRECATE_BACKEND_IKVM"} = 1;
+my $backend;
+stderr_like { $backend = backend::ikvm->new } qr/DEPRECATED/, 'backend can be created but is deprecated';
 my $distri = Test::MockModule->new('distribution');
 $testapi::distri = distribution->new;
 $backend->relogin_vnc;

--- a/t/29-backend-ikvm.t
+++ b/t/29-backend-ikvm.t
@@ -14,6 +14,7 @@ use OpenQA::Test::TimeLimit '5';
 use backend::ikvm;    # SUT
 
 $bmwqemu::vars{WORKER_HOSTNAME} = 'localhost';
+like(exception { backend::ikvm->new }, qr/DEPRECATED/, 'deprecated backend dies by default');
 $bmwqemu::vars{"NO_DEPRECATE_BACKEND_IKVM"} = 1;
 my $backend;
 stderr_like { $backend = backend::ikvm->new } qr/DEPRECATED/, 'backend can be created but is deprecated';

--- a/t/29-backend-pvm.t
+++ b/t/29-backend-pvm.t
@@ -22,5 +22,6 @@ my $cleanup = scope_guard sub { chdir $Bin; undef $dir };
 my $mock = Test::MockModule->new('backend::pvm');
 $mock->redefine(_masterlpar => '42');
 $ENV{PVMCTL} = '/bin/true';
+$bmwqemu::vars{"NO_DEPRECATE_BACKEND_PVM"} = 1;
 stderr_like { backend::pvm->new } qr/DEPRECATED/, 'backend marked as deprecated';
 done_testing;


### PR DESCRIPTION
The backend is not used on openqa.opensuse.org and openqa.suse.de and no
reports have reached us from anyone else using that backend so likely
it is unused and can be removed eventually.

Related progress issue: https://progress.opensuse.org/issues/107029