### PR TITLE
Fix qemu test to actually wait for the process to be stopped

### DIFF
--- a/t/18-qemu.t
+++ b/t/18-qemu.t
@@ -412,8 +412,9 @@ subtest 'qemu was killed due to the system being out of memory' => sub {
     $mock_proc->redefine(check_qemu_oom => sub { return 0; });
     $proc = qemu_proc('-foo', \%vars);
     $proc->exec_qemu;
-    $proc->_process->stop;
+    $proc->_process->sleeptime_during_kill(0.1)->wait_stop;
     my $base_state = path(bmwqemu::STATE_FILE);
+    ok -f $base_state, qq{state file "$base_state" exists};
     my $state = decode_json($base_state->slurp);
     is($state->{msg}, 'QEMU was killed due to the system being out of memory', 'qemu was killed and the reason was shown correctly');
     unlink("./Core-7.2.iso");


### PR DESCRIPTION
Just calling ->stop does not guarantee that the forked process stops in
time for the cleanup code to create the state file for the test code. A
switch to ->wait_stop should make the test more reliable. If that does
not resolve the issue completely, we might have to hook into an event to
manually wait for the process to stop.

Progress: https://progress.opensuse.org/issues/108443