### PR TITLE
Fix logging of hold_key and release_key calls

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -1343,7 +1343,7 @@ Hold one C<$key> until release it
 
 sub hold_key {
     my ($key) = @_;
-    bmwqemu::log_call('hold_key', key => $key);
+    bmwqemu::log_call(key => $key);
     query_isotovideo('backend_hold_key', {key => $key});
 }
 
@@ -1357,7 +1357,7 @@ Release one C<$key> which is kept holding
 
 sub release_key {
     my $key = shift;
-    bmwqemu::log_call('release_key', key => $key);
+    bmwqemu::log_call(key => $key);
     query_isotovideo('backend_release_key', {key => $key});
 }
 


### PR DESCRIPTION
The method name is taken implicitly, passing it as argument breaks the
display of key-value pairs.