### PR TITLE
Fix perl 5.36 warnings on use of @_ in functions with signature

### DIFF
--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -85,7 +85,7 @@ sub do_stop_vm ($self, @) {
 
 # Log stdout and stderr and return them in a list (comped).
 sub scp_get ($self, $src, $dest) {
-    bmwqemu::log_call(@_);
+    bmwqemu::log_call($self, $src, $dest);
 
     my %credentials = $self->get_ssh_credentials(_is_hyperv ? 'hyperv' : 'default');
     my $ssh = $self->new_ssh_connection(%credentials);

--- a/consoles/serial_screen.pm
+++ b/consoles/serial_screen.pm
@@ -122,7 +122,8 @@ An undefined timeout will cause to wait indefinitely. A timeout of 0 means to
 just read once.
 
 =cut
-sub do_read ($self, $, %args) {
+sub do_read {    # no:style:signatures
+    my ($self, undef, %args) = @_;
     my $buffer = '';
     $args{timeout} //= undef;    # wait till data is available
     $args{max_size} //= 2048;
@@ -139,6 +140,8 @@ sub do_read ($self, $, %args) {
         $read = sysread($fd, $buffer, $args{max_size});
         croak "Failed to read from virtio/svirt serial console char device: $ERRNO" if !defined($read) && !($ERRNO{EAGAIN} || $ERRNO{EWOULDBLOCK});
     }
+    # this is why we can't use a signature for this function,
+    # assigning to @_ in a function with signature triggers a warning
     $_[1] = $buffer;
     return $read;
 }

--- a/consoles/ssh_screen.pm
+++ b/consoles/ssh_screen.pm
@@ -27,7 +27,8 @@ sub new ($class, @args) {
     return $self->SUPER::new($self->ssh_channel);
 }
 
-sub do_read ($self, $, %args) {
+sub do_read {    # no:style:signatures
+    my ($self, undef, %args) = @_;
     my $buffer = '';
     $args{timeout} //= undef;    # wait till data is available
     $args{max_size} //= 2048;
@@ -37,6 +38,9 @@ sub do_read ($self, $, %args) {
     while (!$args{timeout} || (consoles::serial_screen::elapsed($stime) < $args{timeout})) {
         my $read = $self->ssh_channel->read($buffer, $args{max_size});
         if (defined($read)) {
+            # this is why we can't use a signature for this function,
+            # assigning to @_ in a function with signature triggers a
+            # warning
             $_[1] = $buffer;
             print {$self->{loghandle}} $buffer if $self->{loghandle};
             return $read;

--- a/t/21-needle-downloader.t
+++ b/t/21-needle-downloader.t
@@ -20,7 +20,7 @@ my $user_agent_mock = Test::MockModule->new('Mojo::UserAgent');
 my @queried_urls;
 $user_agent_mock->redefine(get => sub ($self, $url) {
         push(@queried_urls, $url);
-        return $user_agent_mock->original('get')->(@_);
+        return $user_agent_mock->original('get')->($self, $url);
 });
 
 # setup needle directory

--- a/t/31-sshSerial.t
+++ b/t/31-sshSerial.t
@@ -49,7 +49,9 @@ $mock_channel->mock(blocking => sub ($self, $arg = undef) {
         return $self->{blocking};
 });
 
-$mock_channel->mock(read => sub ($self, $, $size) {
+$mock_channel->mock(read => sub {    # no:style:signatures
+        my ($self, undef, $size) = @_;
+
         my $data = shift @{$self->{read_queue}};
 
         if (!defined($data)) {
@@ -62,6 +64,9 @@ $mock_channel->mock(read => sub ($self, $, $size) {
             $data = substr($data, 0, $size);
         }
 
+        # this is why we can't use a signature for this function,
+        # assigning to @_ in a function with signature triggers a
+        # warning
         $_[1] = $data;
         return length($data);
 });


### PR DESCRIPTION
When running the test suite with perl 5.36 we get several warnings
about use (explicit or implict) of `@_` in functions with
signatures being 'experimental'.

These fixes were all suggested by tinita (thanks). In some cases
we can just use the function arguments, in three cases that fill
buffers we have to drop the signatures, as you cannot assign to
`@_` without triggering the warning when using signatures, and we
don't see an obvious way to have these functions do anything else.

Signed-off-by: Adam Williamson <awilliam@redhat.com>