### PR TITLE
Remove unnecessary but potentially racy signalblocker log lines

### DIFF
--- a/signalblocker.pm
+++ b/signalblocker.pm
@@ -15,7 +15,6 @@ use POSIX ':signal_h';
 
 sub new ($class, @args) {
     # block signals
-    bmwqemu::diag('Blocking SIGCHLD and SIGTERM');
     my %old_sig = %SIG;
     $SIG{TERM} = 'IGNORE';
     $SIG{INT} = 'IGNORE';
@@ -32,7 +31,6 @@ sub new ($class, @args) {
 
 sub DESTROY ($self) {
     # set back signal handling to default to be able to terminate properly
-    bmwqemu::diag('Unblocking SIGCHLD and SIGTERM');
     die "Could not unblock SIGCHLD and SIGTERM\n" unless defined sigprocmask(SIG_UNBLOCK, $self->{_sigset}, undef);
     %SIG = %{$self->{_old_sig}};
 }


### PR DESCRIPTION
As tina.mueller@suse.com found out in
https://progress.opensuse.org/issues/107998 the log lines in
signalblocker might cause race conditions in our tests.
Also, I consider the output in a usual openQA like in the following log
excerpt not helpful to read:

```
[2022-04-09T12:52:55.814954+02:00] [debug] loaded 10829 needles
[2022-04-09T12:52:56.491100+02:00] [debug] Blocking SIGCHLD and SIGTERM
[2022-04-09T12:52:56.589482+02:00] [debug] Unblocking SIGCHLD and SIGTERM
[2022-04-09T12:52:56.782965+02:00] [debug] 65300: channel_out 15, channel_in 14
[2022-04-09T12:52:56.799859+02:00] [debug] Blocking SIGCHLD and SIGTERM
[2022-04-09T12:52:56.901592+02:00] [debug] Unblocking SIGCHLD and SIGTERM
[2022-04-09T12:52:56.911728+02:00] [debug] 579: cmdpipe 13, rsppipe 16
[2022-04-09T12:52:56.912061+02:00] [debug] started mgmt loop with pid 579
[2022-04-09T12:52:57.078008+02:00] [debug] qemu version detected: 5.2.0
```

there are four log lines, two times blocking, two times unblocking,
without information from which process these lines come from. Given that
two uppercase words are used the lines also reads a bit bulky and are
quite unlikely to be helpful for test reviewers. So better  we remove
the lines at all.

Related progress issue: https://progress.opensuse.org/issues/107998