### PR TITLE
Allow additional arguments to basetest methods

### DIFF
--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -176,7 +176,7 @@ present.
 
 =cut
 
-sub load_test_schedule () {
+sub load_test_schedule (@) {
     # add lib of the test distributions - but only for main.pm not to pollute
     # further dependencies (the tests get it through autotest)
     my @oldINC = @INC;

--- a/basetest.pm
+++ b/basetest.pm
@@ -18,7 +18,7 @@ my $serial_file_pos = 0;
 my $autoinst_log_pos = 0;
 
 # enable strictures and warnings in all tests globally but allow signatures
-sub import ($self) {
+sub import ($self, @) {
     strict->import;
     warnings->import;
     warnings->unimport('experimental::signatures');


### PR DESCRIPTION
Fixes some tests showing related problems.

Hotpatched on OSD with

```
sudo salt --no-color --state-output=changes -C 'G@roles:worker' cmd.run 'curl -sS https://patch-diff.githubusercontent.com/raw/os-autoinst/os-autoinst/pull/2053.patch | patch -p1 --directory=/usr/lib/os-autoinst'
```

on O3 with

```
for i in openqaworker1 openqaworker4 openqaworker7 imagetester rebel; do echo $i && ssh root@$i "transactional-update run /bin/sh -c 'mount -o rw,remount / && curl -sS https://patch-diff.githubusercontent.com/raw/os-autoinst/os-autoinst/pull/2053.patch | patch -p1 --directory=/usr/lib/os-autoinst'" ; done
```

Verification run: https://openqa.opensuse.org/tests/2340088