### PR TITLE
Prevent passwords leaked to log by redundant log-message

### DIFF
--- a/consoles/video_base.pm
+++ b/consoles/video_base.pm
@@ -30,8 +30,6 @@ sub _typing_limit () { $bmwqemu::vars{TYPING_LIMIT} // TYPING_LIMIT_DEFAULT || 1
 sub send_key_event ($key, $press_release_delay) { }
 
 sub type_string ($self, $args) {
-    bmwqemu::log_call(%$args, $args->{secret} ? (-masked => $args->{text}) : ());
-
     my $seconds_per_keypress = 1 / _typing_limit;
 
     # further slow down if being asked for.


### PR DESCRIPTION
Commit 4e66dcc0 introduced duplicate log messages with leaked passwords
like this:

```
susedistribution::handle_password_prompt -> lib/susedistribution.pm:70 called testapi::type_password
[2022-07-06T12:06:05.534656+02:00] [debug] <<< testapi::type_string(string="[masked]", max_interval=100, wait_screen_change=0, wait_still_screen=0, timeout=30, similarity_level=47)
[2022-07-06T12:06:05.535894+02:00] [debug] <<< consoles::video_base::type_string(max_interval=100, cmd="backend_type_string", json_cmd_token="HWQIViIt", text="nots3cr3t")
```

We should not need the second log message at all and also it's not
properly handling the password so I am suggesting to simply remove it
completely.

Related progress issue: https://progress.opensuse.org/issues/113312