### PR TITLE
Fix `t/18-qemu-options.t` on newer QEMU versions

### DIFF
--- a/t/18-qemu-options.t
+++ b/t/18-qemu-options.t
@@ -71,7 +71,7 @@ subtest qemu_append_option => sub {
     # multiple options added, only version will be effective
     # test whether QMP connection attempts are aborted when QEMU exists: unset QEMU_QMP_CONNECT_ATTEMPTS temporarily
     my $qmp_connect_attempts = delete $ENV{QEMU_QMP_CONNECT_ATTEMPTS};
-    run_isotovideo(@common_options, QEMU_APPEND => 'M ? -version');
+    run_isotovideo(@common_options, QEMU_APPEND => 'version -M ?');
     like($log, qr/-M \?/, '-M ? option added');
     like($log, qr/-version/, '-version option added');
     like($log, qr/QEMU emulator version/, 'QEMU version printed');


### PR DESCRIPTION
QEMU 5.2.0 from Leap 15.3 always printed the version, regardless whether
`-version` is the first or second parameter. QEMU 6.2.0 from Leap 15.4 or
Tumbleweed gives the first parameter precedence. To have consistent
behavior between those versions, this change moves the version to be the
first parameter.

See https://progress.opensuse.org/issues/112403