### PR TITLE
Hide secrets in all log_call invocations 

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -215,11 +215,13 @@ sub log_call {
     else {
         # key/value pairs
         my @result;
+        my $should_hide = grep { ($_ // '') eq 'secret' } @_;
         while (my ($key, $value) = splice(@_, 0, 2)) {
             if ($key =~ tr/0-9a-zA-Z_//c) {
                 # only quote if needed
                 $key = pp($key);
             }
+            $value = "[masked]" if ($key eq 'text' && $should_hide);
             push @result, join("=", $key, pp($value));
         }
         $params = join(", ", @result);

--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -60,6 +60,11 @@ subtest 'log_call' => sub {
         bmwqemu::log_call(test => $lines);
     }
     stderr_like(\&log_call_indent, qr{\Q<<< main::log_call_indent(test=[\E\n\Q    "a",\E\n\Q    [\E\n\Q      "b"\E\n\Q    ]\E\n\Q  ])}, 'log_call auto indentation');
+
+    sub log_call_test_secret {
+        bmwqemu::log_call(text => "passwd\n", secret => 1);
+    }
+    stderr_like(\&log_call_test_secret, qr{\Q<<< main::log_call_test_secret(text="[masked]", secret=1)}, 'log_call hides sensitive info');
 };
 
 subtest 'update_line_number' => sub {

--- a/testapi.pm
+++ b/testapi.pm
@@ -1465,7 +1465,6 @@ sub type_string {
     $string .= "\n" if $args{lf};
 
     if (is_serial_terminal) {
-        bmwqemu::log_call(text => $log, %args);
         query_isotovideo('backend_type_string', {text => $string, %args});
         return;
     }

--- a/testapi.pm
+++ b/testapi.pm
@@ -1461,7 +1461,6 @@ sub type_string {
     else {
         %args = @_;
     }
-    my $log = $args{secret} ? 'SECRET STRING' : $string;
     $string .= "\n" if $args{lf};
 
     if (is_serial_terminal) {
@@ -1474,7 +1473,7 @@ sub type_string {
     my $wait_still = $args{wait_still_screen} // 0;
     my $wait_timeout = $args{timeout} // 30;
     my $wait_sim_level = $args{similarity_level} // 47;
-    bmwqemu::log_call(string => $log, max_interval => $max_interval, wait_screen_changes => $wait, wait_still_screen => $wait_still,
+    bmwqemu::log_call(string => $string, max_interval => $max_interval, wait_screen_changes => $wait, wait_still_screen => $wait_still,
         timeout => $wait_timeout, similarity_level => $wait_sim_level);
     my @pieces;
     if ($wait) {


### PR DESCRIPTION
My first idea was to encrypt the text and then decrypt it when it is needed for the call.

However the concern was about the logs and i found that the only thing that it needs to be done
is to update the log_call, because this is what is called from all the backends. in this way nothing
else seems to need to change in testapi or anywhere else.

Signed-off-by: ybonatakis <ybonatakis@suse.com>

http://aquarius.suse.cz/tests/9012/logfile?filename=autoinst-log.txt