### PR TITLE
Increase timeout for local VNC connections to prevent incompletes

### DIFF
--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -133,9 +133,9 @@ sub login ($self, $connect_timeout = undef, $timeout = undef) {
     my $port = $self->port || 5900;
     my $description = $self->description || 'VNC server';
     my $is_local = $hostname =~ qr/(localhost|127\.0\.0\.\d+|::1)/;
-    my $local_timeout = $bmwqemu::vars{VNC_TIMEOUT_LOCAL} // 10;
+    my $local_timeout = $bmwqemu::vars{VNC_TIMEOUT_LOCAL} // 60;
     my $remote_timeout = $bmwqemu::vars{VNC_TIMEOUT_REMOTE} // 60;
-    my $local_connect_timeout = $bmwqemu::vars{VNC_CONNECT_TIMEOUT_LOCAL} // $local_timeout;
+    my $local_connect_timeout = $bmwqemu::vars{VNC_CONNECT_TIMEOUT_LOCAL} // 20;
     my $remote_connect_timeout = $bmwqemu::vars{VNC_CONNECT_TIMEOUT_REMOTE} // 240;
     $connect_timeout //= $is_local ? $local_connect_timeout : $remote_connect_timeout;
     $timeout //= $is_local ? $local_timeout : $remote_timeout;


### PR DESCRIPTION
Especially on slow workers like aarch64 we've seen incompletes since
d1adda78adc34c5ac02b5040a2bc0e97eaa83827 and
93ff454deae61e573a9cbf88f172304002fb83a4 have been deployed. These commits
applied the VNC timeouts for also for reads/writes on the socket (which
were previously only applied to establishing the connection).

Apparently the timeout of 10 seconds for local connections is too low for
slow systems like the o3 worker aarch64 leading to incompletes like
`backend died: unexpected end of data at
/usr/lib/os-autoinst/consoles/VNC.pm line 183.`.

I increased the timeouts on that worker to the values of this change and
none of the 582 jobs ran into the problem anymore. So it is likely a more
sensible default.

Note that the error handling could still be improved, e.g. to re-connect
instead of just stopping the backend.

Related ticket: https://progress.opensuse.org/issues/113282