### PR TITLE
Fix condition in script `check_qemu_oom`

### DIFF
--- a/check_qemu_oom
+++ b/check_qemu_oom
@@ -19,4 +19,4 @@ my $qemu_pid = $ARGV[0];
 
 eval { use Pod::Usage; pod2usage(1); } unless $qemu_pid;
 
-exit(index(qx{dmesg}, "Out of memory: Killed process $qemu_pid") != -1) ? 0 : 1;
+exit(index(qx{dmesg} // '', "Out of memory: Killed process $qemu_pid") != -1 ? 0 : 1);


### PR DESCRIPTION
Judging by the code in `OpenQA/Qemu/Proc.pm` and the corresponding test
`t/18-qemu.t` which mocks the script invocation, the script is supposed to
return 0 in case QEMU was indeed stopped by the OOM-killer (and a non-zero
return code otherwise). I suppose that's also already what was attempted
when creating the script but https://github.com/Martchus/os-autoinst/commit/d6ab656e8529c5d6fa433e1e312e30650c50ba60
broke it because the `? 0 : 1` condition wasn't placed in brackets and
hence never executed.

I've not only noticed the problem when reviewing
https://github.com/os-autoinst/os-autoinst/pull/1972 but also when
investigating http://aquarius.suse.cz/tests/8065 which has
`backend died: QEMU was killed due to the system being out of memory` as
reason but QEMU actually stopped for a different reason.