### PR TITLE
Update the CI building to Tumbleweed as well

### DIFF
--- a/tools/check-perl-style
+++ b/tools/check-perl-style
@@ -1,3 +1,3 @@
 #!/bin/sh -e
-export PERL5LIB=tools/lib/perlcritic:$PERL5LIB
+export PERL5LIB=tools/lib/perlcritic:"$PERL5LIB"
 "${1:-perlcritic}" --gentle --include Perl::Critic::Policy::HashKeyQuote "${2:-$PWD}"

--- a/tools/container_run_ci
+++ b/tools/container_run_ci
@@ -39,7 +39,7 @@ done
 
 CI_ENV=$(bash <(curl -s https://codecov.io/env))
 
-IMAGE=registry.opensuse.org/devel/openqa/containers15.3/os-autoinst_dev
+IMAGE=registry.opensuse.org/devel/openqa/containers-tw/os-autoinst_dev
 build_dir="${build_dir:-"build"}"  # default is in accordance with file path in `.github/workflows/ci.yml`
 cre="${cre:-"podman"}"
 $cre pull $IMAGE

--- a/tools/install-new-deps.sh
+++ b/tools/install-new-deps.sh
@@ -19,7 +19,6 @@ listdeps > $OLDDEPS
 DEPS=($(getdeps_container))
 
 sudo zypper --no-refresh install -y -C "${DEPS[@]}"
-sudo zypper --no-refresh install -y --oldpackage libslirp0=4.3.1-1.51
 
 listdeps > $NEWDEPS
 

--- a/tools/invoke-tests
+++ b/tools/invoke-tests
@@ -44,7 +44,8 @@ export PERL5LIB="$source_directory:$source_directory/ppmclibs/blib/lib:$source_d
 if [[ $WITH_COVER_OPTIONS ]]; then
     path_regex="^|$source_directory/|\\.\\./"
     select="($path_regex)(OpenQA|backend|consoles|ppmclibs)/|($path_regex)isotovideo|($path_regex)[^/]+\.pm,-ignore,external/|\.t|data/tests/|fake/tests/|/CheckGitStatus.pm|$prove_path"
-    export PERL5OPT="-I$source_directory/t/lib -I$source_directory/external/os-autoinst-common/lib -MOpenQA::Test::CheckGitStatus -MDevel::Cover=-db,$db,-select,$select,-coverage,statement -MOpenQA::Test::PatchDeparse"
+    # add ' -MOpenQA::Test::PatchDeparse' for older OS versions to avoid warnings
+    export PERL5OPT="-I$source_directory/t/lib -I$source_directory/external/os-autoinst-common/lib -MOpenQA::Test::CheckGitStatus -MDevel::Cover=-db,$db,-select,$select,-coverage,statement"
 fi
 # set variables for tests which need to invoke the make tool
 export OS_AUTOINST_BUILD_DIRECTORY=$build_directory


### PR DESCRIPTION
After upgrading the Dockerfile which should trigger OBS to build a new
Tumbleweed based container image we should use it in CI accordingly.

After:
* https://github.com/os-autoinst/os-autoinst/pull/2124

Related progress issue: https://progress.opensuse.org/issues/111881