### PR TITLE
Avoid command server uploads from running out of space

### DIFF
--- a/commands.pm
+++ b/commands.pm
@@ -228,6 +228,7 @@ sub run_daemon {
     # allow up to 20 GiB for uploads of big hdd images
     $ENV{MOJO_MAX_MESSAGE_SIZE} //= ($bmwqemu::vars{UPLOAD_MAX_MESSAGE_SIZE_GB} // 0) * 1024**3;
     $ENV{MOJO_INACTIVITY_TIMEOUT} //= ($bmwqemu::vars{UPLOAD_INACTIVITY_TIMEOUT} // 300);
+    $ENV{MOJO_TMPDIR} //= path('command-server-tmp')->make_path;
 
     # avoid leaking token
     app->mode('production');


### PR DESCRIPTION
* Use a sub directory within the current working directory (usually the
  "pool" directory setup by the openQA worker) as temporary directory for
  asset uploads instead of `/tmp`
    * Avoid running out of memory when `/tmp` is a tmpfs
    * Avoid running out of disk space when `/tmp` is on a small partition
    * Make moving the temporary file to its final destination a move within
      the same file system
* See https://progress.opensuse.org/issues/108281#note-15 (but does not fix
  the issue)