### PR TITLE
Move version replacement from spec file to build script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,18 @@ add_custom_target(
 add_dependencies(symlinks videoencoder snd2png debugviewer tinycv)
 
 # create installable versions of isotovideo and cv.pm
+set(OS_AUTOINST_VERSION "" CACHE STRING "os-autoinst version to set for the installation")
+if (OS_AUTOINST_VERSION)
+    set(OS_AUTOINST_VERSION_REPLACE "${OS_AUTOINST_VERSION}")
+elseif (GIT_BIN AND IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+    find_program(GIT_BIN git)
+    execute_process(COMMAND "${GIT_BIN}" rev-parse HEAD
+                    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                    OUTPUT_VARIABLE OS_AUTOINST_VERSION_REPLACE)
+    string(REPLACE "\n" "" OS_AUTOINST_VERSION_REPLACE "${OS_AUTOINST_VERSION_REPLACE}")
+else ()
+    set(OS_AUTOINST_VERSION_REPLACE "unknown")
+endif ()
 add_custom_command(
     COMMENT "Make directory to store intermediate files for install target"
     COMMAND mkdir -p "${CMAKE_CURRENT_BINARY_DIR}/install-target"
@@ -156,6 +168,7 @@ add_custom_command(
     COMMENT "Make install version of isotovideo"
     COMMAND
         sed -e "\"s,\\$$installprefix = undef\;,\\$$installprefix = '${CMAKE_INSTALL_PREFIX}/${OS_AUTOINST_DATA_DIR}'\;,\""
+            -e "\"s,my \\$$thisversion = \\(.*\\);,my \\$$thisversion = '${OS_AUTOINST_VERSION_REPLACE}';,\""
         "${CMAKE_CURRENT_SOURCE_DIR}/isotovideo" > "${CMAKE_CURRENT_BINARY_DIR}/install-target/isotovideo"
     DEPENDS "isotovideo" "CMakeLists.txt" "${CMAKE_CURRENT_BINARY_DIR}/install-target"
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/install-target/isotovideo"

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -168,8 +168,6 @@ Convenience package providing os-autoinst + s390 worker jumphost dependencies.
 
 %prep
 %setup -q
-# Replace version number from git to what's reported by the package
-sed  -i 's/ my $thisversion = qx{git.*rev-parse HEAD}.*;/ my $thisversion = "%{version}";/' isotovideo
 
 # don't require qemu within OBS
 # and exclude known flaky tests in OBS check
@@ -186,7 +184,10 @@ rm xt/30-make.t
 
 %build
 %define __builder ninja
-%cmake -DOS_AUTOINST_DOC_DIR:STRING="%{_docdir}/%{name}" -DSYSTEMD_SERVICE_DIR:STRING="%{_unitdir}"
+%cmake \
+    -DOS_AUTOINST_DOC_DIR:STRING="%{_docdir}/%{name}" \
+    -DOS_AUTOINST_VERSION:STRING="%{version}" \
+    -DSYSTEMD_SERVICE_DIR:STRING="%{_unitdir}"
 %cmake_build
 
 %install


### PR DESCRIPTION
* Replace the version lookup via Git in CMake code instead of relying on
  the replacement in the spec file (in the same way we already replace the
  install directory)
* Provide a default so users won't end up by default with an installation
  that is complaining about not being within a Git directory
* Handle the case when Git is not installed or when the source directory is
  not a Git checkout with a fallback to "unknown" so current packaging
  scripts will continue to work