### PR TITLE
testapi: Save time in "wait_screen_change" with "no_wait" option as well

### DIFF
--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -9,7 +9,7 @@ use Mojo::Base -strict, -signatures;
 # -> increment on every change of such APIs
 # -> never move that variable to another place (when refactoring)
 #    because it may be accessed by the tests itself
-our $version = 26;
+our $version = 27;
 
 # major version of the (web socket) API relevant to the developer mode
 # -> increment when making non-backward compatible changes to that API

--- a/testapi.pm
+++ b/testapi.pm
@@ -1324,9 +1324,7 @@ Special characters naming:
 =cut
 
 sub send_key {    # no:style:signatures
-    my $key = shift;
-    my %args = (@_ == 1) ? (do_wait => +shift()) : @_;
-    $args{do_wait} //= 0;
+    my ($key, %args) = @_;
     $args{wait_screen_change} //= 0;
     bmwqemu::log_call(key => $key, %args);
     if ($args{wait_screen_change}) {

--- a/testapi.pm
+++ b/testapi.pm
@@ -559,6 +559,13 @@ sub assert_and_dclick ($mustmatch, %args) {
     return assert_and_click($mustmatch, %args);
 }
 
+# with 'no_wait' actually wait a little bit not to waste too much CPU
+# corresponding to what check_screen/assert_screen also does
+# internally
+sub _sleep_screen_check ($args) {
+    sleep($args->{no_wait} ? 0.01 : 0.5);
+}
+
 =head2 wait_screen_change
 
   wait_screen_change(CODEREF [,$timeout [, similarity_level => 50]]);
@@ -612,7 +619,7 @@ sub wait_screen_change : prototype(&@) {    # no:style:signatures
             bmwqemu::fctres("screen change seen at " . (time - $starttime));
             return 1;
         }
-        sleep(0.5);
+        _sleep_screen_check(\%args);
     }
     save_screenshot;
     bmwqemu::fctres("timed out");
@@ -688,10 +695,7 @@ sub wait_still_screen {    # no:style:signatures
             bmwqemu::fctres("detected same image for $stilltime seconds, last detected similarity is $sim");
             return 1;
         }
-        # with 'no_wait' actually wait a little bit not to waste too much CPU
-        # corresponding to what check_screen/assert_screen also does
-        # internally
-        sleep($args{no_wait} ? 0.01 : 0.5);
+        _sleep_screen_check(\%args);
     }
     $autotest::current_test->timeout_screenshot();
     bmwqemu::fctres("wait_still_screen timed out after $timeout, last detected similarity is $sim");

--- a/testapi.pm
+++ b/testapi.pm
@@ -1328,7 +1328,7 @@ sub send_key {    # no:style:signatures
     $args{wait_screen_change} //= 0;
     bmwqemu::log_call(key => $key, %args);
     if ($args{wait_screen_change}) {
-        wait_screen_change { query_isotovideo('backend_send_key', {key => $key}) };
+        wait_screen_change(sub { query_isotovideo('backend_send_key', {key => $key}) }, undef, %args);
     }
     else {
         query_isotovideo('backend_send_key', {key => $key});
@@ -1455,7 +1455,7 @@ sub type_string {    # no:style:signatures
     }
     for my $piece (@pieces) {
         if ($wait) {
-            wait_screen_change { query_isotovideo('backend_type_string', {text => $piece, max_interval => $max_interval}); };
+            wait_screen_change(sub { query_isotovideo('backend_type_string', {text => $piece, max_interval => $max_interval}) }, undef, %args);
         }
         else {
             query_isotovideo('backend_type_string', {text => $piece, max_interval => $max_interval});


### PR DESCRIPTION
This commit also checks for the "no_wait" option in "wait_screen_change"
same as we already do in other cases like "check_screen/assert_screen"
and "wait_still_screen".

Hotpatched w7 with:

```
curl -sS https://patch-diff.githubusercontent.com/raw/os-autoinst/os-autoinst/pull/2109.patch | patch -p1 --directory=/usr/lib/os-autoinst
```

Triggered verification run with:

```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15173 https://openqa.opensuse.org/tests/2450411 SCHEDULE=tests/boot/boot_to_desktop,tests/x11/chromium WORKER_CLASS=openqaworker7 TEST=okurz_poo109737_wait_screen_change_with_no_wait
```

Created job #2453477: opensuse-Tumbleweed-DVD-x86_64-Build20220704-extra_tests_gnome@64bit -> https://openqa.opensuse.org/t2453477

Related progress issue: https://progress.opensuse.org/issues/109737