### PR TITLE
Sync tools/tidy with openQA

### DIFF
--- a/tools/tidy
+++ b/tools/tidy
@@ -3,11 +3,10 @@
 #
 # perltidy rules can be found in ../.perltidyrc
 #
-
 usage() {
     cat << EOF
 Usage:
- tidy [-c|--check] [-f|--force] [-o|--only-changed] [path/to/file]
+ tidy [-c|--check] [-f|--force] [-o|--only-changed] [-l|--list] [path/to/file]
 
 Options:
  -h, -?, --help       display this help
@@ -15,9 +14,9 @@ Options:
  -f, --force          Force check even if tidy version mismatches
  -o --only-changed    Only tidy files with uncommitted changes in git. This can
                       speed up execution a lot.
+-l --list             List files tidy would touch
  path/to/file         When passing a file as argument, tidy will run perltidy
                       wether it is added to the git tree or not
-
 
 perltidy rules can be found in .perltidyrc
 EOF
@@ -25,10 +24,12 @@ EOF
 }
 
 set -eo pipefail
+dir="$(dirname "$0")"
 
 args=""
 selection='--all'
-opts=$(getopt -o hcfo --long help,check,force,only-changed -n 'parse-options' -- "$@") || usage
+[[ -e "$dir/perlfiles" ]] && selection=$("$dir"/perlfiles)
+opts=$(getopt -o hcfol --long help,check,force,only-changed,list -n "$0" -- "$@") || usage
 eval set -- "$opts"
 while true; do
   case "$1" in
@@ -36,6 +37,7 @@ while true; do
     -c | --check ) args+=' --check-only'; shift ;;
     -f | --force ) force=true; shift ;;
     -o | --only-changed ) selection='--git'; shift ;;
+    -l | --list ) args+='--list'; shift ;;
     -- ) shift; break ;;
     * ) break ;;
   esac
@@ -49,17 +51,16 @@ if ! command -v perltidy > /dev/null 2>&1; then
     exit 1
 fi
 
-# cpan file is in top directory
-dir="$(dirname "$0")/.."
-perltidy_version_expected=$(sed -n "s/^.*Perl::Tidy[^0-9]*\([0-9]*\)['];$/\1/p" "$dir"/cpanfile)
+perltidy_version_expected=$(sed -n "s/^.*Perl::Tidy[^0-9]*\([0-9]*\)['];$/\1/p" "$dir"/../cpanfile)
+# This might be used from another repo like os-autoinst-distri-opensuse
 if [ -z "${perltidy_version_expected}" ]; then
     # No cpanfile in the linked repo, use the one from os-autoinst instead
-    dir="$(dirname "$(readlink -f "$0")")/.."
-    perltidy_version_expected=$(sed -n "s/^.*Perl::Tidy[^0-9]*\([0-9]*\)['];$/\1/p" "$dir"/cpanfile)
+    dir="$(dirname "$(readlink -f "$0")")"
+    perltidy_version_expected=$(sed -n "s/^.*Perl::Tidy[^0-9]*\([0-9]*\)['];$/\1/p" "$dir"/../cpanfile)
 fi
 perltidy_version_found=$(perltidy -version | sed -n '1s/^.*perltidy, v\([0-9]*\)\s*$/\1/p')
 if [ "$perltidy_version_found" != "$perltidy_version_expected" ]; then
-    echo -n "Wrong version of perltidy. Found '$perltidy_version_found', expected '$perltidy_version_expected'."
+    echo -n "Wrong version of perltidy. Found '$perltidy_version_found', expected '$perltidy_version_expected'. "
     if [[ "$force" = "true" ]]; then
         echo "Found '--force', continuing"
     else
@@ -69,7 +70,7 @@ if [ "$perltidy_version_found" != "$perltidy_version_expected" ]; then
 fi
 
 # go to caller directory
-cd "$(dirname "$0")/.."
+cd "$dir/.."
 
 # just to make sure we are at the right location
 test -e tools/tidy || exit 1


### PR DESCRIPTION
* Add --list
* Formatting
* Allow tools/perlfiles for special selection

Issue: https://progress.opensuse.org/issues/110142

For now I'm not adding this to os-autoinst-common because I have to solve the problem that os-autoinst-distri-opensuse uses `readlink -f $0` to get the `os-autoinst/cpanfile`.

See also https://github.com/os-autoinst/openQA/pull/4614