### PR TITLE
Avoid JSON::PP::Boolean warnings

### DIFF
--- a/isotovideo
+++ b/isotovideo
@@ -39,6 +39,10 @@ use Mojo::Base -strict, -signatures;
 use autodie ':all';
 no autodie 'kill';
 
+# Avoid "Subroutine JSON::PP::Boolean::(0+ redefined" warnings
+# Details: https://progress.opensuse.org/issues/90371
+use JSON::PP;
+
 my $installprefix;    # $bmwqemu::scriptdir
 my $fatal_error;    # the last error message caught by the die handler
 


### PR DESCRIPTION
When Cpanel::JSON::XS is loaded before JSON::PP, it will
result in warnings

    Subroutine JSON::PP::Boolean::(0+ redefined at .../overload.pm
    ...

This is because Cpanel::JSON::XS creates the same overloads
as JSON::PP. This is handled in newer versions of JSON::PP, so
it will go away at some point, but until then it is always confusing to see
the warnings.
Adding `-mJSON::PP` makes sure it will be loaded first.