### PR TITLE
Hide string from logs in type_string when using secret=1

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -213,13 +213,13 @@ sub log_call (@args) {
     else {
         # key/value pairs
         my @result;
-        my $should_hide = grep { ($_ // '') eq 'secret' } @args;
+        my %args = @_;
         while (my ($key, $value) = splice(@args, 0, 2)) {
             if ($key =~ tr/0-9a-zA-Z_//c) {
                 # only quote if needed
                 $key = pp($key);
             }
-            $value = "[masked]" if ($key eq 'text' && $should_hide);
+            $value = "[masked]" if ($key =~ /string|text/ && $args{secret});
             push @result, join("=", $key, pp($value));
         }
         $params = join(", ", @result);

--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -62,10 +62,15 @@ subtest 'log_call' => sub {
     }
     stderr_like(\&log_call_indent, qr{\Q<<< main::log_call_indent(test=[\E\n\Q    "a",\E\n\Q    [\E\n\Q      "b"\E\n\Q    ]\E\n\Q  ])}, 'log_call auto indentation');
 
-    sub log_call_test_secret {
+    sub log_call_test_secret_text {
         bmwqemu::log_call(text => "passwd\n", secret => 1);
     }
-    stderr_like(\&log_call_test_secret, qr{\Q<<< main::log_call_test_secret(text="[masked]", secret=1)}, 'log_call hides sensitive info');
+    stderr_like(\&log_call_test_secret_text, qr{\Q<<< main::log_call_test_secret_text(text="[masked]", secret=1)}, 'log_call hides sensitive info');
+
+    sub log_call_test_secret_string {
+        bmwqemu::log_call(string => "passwd\n", secret => 1);
+    }
+    stderr_like(\&log_call_test_secret_string, qr{\Q<<< main::log_call_test_secret_string(string="[masked]", secret=1)}, 'log_call hides sensitive info');
 };
 
 subtest 'update_line_number' => sub {

--- a/testapi.pm
+++ b/testapi.pm
@@ -1474,7 +1474,7 @@ sub type_string {
     my $wait_timeout = $args{timeout} // 30;
     my $wait_sim_level = $args{similarity_level} // 47;
     bmwqemu::log_call(string => $string, max_interval => $max_interval, wait_screen_changes => $wait, wait_still_screen => $wait_still,
-        timeout => $wait_timeout, similarity_level => $wait_sim_level);
+        timeout => $wait_timeout, similarity_level => $wait_sim_level, secret => $args{secret});
     my @pieces;
     if ($wait) {
         # split string into an array of pieces of specified size


### PR DESCRIPTION
Background: https://github.com/os-autoinst/os-autoinst/pull/2002

This PR is printing $string on the logs regardless if it's a secret or not.

https://progress.opensuse.org/issues/111010


This should avoid things like
```
[2022-05-12T15:59:08.330771+02:00] [debug] tests/jeos/firstrun.pm:116 called testapi::type_password
[2022-05-12T15:59:08.331044+02:00] [debug] <<< testapi::type_string(string="nots3cr3t", max_interval=100, wait_screen_changes=0, wait_still_screen=0, timeout=30, similarity_level=47, secret=1)
```