### PR TITLE
WIP: When git cloning $CASEDIR, use --reference-if-able against normal repo to save bandwidth

### DIFF
--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -49,6 +49,10 @@ sub checkout_git_repo_and_branch ($dir_variable, %args) {
     my $local_path = $url->path->parts->[-1] =~ s/\.git$//r;
     my $clone_cmd = 'env GIT_SSH_COMMAND="ssh -oBatchMode=yes" git clone';
     my $clone_args = "--depth $args{clone_depth}";
+
+    my $distri = $bmwqemu::vars{"DISTRI"} || undef;
+    $clone_args .= " --reference-if-able /var/lib/openqa/tests/$distri" if ( length $distri );
+
     my $branch_args = '';
     my ($return_code, @out);
     my $handle_output = sub {


### PR DESCRIPTION
This lets git make use of the data already in a local copy of the test repo when cloning a CASEDIR, which saves bandwidth, and for some reason makes it work better (I no longer see claims that it cannot find a referenced commit).

Things that need work:

1.  It has a hardwired path.
   Is it enough to assume that one is running in `~geekotest` and specify the path as `./tests/$distri`, or is the path to use in a variable that I should be using?

1. Would it be better to make this an option?
    `checkout_git_repo_and_branch()` could have a `--reference` option, and then one could decide whether to do it in the caller.

<hr>

In a somewhat related thought, it occurs to me that it would be good to have the worker pull the normal repo at the start of each job to get rid of the need to run fetchneedles incessantly.  Perhaps that has not been done in the past because it introduces the possibility of a malicious test getting write access to the local test repo, in which case how about always doing a clone as here, with `--reference-if-able`?  That would ensure that the worker had the very latest copy, would avoid pointless downloads when nothing had changed, and would not require write access to the local repo.  One could then have fetchneedles run much less often, without losing anything.

Alternatively, how about just having the workers be able to trigger a fetchneedles run at the start of a job, without getting write access directly?

If any of that's interesting, should I create a separate issue or PR?