### PR TITLE
Pass -x and -y as array arguments

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -317,7 +317,7 @@ sub start_encoder ($self) {
     my $cwd = Cwd::getcwd;
     my @cmd = (qw(nice -n 19), "$bmwqemu::scriptdir/videoencoder", "$cwd/video.ogv");
     push(@cmd, '-n') if $bmwqemu::vars{NOVIDEO} || ($has_external_video_encoder_configured && !$bmwqemu::vars{EXTERNAL_VIDEO_ENCODER_ADDITIONALLY});
-    push(@cmd, "-x $self->{xres} -y $self->{yres}");
+    push @cmd, '-x', $self->{xres}, '-y', $self->{yres};
     $self->_invoke_video_encoder(encoder_pipe => 'built-in video encoder', @cmd);
 
     # open file for recording real time clock timestamps as subtitle


### PR DESCRIPTION
Before they were passed as a single string "-x 1 -y 2" which results
in videoencoder only receiving the -x correctly.

Followup to #2070