### PR TITLE
t: Increase timeout for scripts

### DIFF
--- a/t/44-scripts.t
+++ b/t/44-scripts.t
@@ -24,9 +24,9 @@ for my $key (keys %types) {
 }
 
 for my $script (sort keys %types) {
-    my $out = qx{timeout 3 $Bin/../$script --help 2>&1};
-    my $rc = $?;
-    is($rc, 0, "Calling '$script --help' returns exit code 0") or diag "Output: $out";
+    my $out = qx{timeout 8 $Bin/../$script --help 2>&1};
+    my $rc = $? >> 8;
+    is $rc, 0, "Calling '$script --help' returns exit code 0" or diag "Output($script): $out";
 }
 
 done_testing;


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/113141

Especially on aarch64 builds it can happen that a command like
`isotovideo --help` exceeds the 3 seconds timeout.

Since we have the overall OpenQA::Test::TimeLimit I think it's ok to
increase the timeout.