### PR TITLE
Add code to request VMWare VNC access over web sockets and use it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ set(PERL_FILES
     consoles/virtio_terminal.pm
     consoles/vnc_base.pm
     consoles/VNC.pm
+    consoles/VMWare.pm
     distribution.pm
     lockapi.pm
     log.pm
@@ -216,11 +217,13 @@ install(
     COMPONENT "openvswitch"
     EXCLUDE_FROM_ALL
 )
-install(
-    FILES "check_qemu_oom"
-    DESTINATION "${OS_AUTOINST_DATA_DIR}"
-    PERMISSIONS ${EXECUTABLE_PERMISSIONS}
-)
+foreach (EXTRA_SCRIPT check_qemu_oom dewebsockify vnctest)
+    install(
+        FILES "${EXTRA_SCRIPT}"
+        DESTINATION "${OS_AUTOINST_DATA_DIR}"
+        PERMISSIONS ${EXECUTABLE_PERMISSIONS}
+    )
+endforeach ()
 add_custom_target(install-openvswitch
     COMMAND "${CMAKE_COMMAND}" -DCMAKE_INSTALL_COMPONENT=openvswitch -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")
 

--- a/consoles/VMWare.pm
+++ b/consoles/VMWare.pm
@@ -110,8 +110,9 @@ sub launch_vnc_server ($self, $listen_port) {
     }
 }
 
-sub deduce_url_from_vars () {
+sub deduce_url_from_vars ($vnc_console) {
     return undef unless $bmwqemu::vars{VMWARE_VNC_OVER_WS};
+    return undef unless $vnc_console->hostname eq ($bmwqemu::vars{VIRSH_GUEST} // '');
     my $host = $bmwqemu::vars{VMWARE_HOST} or die "VMWARE_VNC_OVER_WS set but not VMWARE_HOST\n";
     my $user = $bmwqemu::vars{VMWARE_USERNAME} // 'root';
     my $password = $bmwqemu::vars{VMWARE_PASSWORD} or die "VMWARE_VNC_OVER_WS set but not VMWARE_PASSWORD\n";
@@ -119,7 +120,7 @@ sub deduce_url_from_vars () {
 }
 
 sub setup_for_vnc_console ($vnc_console) {
-    return undef unless my $ws_url = $vnc_console->vmware_vnc_over_ws_url // deduce_url_from_vars;
+    return undef unless my $ws_url = $vnc_console->vmware_vnc_over_ws_url // deduce_url_from_vars($vnc_console);
     my $self = $vnc_console->{_vmware_handler} //= consoles::VMWare->new;
     log::diag 'Establishing VNC connection over WebSockets via ' . Mojo::URL->new($ws_url)->to_string;
     $vnc_console->hostname('127.0.0.1');

--- a/consoles/VMWare.pm
+++ b/consoles/VMWare.pm
@@ -10,11 +10,13 @@ use Mojo::JSON qw(encode_json);
 use Mojo::UserAgent;
 use Mojo::URL;
 use Mojo::Util qw(xml_escape);
+
+use bmwqemu;
 use log;
 
 has protocol => 'https';
 has host => undef;
-has vm_id => 1;
+has vm_id => undef;
 has username => 'root';
 has password => undef;
 has dewebsockify_pid => undef;
@@ -38,7 +40,7 @@ sub configure_from_url ($self, $url) {
     $url = Mojo::URL->new($url);
     $self->protocol($url->protocol)->host($url->host);
     $self->username($url->username)->password($url->password);
-    $self->vm_id(substr $url->path, 1);
+    $self->vm_id(substr($url->path, 1)) if length $url->path > 1;
 }
 
 sub get_vmware_wss_url ($self) {
@@ -49,8 +51,8 @@ sub get_vmware_wss_url ($self) {
     my $api_url = "$protocol://$host/sdk";
     my $username = xml_escape $self->username;
     my $password = xml_escape $self->password;
-    log::diag "VMWare credentials: username: $username, password: $password";    # FIXME: remove before merging
-    my $vm_id = xml_escape $self->vm_id;
+    my $vm_id = xml_escape($self->vm_id || $bmwqemu::vars{VIRSH_VM_ID});
+    log::diag "VMWare credentials: username: $username, password: $password, id: $vm_id";    # FIXME: remove before merging
     my $auth_xml = qq{<Envelope xmlns="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Header><operationID>esxui-8fb8</operationID></Header><Body><Login xmlns="urn:vim25"><_this type="SessionManager">ha-sessionmgr</_this><userName>$username</userName><password>$password</password></Login></Body></Envelope>};
     my $request_wss_xml = qq{<Envelope xmlns="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Header><operationID>esxui-c51d</operationID></Header><Body><AcquireTicket xmlns="urn:vim25"><_this type="VirtualMachine">$vm_id</_this><ticketType>webmks</ticketType></AcquireTicket></Body></Envelope>};
 
@@ -76,7 +78,7 @@ sub get_vmware_wss_url ($self) {
     my $url_error = _get_vmware_error($wss_dom);
     die "VMWare web socket URL request failed: $url_error\n" if $url_error;
     my $wss_url = $wss_dom->find('url')->first;
-    die "VMWare did not return a web socket URL\n" unless $wss_url && $wss_url->text;
+    die "VMWare did not return a web socket URL, it responsed:\n" . $res->body unless $wss_url && $wss_url->text;
     my $cookie = $request_wss_txn->req->cookies->[0];
     die "VMWare did not return a session cookie\n" unless $cookie;
     return (Mojo::URL->new($wss_url->text), $cookie);

--- a/consoles/VMWare.pm
+++ b/consoles/VMWare.pm
@@ -89,10 +89,12 @@ sub _cleanup_previous_dewebsockify_process ($self) {
     $self->dewebsockify_pid(undef);
 }
 
-sub _start_dewebsockify_process ($self, $listen_port, $websockets_url, $session) {
+sub _start_dewebsockify_process ($self, $listen_port, $websockets_url, $session, $log_level = undef) {
+    my @args = ("$bmwqemu::scriptdir/dewebsockify", '--listenport', $listen_port, '--websocketurl', $websockets_url, '--cookie', "vmware_client=VMware; $session");
+    push @args, '--loglevel', $log_level if $log_level;
     my $pid = fork;
     return $self->dewebsockify_pid($pid) if $pid;
-    exec "$bmwqemu::scriptdir/dewebsockify", '--listenport', $listen_port, '--websocketurl', $websockets_url, '--cookie', "vmware_client=VMware; $session";
+    exec @args;    # uncoverable statement
 }
 
 sub launch_vnc_server ($self, $listen_port) {

--- a/consoles/VMWare.pm
+++ b/consoles/VMWare.pm
@@ -1,0 +1,80 @@
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package consoles::VMWare;
+
+use Mojo::Base -base, -signatures;
+
+use Mojo::JSON qw(encode_json);
+use Mojo::UserAgent;
+use Mojo::URL;
+use Mojo::Util qw(xml_escape);
+
+has protocol => 'https';
+has host => undef;
+has vm_id => 1;
+has username => 'root';
+has password => undef;
+
+sub _get_vmware_error ($dom) {
+    my $faultstring_element = $dom->find('faultstring')->first;
+    return $faultstring_element ? $faultstring_element->text : '';
+}
+
+sub _prepare_vmware_request ($ua, $api_url, $xml) {
+    my $txn = $ua->build_tx(POST => $api_url);
+    my $headers = $txn->req->headers;
+    $txn->req->body($xml);
+    $headers->header(SOAPAction => 'urn:vim25/7.0.2.0');
+    $headers->content_type('text/xml');
+    $headers->content_length(length $xml);
+    return ($txn, $headers);
+}
+
+sub configure_from_url ($self, $url) {
+    $url = Mojo::URL->new($url);
+    $self->protocol($url->protocol)->host($url->host);
+    $self->username($url->username)->password($url->password);
+    $self->vm_id(substr $url->path, 1);
+}
+
+sub get_vmware_wss_url ($self) {
+
+    # make XML for requests
+    my $protocol = $self->protocol or die "No protocol specified\n";
+    my $host = $self->host or die "No VMWare host specified\n";
+    my $api_url = "$protocol://$host/sdk";
+    my $username = xml_escape $self->username;
+    my $password = xml_escape $self->password;
+    my $vm_id = xml_escape $self->vm_id;
+    my $auth_xml = qq{<Envelope xmlns="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Header><operationID>esxui-8fb8</operationID></Header><Body><Login xmlns="urn:vim25"><_this type="SessionManager">ha-sessionmgr</_this><userName>$username</userName><password>$password</password></Login></Body></Envelope>};
+    my $request_wss_xml = qq{<Envelope xmlns="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Header><operationID>esxui-c51d</operationID></Header><Body><AcquireTicket xmlns="urn:vim25"><_this type="VirtualMachine">$vm_id</_this><ticketType>webmks</ticketType></AcquireTicket></Body></Envelope>};
+
+    # request VMWare session
+    my $ua = ($self->{_vmware_ua} //= Mojo::UserAgent->new);
+    my ($auth_txn, $auth_headers) = _prepare_vmware_request($ua, $api_url, $auth_xml);
+    $auth_headers->cookie('vmware_client=VMware');
+    $ua->insecure(1);    # so far our setup doesn't have a proper certificate
+    $ua->start($auth_txn);
+
+    # check for auth error
+    my $auth_error = _get_vmware_error($auth_txn->result->dom);
+    die "VMWare auth request failed: $auth_error\n" if $auth_error;
+
+    # request web socket URL
+    my ($request_wss_txn) = _prepare_vmware_request($ua, $api_url, $request_wss_xml);
+    $ua->start($request_wss_txn);
+
+    # read web socket URL
+    my $res = $request_wss_txn->result;
+    my $wss_dom = $res->dom;
+    my $url_error = _get_vmware_error($wss_dom);
+    die "VMWare web socket URL request failed: $url_error\n" if $url_error;
+    my $wss_url = $wss_dom->find('url')->first;
+    die "VMWare did not return a web socket URL\n" unless $wss_url && $wss_url->text;
+    my $cookie = $request_wss_txn->req->cookies->[0];
+    die "VMWare did not return a session cookie\n" unless $cookie;
+    return (Mojo::URL->new($wss_url->text), $cookie);
+}
+
+1;

--- a/consoles/VMWare.pm
+++ b/consoles/VMWare.pm
@@ -110,8 +110,16 @@ sub launch_vnc_server ($self, $listen_port) {
     }
 }
 
+sub deduce_url_from_vars () {
+    return undef unless $bmwqemu::vars{VMWARE_VNC_OVER_WS};
+    my $host = $bmwqemu::vars{VMWARE_HOST} or die "VMWARE_VNC_OVER_WS set but not VMWARE_HOST\n";
+    my $user = $bmwqemu::vars{VMWARE_USERNAME} // 'root';
+    my $password = $bmwqemu::vars{VMWARE_PASSWORD} or die "VMWARE_VNC_OVER_WS set but not VMWARE_PASSWORD\n";
+    return Mojo::URL->new("https://$host")->userinfo("$user:$password")->to_unsafe_string;
+}
+
 sub setup_for_vnc_console ($vnc_console) {
-    return undef unless my $ws_url = $vnc_console->vmware_vnc_over_ws_url;
+    return undef unless my $ws_url = $vnc_console->vmware_vnc_over_ws_url // deduce_url_from_vars;
     my $self = $vnc_console->{_vmware_handler} //= consoles::VMWare->new;
     log::diag 'Establishing VNC connection over WebSockets via ' . Mojo::URL->new($ws_url)->to_string;
     $vnc_console->hostname('127.0.0.1');

--- a/consoles/VMWare.pm
+++ b/consoles/VMWare.pm
@@ -59,7 +59,7 @@ sub get_vmware_wss_url ($self) {
     $ua->cookie_jar->empty;    # avoid auth error because we're already logged in
     my ($auth_txn, $auth_headers) = _prepare_vmware_request($ua, $api_url, $auth_xml);
     $auth_headers->cookie('vmware_client=VMware');
-    $ua->insecure(1);    # so far our setup doesn't have a proper certificate
+    $ua->insecure($bmwqemu::vars{VMWARE_VNC_OVER_WS_INSECURE} // 0);
     $ua->start($auth_txn);
 
     # check for auth error
@@ -92,6 +92,7 @@ sub _cleanup_previous_dewebsockify_process ($self) {
 sub _start_dewebsockify_process ($self, $listen_port, $websockets_url, $session, $log_level = undef) {
     my @args = ("$bmwqemu::scriptdir/dewebsockify", '--listenport', $listen_port, '--websocketurl', $websockets_url, '--cookie', "vmware_client=VMware; $session");
     push @args, '--loglevel', $log_level if $log_level;
+    push @args, '--insecure' if $bmwqemu::vars{VMWARE_VNC_OVER_WS_INSECURE};
     my $pid = fork;
     return $self->dewebsockify_pid($pid) if $pid;
     exec @args;    # uncoverable statement

--- a/consoles/VMWare.pm
+++ b/consoles/VMWare.pm
@@ -100,14 +100,16 @@ sub launch_vnc_server ($self, $listen_port) {
 
     my $attempts = $bmwqemu::vars{VMWARE_VNC_OVER_WS_REQUEST_ATTEMPTS} // 11;
     my $delay = $bmwqemu::vars{VMWARE_VNC_OVER_WS_REQUEST_DELAY} // 5;
+    my $error;
     for (; $attempts >= 0; --$attempts) {
         my ($websockets_url, $session) = eval { $self->get_vmware_wss_url };
-        return $self->_start_dewebsockify_process($listen_port, $websockets_url, $session) unless my $error = $@;
+        return $self->_start_dewebsockify_process($listen_port, $websockets_url, $session) unless $error = $@;
         die $error if $error =~ qr/incorrect user name or password/;    # no use to attempt further
         chomp $error;
         log::diag "$error, trying $attempts more times";
         sleep $delay;
     }
+    die $error;
 }
 
 sub deduce_url_from_vars ($vnc_console) {

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -118,15 +118,7 @@ my @encodings = (
 );
 
 sub login ($self, $connect_timeout = undef, $timeout = undef) {
-    my $port = $self->port || 5900;
-    if (my $ws_url = $self->vmware_vnc_over_ws_url) {
-        my $vmware_handler = $self->{_vmware_handler} //= consoles::VMWare->new;
-        bmwqemu::diag "Establishing VNC connection over WebSockets via $ws_url";
-        $self->hostname('127.0.0.1');
-        $self->description('VNC over WebSockets server provided by VMWare');
-        $vmware_handler->configure_from_url($ws_url);
-        $vmware_handler->launch_vnc_server($port);
-    }
+    consoles::VMWare::setup_for_vnc_console($self);
 
     # arbitrary
     my $connect_failure_limit = 2;
@@ -142,6 +134,7 @@ sub login ($self, $connect_timeout = undef, $timeout = undef) {
     $self->{_inflater} = undef;
 
     my $hostname = $self->hostname || 'localhost';
+    my $port = $self->port || 5900;
     my $description = $self->description || 'VNC server';
     my $is_local = $hostname =~ qr/(localhost|127\.0\.0\.\d+|::1)/;
     my $local_timeout = $bmwqemu::vars{VNC_TIMEOUT_LOCAL} // 60;

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -12,11 +12,13 @@ use Carp qw(confess cluck carp croak);
 use Data::Dumper 'Dumper';
 use Scalar::Util 'blessed';
 use OpenQA::Exceptions;
+use consoles::VMWare;
 
 has [qw(description hostname port username password socket name width height depth
       no_endian_conversion  _pixinfo _colourmap _framebuffer _rfb_version screen_on
       _bpp _true_colour _do_endian_conversion absolute ikvm keymap _last_update_received
-      _last_update_requested check_vnc_stalls _vnc_stalled vncinfo old_ikvm dell)];
+      _last_update_requested check_vnc_stalls _vnc_stalled vncinfo old_ikvm dell
+      vmware_vnc_over_ws_url)];
 
 our $VERSION = '0.40';
 
@@ -116,6 +118,16 @@ my @encodings = (
 );
 
 sub login ($self, $connect_timeout = undef, $timeout = undef) {
+    my $port = $self->port || 5900;
+    if (my $ws_url = $self->vmware_vnc_over_ws_url) {
+        my $vmware_handler = $self->{_vmware_handler} //= consoles::VMWare->new;
+        bmwqemu::diag "Establishing VNC connection over WebSockets via $ws_url";
+        $self->hostname('127.0.0.1');
+        $self->description('VNC over WebSockets server provided by VMWare');
+        $vmware_handler->configure_from_url($ws_url);
+        $vmware_handler->launch_vnc_server($port);
+    }
+
     # arbitrary
     my $connect_failure_limit = 2;
 
@@ -130,7 +142,6 @@ sub login ($self, $connect_timeout = undef, $timeout = undef) {
     $self->{_inflater} = undef;
 
     my $hostname = $self->hostname || 'localhost';
-    my $port = $self->port || 5900;
     my $description = $self->description || 'VNC server';
     my $is_local = $hostname =~ qr/(localhost|127\.0\.0\.\d+|::1)/;
     my $local_timeout = $bmwqemu::vars{VNC_TIMEOUT_LOCAL} // 60;

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -10,6 +10,7 @@ require IPC::System::Simple;
 use XML::LibXML;
 use File::Temp 'tempfile';
 use File::Basename;
+use Mojo::DOM;
 use Mojo::JSON qw(decode_json);
 
 use backend::svirt;
@@ -526,8 +527,12 @@ __END"
 
     $ret = $self->run_cmd("virsh $remote_vmm start " . $self->name . ' 2> >(tee /tmp/os-autoinst-' . $self->name . '-stderr.log >&2)');
     bmwqemu::diag("Dump actually used libvirt configuration file " . ($ret ? "(broken)" : "(working)"));
-    $self->run_cmd("virsh $remote_vmm dumpxml " . $self->name);
+    my $config = $self->get_cmd_output("virsh $remote_vmm dumpxml " . $self->name);
     die "virsh start failed" if $ret;
+    my $config_domain = Mojo::DOM->new($config)->at('domain');
+    my $vm_id = $config_domain ? $config_domain->attr('id') : '';
+    die 'virsh domain XML does not specify VM ID which is required from VNC over WebSockets' if !$vm_id && $bmwqemu::vars{VMWARE_VNC_OVER_WS};
+    $bmwqemu::vars{VIRSH_VM_ID} = $vm_id;
 
     $self->backend->start_serial_grab($self->name);
 

--- a/dewebsockify
+++ b/dewebsockify
@@ -21,12 +21,12 @@ sub usage ($r = 0) {
 
 # read CLI args
 my %options;
-GetOptions(\%options, 'websocketurl=s', 'listenport=s', 'cookie=s', 'help|h|?') or usage(1);
+GetOptions(\%options, 'websocketurl=s', 'listenport=s', 'cookie=s', 'loglevel=s', 'help|h|?') or usage(1);
 usage if $options{help};
 my $ws_url = $options{websocketurl} or die "websocket URL missing\n";
 my $port = $options{listenport} // 5900;
 my $cookie = $options{cookie} ? $options{cookie} : undef;
-my $log = Mojo::Log->new;
+my $log = Mojo::Log->new(level => $options{loglevel} // 'info');
 $log->debug("websocket url: $ws_url");
 $log->debug("listen port: $port");
 $log->debug("cookie: " . $cookie) if $cookie;
@@ -71,7 +71,7 @@ $server->on(accept => sub ($server, $handle) {
                     $log->error('Unable to upgrade to WebSocket connection');
                 }
                 my $body = $tx->res->body;
-                $log->debug($body) if $body;
+                $log->trace($body) if $body;
                 $ws_connection = undef;
                 $stream->close_gracefully if $stream;
                 return undef;
@@ -82,10 +82,10 @@ $server->on(accept => sub ($server, $handle) {
 
             # pass data from websocket to raw socket
             $tx->on(text => sub ($tx, $text) {
-                $log->debug("WebSocket text message: $text");
+                $log->trace("WebSocket text message: $text");
             });
             $tx->on(binary => sub ($tx, $bytes) {
-                $log->debug("WebSocket binary message:\n" . sprintf("%v02X", $bytes));
+                $log->trace("WebSocket binary message:\n" . sprintf("%v02X", $bytes));
                 $stream->write($bytes) if $stream;
             });
 

--- a/dewebsockify
+++ b/dewebsockify
@@ -1,0 +1,134 @@
+#!/usr/bin/perl -w
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+use Mojo::Base -strict, -signatures;
+
+use Getopt::Long;
+use Mojo::Cookie::Request;
+use Mojo::IOLoop;
+use Mojo::IOLoop::Server;
+use Mojo::IOLoop::Stream;
+use Mojo::Log;
+use Mojo::UserAgent;
+
+sub usage ($r = 0) {
+    say 'Listens on a TCP port forwarding data to the specified websocket server
+    example: --websocketurl wss://... --listenport 590x --cookie "vmware_client=VMware; some_session=foobar"';
+    exit $r;
+}
+
+# read CLI args
+my %options;
+GetOptions(\%options, 'websocketurl=s', 'listenport=s', 'cookie=s', 'help|h|?') or usage(1);
+usage if $options{help};
+my $ws_url = $options{websocketurl} or die "websocket URL missing\n";
+my $port = $options{listenport} // 5900;
+my $cookie = $options{cookie} ? $options{cookie} : undef;
+my $log = Mojo::Log->new;
+$log->debug("websocket url: $ws_url");
+$log->debug("listen port: $port");
+$log->debug("cookie: " . $cookie) if $cookie;
+
+# create listen socket
+my $ua = Mojo::UserAgent->new;
+my $server = Mojo::IOLoop::Server->new;
+my $ws_connection;
+my $stream;
+my @tosend;
+$ua->insecure(1);  # so far our setup doesn't have a proper certificate
+
+# accept new connections
+$server->on(accept => sub ($server, $handle) {
+    if ($stream) {
+        $log->info('Rejecting new client; already one client connected');
+        return undef;
+    }
+    $stream = Mojo::IOLoop::Stream->new($handle);
+    $stream->start;
+    $stream->reactor->start unless $stream->reactor->is_running;
+
+    # establish websocket connection
+    if (!$ws_connection) {
+        $log->info("Establishing WebSocket connection to $ws_url");
+        @tosend = ();
+        my $tx = $ua->build_websocket_tx($ws_url);
+        my $req = $tx->req;
+        my $headers = $tx->req->headers;
+        $req->cookies($cookie) if $cookie;
+        $headers->add(Pragma => 'no-cache');
+        $headers->add('Sec-WebSocket-Protocol' => 'binary, vmware-vvc');
+        $ua->start($tx => sub ($ua, $tx) {
+
+            # handle errors
+            if (!$tx->is_websocket) {
+                if (my $err = $tx->error) {
+                    $log->error($err->{code} ? "WebSocket $err->{code} response: $err->{message}"
+                                             : "WebSocket connection error: $err->{message}");
+                }
+                else {
+                    $log->error('Unable to upgrade to WebSocket connection');
+                }
+                my $body = $tx->res->body;
+                $log->debug($body) if $body;
+                $ws_connection = undef;
+                $stream->close_gracefully if $stream;
+                return undef;
+            }
+            $log->info('WebSocket connection established');
+            $tx->max_websocket_size(1024**3);  # required to avoid 1009 error, at least when using raw encoding
+            $ws_connection = $tx;
+
+            # pass data from websocket to raw socket
+            $tx->on(text => sub ($tx, $text) {
+                $log->debug("WebSocket text message: $text");
+            });
+            $tx->on(binary => sub ($tx, $bytes) {
+                $log->debug("WebSocket binary message:\n" . sprintf("%v02X", $bytes));
+                $stream->write($bytes) if $stream;
+            });
+
+            # pass pending data from raw socket to websocket
+            $tx->send($_) for @tosend;
+            @tosend = ();
+
+            # handle websocket connection finish
+            # note: Terminating here because at least for VMWare one needed a new URL/ticket anyways.
+            $tx->on(finish => sub ($tx, $code, $reason) {
+                $log->info("WebSocket closed with status $code.");
+                $ws_connection = undef;
+                $stream->close_gracefully if $stream;
+                Mojo::IOLoop->stop_gracefully;
+            });
+        });
+    }
+
+    # pass data from raw socket to websocket
+    $stream->on(read => sub ($s, $bytes) {
+        if ($ws_connection) {
+            $log->debug("Raw socket message:\n" . sprintf("%v02X", $bytes));
+            $ws_connection->send({binary => $bytes});
+        }
+        else {
+            $log->debug("Raw socket message (forwarding later):\n" . sprintf("%v02X", $bytes));
+            push @tosend, $bytes;
+        }
+    });
+
+    # handle raw socket close/error
+    $stream->on(close => sub ($s) {
+        $log->info('Client closed connection');
+        $stream = undef;
+        $ws_connection->finish if $ws_connection;
+    });
+    $stream->on(error => sub ($stream, $err) {
+        $log->error("Client error: $err");
+    });
+
+    $log->info('Client accepted');
+});
+
+$server->listen(port => $port);
+$server->start;
+Mojo::IOLoop->start unless Mojo::IOLoop->is_running;

--- a/dewebsockify
+++ b/dewebsockify
@@ -15,13 +15,13 @@ use Mojo::UserAgent;
 
 sub usage ($r = 0) {
     say 'Listens on a TCP port forwarding data to the specified websocket server
-    example: --websocketurl wss://... --listenport 590x --cookie "vmware_client=VMware; some_session=foobar"';
+    example: --websocketurl wss://... --listenport 590x --cookie "vmware_client=VMware; some_session=foobar" --insecure';
     exit $r;
 }
 
 # read CLI args
 my %options;
-GetOptions(\%options, 'websocketurl=s', 'listenport=s', 'cookie=s', 'loglevel=s', 'help|h|?') or usage(1);
+GetOptions(\%options, 'websocketurl=s', 'listenport=s', 'cookie=s', 'loglevel=s', 'insecure', 'help|h|?') or usage(1);
 usage if $options{help};
 my $ws_url = $options{websocketurl} or die "websocket URL missing\n";
 my $port = $options{listenport} // 5900;
@@ -37,7 +37,7 @@ my $server = Mojo::IOLoop::Server->new;
 my $ws_connection;
 my $stream;
 my @tosend;
-$ua->insecure(1);  # so far our setup doesn't have a proper certificate
+$ua->insecure($options{insecure} // 0);
 
 # accept new connections
 $server->on(accept => sub ($server, $handle) {

--- a/dewebsockify
+++ b/dewebsockify
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/perl
 # Copyright 2022 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/dewebsockify
+++ b/dewebsockify
@@ -107,12 +107,12 @@ $server->on(accept => sub ($server, $handle) {
     # pass data from raw socket to websocket
     $stream->on(read => sub ($s, $bytes) {
         if ($ws_connection) {
-            $log->debug("Raw socket message:\n" . sprintf("%v02X", $bytes));
-            $ws_connection->send({binary => $bytes});
+            $log->debug("Raw socket message:\n" . sprintf("%v02X", $bytes));  # uncoverable statement
+            $ws_connection->send({binary => $bytes});  # uncoverable statement
         }
         else {
-            $log->debug("Raw socket message (forwarding later):\n" . sprintf("%v02X", $bytes));
-            push @tosend, $bytes;
+            $log->debug("Raw socket message (forwarding later):\n" . sprintf("%v02X", $bytes));  # uncoverable statement
+            push @tosend, $bytes;  # uncoverable statement
         }
     });
 
@@ -120,10 +120,10 @@ $server->on(accept => sub ($server, $handle) {
     $stream->on(close => sub ($s) {
         $log->info('Client closed connection');
         $stream = undef;
-        $ws_connection->finish if $ws_connection;
+        $ws_connection ? $ws_connection->finish : Mojo::IOLoop->stop_gracefully;
     });
     $stream->on(error => sub ($stream, $err) {
-        $log->error("Client error: $err");
+        $log->error("Client error: $err");  # uncoverable statement
     });
 
     $log->info('Client accepted');

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -256,6 +256,8 @@ cd %{__builddir}
 %{_prefix}/lib/os-autoinst/autotest.pm
 %{_prefix}/lib/os-autoinst/*.py
 %{_prefix}/lib/os-autoinst/check_qemu_oom
+%{_prefix}/lib/os-autoinst/dewebsockify
+%{_prefix}/lib/os-autoinst/vnctest
 
 %dir %{_prefix}/lib/os-autoinst/schema
 %{_prefix}/lib/os-autoinst/schema/Wheels-01.yaml

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -218,6 +218,7 @@ VMWARE_NFS_DATASTORE;string;;VMware datastore with openQA NFS directories
 VMWARE_SERIAL_PORT;string;;TCP port where is VM's serial port stream to be expected on the ESX server
 VMWARE_BRIDGE;string;;VMware's bridge name (usual default is 'VM Network')
 VMWARE_REMOTE_VMM;string;;Set the vmware Virtual Machine Manager
+VMWARE_VNC_OVER_WS;boolean;0;Whether to use VNC over WebSockets (instead of raw VNC connection)
 HYPERV_USERNAME;string;;Administrator account name
 HYPERV_PASSWORD;string;;Password for above account
 HYPERV_SERVER;string;;Windows Server (2008 R2, 2012 R2, or 2016) instance IP address

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -219,6 +219,7 @@ VMWARE_SERIAL_PORT;string;;TCP port where is VM's serial port stream to be expec
 VMWARE_BRIDGE;string;;VMware's bridge name (usual default is 'VM Network')
 VMWARE_REMOTE_VMM;string;;Set the vmware Virtual Machine Manager
 VMWARE_VNC_OVER_WS;boolean;0;Whether to use VNC over WebSockets (instead of raw VNC connection)
+VMWARE_VNC_OVER_WS_INSECURE;boolean;0;Do not require a valid TLS certificate for VNC over WebSockets
 HYPERV_USERNAME;string;;Administrator account name
 HYPERV_PASSWORD;string;;Password for above account
 HYPERV_SERVER;string;;Windows Server (2008 R2, 2012 R2, or 2016) instance IP address

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -110,12 +110,13 @@ subtest 'starting VMware console' => sub {
     $bmwqemu::vars{VMWARE_USERNAME} = 'u';
     $bmwqemu::vars{VMWARE_PASSWORD} = 'p';
 
-    my $chan_mock = Test::MockObject->new->set_true(qw(write send_eof close));
+    my $chan_mock = Test::MockObject->new->set_true(qw(write send_eof close read2 eof exit_status));
     my $backend_mock = Test::MockModule->new('backend::svirt');
     my $console_mock = Test::MockModule->new('consoles::sshVirtsh');
     my $tmp_mock = Test::MockModule->new('File::Temp');
     my (@cmds, @ssh_cmds);
     $console_mock->redefine(run_cmd => sub ($self, $cmd, %args) { push @cmds, $cmd; 0 });
+    $console_mock->redefine(get_cmd_output => sub ($self, $cmd, %args) { push @cmds, $cmd; 0 });
     $backend_mock->redefine(run_ssh => sub ($self, $cmd, %args) { push @ssh_cmds, $cmd; (undef, $chan_mock) });
     $backend_mock->redefine(start_serial_grab => 1);
     $console_mock->redefine(get_ssh_credentials => sub { (hostname => 'foo', username => 'root', password => '123') });

--- a/t/27-consoles-vmware.t
+++ b/t/27-consoles-vmware.t
@@ -96,6 +96,20 @@ subtest 'request WebSockets URL' => sub {
     is $cookie, 'the cookie', 'cookie returned';
 };
 
+subtest 'deducing VNC over WebSockets URL from vars' => sub {
+    is consoles::VMWare::deduce_url_from_vars, undef, 'no URL if VMWARE_VNC_OVER_WS not set';
+
+    $bmwqemu::vars{VMWARE_VNC_OVER_WS} = 1;
+    throws_ok { consoles::VMWare::deduce_url_from_vars } qr/VMWARE_VNC_OVER_WS set but not VMWARE_HOST/, 'error if vars specified inconsistently';
+
+    $bmwqemu::vars{VMWARE_HOST} = 'the-host';
+    throws_ok { consoles::VMWare::deduce_url_from_vars } qr/VMWARE_VNC_OVER_WS set but not VMWARE_PASSWORD/, 'error if password missing';
+
+    $bmwqemu::vars{VMWARE_USERNAME} = 'foo';
+    $bmwqemu::vars{VMWARE_PASSWORD} = 'bar';
+    is consoles::VMWare::deduce_url_from_vars, 'https://foo:bar@the-host', 'URL deduced from vars';
+};
+
 subtest 'test against real VMWare instance' => sub {
     my $vmware = consoles::VMWare->new;
     my $instance_url = $ENV{OS_AUTOINST_TEST_AGAINST_REAL_VMWARE_INSTANCE};

--- a/t/27-consoles-vmware.t
+++ b/t/27-consoles-vmware.t
@@ -8,35 +8,78 @@ use Test::Warnings;
 use Mojo::Base -strict, -signatures;
 use utf8;
 
+# disable time limit when testing against real VMWare instance
+BEGIN {
+    $ENV{OPENQA_TEST_TIMEOUT_DISABLE} = 1 if $ENV{OS_AUTOINST_TEST_AGAINST_REAL_VMWARE_INSTANCE};
+}
+
 use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 
+use Test::MockObject;
+use Test::MockModule;
+use Test::Output qw(combined_like);
+
 use consoles::VMWare;
 
-# configure test instance
-my $vmware = consoles::VMWare->new;
-my $instance_url = $ENV{OS_AUTOINST_TEST_AGAINST_REAL_VMWARE_INSTANCE};
-unless ($instance_url) {
-    plan skip_all => 'Set OS_AUTOINST_TEST_AGAINST_REAL_VMWARE_INSTANCE to run this test.';
-    exit(0);
-}
-$vmware->configure_from_url($instance_url);
-note 'host: ' . $vmware->host // '?';
-note 'username: ' . $vmware->username // '?';
-note 'password: ' . $vmware->password // '?';
-note 'instance: ' . $vmware->vm_id // '?';
+$bmwqemu::scriptdir = "$Bin/..";
 
-# request wss URL and session cookie
-my ($wss_url, $session) = $vmware->get_vmware_wss_url;
-like $wss_url, qr{wss://.+/ticket/.+}, 'wss URL returned for VMWare host';
-like $session, qr{vmware_soap_session=.+}, 'session cookie returned';
-note "wss url: $wss_url\n";
-note "session: $session\n";
+subtest 'test configuration with fake URL' => sub {
+    my $vmware_mock = Test::MockModule->new('consoles::VMWare');
+    my (@get_vmware_wss_url_args, @dewebsockify_args);
+    $vmware_mock->redefine(get_vmware_wss_url => sub ($self) { ('wss://foo', 'session') });
+    $vmware_mock->redefine(_start_dewebsockify_process => sub ($self, @args) { @dewebsockify_args = @args });
 
-# spawn test instance of dewebsockify for manually testing with vncviewer
-if (my $port = $ENV{OS_AUTOINST_DEWEBSOCKIFY_PORT}) {
-    system "'$Bin/../dewebsockify' --listenport '$port' --websocketurl '$wss_url' --cookie 'vmware_client=VMware; $session'";
-}
+    my $fake_vnc = Test::MockObject->new;
+    $fake_vnc->set_always(vmware_vnc_over_ws_url => undef);
+    is consoles::VMWare::setup_for_vnc_console($fake_vnc), undef, 'noop if URL not set';
+
+    $fake_vnc->set_always(vmware_vnc_over_ws_url => 'https://root:secret%23@foo.bar');
+    $fake_vnc->set_always(port => 12345);
+    $fake_vnc->set_true(qw(hostname description));
+    $fake_vnc->clear;
+
+    my $vmware;
+    combined_like { $vmware = consoles::VMWare::setup_for_vnc_console($fake_vnc) }
+    qr{Establishing VNC connection over WebSockets via https://foo\.bar}, 'log message present without secrets';
+    ok $vmware, 'VMWare "console" returned if URL is set' or return undef;
+    $fake_vnc->called_pos_ok(2, 'hostname', 'hostname assigned');
+    $fake_vnc->called_args_pos_is(2, 2, '127.0.0.1', 'hostname set to localhost');
+    $fake_vnc->called_pos_ok(3, 'description', 'description assigned');
+    $fake_vnc->called_args_pos_is(3, 2, 'VNC over WebSockets server provided by VMWare', 'description set accordingly');
+    is_deeply \@dewebsockify_args, [12345, 'wss://foo', 'session'], 'dewebsockify called with expected args'
+      or diag explain \@dewebsockify_args;
+    is $vmware->host, 'foo.bar', 'hostname set';
+    is $vmware->vm_id, undef, 'no VM-ID set (as our URL did not include one)';
+    is $vmware->username, 'root', 'username set';
+    is $vmware->password, 'secret#', 'password set (with URL-encoded character)';
+};
+
+subtest 'test against real VMWare instance' => sub {
+    my $vmware = consoles::VMWare->new;
+    my $instance_url = $ENV{OS_AUTOINST_TEST_AGAINST_REAL_VMWARE_INSTANCE};
+    unless ($instance_url) {
+        plan skip_all => 'Set OS_AUTOINST_TEST_AGAINST_REAL_VMWARE_INSTANCE to run this test.';
+        exit(0);
+    }
+    $vmware->configure_from_url($instance_url);
+    note 'host: ' . $vmware->host // '?';
+    note 'username: ' . $vmware->username // '?';
+    note 'password: ' . $vmware->password // '?';
+    note 'instance: ' . $vmware->vm_id // '?';
+
+    # request wss URL and session cookie
+    my ($wss_url, $session) = $vmware->get_vmware_wss_url;
+    like $wss_url, qr{wss://.+/ticket/.+}, 'wss URL returned for VMWare host';
+    like $session, qr{vmware_soap_session=.+}, 'session cookie returned';
+    note "wss url: $wss_url\n";
+    note "session: $session\n";
+
+    # spawn test instance of dewebsockify for manually testing with vncviewer
+    if (my $port = $ENV{OS_AUTOINST_DEWEBSOCKIFY_PORT}) {
+        system "'$Bin/../dewebsockify' --listenport '$port' --websocketurl '$wss_url' --cookie 'vmware_client=VMware; $session'";
+    }
+};
 
 done_testing;

--- a/t/27-consoles-vmware.t
+++ b/t/27-consoles-vmware.t
@@ -1,0 +1,42 @@
+#!/usr/bin/perl
+
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+use Test::Warnings;
+use Mojo::Base -strict, -signatures;
+use utf8;
+
+use FindBin '$Bin';
+use lib "$Bin/../external/os-autoinst-common/lib";
+use OpenQA::Test::TimeLimit '5';
+
+use consoles::VMWare;
+
+# configure test instance
+my $vmware = consoles::VMWare->new;
+my $instance_url = $ENV{OS_AUTOINST_TEST_AGAINST_REAL_VMWARE_INSTANCE};
+unless ($instance_url) {
+    plan skip_all => 'Set OS_AUTOINST_TEST_AGAINST_REAL_VMWARE_INSTANCE to run this test.';
+    exit(0);
+}
+$vmware->configure_from_url($instance_url);
+note 'host: ' . $vmware->host // '?';
+note 'username: ' . $vmware->username // '?';
+note 'password: ' . $vmware->password // '?';
+note 'instance: ' . $vmware->vm_id // '?';
+
+# request wss URL and session cookie
+my ($wss_url, $session) = $vmware->get_vmware_wss_url;
+like $wss_url, qr{wss://.+/ticket/.+}, 'wss URL returned for VMWare host';
+like $session, qr{vmware_soap_session=.+}, 'session cookie returned';
+note "wss url: $wss_url\n";
+note "session: $session\n";
+
+# spawn test instance of dewebsockify for manually testing with vncviewer
+if (my $port = $ENV{OS_AUTOINST_DEWEBSOCKIFY_PORT}) {
+    system "'$Bin/../dewebsockify' --listenport '$port' --websocketurl '$wss_url' --cookie 'vmware_client=VMware; $session'";
+}
+
+done_testing;

--- a/t/27-consoles-vmware.t
+++ b/t/27-consoles-vmware.t
@@ -188,8 +188,10 @@ subtest 'turning WebSocket into normal socket via dewebsockify' => sub {
                     $stream->close;
                     return $loop->stop;
                 }
-                $stream->on(read => sub ($stream, $bytes) { $data_received_via_raw_socket .= $bytes });
-                $stream->write('message sent from raw socket');
+                $stream->on(read => sub ($stream, $bytes) {
+                        $data_received_via_raw_socket .= $bytes;
+                        $stream->write('message sent from raw socket') if length $data_received_via_raw_socket >= length 'binary sent from WebSocket';
+                });
         });
     };
     $t->ua->ioloop->next_tick($connect_to_dewebsockify);

--- a/t/27-consoles-vmware.t
+++ b/t/27-consoles-vmware.t
@@ -31,6 +31,7 @@ use Mojo::Server::Daemon;
 use consoles::VMWare;
 
 $bmwqemu::scriptdir = "$Bin/..";
+$bmwqemu::vars{VMWARE_VNC_OVER_WS_INSECURE} = 1;
 
 sub mk_res ($code, @text) { map { Mojo::Message::Response->new->code($code)->body($_) } @text }
 
@@ -258,7 +259,7 @@ subtest 'test against real VMWare instance' => sub {
 
     # spawn test instance of dewebsockify for manually testing with vncviewer
     if (my $port = $ENV{OS_AUTOINST_DEWEBSOCKIFY_PORT}) {
-        system "'$Bin/../dewebsockify' --listenport '$port' --websocketurl '$wss_url' --cookie 'vmware_client=VMware; $session'";
+        system "'$Bin/../dewebsockify' --listenport '$port' --websocketurl '$wss_url' --cookie 'vmware_client=VMware; $session' --insecure";
     }
 };
 

--- a/vnctest
+++ b/vnctest
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/perl
 # Copyright 2022 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -32,7 +32,7 @@ require tinycv;
 
 my $image_path = '/tmp/vnc-framebuffer.png' // $ENV{VNC_TEST_TEMP_IMAGE_PATH};
 unlink $image_path;
-exec "$Bin/debugviewer/debugviewer", $image_path if fork == 0;
+exec "$Bin/debugviewer/debugviewer", $image_path if $ENV{VNC_TEST_DEBUGVIEWER} && fork == 0;
 
 $log->info('Initializing VNC');
 my $vnc = consoles::VNC->new(%options);

--- a/vnctest
+++ b/vnctest
@@ -1,0 +1,53 @@
+#!/usr/bin/perl -w
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+use Mojo::Base -strict, -signatures;
+use Mojo::Log;
+use Getopt::Long;
+use Time::HiRes;
+
+use FindBin '$Bin';
+use lib "$Bin";
+use consoles::VNC;
+use cv;
+use needle;
+
+sub usage ($r = 0) {
+    say 'Connects to the specified VNC server using os-autoinst\'s VNC module
+    example: --hostname localhost --port 590x';
+    exit $r;
+}
+my %options;
+GetOptions(\%options, 'hostname=s', 'port=s', 'password=s', 'update-delay=s', 'verbose|v', 'help|h|?') or usage(1);
+usage if $options{help};
+
+my $update_delay = $options{'update-delay'} // 1;
+my $log = Mojo::Log->new;
+$log->level($options{verbose} ? 'debug' : 'info');
+$log->debug('Loading tinycv');
+cv::init;
+require tinycv;
+
+my $image_path = '/tmp/vnc-framebuffer.png' // $ENV{VNC_TEST_TEMP_IMAGE_PATH};
+unlink $image_path;
+exec "$Bin/debugviewer/debugviewer", $image_path if fork == 0;
+
+$log->info('Initializing VNC');
+my $vnc = consoles::VNC->new(%options);
+my $incremental = 0;
+$vnc->login;
+
+while(1) {
+    $log->info('Send update request');
+    $vnc->send_update_request($incremental);
+    $incremental = 1;
+    $log->debug('Updating frame buffer');
+    if ($vnc->update_framebuffer) {
+        my $frame_buffer = $vnc->_framebuffer;
+        $log->debug($frame_buffer ? 'Update received, has frame buffer' : 'Update received');
+        $frame_buffer->write($image_path) if $frame_buffer;
+    }
+    sleep $update_delay;
+}


### PR DESCRIPTION
* See particular commit messages and https://progress.opensuse.org/issues/113201
* ~~See commit on https://github.com/Martchus/os-autoinst-distri-opensuse/commits/svirt-vmware-vnc-cfg/lib/susedistribution.pm for required changed to the test distribution~~
    * ~~So this change has only an effect if `VMWARE_VNC_OVER_WS` is set to a truthy value (otherwise the VNC console is used as-is, without attempting to use WebSockets).~~
* One only needs to set `VMWARE_VNC_OVER_WS=1` (as documented in `backend_vars.md`) to use it