### PR TITLE
Avoid duplicated endianness-check

### DIFF
--- a/t/27-consoles-vnc.t
+++ b/t/27-consoles-vnc.t
@@ -305,7 +305,6 @@ subtest 'server initialization' => sub {
     $vnc_mock->unmock('_server_initialization');
     @printed = ();
 
-    my $client_is_big_endian = unpack('h*', pack('s', 1)) =~ /01/ ? 1 : 0;
     my $framebuffer_width = 1024;
     my $framebuffer_height = 512;
     my $bits_per_pixel = 32;
@@ -341,7 +340,7 @@ subtest 'server initialization' => sub {
     $red_shift = 10;
     $green_shift = 5;
     $blue_shift = 0;
-    my @params = ($bits_per_pixel, $depth, $server_is_big_endian != $client_is_big_endian, $true_colour_flag, $red_max, $green_max, $blue_max, $red_shift, $green_shift, $blue_shift);
+    my @params = ($bits_per_pixel, $depth, $server_is_big_endian != $machine_is_big_endian, $true_colour_flag, $red_max, $green_max, $blue_max, $red_shift, $green_shift, $blue_shift);
     my @expected = (
         pack(CCCCCCCCnnnCCCCCC => 0, 0, 0, 0, @params, 0, 0, 0),    # setpixelformat
         pack(CCn => 2, 0, 5),    # five supported encodings (no ZRLE due to dell flag)


### PR DESCRIPTION
* The check is quite redundant (has been introduced by
  a2f9e76bbd69efa85d2753e7e6976f5067ebdc5b)
* As suggested by
  https://github.com/os-autoinst/os-autoinst/pull/2077#issuecomment-1151287855=