### PR TITLE
Enforce resolution specified via XRES/YRES in all QEMU video configs

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -671,18 +671,19 @@ sub start_qemu ($self) {
     my $use_usb_kbd;
     my $arch = $vars->{ARCH} // '';
     $arch = 'arm' if ($arch =~ /armv6|armv7/);
-    my $custom_video_device = $vars->{QEMU_VIDEO_DEVICE} // 'virtio-gpu-pci';
 
     if ($arch eq 'aarch64' || $arch eq 'arm') {
+        my $custom_video_device = $vars->{QEMU_VIDEO_DEVICE} // 'virtio-gpu-pci';
         my $video_device = ($vars->{QEMU_OVERRIDE_VIDEO_DEVICE_AARCH64}) ? 'VGA' : "${custom_video_device},xres=$self->{xres},yres=$self->{yres}";
         sp('device', $video_device);
         $arch_supports_boot_order = 0;
         $use_usb_kbd = 1;
     }
-    elsif ($vars->{OFW}) {
-        $use_usb_kbd = $self->qemu_params_ofw;
+    else {
+        $use_usb_kbd = $self->qemu_params_ofw if $vars->{OFW};
+        $vars->{QEMUVGA} //= 'std';
+        sp('device', "$vars->{QEMUVGA},xres=$self->{xres},yres=$self->{yres}");
     }
-    sp('vga', $vars->{QEMUVGA}) if $vars->{QEMUVGA};
 
     my @nicmac;
     my @nicvlan;

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -143,7 +143,7 @@ QEMUTHREADS;integer;0;Number of cpu threads used by VM
 QEMUTPM;'instance' or appropriate value for local swtpm config;undef;Configure VM to use a TPM emulator device, with appropriate args for the arch. If a TPM device is available at QEMUTPM_PATH_PREFIX + X, where X is the value of QEMUTPM or the worker instance number if QEMUTPM is set to 'instance', it will be used. Otherwise it will be created at test startup. See QEMUTPM_VER in the latter case.
 QEMUTPM_VER;'1.2' or '2.0' depending on which TPM chip should be emulated;'2.0';If no TPM device has been setup otherwise, swtpm will be used internally to create one with a socket at /tmp/mytpmX
 QEMUTPM_PATH_PREFIX;string;'/tmp/mytpm';Path prefix to use or create TPM emulator device in
-QEMUVGA;see qemu -device ?;cirrus;VGA device to use with VM
+QEMUVGA;see qemu -device ?;std;VGA device to use with VM
 QEMU_COMPRESS_QCOW2;boolean;1;compress qcow2 images intended for upload
 QEMU_IMG_CREATE_TRIES;integer;3;Define number of tries for qemu-img commands
 QEMU_HUGE_PAGES_PATH;string;undef;Define a path to use huge pages (e.g. /dev/hugepages/)


### PR DESCRIPTION
* Use `-device` option with `xres` and `yres` parameters to specify the
  video device (instead of using `-vga` which supposedly doesn't allow
  specifying these parameters)
    * Don't rely on QEMU's default for `xres`/`yres` to match our defaults
    * Make `XRES`/`YRES` parameters introduced by
      https://github.com/os-autoinst/os-autoinst/commit/cfcb4962e65c55225d47221ee8121d35b5990575 work for non-ARM
      architectures as well
* Move variable for ARM-specific variable `QEMU_VIDEO_DEVICE` into the
  right scope
* Fix https://progress.opensuse.org/issues/111992

---

I also added an additional commit to update the documentation which is outdated since https://github.com/os-autoinst/os-autoinst/commit/bca214ee1dfc257c694cf1b4650dec0fa7d984a1.