### PR TITLE
Use proper perl "signatures" in common files - distribution

### DIFF
--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -18,7 +18,7 @@ subtest 'script_run' => sub {
     my $mock_testapi = Test::MockModule->new('testapi');
     $mock_testapi->redefine(type_string => undef);
     $mock_testapi->redefine(wait_serial => undef);
-    like(warning { $d->script_run }->[0], qr/^Use of uninitialized.*\$cmd/, 'Warning on incorrect usage');
+    like(exception { $d->script_run }, qr/^Too few arguments/, 'Error on incorrect usage');
     like(warning { $d->script_run('foo') }, qr/^Use of uninitialized.*serialdev/, 'Warning on undefined serialdev');
     {
         no warnings 'once';


### PR DESCRIPTION
Using a command like

```
sed -i "/^use strict;/ {N;s/use strict;/use Mojo::Base -strict, -signatures;/}" $(git ls-files)
for i in $(git grep -l 'use \(strict\|warnings\)'); do grep -q 'use Mojo::Base -strict' $i && sed -i '/use \(strict\|warnings\)/d' $i; done
tools/tidy --only-changed
```

and some manual fixes.