### PR TITLE
Fix return value of set_assert_screen_timeout

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -913,6 +913,7 @@ sub set_tags_to_assert ($self, $args) {
 sub set_assert_screen_timeout ($self, $timeout) {
     return bmwqemu::fctwarn('set_assert_screen_timeout called with non-numeric timeout') unless looks_like_number($timeout);
     $self->assert_screen_deadline(time + $timeout);
+    return $self->assert_screen_deadline;
 }
 
 sub _time_to_assert_screen_deadline ($self) {


### PR DESCRIPTION
Mojo accessors return the object on set.

This should fix https://github.com/os-autoinst/openQA/pull/4569