### PR TITLE
Add error handling for uninitialized isotovideo socket

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -317,7 +317,7 @@ sub query_isotovideo {
     }
     $json{cmd} = $cmd;
 
-    # send the command to isotovideo
+    die "isotovideo is not initialized. Ensure that you only call test API functions from test modules, not schedule code\n" unless defined $isotovideo;
     myjsonrpc::send_json($isotovideo, \%json);
 
     # wait for response (if test is paused, this will block until resume)

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -100,6 +100,7 @@ use basetest;
 my $mock_basetest = Test::MockModule->new('basetest');
 $mock_basetest->noop('_result_add_screenshot');
 $autotest::current_test = basetest->new();
+$autotest::isotovideo = 1;
 
 # we have to mock out wait_screen_change for the type_string tests
 # that use it, as it doesn't work with the fake send_json and read_json

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -78,6 +78,9 @@ is($autotest::tests{'tests-start1'}->{name}, 'start#1', 'handle duplicate tests'
 is($autotest::tests{'tests-start1'}->{$_}, $autotest::tests{'tests-start'}->{$_}, "duplicate tests point to the same $_")
   for qw(script fullname category class);
 
+like warning { autotest::run_all }, qr/isotovideo.*not initialized/, 'autotest methods need a valid isotovideo socket';
+@sent = ();
+$autotest::isotovideo = 1;
 stderr_like { autotest::run_all } qr/finished/, 'run_all outputs status on stderr';
 ($died, $completed) = get_tests_done;
 is($died, 0, 'start+next+start should not die');

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -30,6 +30,7 @@ my $serial_buffer = "";
 # Mock the JSON call for read_serial
 my $cmds;
 my $jsonmod = Test::MockModule->new('myjsonrpc');
+$autotest::isotovideo = 1;
 
 sub fake_send_json ($to_fd, $cmd) { push(@$cmds, $cmd) }
 sub fake_read_json ($fd) {

--- a/t/32-console_proxy.t
+++ b/t/32-console_proxy.t
@@ -45,6 +45,7 @@ $mock_baseclass->redefine('console', $console);
 my $baseclass = backend::baseclass->new();
 testapi::set_distribution(distribution->new());
 $autotest::current_test = basetest->new();
+$autotest::isotovideo = 1;
 
 my $jsonrpc_cmds = [];
 my $jsonrpc_results = [];


### PR DESCRIPTION
When trying to call test API functions from schedule code, e.g. the
main.pm one would get an error message like:

```
myjsonprc: called on undefined file descriptor at
/usr/lib/os-autoinst/myjsonrpc.pm line 40.
```

which is not very helpful to beginners. The problem is that test API
functions which only work as expected from within test modules are
called by users in unexpected cases, e.g. from scheduling code like a
main.pm file. In this case the isotovideo socket was not yet initialized
and we would try to execute a command on the worker, not the system
under test, for example a virtual machine.

This commit introduces an explicit message with a hint to the user what
to check in case they try to call tests in the wrong way where we would
end up calling the send_json function within an uninitialized object.

The problem was originally discovered when supporting a user receiving
such unexpected errors.