### PR TITLE
qemu: Treat qxl as an unsupported backend

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -503,7 +503,7 @@ sub delete_virtio_console_fifo () { unlink $_ or bmwqemu::fctwarn("Could not unl
 
 sub qemu_params_ofw ($self) {
     my $vars = \%bmwqemu::vars;
-    $vars->{QEMUVGA} ||= "std";
+    $vars->{QEMUVGA} ||= 'std';
     $vars->{QEMUMACHINE} //= "usb=off";
     sp('g', '1024x768');
     # newer qemu needs safe cache capability level quirk settings
@@ -681,7 +681,9 @@ sub start_qemu ($self) {
     elsif ($vars->{OFW}) {
         $use_usb_kbd = $self->qemu_params_ofw;
     }
-    sp('vga', $vars->{QEMUVGA}) if $vars->{QEMUVGA};
+    # qxl hard-codes the default resolution, see poo#111992
+    die "qxl is unsupported\n" if ($vars->{QEMUVGA} // '') eq 'qxl';
+    sp('vga', $vars->{QEMUVGA});
 
     my @nicmac;
     my @nicvlan;

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -192,4 +192,12 @@ subtest qemu_tpm_option => sub {
     like $runcmd, qr|swtpm socket --tpmstate dir=.*mytpm6 --ctrl type=unixio,path=.*mytpm6/swtpm-sock --log level=20 -d|, 'swtpm 1.2 device created';
 };
 
+subtest qemu_vga_option => sub {
+    my $runcmd;
+    $backend_mock->redefine(runcmd => sub (@cmd) { $runcmd = join(' ', @cmd) });
+    unlike qemu_cmdline(QEMUVGA => undef), qr|-vga|, 'nothing specified by default';
+    like qemu_cmdline(QEMUVGA => 'std'), qr|-vga std|, 'std selected explicitly';
+    throws_ok { qemu_cmdline(QEMUVGA => 'qxl') } qr/qxl is unsupported/, 'unsupported vga aborts execution';
+};
+
 done_testing();


### PR DESCRIPTION
- Setting QEMUVGA to qxl is considered unsupported.
- Add unit test coverage for -vga.

See: https://progress.opensuse.org/issues/111992