### PR TITLE
ci: Upload coverage HTML as an artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,13 @@ jobs:
           file: ./build/cover_db/codecov.json
           fail_ci_if_error: true
           verbose: true
+      - run: |
+          tar cvf coverage.tar build/cover_db
+      - uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: coverage.tar
+          retention-days: 15
   static-check-containers:
     runs-on: ubuntu-latest
     steps:

--- a/tools/container_run_ci
+++ b/tools/container_run_ci
@@ -61,4 +61,5 @@ cd /opt
 export CI=1 WITH_COVER_OPTIONS=1 CHECK_GIT_STATUS=1
 cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -S . -B \"$build_dir\"
 cmake --build \"$build_dir\" --verbose --target check
-cmake --build \"$build_dir\" --verbose --target $target"
+cmake --build \"$build_dir\" --verbose --target $target
+cover -report html_basic \"$build_dir\"/cover_db"


### PR DESCRIPTION
Sometimes the codecov report is updated late, sometimes it disagrees with what
Devel::Cover reports.
And while codecov reports only line coverage, Devel::Cover reports statements,
which can sometimes help.

Usage: Click on the CI run "Summary" and download the "coverage.zip"

Issue: https://progress.opensuse.org/issues/111251