### PR TITLE
Fix VNC console tests under big-endian systems such as s390x

### DIFF
--- a/t/27-consoles-vnc.t
+++ b/t/27-consoles-vnc.t
@@ -39,6 +39,10 @@ is $c->_receive_bell, 1, 'can call _receive_bell';
 is_deeply \@printed, ['RFB 003.006', pack('C', 1)], 'protocol version and security type replied' or diag explain \@printed;
 @printed = ();
 
+# ensure endian conversion is setup correctly (despite initially mocking _server_initialization)
+my $machine_is_big_endian = unpack('h*', pack('s', 1)) =~ /01/ ? 1 : 0;
+$c->_do_endian_conversion($machine_is_big_endian);
+
 subtest 'send update request' => sub {
     $c->width(1024);
     $c->height(512);


### PR DESCRIPTION
See https://progress.opensuse.org/issues/111608

---

@AdamWill I don't have a real big-endian system to test. Maybe you can test it within your builds. However, when I set the endian conversion incorrectly, I can reproduce the exact same issue you're seeing on s390x on x86_64. So I'm confident this change makes a difference (and works).