### PR TITLE
myjsonrpc: Don't limit how often select may return EINTR

### DIFF
--- a/myjsonrpc.pm
+++ b/myjsonrpc.pm
@@ -96,17 +96,13 @@ sub read_json ($socket, $cmd_token = undef, $multi = undef) {
 
         # wait for next read
         my @res = $s->can_read;
-        my $remaining_attempts = 5;
         while (!@res) {
             # throw an error except can_read has been interrupted
             my $error = $!;
             confess "ERROR: unable to wait for JSON reply: $error\n" unless $!{EINTR};
-            confess "ERROR: can_read's underlying system call has been interrupted too many times\n" unless $remaining_attempts;
-
             # try again if can_read's underlying system call has been interrupted as suggested by the perlipc documentation
             bmwqemu::diag("($$) read_json($fd): can_read's underlying system call has been interrupted, trying again\n") if DEBUG_JSON;
             @res = $s->can_read;
-            $remaining_attempts -= 1;
         }
 
         my $qbuffer;


### PR DESCRIPTION
select returns EINTR if the wait was interrupted by any signal. The previous
code errored out if this happened more than five times, which is not wrong
and not unlikely to happen. The limit doesn't really have a purpose anyway,
so just remove it.

Related ticket: https://progress.opensuse.org/issues/107710

Verification run: http://10.160.67.86/tests/1201