### PR TITLE
End color escape sequences at the end of the line

### DIFF
--- a/log.pm
+++ b/log.pm
@@ -33,34 +33,35 @@ sub log_format_callback ($time, $level, @items) {
 sub diag (@args) {
     confess "missing input" unless @args;
     logger->append(color('white'));
-    logger->debug(@args)->append(color('reset'));
+    $args[-1] .= color('reset');
+    logger->debug(@args);
     return;
 }
 
 sub fctres ($text, $fname = undef) {
     $fname //= (caller(1))[3];
     logger->append(color('green'));
-    logger->debug(">>> $fname: $text")->append(color('reset'));
+    logger->debug(">>> $fname: $text" . color('reset'));
     return;
 }
 
 sub fctinfo ($text, $fname = undef) {
     $fname //= (caller(1))[3];
     logger->append(color('yellow'));
-    logger->info("::: $fname: $text")->append(color('reset'));
+    logger->info("::: $fname: $text" . color('reset'));
     return;
 }
 
 sub fctwarn ($text, $fname = undef) {
     $fname //= (caller(1))[3];
     logger->append(color('red'));
-    logger->warn("!!! $fname: $text")->append(color('reset'));
+    logger->warn("!!! $fname: $text" . color('reset'));
     return;
 }
 
 sub modstate (@text) {
     logger->append(color('bold blue'));
-    logger->debug("||| @{[join(' ', @text)]}")->append(color('reset'));
+    logger->debug("||| @{[join(' ', @text)]}" . color('reset'));
     return;
 }
 


### PR DESCRIPTION
Before the end sequence was only added after the line including
the line feed was printed.

That can lead to confusing things, like code using the log output
and inserting something at the beginning, or trying to match something
at the beginning of the line, which won't work because there is the
color control sequence.

Before:

    ESC[32m[2022-07-25T18:16:56.666317+02:00] [debug] >>> : res
    ESC[0mESC[33m[2022-07-25T18:16:56.666397+02:00] [info] ::: : info
    ESC[0mESC[31m[2022-07-25T18:16:56.666430+02:00] [warn] !!! : warn
    ESC[0mESC[1;34m[2022-07-25T18:16:56.666458+02:00] [debug] ||| 1 2 3
    ESC[0mESC[37m[2022-07-25T18:16:56.666483+02:00] [debug] a
      b
      c
    ESC[0m

After:

    ESC[32m[2022-07-25T18:30:18.924681+02:00] [debug] >>> foo::foo: resESC[0m
    ESC[33m[2022-07-25T18:30:18.924759+02:00] [info] ::: foo::foo: infoESC[0m
    ESC[31m[2022-07-25T18:30:18.924790+02:00] [warn] !!! foo::foo: warnESC[0m
    ESC[1;34m[2022-07-25T18:30:18.924816+02:00] [debug] ||| 1 2 3ESC[0m
    ESC[37m[2022-07-25T18:30:18.924840+02:00] [debug] a
      b
      cESC[0m