### PR TITLE
t: Also prevent git-related problems in 14-isotovideo and 30-make

### DIFF
--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -73,6 +73,9 @@ subtest 'isotovideo with custom git repo parameters specified' => sub {
     $base_state->remove if -e $base_state;
     path('vars.json')->remove if -e 'vars.json';
     path('repo.git')->make_path;
+    # some git variables might be set if this test is
+    # run during a `git rebase -x 'make test'`
+    delete @ENV{qw(GIT_DIR GIT_REFLOG_ACTION GIT_WORK_TREE)};
     my $git_init_output = qx{git init -q --bare repo.git 2>&1};
     is($?, 0, 'initialized test repo') or diag explain $git_init_output;
     # Ensure the checkout folder does not exist so that git clone tries to

--- a/xt/30-make.t
+++ b/xt/30-make.t
@@ -13,6 +13,9 @@ use OpenQA::Test::TimeLimit '20';
 
 my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
 my $srcdir = path("$Bin/..")->realpath;
+# some git variables might be set if this test is
+# run during a `git rebase -x 'make test'`
+delete @ENV{qw(GIT_DIR GIT_REFLOG_ACTION GIT_WORK_TREE)};
 stderr_like { is qx{git -C $dir clone $srcdir os-autoinst}, '', 'prepare working copy with git' } qr/Cloning/, 'git clone';
 chdir "$dir/os-autoinst" or die "Failed to change directory to $dir/os-autoinst";
 my $cleanup = scope_guard sub { chdir $Bin; undef $dir };


### PR DESCRIPTION
Same as in 34-git.t better clean out git variables before trying to play
with git in tests. This prevents problems on e.g. `git rebase -x` in a
local development environment.