### PR TITLE
Avoid backend from being stuck on broken VNC connections for too long

### DIFF
--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -158,6 +158,11 @@ sub login ($self, $connect_timeout = undef, $timeout = undef) {
             next;
         }
         $socket->sockopt(Socket::TCP_NODELAY, 1);    # turn off Naegle's algorithm for vnc
+
+        # set timeout for receiving/sending as the timeout specified via c'tor only applies to connect/accept
+        my $struct_timeval = pack('l!l!', $timeout, 0);    # defined in `#include <sys/time.h>`
+        $socket->sockopt(Socket::SO_RCVTIMEO, $struct_timeval);
+        $socket->sockopt(Socket::SO_SNDTIMEO, $struct_timeval);
     }
     $self->socket($socket);
 

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -160,9 +160,9 @@ sub login ($self, $connect_timeout = undef, $timeout = undef) {
         $socket->sockopt(Socket::TCP_NODELAY, 1);    # turn off Naegle's algorithm for vnc
 
         # set timeout for receiving/sending as the timeout specified via c'tor only applies to connect/accept
-        my $struct_timeval = pack('l!l!', $timeout, 0);    # defined in `#include <sys/time.h>`
-        $socket->sockopt(Socket::SO_RCVTIMEO, $struct_timeval);
-        $socket->sockopt(Socket::SO_SNDTIMEO, $struct_timeval);
+        # note: Using native code to set VNC socket timeout because from C++ we can simply include `struct timeval`
+        #       from `#include <sys/time.h>` instead of relying on unportable manual packing.
+        tinycv::set_socket_timeout($socket->fileno, $timeout) or bmwqemu::fctwarn "Unable to set VNC socket timeout: $!";
     }
     $self->socket($socket);
 

--- a/t/27-consoles-vnc.t
+++ b/t/27-consoles-vnc.t
@@ -70,6 +70,16 @@ subtest 'repeating handshake with max. version' => sub {
     @printed = ();
 };
 
+subtest 'setting socket timeout' => sub {
+    my %socket_args;
+    $bmwqemu::vars{VNC_TIMEOUT_REMOTE} = 6;
+    $inet_mock->redefine(new => sub ($class, @args) { %socket_args = @args; $s });
+    $c->hostname('10.161.145.95');
+    throws_ok { $c->login } qr/unexpected end of data/, 'login dies on unexpected end of data';
+    is $socket_args{Timeout}, 6, 'remote timeout passed to socket' or diag explain \%socket_args;
+    @printed = ();
+};
+
 subtest 'handling connect timeout' => sub {
     $bmwqemu::vars{VNC_CONNECT_TIMEOUT_LOCAL} = 5;
     $bmwqemu::vars{VNC_CONNECT_TIMEOUT_REMOTE} = 10;


### PR DESCRIPTION
* Blocking reads/writes on the VNC socket can cause the backend process to
  hang (and therefore also the test driver to hang) leading to tests
  being stopped by the openQA worker after the overall timeout exceeded
* See https://progress.opensuse.org/issues/111004 for the observation of
  the problem
* Set VNC socket timeout so the backend would not block for too long
  similar to how we already limit the number of connection attempts