### PR TITLE
send_key_until_needlematch: Avoid check_screen timeout in the first iteration

### DIFF
--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -9,7 +9,7 @@ use Mojo::Base -strict, -signatures;
 # -> increment on every change of such APIs
 # -> never move that variable to another place (when refactoring)
 #    because it may be accessed by the tests itself
-our $version = 26;
+our $version = 27;
 
 # major version of the (web socket) API relevant to the developer mode
 # -> increment when making non-backward compatible changes to that API

--- a/testapi.pm
+++ b/testapi.pm
@@ -1378,13 +1378,16 @@ sub send_key_until_needlematch {
 
     $counter //= 20;
     $timeout //= 1;
-    while (!check_screen($tag, $timeout)) {
+
+    my $real_timeout = 0;
+    while (!check_screen($tag, $real_timeout)) {
         wait_screen_change {
             send_key $key;
         };
         if (!$counter--) {
             assert_screen $tag, 1;
         }
+        $real_timeout = $timeout;
     }
 }
 


### PR DESCRIPTION
When send_key_until_needlematch is called, the key was not pressed yet, so
the expected state is either already there or won't automatically appear,
so don't waste time waiting for it. Instead press the key immediately if
check_screen fails.

VR: http://10.168.4.168/tests/1232