### PR TITLE
PART 2: Add proper command line parsing for all scripts - Based on #1970

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,7 +1,0 @@
-#!/bin/sh -ex
-
-mkdir --parent --verbose m4
-aclocal --install -Im4
-autoreconf --verbose --install --symlink --force
-
-./configure "$@"

--- a/check_qemu_oom
+++ b/check_qemu_oom
@@ -14,7 +14,20 @@ check_qemu_oom qemu_pid
 =cut
 
 use Mojo::Base -strict, -signatures;
+use Getopt::Long;
 
+Getopt::Long::Configure("no_ignore_case");
+
+my %options;
+
+sub usage ($r) {
+    eval { require Pod::Usage; Pod::Usage::pod2usage($r) };
+    die "cannot display help, install perl(Pod::Usage)\n" if $@;
+}
+
+GetOptions(\%options, 'help|h|?') or usage(1);
+usage(0) if $options{help};
+usage(1) unless @ARGV;
 my $qemu_pid = $ARGV[0];
 
 eval { use Pod::Usage; pod2usage(1); } unless $qemu_pid;

--- a/container/os-autoinst_dev/Dockerfile
+++ b/container/os-autoinst_dev/Dockerfile
@@ -31,6 +31,7 @@ RUN zypper in -y -C \
        perl-base \
        pkg-config \
        procps \
+       python3-Pillow-tk \
        python3-black \
        python3-setuptools \
        python3-yamllint \

--- a/crop.py
+++ b/crop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2013-2016 SUSE LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,12 +19,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-try:
-    # Python 2
-    from Tkinter import Tk, Canvas, NW
-except ImportError:
-    # Python 3
-    from tkinter import Tk, Canvas, NW
+from tkinter import Tk, Canvas, NW
 from PIL import Image, ImageTk
 import json
 import optparse

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -108,6 +108,7 @@ test_requires:
   '%yamllint_requires':
   perl(YAML::PP):
   perl(Inline::Python):
+  python3-Pillow-tk:
 
 main_requires:
   git-core:

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -164,7 +164,6 @@ Convenience package providing os-autoinst + s390 worker jumphost dependencies.
 
 %prep
 %setup -q
-sed -e 's,/bin/env python,/bin/python3,' -i crop.py
 # Replace version number from git to what's reported by the package
 sed  -i 's/ my $thisversion = qx{git.*rev-parse HEAD}.*;/ my $thisversion = "%{version}";/' isotovideo
 

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -78,7 +78,7 @@ Source0:        %{name}-%{version}.tar.xz
 # The following line is generated from dependencies.yaml
 %define test_version_only_requires perl(Mojo::IOLoop::ReadWriteProcess) >= 0.28
 # The following line is generated from dependencies.yaml
-%define test_requires %build_requires %spellcheck_requires %test_base_requires %yamllint_requires perl(Inline::Python) perl(YAML::PP)
+%define test_requires %build_requires %spellcheck_requires %test_base_requires %yamllint_requires perl(Inline::Python) perl(YAML::PP) python3-Pillow-tk
 # The following line is generated from dependencies.yaml
 %define devel_requires %python_style_requires %test_requires ShellCheck perl(Code::TidyAll) perl(Devel::Cover) perl(Devel::Cover::Report::Codecov) perl(Perl::Tidy)
 %define s390_zvm_requires /usr/bin/xkbcomp /usr/bin/Xvnc x3270 icewm xterm xterm-console xdotool fonts-config mkfontdir mkfontscale
@@ -90,6 +90,8 @@ Recommends:     qemu >= 4.0.0
 Recommends:     qemu-tools 
 # Optional dependency for Python test API support
 Recommends:     perl(Inline::Python)
+# Optional dependency for crop.py
+Recommends:     python3-Pillow-tk
 Requires(pre):  %{_bindir}/getent
 Requires(pre):  %{_sbindir}/useradd
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/os-autoinst-openvswitch
+++ b/os-autoinst-openvswitch
@@ -1,4 +1,21 @@
 #!/usr/bin/perl
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+=head1 SYNOPSIS
+
+os-autoinst-openvswitch [OPTIONS]
+
+=head1 OPTIONS
+
+=over 4
+
+=item B<-h, -?, --help>
+
+Show this help.
+
+=cut
+
 package OVS;
 
 use Mojo::Base 'Net::DBus::Object', -signatures;

--- a/os-autoinst-openvswitch
+++ b/os-autoinst-openvswitch
@@ -20,11 +20,21 @@ package OVS;
 
 use Mojo::Base 'Net::DBus::Object', -signatures;
 use autodie ':all';
+use Getopt::Long;
 use Net::DBus::Exporter 'org.opensuse.os_autoinst.switch';
 require IPC::System::Simple;
 use IPC::Open3;
 use Symbol 'gensym';
 use Time::Seconds;
+
+sub usage ($r) {
+    eval { require Pod::Usage; Pod::Usage::pod2usage($r) };
+    die "cannot display help, install perl(Pod::Usage)\n" if $@;
+}
+
+my %options;
+GetOptions(\%options, 'help|h|?') or usage(1);
+usage(0) if $options{help};
 
 sub new ($class, $service) {
     my $self = $class->SUPER::new($service, '/switch');

--- a/t/44-scripts.t
+++ b/t/44-scripts.t
@@ -1,0 +1,32 @@
+#!/usr/bin/env perl
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+use Test::Warnings ':report_warnings';
+
+use FindBin '$Bin';
+use lib "$FindBin::Bin/lib", "$Bin/../external/os-autoinst-common/lib";
+use OpenQA::Test::TimeLimit '120';
+
+my %allowed_types = (
+    'text/x-perl' => 1,
+    'text/x-python' => 1,
+    'text/x-shellscript' => 1,
+);
+
+# Could also use MIME::Types, would be new dependency
+chomp(my @types = qx{cd $Bin/..; for i in *; do echo \$i; file --mime-type --brief \$i; done});
+
+my %types = @types;
+for my $key (keys %types) {
+    delete $types{$key} unless $allowed_types{$types{$key}};
+}
+
+for my $script (sort keys %types) {
+    my $out = qx{timeout 3 $Bin/../$script --help 2>&1};
+    my $rc = $?;
+    is($rc, 0, "Calling '$script --help' returns exit code 0") or diag "Output: $out";
+}
+
+done_testing;


### PR DESCRIPTION
Based on:
* https://github.com/os-autoinst/os-autoinst/pull/1970

This also ensures that scripts are included in coverage analysis

In https://github.com/os-autoinst/os-autoinst/pull/1970 I realized that we don't have any coverage for most scripts in the top-level folder.