### PR TITLE
Do not require additional command to pause on a test module

### DIFF
--- a/t/19-isotovideo-command-processing.t
+++ b/t/19-isotovideo-command-processing.t
@@ -98,10 +98,7 @@ subtest 'set pause at test' => sub {
     reset_state;
 
     stderr_like {
-        $command_handler->process_command($answer_fd, {
-                cmd => 'set_pause_at_test',
-                name => 'some test',
-        });
+        $command_handler->process_command($answer_fd, {cmd => 'set_pause_at_test', name => 'some test'})
     } qr/paused.*some test/, 'log for pause';
     is_deeply($last_received_msg_by_fd[$answer_fd], {ret => 1}, 'answer received');
     is_deeply($last_received_msg_by_fd[$cmd_srv_fd], {set_pause_at_test => 'some test'}, 'broadcasted via command server');
@@ -121,10 +118,7 @@ subtest 'set pause at test' => sub {
     is $command_handler->postponed_answer_fd, $answer_fd, 'answer postponed';
 
     stderr_like {
-        $command_handler->process_command($answer_fd, {
-                cmd => 'set_pause_at_test',
-                name => undef,
-        });
+        $command_handler->process_command($answer_fd, {cmd => 'set_pause_at_test', name => undef});
     } qr/no longer.*paused/, 'log for unpause';
     is_deeply($last_received_msg_by_fd[$answer_fd], {ret => 1}, 'answer received');
     is_deeply($last_received_msg_by_fd[$cmd_srv_fd], {set_pause_at_test => undef}, 'broadcasted via command server');
@@ -132,46 +126,27 @@ subtest 'set pause at test' => sub {
 };
 
 subtest 'report timeout, set pause on assert/check screen timeout' => sub {
-    my %basic_report_timeout_cmd = (
-        cmd => 'report_timeout',
-        msg => 'some test',
-    );
-
+    my %basic_report_timeout_cmd = (cmd => 'report_timeout', msg => 'some test');
     reset_state;
 
     # report timeout when not supposted to pause
-    $command_handler->process_command($answer_fd, {
-            cmd => 'is_configured_to_pause_on_timeout',
-            check => 0,
-    });
+    $command_handler->process_command($answer_fd, {cmd => 'is_configured_to_pause_on_timeout', check => 0});
     is_deeply($last_received_msg_by_fd[$answer_fd], {ret => 0}, 'not configured to pause on assert_screen');
-    $command_handler->process_command($answer_fd, {
-            cmd => 'is_configured_to_pause_on_timeout',
-            check => 1,
-    });
+    $command_handler->process_command($answer_fd, {cmd => 'is_configured_to_pause_on_timeout', check => 1});
     is_deeply($last_received_msg_by_fd[$answer_fd], {ret => 0}, 'not configured to pause on check_screen');
     $command_handler->process_command($answer_fd, \%basic_report_timeout_cmd);
     is_deeply($last_received_msg_by_fd[$answer_fd], {ret => 0}, 'not supposed to pause');
     is_deeply($last_received_msg_by_fd[$cmd_srv_fd], undef, 'nothing sent to cmd srv');
 
     # enable pause on assert_screen timeout
-    $command_handler->process_command($answer_fd, {
-            cmd => 'set_pause_on_screen_mismatch',
-            pause_on => 'assert_screen',
-    });
+    $command_handler->process_command($answer_fd, {cmd => 'set_pause_on_screen_mismatch', pause_on => 'assert_screen'});
     is_deeply($last_received_msg_by_fd[$cmd_srv_fd], {
             set_pause_on_screen_mismatch => 'assert_screen',
     }, 'event passed cmd srv');
     is($command_handler->pause_on_screen_mismatch, 'assert_screen', 'enabling pause on assert_screen timeout');
-    $command_handler->process_command($answer_fd, {
-            cmd => 'is_configured_to_pause_on_timeout',
-            check => 0,
-    });
+    $command_handler->process_command($answer_fd, {cmd => 'is_configured_to_pause_on_timeout', check => 0});
     is_deeply($last_received_msg_by_fd[$answer_fd], {ret => 1}, 'configured to pause on assert_screen');
-    $command_handler->process_command($answer_fd, {
-            cmd => 'is_configured_to_pause_on_timeout',
-            check => 1,
-    });
+    $command_handler->process_command($answer_fd, {cmd => 'is_configured_to_pause_on_timeout', check => 1});
     is_deeply($last_received_msg_by_fd[$answer_fd], {ret => 0}, 'not configured to pause on check_screen');
 
     # report timeout when supposed to pause
@@ -191,23 +166,14 @@ subtest 'report timeout, set pause on assert/check screen timeout' => sub {
     is_deeply($last_received_msg_by_fd[$answer_fd], {ret => 0}, 'not supposed to pause on check_screen');
 
     # enable pause on check_screen timeout
-    $command_handler->process_command($answer_fd, {
-            cmd => 'set_pause_on_screen_mismatch',
-            pause_on => 'check_screen',
-    });
+    $command_handler->process_command($answer_fd, {cmd => 'set_pause_on_screen_mismatch', pause_on => 'check_screen'});
     is_deeply($last_received_msg_by_fd[$cmd_srv_fd], {
             set_pause_on_screen_mismatch => 'check_screen',
     }, 'event passed cmd srv');
     is($command_handler->pause_on_screen_mismatch, 'check_screen', 'enabling pause on check_screen timeout');
-    $command_handler->process_command($answer_fd, {
-            cmd => 'is_configured_to_pause_on_timeout',
-            check => 0,
-    });
+    $command_handler->process_command($answer_fd, {cmd => 'is_configured_to_pause_on_timeout', check => 0});
     is_deeply($last_received_msg_by_fd[$answer_fd], {ret => 1}, 'configured to pause on assert_screen');
-    $command_handler->process_command($answer_fd, {
-            cmd => 'is_configured_to_pause_on_timeout',
-            check => 1,
-    });
+    $command_handler->process_command($answer_fd, {cmd => 'is_configured_to_pause_on_timeout', check => 1});
     is_deeply($last_received_msg_by_fd[$answer_fd], {ret => 1}, 'configured to pause on check_screen');
     stderr_like {
         $command_handler->process_command($answer_fd, \%basic_report_timeout_cmd);
@@ -215,10 +181,7 @@ subtest 'report timeout, set pause on assert/check screen timeout' => sub {
     is_deeply($last_received_msg_by_fd[$answer_fd], {ret => 1}, 'supposed to pause on check_screen');
 
     # disabling pause on assert_screen timeout disables pause on check_screen timeout as well
-    $command_handler->process_command($answer_fd, {
-            cmd => 'set_pause_on_screen_mismatch',
-            pause_on => undef,
-    });
+    $command_handler->process_command($answer_fd, {cmd => 'set_pause_on_screen_mismatch', pause_on => undef});
     is_deeply($last_received_msg_by_fd[$cmd_srv_fd], {
             set_pause_on_screen_mismatch => 0,
     }, 'event passed cmd srv');
@@ -230,10 +193,7 @@ subtest 'report timeout, set pause on assert/check screen timeout' => sub {
 subtest 'set_pause_on_next_command, postponing command, resuming' => sub {
     # enable pausing on next command
     is($command_handler->pause_on_next_command, 0, 'pause on next command disabled by default');
-    $command_handler->process_command($answer_fd, {
-            cmd => 'set_pause_on_next_command',
-            flag => 1,
-    });
+    $command_handler->process_command($answer_fd, {cmd => 'set_pause_on_next_command', flag => 1});
     is_deeply($last_received_msg_by_fd[$cmd_srv_fd], {
             set_pause_on_next_command => 1,
     }, 'event passed cmd srv');
@@ -251,10 +211,7 @@ subtest 'set_pause_on_next_command, postponing command, resuming' => sub {
     is($command_handler->postponed_answer_fd, $answer_fd, 'answer fd for postponed command set');
 
     # disable pausing on next command again
-    $command_handler->process_command($answer_fd, {
-            cmd => 'set_pause_on_next_command',
-            flag => 0,
-    });
+    $command_handler->process_command($answer_fd, {cmd => 'set_pause_on_next_command', flag => 0});
     is_deeply($last_received_msg_by_fd[$cmd_srv_fd], {
             set_pause_on_next_command => 0,
     }, 'event passed cmd srv');


### PR DESCRIPTION
Make developer mode pause directly when reaching a test module to pause
on (instead of only pausing on the next command within that test module).