### PR TITLE
t: Mock log functions to avoid capture problems

### DIFF
--- a/t/29-backend-driver.t
+++ b/t/29-backend-driver.t
@@ -10,8 +10,9 @@ use Mojo::Util qw(scope_guard);
 use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
-use Test::Output qw(combined_like stderr_like);
+use Test::Output qw(combined_from);
 use Test::Warnings qw(:all :report_warnings);
+use Test::MockModule;
 use log qw(logger);
 
 use backend::driver;
@@ -20,16 +21,30 @@ my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
 chdir $dir;
 my $cleanup = scope_guard sub { chdir $Bin; undef $dir };
 
+my (@diag, @fctinfo);
+my $mocklog = Test::MockModule->new('backend::driver');
+$mocklog->redefine(diag => sub { push @diag, @_ });
+$mocklog->redefine(fctinfo => sub { push @fctinfo, @_ });
+sub reset_logs { @diag = (); @fctinfo = () }
+
 my $driver;
 logger->handle->autoflush(1);
-combined_like { $driver = backend::driver->new('null') } qr/channel_out.+channel_in/, 'log output for backend driver creation';
+my $out = combined_from { $driver = backend::driver->new('null') };
+like "@diag", qr/channel_out.+channel_in/, 'log output for backend driver creation';
+reset_logs();
+
 ok $driver, 'can create driver';
-combined_like { ok $driver->start, 'can start driver' } qr/channel_out.+channel_in/, 'log content again';
+$out = combined_from { ok $driver->start, 'can start driver' };
+like "@diag", qr/channel_out.+channel_in/, 'log content again';
+reset_logs();
+
 isnt $driver->{backend_process}, {}, 'backend process was started' or explain $driver->{backend_process};
 is $driver->extract_assets, undef, 'extract_assets';
 ok $driver->start_vm, 'start_vm';
 is $driver->mouse_hide, 0, 'mouse_hide';
-combined_like { is $driver->stop_backend, undef, 'stop_backend' } qr/backend.*exited/, 'exit logged';
+$out = combined_from { is $driver->stop_backend, undef, 'stop_backend' };
+like "@diag", qr/backend.*exited/, 'exit logged';
+reset_logs();
 is $driver->stop, undef, 'stop';
 done_testing;
 


### PR DESCRIPTION
Capturing output from parent and child processes can lead to
overwritten output.

Issue: https://progress.opensuse.org/issues/107998