### PR TITLE
Use Mojo::Base in autotest as well

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -4,8 +4,7 @@
 
 package autotest;
 
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use bmwqemu;
 use Exporter 'import';
@@ -89,6 +88,7 @@ e.g. by making use of the openQA asset download feature.
 
 sub loadtest {
     my ($script, %args) = @_;
+    no utf8;    # Inline Python fails on utf8, so let's exclude it here
     my $casedir = $bmwqemu::vars{CASEDIR};
     my $script_path = find_script($script);
     my ($name, $category) = parse_test_path($script_path);

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -305,7 +305,9 @@ subtest 'load test successfully when CASEDIR is a relative path' => sub {
     like warning { loadtest 'start' }, qr{Subroutine run redefined}, 'We get a warning for loading a test a second time';
 };
 
-stderr_like { autotest::loadtest('tests/test.py') } qr{scheduling test tests/test.py}, 'can load python test module at all';
+stderr_like {
+    lives_ok { autotest::loadtest('tests/test.py') } 'can load test module'
+} qr{scheduling test tests/test.py}, 'python test module referenced';
 loadtest 'test.py', 'we can also parse python test modules';
 
 stderr_like {

--- a/xt/01-style.t
+++ b/xt/01-style.t
@@ -17,4 +17,5 @@ is qx{git grep -L '^#!.*perl' t/**.t}, '', 'All test files have shebang';
 is qx{git ls-files -s t/**.t | grep -v ^1007}, '', 'All test modules are executable';
 is qx{git grep -l '^use POSIX;'}, '', 'Use of bare POSIX import is discouraged, see https://perldoc.perl.org/POSIX';
 is qx{git grep --all-match -P -e '^use Mojo::Base' -e '^use base (?!.*# no:style)'}, '', 'No redundant Mojo::Base+base';
+is qx{git grep -I -l -P '^use (warnings|strict)' ':!external/'}, '', 'No files using "warning|strict", should use Mojo::Base instead';
 done_testing;


### PR DESCRIPTION
Previously I tried to convert most perl files to use Mojo::Base already,
especially for signatures. In autotest this previously failed in
conjunction with Inline Python but we could narrow it down to problems
with the utf8 statement.