### PR TITLE
Fix signature for `post_fail_hook` in basetest

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -108,7 +108,7 @@ Function is run after test has failed to e.g. recover log files
 
 =cut
 
-sub post_fail_hook () { 1 }
+sub post_fail_hook ($self) { 1 }
 
 =head2 _framenumber_to_timerange
 

--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -75,8 +75,10 @@ for my $result (glob("testresults/result*fail*.json")) {
 }
 
 subtest 'Assert screen failure' => sub {
-    my $count = () = path('autoinst-log.txt')->slurp =~ /(?<=no candidate needle with tag\(s\)) '(no_tag, no_tag2|no_tag3)'/g;
+    my $log = path('autoinst-log.txt')->slurp;
+    my $count = () = $log =~ /(?<=no candidate needle with tag\(s\)) '(no_tag, no_tag2|no_tag3)'/g;
     is $count, 2, 'Assert screen failures';
+    unlike $log, qr/post_fail_hook failed/, 'post_fail_hook could be invoked';
 };
 
 done_testing();


### PR DESCRIPTION
This function is invoked with as `$self->post_fail_hook` so one parameter
is expected.