### PR TITLE
Allow for different resolutions to be used when running tests

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -59,6 +59,8 @@ sub new ($class) {
     $self->{min_video_similarity} = 10000;
     $self->{children} = [];
     $self->{ssh_connections} = {};
+    $self->{xres} = $bmwqemu::vars{XRES} // 1024;
+    $self->{yres} = $bmwqemu::vars{YRES} // 768;
 
     return $self;
 }
@@ -315,9 +317,7 @@ sub start_encoder ($self) {
     my $cwd = Cwd::getcwd;
     my @cmd = (qw(nice -n 19), "$bmwqemu::scriptdir/videoencoder", "$cwd/video.ogv");
     push(@cmd, '-n') if $bmwqemu::vars{NOVIDEO} || ($has_external_video_encoder_configured && !$bmwqemu::vars{EXTERNAL_VIDEO_ENCODER_ADDITIONALLY});
-    my $xres = $bmwqemu::vars{XRES} // '1024';
-    my $yres = $bmwqemu::vars{YRES} // '768';
-    push(@cmd, "-x $xres -y $yres");
+    push(@cmd, "-x $self->{xres} -y $self->{yres}");
     $self->_invoke_video_encoder(encoder_pipe => 'built-in video encoder', @cmd);
 
     # open file for recording real time clock timestamps as subtitle
@@ -466,9 +466,7 @@ sub enqueue_screenshot ($self, $image) {
     my $watch = OpenQA::Benchmark::Stopwatch->new();
     $watch->start();
 
-    my $xres = $bmwqemu::vars{XRES} // 1024;
-    my $yres = $bmwqemu::vars{YRES} // 768;
-    $image = $image->scale(int($xres), int($yres));
+    $image = $image->scale($self->{xres}, $self->{yres});
     $watch->lap("scaling");
 
     my $lastscreenshot = $self->last_image;

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -463,7 +463,9 @@ sub enqueue_screenshot ($self, $image) {
     my $watch = OpenQA::Benchmark::Stopwatch->new();
     $watch->start();
 
-    $image = $image->scale(1920, 720);
+    my $xres = $bmwqemu::vars{XRES} // 1024;
+    my $yres = $bmwqemu::vars{YRES} // 768;
+    $image = $image->scale(int($xres), int($yres));
     $watch->lap("scaling");
 
     my $lastscreenshot = $self->last_image;

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -463,7 +463,7 @@ sub enqueue_screenshot ($self, $image) {
     my $watch = OpenQA::Benchmark::Stopwatch->new();
     $watch->start();
 
-    $image = $image->scale(1024, 768);
+    $image = $image->scale(1920, 720);
     $watch->lap("scaling");
 
     my $lastscreenshot = $self->last_image;

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -315,6 +315,9 @@ sub start_encoder ($self) {
     my $cwd = Cwd::getcwd;
     my @cmd = (qw(nice -n 19), "$bmwqemu::scriptdir/videoencoder", "$cwd/video.ogv");
     push(@cmd, '-n') if $bmwqemu::vars{NOVIDEO} || ($has_external_video_encoder_configured && !$bmwqemu::vars{EXTERNAL_VIDEO_ENCODER_ADDITIONALLY});
+    my $xres = $bmwqemu::vars{XRES} // '1024';
+    my $yres = $bmwqemu::vars{YRES} // '768';
+    push(@cmd, "-x $xres -y $yres");
     $self->_invoke_video_encoder(encoder_pipe => 'built-in video encoder', @cmd);
 
     # open file for recording real time clock timestamps as subtitle

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -672,7 +672,7 @@ sub start_qemu ($self) {
     $arch = 'arm' if ($arch =~ /armv6|armv7/);
 
     if ($arch eq 'aarch64' || $arch eq 'arm') {
-        my $video_device = ($vars->{QEMU_OVERRIDE_VIDEO_DEVICE_AARCH64}) ? 'VGA' : 'virtio-gpu-pci';
+        my $video_device = ($vars->{QEMU_OVERRIDE_VIDEO_DEVICE_AARCH64}) ? 'VGA' : 'virtio-gpu-gl,edid=on,xres=1920,yres=720,max_outputs=1';
         sp('device', $video_device);
         $arch_supports_boot_order = 0;
         $use_usb_kbd = 1;

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -670,9 +670,12 @@ sub start_qemu ($self) {
     my $use_usb_kbd;
     my $arch = $vars->{ARCH} // '';
     $arch = 'arm' if ($arch =~ /armv6|armv7/);
+    my $xres = $vars->{XRES} // '1024';
+    my $yres = $vars->{YRES} // '768';
+    my $custom_video_device = $vars->{QEMU_VIDEO_DEVICE} // 'virtio-gpu-pci';
 
     if ($arch eq 'aarch64' || $arch eq 'arm') {
-        my $video_device = ($vars->{QEMU_OVERRIDE_VIDEO_DEVICE_AARCH64}) ? 'VGA' : 'virtio-gpu-gl,edid=on,xres=1920,yres=720,max_outputs=1';
+        my $video_device = ($vars->{QEMU_OVERRIDE_VIDEO_DEVICE_AARCH64}) ? 'VGA' : "${custom_video_device},xres=${xres},yres=${yres}";
         sp('device', $video_device);
         $arch_supports_boot_order = 0;
         $use_usb_kbd = 1;

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -670,12 +670,10 @@ sub start_qemu ($self) {
     my $use_usb_kbd;
     my $arch = $vars->{ARCH} // '';
     $arch = 'arm' if ($arch =~ /armv6|armv7/);
-    my $xres = $vars->{XRES} // '1024';
-    my $yres = $vars->{YRES} // '768';
     my $custom_video_device = $vars->{QEMU_VIDEO_DEVICE} // 'virtio-gpu-pci';
 
     if ($arch eq 'aarch64' || $arch eq 'arm') {
-        my $video_device = ($vars->{QEMU_OVERRIDE_VIDEO_DEVICE_AARCH64}) ? 'VGA' : "${custom_video_device},xres=${xres},yres=${yres}";
+        my $video_device = ($vars->{QEMU_OVERRIDE_VIDEO_DEVICE_AARCH64}) ? 'VGA' : "${custom_video_device},xres=$self->{xres},yres=$self->{yres}";
         sp('device', $video_device);
         $arch_supports_boot_order = 0;
         $use_usb_kbd = 1;

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -191,8 +191,6 @@ VNCKB;;;Set the keyboard layout if you are not using en-us
 WORKER_CLASS;string;undef;qemu system types
 WORKER_HOSTNAME;string;undef;Worker hostname
 QEMU_VIDEO_DEVICE;string;virtio-gpu-pci;Video device to use for ARM architectures (can have options appended e.g. virtio-gpu-gl,edid=on)
-XRES;integer;1024;Resolution of display on x axis
-YRES;integer;768;Resolution of display on y axis
 |====================
 
 .SVIRT backend

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -191,6 +191,8 @@ VNCKB;;;Set the keyboard layout if you are not using en-us
 WORKER_CLASS;string;undef;qemu system types
 WORKER_HOSTNAME;string;undef;Worker hostname
 QEMU_VIDEO_DEVICE;string;virtio-gpu-pci;Video device to use for ARM architectures (can have options appended e.g. virtio-gpu-gl,edid=on)
+XRES;integer;1024;Resolution of display on x axis
+YRES;integer;768;Resolution of display on y axis
 |====================
 
 .SVIRT backend

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -43,6 +43,8 @@ UPLOAD_METER;boolean;0;Display curl progress meter in `upload_logs()` and `uploa
 UPLOAD_MAX_MESSAGE_SIZE_GB;integer;0;Specifies the max. upload size in GiB for the test API functions `upload_logs()` and `upload_assets()` and the underlying command server API. Zero denotes infinity.
 UPLOAD_INACTIVITY_TIMEOUT;integer;300;Specifies the inactivity timeout in seconds for the test API functions `upload_logs()` and `upload_assets()` and underlying the command server API.
 NO_DEPRECATE_BACKEND_$backend;boolean;0;Only warn about deprecated backends instead of aborting
+XRES;integer;1024;Resolution of display on x axis
+YRES;integer;768;Resolution of display on y axis
 
 |====================
 
@@ -188,8 +190,6 @@ VNC;integer;worker instance + 90;Display on which VNC server is running. Actual 
 VNCKB;;;Set the keyboard layout if you are not using en-us
 WORKER_CLASS;string;undef;qemu system types
 WORKER_HOSTNAME;string;undef;Worker hostname
-XRES;integer;1024;Resolution of display on x axis
-YRES;integer;768;Resolution of display on y axis
 QEMU_VIDEO_DEVICE;string;virtio-gpu-pci;Video device to use for ARM architectures (can have options appended e.g. virtio-gpu-gl,edid=on)
 |====================
 

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -188,6 +188,9 @@ VNC;integer;worker instance + 90;Display on which VNC server is running. Actual 
 VNCKB;;;Set the keyboard layout if you are not using en-us
 WORKER_CLASS;string;undef;qemu system types
 WORKER_HOSTNAME;string;undef;Worker hostname
+XRES;integer;1024;Resolution of display on x axis
+YRES;integer;768;Resolution of display on y axis
+QEMU_VIDEO_DEVICE;string;virtio-gpu-pci;Video device to use for ARM architectures (can have options appended e.g. virtio-gpu-gl,edid=on)
 |====================
 
 .SVIRT backend

--- a/videoencoder.cpp
+++ b/videoencoder.cpp
@@ -116,7 +116,7 @@ static unsigned char clamp(int d)
 
 using namespace cv;
 
-void rgb_to_yuv(Mat* image, th_ycbcr_buffer ycbcr)
+void rgb_to_yuv(Mat* image, th_ycbcr_buffer ycbcr, int xres, int yres)
 {
     unsigned int x;
     unsigned int y;
@@ -128,9 +128,9 @@ void rgb_to_yuv(Mat* image, th_ycbcr_buffer ycbcr)
     unsigned char* yuv_v;
 
     unsigned long w, h;
-    w = yuv_w = 1024;
+    w = yuv_w = xres;
     /* Must hold: yuv_h >= h */
-    h = 768;
+    h = yres;
 
     yuv_w = ycbcr[0].width;
 
@@ -171,11 +171,19 @@ int main(int argc, char* argv[])
     int ret;
 
     bool output_video = true;
+    int xres = 1024;
+    int yres = 768;
     int opt;
-    while ((opt = getopt(argc, argv, "n")) != -1) {
+    while ((opt = getopt(argc, argv, "nx:y:")) != -1) {
         switch (opt) {
         case 'n':
             output_video = false;
+            break;
+        case 'x':
+            xres = atoi(optarg);
+            break;
+        case 'y':
+            yres = atoi(optarg);
             break;
         default: /* '?' */
             fprintf(stderr,
@@ -208,8 +216,8 @@ int main(int argc, char* argv[])
         return 1;
     }
 
-    unsigned int w = 1024;
-    unsigned int h = 768;
+    unsigned int w = xres;
+    unsigned int h = yres;
     th_ycbcr_buffer ycbcr;
 
     ycbcr[0].width = w;
@@ -365,7 +373,7 @@ int main(int argc, char* argv[])
             }
 
             if (output_video)
-                rgb_to_yuv(&last_frame_image, ycbcr);
+                rgb_to_yuv(&last_frame_image, ycbcr, xres, yres);
 
         } else if (line[0] == 'R') {
             // Just repeat the last frame

--- a/videoencoder.cpp
+++ b/videoencoder.cpp
@@ -56,6 +56,7 @@ video.
 #include <cassert>
 #include <csignal>
 #include <cstdio>
+#include <cstdlib>
 
 using namespace std;
 
@@ -216,8 +217,8 @@ int main(int argc, char* argv[])
         return 1;
     }
 
-    unsigned int w = xres;
-    unsigned int h = yres;
+    int w = xres;
+    int h = yres;
     th_ycbcr_buffer ycbcr;
 
     ycbcr[0].width = w;


### PR DESCRIPTION
This pull request will allow for a custom resolution to be passed to os-autoinst when running under Qemu. The variables `XRES` and `YRES` control the resolution, and default to 1024 and 768 respectively.

For now this PR includes a change to allow the use of a video device other than `virtio-gpu-pci` for ARM architectures.

~~More changes are required in order to generate the video at the correct resolution.~~