### PR TITLE
Fix code coverage and run tests from root dir

### DIFF
--- a/cv.pm
+++ b/cv.pm
@@ -10,11 +10,12 @@ use constant BPP => 3;
 use ExtUtils::testlib;
 
 use File::Basename;
+use Cwd qw(realpath);
 
 sub init () {
     use Config;
     my $vendorlib = $Config{installvendorlib};
-    my $libdir = dirname(__FILE__);
+    my $libdir = realpath(dirname(__FILE__));
     # undef is substituted at install time, see CMakeLists.txt
     my $sysdir = undef;
     return if ($sysdir && $libdir eq $sysdir);

--- a/isotovideo
+++ b/isotovideo
@@ -18,6 +18,10 @@ Parses command line parameters, vars.json and tests the given assets/ISOs.
 
 Enable direct output to STDERR instead of autoinst-log.txt
 
+=item B<--workdir=>
+
+isotovideo will chdir to that directory on startup
+
 =item B<-v, --version>
 
 Show the current program version and test API version
@@ -102,9 +106,11 @@ sub version () {
     exit 0;
 }
 
-GetOptions(\%options, 'debug|d', 'help|h|?', 'version|v') or usage(1);
+GetOptions(\%options, 'debug|d', 'workdir=s', 'help|h|?', 'version|v') or usage(1);
 usage(0) if $options{help};
 version() if $options{version};
+
+chdir $options{workdir} if $options{workdir};
 
 # global exit status
 my $return_code = 1;

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -30,9 +30,11 @@ sub isotovideo (%args) {
     $args{default_opts} //= 'backend=null';
     $args{opts} //= '';
     $args{exit_code} //= 1;
-    my @cmd = ($^X, "$toplevel_dir/isotovideo", '-d', $args{default_opts}, split(' ', $args{opts}));
+    chdir "$Bin/..";
+    my @cmd = ($^X, "$toplevel_dir/isotovideo", '--workdir', $pool_dir, '-d', $args{default_opts}, split(' ', $args{opts}));
+    chdir $pool_dir;
     note "Starting isotovideo with: @cmd";
-    my $output = qx(@cmd);
+    my $output = qx(cd $toplevel_dir && @cmd);
     my $res = $?;
     return fail 'failed to execute isotovideo: ' . $! if $res == -1;    # uncoverable statement
     return fail 'isotovideo died with signal ' . ($res & 127) if $res & 127;    # uncoverable statement
@@ -42,9 +44,9 @@ sub isotovideo (%args) {
 }
 
 subtest 'get the version number' => sub {
-    # Make sure we're in a folder we can't write to, no base_state.json should be created here
-    chdir('/');
-    combined_like { system $^X, "$toplevel_dir/isotovideo", '--version' } qr/Current version is.+\[interface v[0-9]+\]/, 'version printed';
+    chdir "$Bin/..";
+    combined_like { system $^X, "$toplevel_dir/isotovideo", '--workdir', $pool_dir, '--version' } qr/Current version is.+\[interface v[0-9]+\]/, 'version printed';
+    chdir $pool_dir;
     ok(!-e bmwqemu::STATE_FILE, 'no state file was written');
 };
 

--- a/t/18-qemu-options.t
+++ b/t/18-qemu-options.t
@@ -44,7 +44,7 @@ my $log_file = path('autoinst-log.txt');
 my $log = '';
 sub run_isotovideo (@args) {
     $vars_json->spurt(encode_json({@common_options, @args}));
-    ok system("perl $toplevel_dir/isotovideo -d qemu_disable_snapshots=1 2>&1 | tee autoinst-log.txt") == 0, 'zero exit status';
+    ok system("cd $toplevel_dir && perl $toplevel_dir/isotovideo --workdir $pool_dir -d qemu_disable_snapshots=1 2>&1 | tee $pool_dir/autoinst-log.txt") == 0, 'zero exit status';
     $log = $log_file->slurp;
 }
 

--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -47,7 +47,7 @@ path('vars.json')->spurt(<<EOV);
 EOV
 # create screenshots
 path('live_log')->touch;
-system("perl $toplevel_dir/isotovideo -d 2>&1 | tee autoinst-log.txt");
+system("cd $toplevel_dir && perl $toplevel_dir/isotovideo --workdir $pool_dir -d 2>&1 | tee $pool_dir/autoinst-log.txt");
 my $log = path('autoinst-log.txt')->slurp;
 like $log, qr/\d*: EXIT 0/, 'test executed fine';
 like $log, qr/\d* Snapshots are supported/, 'Snapshots are enabled';

--- a/tools/invoke-tests
+++ b/tools/invoke-tests
@@ -40,7 +40,7 @@ db="$build_directory/cover_db"
 [[ $SKIP_IF_COVER_DB_EXISTS ]] && [[ -d $db ]] && exit 0
 
 # set Perl module include path and coverage options
-export PERL5LIB="$source_directory:$source_directory/ppmclibs:$source_directory/ppmclibs/blib/arch/auto/tinycv:$PERL5LIB"
+export PERL5LIB="$source_directory:$source_directory/ppmclibs/blib/lib:$source_directory/ppmclibs/blib/arch/auto/tinycv:$PERL5LIB"
 if [[ $WITH_COVER_OPTIONS ]]; then
     path_regex="^|$source_directory/|\\.\\./"
     select="($path_regex)(OpenQA|backend|consoles|ppmclibs)/|($path_regex)isotovideo|($path_regex)[^/]+\.pm,-ignore,external/|\.t|data/tests/|fake/tests/|/CheckGitStatus.pm|$prove_path"
@@ -57,7 +57,5 @@ if [[ $TESTS = *[!\ ]* ]]; then
     "$prove_path" $PROVE_ARGS $TESTS
 else
     # shellcheck disable=SC2086
-    cd t && "$prove_path" $PROVE_ARGS -r
-    # shellcheck disable=SC2086
-    cd ../xt && "$prove_path" $PROVE_ARGS -r
+    "$prove_path" $PROVE_ARGS -r t xt
 fi


### PR DESCRIPTION
* Add `--workdir` option to isotovideo
* ci: Run tests from toplevel directory

Issue: https://progress.opensuse.org/issues/111251

`isotovideo --workdir /path/to/pool` will make isotovideo chdir into that directory at the beginning.

If we run isotovideo in a test from the os-autoinst directory with the `--workdir` option, then the module loading will happen in the os-autoinst directory, which results in Devel::Cover being able to count them as the same files as with the other tests.