### PR TITLE
CI: Also run container build tests in pull requests on changes

### DIFF
--- a/.github/workflows/ci_extended.yml
+++ b/.github/workflows/ci_extended.yml
@@ -1,7 +1,13 @@
 ---
 name: ci extended
 # yamllint disable-line rule:truthy
-on: push
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - 'container/**'
 jobs:
   test-containers:
     runs-on: ubuntu-latest

--- a/container/os-autoinst_dev/Dockerfile
+++ b/container/os-autoinst_dev/Dockerfile
@@ -33,6 +33,7 @@ RUN zypper in -y -C \
        qemu \
        qemu-tools \
        qemu-x86 \
+       shadow \
        sudo \
        which \
        xorg-x11-Xvnc \

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -51,6 +51,7 @@ devel_requires:
 
 docker_requires:
   pkgconfig(opencv):
+  shadow:
   sudo:
   which:
 


### PR DESCRIPTION
We already have container tests but so far ran these only after a push
to the master branch, likely due to them being potentially more
heavy-weight and long-running. What we can do is to run them
unconditionally on pushes to the master branch but also always run them
in pull request CI runs but only if the 'container/' path is touched,
e.g. changes to the Dockerfile files.