### PR TITLE
bmwqemu: Hide secrets on log output with log_call()

### DIFF
--- a/consoles/serial_screen.pm
+++ b/consoles/serial_screen.pm
@@ -69,7 +69,7 @@ consoles.
 sub type_string ($self, $nargs) {
     my $fd = $self->{fd_write};
 
-    bmwqemu::log_call(%$nargs);
+    bmwqemu::log_call(%$nargs, $nargs->{secret} ? (-masked => $nargs->{text}) : ());
 
     my $text = $nargs->{text};
     my $term;

--- a/consoles/ssh_screen.pm
+++ b/consoles/ssh_screen.pm
@@ -49,7 +49,7 @@ sub do_read ($self, $, %args) {
 }
 
 sub type_string ($self, $nargs) {
-    bmwqemu::log_call(%$nargs);
+    bmwqemu::log_call(%$nargs, $nargs->{secret} ? (-masked => $nargs->{text}) : ());
 
     my $text = $nargs->{text};
     my $terminate_with = $nargs->{terminate_with} // '';

--- a/consoles/video_base.pm
+++ b/consoles/video_base.pm
@@ -30,6 +30,8 @@ sub _typing_limit () { $bmwqemu::vars{TYPING_LIMIT} // TYPING_LIMIT_DEFAULT || 1
 sub send_key_event ($key, $press_release_delay) { }
 
 sub type_string ($self, $args) {
+    bmwqemu::log_call(%$args, $args->{secret} ? (-masked => $args->{text}) : ());
+
     my $seconds_per_keypress = 1 / _typing_limit;
 
     # further slow down if being asked for.

--- a/testapi.pm
+++ b/testapi.pm
@@ -1474,7 +1474,7 @@ sub type_string {
     my $wait_timeout = $args{timeout} // 30;
     my $wait_sim_level = $args{similarity_level} // 47;
     bmwqemu::log_call(string => $string, max_interval => $max_interval, wait_screen_changes => $wait, wait_still_screen => $wait_still,
-        timeout => $wait_timeout, similarity_level => $wait_sim_level);
+        timeout => $wait_timeout, similarity_level => $wait_sim_level, $args{secret} ? (-masked => $string) : ());
     my @pieces;
     if ($wait) {
         # split string into an array of pieces of specified size


### PR DESCRIPTION
Parse given parameters for `-masked => <string>` and replace
all occurrence from the given string with `[masked]`.

-- 
Background: https://github.com/os-autoinst/os-autoinst/pull/2002 and https://github.com/os-autoinst/os-autoinst/pull/2054

https://progress.opensuse.org/issues/111010

This should avoid things like
```
[2022-05-12T15:59:08.330771+02:00] [debug] tests/jeos/firstrun.pm:116 called testapi::type_password
[2022-05-12T15:59:08.331044+02:00] [debug] <<< testapi::type_string(string="nots3cr3t", max_interval=100, wait_screen_changes=0, wait_still_screen=0, timeout=30, similarity_level=47, secret=1)
```