### PR TITLE
qemu: stop hard-coding resolution for PPC/ SPARC

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -505,7 +505,8 @@ sub qemu_params_ofw ($self) {
     my $vars = \%bmwqemu::vars;
     $vars->{QEMUVGA} ||= "std";
     $vars->{QEMUMACHINE} //= "usb=off";
-    sp('g', '1024x768');
+    # set the initial resolution on PCC and SPARC
+    sp('g', "$self->{xres}x$self->{yres}");
     # newer qemu needs safe cache capability level quirk settings
     # https://progress.opensuse.org/issues/75259
     my $caps = ',cap-cfpc=broken,cap-sbbc=broken,cap-ibs=broken';

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -141,8 +141,8 @@ sub qemu_cmdline (%args) {
     return join(' ', $backend->{proc}->gen_cmdline);
 }
 
-$bmwqemu::vars{OFW} = 1;
-like qemu_cmdline(), qr/cap-cfpc=broken/, 'OFW workarounds applied';
+like qemu_cmdline(OFW => 1, XRES => 640, YRES => 480), qr/-g 640x480/, 'res is set for ppc/sparc';
+like qemu_cmdline(OFW => 1), qr/cap-cfpc=broken/, 'OFW workarounds applied';
 
 # test QEMU_HUGE_PAGES_PATH with different options
 subtest qemu_huge_pages_option => sub {


### PR DESCRIPTION
As per documentation this is not relevant in most cases. Still it should pass the expected resolution to avoid surprises and we can comment it.