### PR TITLE
Enforce using signatures everywhere (with exceptions marked)

### DIFF
--- a/OpenQA/Benchmark/Stopwatch.pm
+++ b/OpenQA/Benchmark/Stopwatch.pm
@@ -236,9 +236,7 @@ sub as_data ($self) {
     return \%data;
 }
 
-sub time {
-    &{$_[0]{_time}};
-}
+sub time ($self) { $self->{_time}->() }
 
 =head1 AUTHOR
 

--- a/xt/01-style.t
+++ b/xt/01-style.t
@@ -13,7 +13,7 @@ ok system(qq{git grep -I -l '[#/ ]*SPDX-License-Identifier ' ':!COPYING' ':!exte
 is qx{git grep -I -L '^use Test::Most' t/**.t}, '', 'All tests use Test::Most';
 is qx{git grep -I -L '^use Test::Warnings' t/**.t}, '', 'All tests use Test::Warnings';
 is qx{git grep -I -l '^use testapi' backend/ consoles/}, '', 'No backend or console files use external facing testapi';
-is qx{git grep -l -e 'sub \\S\\+ [^(]\\+' --and --not -e 'sub [(\{]' --and --not -e 'sub \\S\\+(' backend/ consoles/}, '', 'All backends and consoles use sub signatures everywhere (nameless still allowed)';
+is qx{git grep -l -e '^sub \\S\\+ [^(]\\+' --and --not -e 'sub [(\{]' --and --not -e 'sub \\S\\+(' --and --not -e 'sub \\S\\+;' --and --not -e '# no:style:signatures' ':!testapi.pm' ':!external/'}, '', 'All files use sub signatures everywhere (nameless and in-place definitions still allowed)';
 is qx{git grep -L '^#!.*perl' t/**.t}, '', 'All test files have shebang';
 is qx{git ls-files -s t/**.t | grep -v ^1007}, '', 'All test modules are executable';
 is qx{git grep -l '^use POSIX;'}, '', 'Use of bare POSIX import is discouraged, see https://perldoc.perl.org/POSIX';


### PR DESCRIPTION
This is part of the recent changes in https://github.com/os-autoinst/os-autoinst/pull/1696 with no changes to testapi.pm yet.