### PR TITLE
Stop showing ipmi password in error ouput

### DIFF
--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -41,8 +41,9 @@ sub ipmitool ($self, $cmd, %args) {
     }
     chomp $stdout;
     chomp $stderr;
+    # Output error message with ipmi password masked
+    die join(' ', map { $_ eq $bmwqemu::vars{IPMI_PASSWORD} ? "[masked]" : $_ } @cmd) . ": $stderr" unless ($ret);
 
-    die join(' ', @cmd) . ": $stderr" unless ($ret);
     bmwqemu::diag("IPMI: $stdout");
     return $stdout;
 }

--- a/t/29-backend-ipmi.t
+++ b/t/29-backend-ipmi.t
@@ -25,6 +25,7 @@ my @ipmi_cmdline = $backend->ipmi_cmdline;
 is_deeply \@ipmi_cmdline, [qw(ipmitool -I lanplus -H fake_HOSTNAME -U fake_USER -P fake_PASSWORD)], 'valid ipmi_cmdline';
 
 my $ipmi = Test::MockModule->new('backend::ipmi');
+throws_ok { $backend->ipmitool('foo') } qr/[masked]/, 'ipmi password masked in error output';
 $ipmi->redefine(ipmi_cmdline => sub { (qw(echo simulating ipmi)) });
 my $ret;
 combined_like { $ret = $backend->ipmitool('foo') } qr/IPMI: simulating ipmi foo/, 'log output for IPMI call';


### PR DESCRIPTION
Stop showing ipmi passwords in autoinst.txt from a ipmi backend job. 

The error output is changed to:
```
[2022-07-13T03:02:30.777057-04:00] [info] ::: backend::baseclass::die_handler: Backend process died, backend errors are reported below in the following lines:
  ipmitool -I lanplus -H 10.67.135.53 -U tester -P <secret> mc guid: Error: Unable to establish IPMI v2 / RMCP+ session at /usr/lib/os-autoinst/backend/ipmi.pm line 48.
```

- ticket: https://progress.opensuse.org/issues/110227
- verification run: http://10.67.129.102/tests/298


@kalikiana @okurz @alice-suse and others, welcome review!
