### PR TITLE
Make lowercase settings fatal

### DIFF
--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -9,7 +9,7 @@ use Mojo::Base -strict, -signatures;
 # -> increment on every change of such APIs
 # -> never move that variable to another place (when refactoring)
 #    because it may be accessed by the tests itself
-our $version = 28;
+our $version = 29;
 
 # major version of the (web socket) API relevant to the developer mode
 # -> increment when making non-backward compatible changes to that API

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -301,7 +301,7 @@ sub wait_for_one_more_screenshot () { sleep 1 }
 package bmwqemu::tiedvars;
 use Tie::Hash;
 use base qw/ Tie::StdHash /;    # no:style prevent style warning regarding use of Mojo::Base and base in this file
-use Carp ();
+use Carp 'croak';
 
 sub TIEHASH ($class, %args) {
     my $self = bless {
@@ -310,7 +310,7 @@ sub TIEHASH ($class, %args) {
 }
 
 sub STORE ($self, $key, $val) {
-    warn Carp::longmess "Settings key '$key' is invalid" unless $key =~ m/^(?:[A-Z0-9_]+)\z/;
+    croak("Settings key '$key' is invalid (check your test settings)") unless $key =~ m/^(?:[A-Z0-9_]+)\z/;
     $self->{data}->{$key} = $val;
 }
 

--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -156,10 +156,12 @@ subtest 'HDD variables sanity check' => sub {
 
 subtest 'invalid vars characters' => sub {
     my $num = scalar %bmwqemu::vars;
-    like warning { $bmwqemu::vars{lowercase_not_accepted} = 23 }, qr{Settings key 'lowercase_not_accepted' is invalid.*12-bmwqemu.t}s, 'Warning is issued for invalid setting keys';
+    throws_ok { $bmwqemu::vars{lowercase_not_accepted} = 23 } qr{Settings key 'lowercase_not_accepted' is invalid.*12-bmwqemu.t}s, 'Invalid keys results in an exception';
+    $bmwqemu::vars{LOWERCASE_NOT_ACCEPTED} = 23;
     my $new_num = %bmwqemu::vars;
     is $new_num, $num + 1, '%vars in scalar context works';
-    is exists $bmwqemu::vars{lowercase_not_accepted}, 1, 'exists $vars{...} works';
+    is exists $bmwqemu::vars{lowercase_not_accepted}, '', 'exists $vars{...} works, lowercase key not found';
+    is exists $bmwqemu::vars{LOWERCASE_NOT_ACCEPTED}, 1, 'exists $vars{...} works';
 };
 
 my %new_json = (foo => 'bar', baz => 42);


### PR DESCRIPTION
Avoid red herring, by removing a warning that should be a fatal error.

https://progress.opensuse.org/issues/113528#note-9