### PR TITLE
Fix git version readout from sub-directory + tests

### DIFF
--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -14,9 +14,9 @@ use Try::Tiny;
 our @EXPORT_OK = qw(git_rev_parse checkout_git_repo_and_branch
   checkout_git_refspec handle_generated_assets load_test_schedule);
 
-sub git_rev_parse ($dirname) {
+sub git_rev_parse ($dirname, $cmd_prefix = '') {
     $dirname = path($dirname)->realpath;
-    chomp(my $version = qx{git -C "$dirname" rev-parse HEAD 2>&1});
+    chomp(my $version = qx{$cmd_prefix git -C "$dirname" rev-parse HEAD 2>&1});
     return $version if $? == 0;
     return 'UNKNOWN' unless $version =~ /(git config.*safe.directory.*$)/;
     my $addsafe = 'TMPDIR=$(mktemp -d --tmpdir os-autoinst-git.XXXXX) && HOME=$TMPDIR && ' . $1;

--- a/t/20-openqa-isotovideo-utils.t
+++ b/t/20-openqa-isotovideo-utils.t
@@ -27,6 +27,9 @@ qr/git hash in.*UNKNOWN/, 'checkout_git_refspec also detects UNKNOWN';
 my $toplevel_dir = "$Bin/..";
 my $version = -e "$toplevel_dir/.git" ? qr/[a-f0-9]+/ : qr/UNKNOWN/;
 like git_rev_parse($toplevel_dir), $version, 'can parse working copy version (if it is git)';
+note 'call again git_rev_parse under different user (if available)';
+qx{command -v sudo >/dev/null && sudo -u nobody true};
+like git_rev_parse($toplevel_dir, 'sudo -u nobody'), $version, 'can parse git version as different user' if $? == 0;
 
 subtest 'error handling when loading test schedule' => sub {
     chdir($dir);


### PR DESCRIPTION
* Add test for git version reading as non-owner
* Add back support for reading layered test distribution's git versions
* t: Add unit tests for 'git_rev_parse' and 'checkout_git_refspec'