### PR TITLE
testapi: Fix validate_script_output() argument parsing

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -1239,14 +1239,9 @@ alternatively matches a regular expression. Use it as
 =cut
 
 sub validate_script_output {
-    my ($script, $check) = splice(@_, 0, 2);
-    my %args = compat_args(
-        {
-            timeout => 30,
-            quiet => testapi::get_var('_QUIET_SCRIPT_CALLS')
-        }, ['timeout'], @_);
+    my ($script, $check, @args) = @_;
 
-    my $output = script_output($script, %args);
+    my $output = script_output($script, @args);
     my $res = 'ok';
 
     my $message = '';


### PR DESCRIPTION
Not all possible arguments where specified in `validate_script_output()`
`testapi::compat_args()` usage. This caused problems when calling it like
```
validate_script_output( $script, $match, proceed_on_failure => 1);
```
Here `testapi::compat_args()` would use the string 'proceed_on_failure'
as positioned timeout value, as it isn't given as a known key.

Also the default values for `script_output()` call inside of
`validate_script_output()` should not be set. E.g. the timeout was
explicit set to 30 in `validate_script_ouput()`.
