### PR TITLE
Use combined operators

### DIFF
--- a/backend/pvm.pm
+++ b/backend/pvm.pm
@@ -46,8 +46,7 @@ sub do_extract_assets ($self, $args) {
     my $disk = $vars->{"HDD_$hdd_num"};
     my $lpar = $self->{masterlpar};
     my $cmd = "pvmctl scsi list -w";
-    $cmd = $cmd . " VirtualDisk.name=$disk";
-    $cmd = $cmd . " -d VirtualDisk.udid --hide-label";
+    $cmd .= " VirtualDisk.name=$disk -d VirtualDisk.udid --hide-label";
     #attach disk
     diag "Attaching $disk to $lpar";
     $self->pvmctl("scsi", "create", "lv", $disk, $lpar);

--- a/consoles/video_base.pm
+++ b/consoles/video_base.pm
@@ -49,7 +49,7 @@ sub type_string ($self, $args) {
         # typical max_interval values are
         #   4ish:  veeery slow
         #   15ish: slow
-        $seconds_per_keypress = $seconds_per_keypress + 1 / sqrt($args->{max_interval});
+        $seconds_per_keypress += 1 / sqrt($args->{max_interval});
     }
 
     for my $letter (split("", $args->{text})) {


### PR DESCRIPTION
Use combined operators to simplify codes. I checked all the codes by the regular expression. Only these two assignments can use combined operators.