### PR TITLE
Fix error from stricter git permission checks

### DIFF
--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -12,15 +12,16 @@ use bmwqemu;
 use autotest;
 use Try::Tiny;
 
-our @EXPORT_OK = qw(checkout_git_repo_and_branch checkout_git_refspec
-  handle_generated_assets load_test_schedule);
+our @EXPORT_OK = qw(git_rev_parse checkout_git_repo_and_branch
+  checkout_git_refspec handle_generated_assets load_test_schedule);
+
+sub git_rev_parse($dirname) {
+    chomp(my $version = (-d "$dirname/.git" ? qx{git -C $dirname rev-parse HEAD} : '') || 'UNKNOWN');
+    return $version;
+}
 
 sub calculate_git_hash ($git_repo_dir) {
-    my $dir = getcwd();
-    chdir($git_repo_dir);
-    chomp(my $git_hash = qx{git rev-parse HEAD ||:});
-    $git_hash ||= "UNKNOWN";
-    chdir($dir);
+    my $git_hash = git_rev_parse($git_repo_dir);
     bmwqemu::diag "git hash in $git_repo_dir: $git_hash";
     return $git_hash;
 }

--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -16,7 +16,7 @@ our @EXPORT_OK = qw(git_rev_parse checkout_git_repo_and_branch
   checkout_git_refspec handle_generated_assets load_test_schedule);
 
 sub git_rev_parse($dirname) {
-    chomp(my $version = (-d "$dirname/.git" ? qx{git -C $dirname rev-parse HEAD} : '') || 'UNKNOWN');
+    chomp(my $version = (-e "$dirname/.git" ? qx{git -C $dirname rev-parse HEAD} : '') || 'UNKNOWN');
     return $version;
 }
 

--- a/isotovideo
+++ b/isotovideo
@@ -80,7 +80,7 @@ use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 Getopt::Long::Configure("no_ignore_case");
 use OpenQA::Isotovideo::CommandHandler;
 use OpenQA::Isotovideo::Interface;
-use OpenQA::Isotovideo::Utils qw(checkout_git_repo_and_branch
+use OpenQA::Isotovideo::Utils qw(git_rev_parse checkout_git_repo_and_branch
   checkout_git_refspec handle_generated_assets load_test_schedule);
 
 session->enable;
@@ -94,9 +94,7 @@ sub usage ($r) {
 }
 
 sub _get_version_string () {
-    my $dirname = curfile->dirname;
-    my $thisversion = (-d "$dirname/.git" ? qx{git -C $dirname rev-parse HEAD} : '') || 'unknown';
-    chomp $thisversion;
+    my $thisversion = git_rev_parse(curfile->dirname);
     return "Current version is $thisversion [interface v$OpenQA::Isotovideo::Interface::version]";
 }
 

--- a/t/20-openqa-isotovideo-utils.t
+++ b/t/20-openqa-isotovideo-utils.t
@@ -53,4 +53,6 @@ subtest 'error handling when loading test schedule' => sub {
     };
 };
 
+is_deeply OpenQA::Isotovideo::Utils::_store_asset(0, 'foo.qcow2', 'bar'), {hdd_num => 0, name => 'foo.qcow2', dir => 'bar', format => 'qcow2'}, '_store_asset returns correct parameters';
+
 done_testing;

--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -29,6 +29,7 @@ note("pool dir: $pool_dir");
 chdir($pool_dir);
 my $cleanup = scope_guard sub { chdir $Bin; undef $dir };
 
+my $casedir = path($data_dir, 'tests');
 path('vars.json')->spurt(<<EOV);
 {
    "ARCH" : "i386",
@@ -36,7 +37,7 @@ path('vars.json')->spurt(<<EOV);
    "QEMU" : "i386",
    "QEMU_NO_TABLET" : "1",
    "QEMU_NO_FDC_SET" : "1",
-   "CASEDIR" : "$data_dir/tests",
+   "CASEDIR" : "$casedir",
    "ISO" : "$data_dir/Core-7.2.iso",
    "CDMODEL" : "ide-cd",
    "HDDMODEL" : "ide-hd",

--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -49,6 +49,8 @@ EOV
 path('live_log')->touch;
 system("cd $toplevel_dir && perl $toplevel_dir/isotovideo --workdir $pool_dir -d 2>&1 | tee $pool_dir/autoinst-log.txt");
 my $log = path('autoinst-log.txt')->slurp;
+my $version = -e "$toplevel_dir/.git" ? qr/[a-f0-9]+/ : 'UNKNOWN';
+like $log, qr/Current version is $version [interface v[0-9]+]/, 'version read from git';
 like $log, qr/\d*: EXIT 0/, 'test executed fine';
 like $log, qr/\d* Snapshots are supported/, 'Snapshots are enabled';
 unlike $log, qr/Tests died:/, 'Tests did not fail within modules' or diag "autoinst-log.txt: $log";


### PR DESCRIPTION
git version 2.35 introduced strict checks on directory ownership
refusing to operate on directories not owned by the user calling git.
In the case of openQA tests not running from openQA worker cache
synchronized test distributions this caused the git revision of test
distribution directories to be not parsed and ending up as 'UNKNOWN',
our fallback string.

This commit fixes this problem by adding the requested git directory to
the list of "safe directories" in the user's global git config. This of
course means that the user account must be able to write to the
according config file.

Production verification run: https://openqa.opensuse.org/tests/2454002

Related progress issue: https://progress.opensuse.org/issues/113030