### PR TITLE
Add perl-Template-Toolkit to dependencies for devel

### DIFF
--- a/container/os-autoinst_dev/Dockerfile
+++ b/container/os-autoinst_dev/Dockerfile
@@ -106,6 +106,7 @@ RUN zypper in -y -C \
        'perl(Scalar::Util)' \
        'perl(Socket)' \
        'perl(Socket::MsgHdr)' \
+       'perl(Template::Toolkit)' \
        'perl(Term::ANSIColor)' \
        'perl(Test::Fatal)' \
        'perl(Test::Mock::Time)' \

--- a/cpanfile
+++ b/cpanfile
@@ -100,6 +100,7 @@ on 'devel' => sub {
     requires 'Devel::Cover';
     requires 'Devel::Cover::Report::Codecov';
     requires 'Perl::Tidy', '== 20220217';
+    requires 'Template::Toolkit';
 
 };
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -45,6 +45,7 @@ devel_requires:
   perl(Code::TidyAll):
   perl(Devel::Cover):
   perl(Devel::Cover::Report::Codecov):
+  perl(Template::Toolkit):
   perl(Perl::Tidy): '== 20220217'
   ShellCheck:
 

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -80,7 +80,7 @@ Source0:        %{name}-%{version}.tar.xz
 # The following line is generated from dependencies.yaml
 %define test_requires %build_requires %spellcheck_requires %test_base_requires %yamllint_requires perl(Inline::Python) perl(YAML::PP) python3-Pillow-tk
 # The following line is generated from dependencies.yaml
-%define devel_requires %python_style_requires %test_requires ShellCheck perl(Code::TidyAll) perl(Devel::Cover) perl(Devel::Cover::Report::Codecov) perl(Perl::Tidy)
+%define devel_requires %python_style_requires %test_requires ShellCheck perl(Code::TidyAll) perl(Devel::Cover) perl(Devel::Cover::Report::Codecov) perl(Perl::Tidy) perl(Template::Toolkit)
 %define s390_zvm_requires /usr/bin/xkbcomp /usr/bin/Xvnc x3270 icewm xterm xterm-console xdotool fonts-config mkfontdir mkfontscale
 BuildRequires:  %test_requires %test_version_only_requires
 Requires:       %main_requires


### PR DESCRIPTION
Is soft dependency od perl-Devel-Cover and without it commmand
`make coverage` fails