### PR TITLE
container: Fix missing 'useradd' in newer distributions

### DIFF
--- a/container/os-autoinst_dev/Dockerfile
+++ b/container/os-autoinst_dev/Dockerfile
@@ -33,6 +33,7 @@ RUN zypper in -y -C \
        qemu \
        qemu-tools \
        qemu-x86 \
+       shadow \
        sudo \
        which \
        xorg-x11-Xvnc \

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -51,6 +51,7 @@ devel_requires:
 
 docker_requires:
   pkgconfig(opencv):
+  shadow:
   sudo:
   which:
 


### PR DESCRIPTION
With the switch to opensuse/tumbleweed as a base the command "useradd"
was not available anymore because dependencies in the base layer changed
hence we should specify the dependency for the commands we need
explicitly.

This time I actually tested with

```
podman build container/os-autoinst_dev
```