### PR TITLE
fullstack: Address die_on_timeout deprecation messages with script_run

### DIFF
--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -52,6 +52,7 @@ my $log = path('autoinst-log.txt')->slurp;
 like $log, qr/\d*: EXIT 0/, 'test executed fine';
 like $log, qr/\d* Snapshots are supported/, 'Snapshots are enabled';
 unlike $log, qr/Tests died:/, 'Tests did not fail within modules' or diag "autoinst-log.txt: $log";
+unlike $log, qr/script_run: DEPRECATED call of script_run.+die_on_timeout/, 'no deprecation warning for script_run';
 like $log, qr/do not wait_still_screen/, 'test type string and do not wait';
 like $log, qr/wait_still_screen: detected same image for 0.2 seconds/, 'test type string and wait for .2 seconds';
 like $log, qr/wait_still_screen: detected same image for 1 seconds/, 'test type string and wait for 1 seconds';

--- a/t/data/tests/main.pm
+++ b/t/data/tests/main.pm
@@ -8,7 +8,9 @@ use Cwd 'abs_path';
 use testapi;
 use testdistribution;
 
-testapi::set_distribution(testdistribution->new());
+my $distri = testdistribution->new();
+$distri->{script_run_die_on_timeout} = 1;
+testapi::set_distribution($distri);
 
 sub unregister_needle_tags ($tag) {
     my @a = @{needle::tags($tag)};


### PR DESCRIPTION
By default die_on_timeout is -1, which leads to several DEPRECATION
messages when running the fullstack test.