### PR TITLE
Fix flaky poweroff in openQA full stack tests with direct "sudo poweroff"

### DIFF
--- a/t/data/tests/tests/shutdown.pm
+++ b/t/data/tests/tests/shutdown.pm
@@ -5,8 +5,7 @@ use Mojo::Base 'basetest', -signatures;
 use testapi;
 
 sub run {
-    type_string "sudo su\n";
-    type_string "poweroff\n";
+    enter_cmd 'sudo poweroff';
     assert_shutdown(get_var('INTEGRATION_TESTS') ? 90 : undef);
 }
 


### PR DESCRIPTION
Instead of ending up with typing "sudo su" and then typing (too soon)
"poweroff" in a prompt that is not ensured to be present and responsive
we should just type "sudo poweroff" to avoid any need for checking the
subsequent root prompt readyness. This is straightforward, simpler than
the previous approach and should fix those instabilities which we saw
especially in the openQA full stack test using the os-autoinst test
module definitions from here.

Related progress issue: https://progress.opensuse.org/issues/106912