### PR TITLE
Revert "Fix endian conversion in VNC code for s390x/ppc64"

### DIFF
--- a/ppmclibs/tinycv_impl.cc
+++ b/ppmclibs/tinycv_impl.cc
@@ -649,11 +649,11 @@ static uint16_t read_u16(const unsigned char* data, size_t& offset,
 {
     uint16_t pixel;
     if (do_endian_conversion) {
-        pixel =  (data[offset++] >> 0);
-        pixel |= (data[offset++] >> 8);
+        pixel = data[offset++] * 256;
+        pixel += data[offset++];
     } else {
-        pixel = *(uint16_t*)(data + offset);
-        offset += 2;
+        pixel = data[offset++];
+        pixel += data[offset++] * 256;
     }
     return pixel;
 }
@@ -669,10 +669,13 @@ Vec3b VNCInfo::read_pixel(const unsigned char* data, size_t& offset)
         pixel = read_u16(data, offset, do_endian_conversion);
     } else if (bytes_per_pixel == 4) {
         if (do_endian_conversion) {
-            pixel =  (data[offset++] >> 0);
-            pixel |= (data[offset++] >> 8);
-            pixel |= (data[offset++] >> 16);
-            pixel |= (data[offset++] >> 24);
+            pixel = data[offset++];
+            pixel <<= 8;
+            pixel |= data[offset++];
+            pixel <<= 8;
+            pixel |= data[offset++];
+            pixel <<= 8;
+            pixel |= data[offset++];
         } else {
             pixel = *(uint32_t*)(data + offset);
             offset += 4;


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst#2093 due to problems described in https://progress.opensuse.org/issues/111608 as well as https://github.com/os-autoinst/os-autoinst/pull/2093