### PR TITLE
virtio_terminal_improvements

### DIFF
--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -75,16 +75,12 @@ sub load_snapshot ($self, $name) {
     }
 }
 
-sub get_snapshot ($self, $name = undef, $key = undef) {
-    return undef unless defined($name);
-
+sub get_snapshot ($self, $name, $key = undef) {
     my $snapshot = $self->{snapshots}->{$name};
     return (defined($key) && $snapshot) ? $snapshot->{$key} : $snapshot;
 }
 
-sub set_snapshot ($self, $name = undef, $key = undef, $value = undef) {
-    return undef if (!defined($name) || !defined($key));
-
+sub set_snapshot ($self, $name, $key, $value = undef) {
     $self->{snapshots}->{$name}->{$key} = $value;
 }
 

--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -49,18 +49,15 @@ sub new ($class, $testapi_console, $args) {
     return $self;
 }
 
-sub screen ($self) {
-    return $self->{screen};
-}
+sub screen ($self) { $self->{screen} }
 
 sub disable ($self) {
-    if ($self->{fd_read} > 0) {
-        close $self->{fd_read};
-        close $self->{fd_write};
-        $self->{fd_read} = 0;
-        $self->{fd_write} = 0;
-        $self->{screen} = undef;
-    }
+    return undef unless $self->{fd_read} > 0;
+    close $self->{fd_read};
+    close $self->{fd_write};
+    $self->{fd_read} = 0;
+    $self->{fd_write} = 0;
+    $self->{screen} = undef;
 }
 
 sub save_snapshot ($self, $name) {
@@ -78,16 +75,14 @@ sub load_snapshot ($self, $name) {
     }
 }
 
-sub get_snapshot {
-    my ($self, $name, $key) = @_;
+sub get_snapshot ($self, $name = undef, $key = undef) {
     return undef unless defined($name);
 
     my $snapshot = $self->{snapshots}->{$name};
     return (defined($key) && $snapshot) ? $snapshot->{$key} : $snapshot;
 }
 
-sub set_snapshot {
-    my ($self, $name, $key, $value) = @_;
+sub set_snapshot ($self, $name = undef, $key = undef, $value = undef) {
     return undef if (!defined($name) || !defined($key));
 
     $self->{snapshots}->{$name}->{$key} = $value;
@@ -97,26 +92,21 @@ sub set_snapshot {
 This is a helper method for system which do not have F_GETPIPE_SZ in
 there Fcntl bindings. See https://perldoc.perl.org/Fcntl.html
 =cut
-sub F_GETPIPE_SZ {
-    return eval 'no warnings "all"; Fcntl::F_GETPIPE_SZ;' || 1032;
-}
+sub F_GETPIPE_SZ () { eval 'no warnings "all"; Fcntl::F_GETPIPE_SZ;' || 1032 }
 
 =head2 F_SETPIPE_SZ
 This is a helper method for system which do not have F_SETPIPE_SZ in
 there Fcntl bindings. See: https://perldoc.perl.org/Fcntl.html
 =cut
-sub F_SETPIPE_SZ {
-    return eval 'no warnings "all"; Fcntl::F_SETPIPE_SZ;' || 1031;    # uncoverable statement
-}
+# uncoverable statement
+sub F_SETPIPE_SZ () { eval 'no warnings "all"; Fcntl::F_SETPIPE_SZ;' || 1031 }
 
 sub set_pipe_sz ($self, $fd, $newsize) {
     no autodie;
     return fcntl($fd, F_SETPIPE_SZ(), int($newsize));
 }
 
-sub get_pipe_sz ($self, $fd) {
-    return fcntl($fd, F_GETPIPE_SZ(), 0);
-}
+sub get_pipe_sz ($self, $fd) { fcntl($fd, F_GETPIPE_SZ(), 0) }
 
 =head2 open_pipe
 
@@ -164,6 +154,6 @@ sub activate ($self) {
     return;
 }
 
-sub is_serial_terminal { 1 }
+sub is_serial_terminal ($self, @) { 1 }
 
 1;

--- a/t/10-virtio_terminal.t
+++ b/t/10-virtio_terminal.t
@@ -143,11 +143,7 @@ subtest "Test snapshot handling" => sub {
     my $helper = prepare_pipes($socket_path, $test_data);
     my $term = consoles::virtio_terminal->new('unit-test-console', {socked_path => $socket_path});
 
-    is_deeply($term->get_snapshot(), undef, "Return undef if no name is given");
-    is_deeply($term->get_snapshot('unknown_snapshot'), undef, "Return undef, if snapshotname doesn't exist");
     is_deeply($term->get_snapshot('unknown_snapshot', 'unknown_key'), undef, "Return undef, if snapshot and key doesn't exist");
-    is_deeply($term->set_snapshot(), undef, "Return undef, if snapshot name not given");
-    is_deeply($term->set_snapshot('foo'), undef, "Return undef, if key not given");
     is_deeply($term->{snapshots}, {}, "Snapshots are empty");
 
     $term->select();

--- a/t/10-virtio_terminal.t
+++ b/t/10-virtio_terminal.t
@@ -35,7 +35,7 @@ sub prepare_pipes ($socket_path, $write_buffer = undef) {
         my $running = 1;
         $SIG{USR1} = sub { $running = 0; };
         $SIG{ALRM} = sub {
-            die('Timeout for pipe other side helper');
+            die('Timeout for pipe other side helper');    # uncoverable statement
         };
         alarm ONE_MINUTE;
         my $fd_r = IO::Handle->new();


### PR DESCRIPTION
* Rely on signatures for get/set_snapshot in virtio_console
* Use consistent signatures in consoles::virtio_terminal.pm
* t: Mark custom timeout handler as uncoverable