### PR TITLE
Fix using little-endian VNC server on big-endian

### DIFF
--- a/ppmclibs/tinycv_impl.cc
+++ b/ppmclibs/tinycv_impl.cc
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <sys/time.h>
+#include <byteswap.h>
 
 #include <algorithm> // std::min
 #include <vector>
@@ -647,13 +648,10 @@ void image_map_raw_data_rgb555(Image* a, const unsigned char* data)
 static uint16_t read_u16(const unsigned char* data, size_t& offset,
     bool do_endian_conversion)
 {
-    uint16_t pixel;
+    uint16_t pixel = *(uint16_t*)(data + offset);
+    offset += 2;
     if (do_endian_conversion) {
-        pixel = data[offset++] * 256;
-        pixel += data[offset++];
-    } else {
-        pixel = data[offset++];
-        pixel += data[offset++] * 256;
+        pixel = bswap_16(pixel);
     }
     return pixel;
 }
@@ -668,17 +666,10 @@ Vec3b VNCInfo::read_pixel(const unsigned char* data, size_t& offset)
     if (bytes_per_pixel == 2) {
         pixel = read_u16(data, offset, do_endian_conversion);
     } else if (bytes_per_pixel == 4) {
+        pixel = *(uint32_t*)(data + offset);
+        offset += 4;
         if (do_endian_conversion) {
-            pixel = data[offset++];
-            pixel <<= 8;
-            pixel |= data[offset++];
-            pixel <<= 8;
-            pixel |= data[offset++];
-            pixel <<= 8;
-            pixel |= data[offset++];
-        } else {
-            pixel = *(uint32_t*)(data + offset);
-            offset += 4;
+            pixel = bswap_32(pixel);
         }
     } else if (bytes_per_pixel == 1) {
         pixel = data[offset++];


### PR DESCRIPTION
* Fix connecting to a little-endian VNC server from a big-endian
  system
* Use byte swap functions instead of custom code to swap the
  byte order
    * The bswap_32()/bswap_16() functions have the same
      behavior as our custom code on little-endian systems and
      therefore this change should not do anything on
      little-endian systems.
    * The bswap_32()/bswap_16() functions change the byte order
      also on big-endian systems (in contrast to our custom
      code).
* The VNC consoles test has been updated to test both cases
  (byte order swap necassary and not necassary). Before it
  only tested the case of a little-endian VNC server (and was
  therefore only failing on bit-endian systems before this
  change).
* Tested the behavior on x86_64 and also on a Tumbleweed
  ppc64 VM.
* See https://progress.opensuse.org/issues/111608.