### PR TITLE
Fix re-connecting via VNC over WebSockets

### DIFF
--- a/consoles/VMWare.pm
+++ b/consoles/VMWare.pm
@@ -117,7 +117,7 @@ sub launch_vnc_server ($self, $listen_port) {
 
 sub deduce_url_from_vars ($vnc_console) {
     return undef unless $bmwqemu::vars{VMWARE_VNC_OVER_WS};
-    return undef unless $vnc_console->hostname eq ($bmwqemu::vars{VIRSH_GUEST} // '');
+    return undef unless ($vnc_console->original_hostname // $vnc_console->hostname) eq ($bmwqemu::vars{VIRSH_GUEST} // '');
     my $host = $bmwqemu::vars{VMWARE_HOST} or die "VMWARE_VNC_OVER_WS set but not VMWARE_HOST\n";
     my $user = $bmwqemu::vars{VMWARE_USERNAME} // 'root';
     my $password = $bmwqemu::vars{VMWARE_PASSWORD} or die "VMWARE_VNC_OVER_WS set but not VMWARE_PASSWORD\n";
@@ -128,6 +128,7 @@ sub setup_for_vnc_console ($vnc_console) {
     return undef unless my $ws_url = $vnc_console->vmware_vnc_over_ws_url // deduce_url_from_vars($vnc_console);
     my $self = $vnc_console->{_vmware_handler} //= consoles::VMWare->new;
     log::diag 'Establishing VNC connection over WebSockets via ' . Mojo::URL->new($ws_url)->to_string;
+    $vnc_console->original_hostname($vnc_console->hostname) unless $vnc_console->original_hostname;
     $vnc_console->hostname('127.0.0.1');
     $vnc_console->description('VNC over WebSockets server provided by VMWare');
     $self->configure_from_url($ws_url);

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -18,7 +18,7 @@ has [qw(description hostname port username password socket name width height dep
       no_endian_conversion  _pixinfo _colourmap _framebuffer _rfb_version screen_on
       _bpp _true_colour _do_endian_conversion absolute ikvm keymap _last_update_received
       _last_update_requested check_vnc_stalls _vnc_stalled vncinfo old_ikvm dell
-      vmware_vnc_over_ws_url)];
+      vmware_vnc_over_ws_url original_hostname)];
 
 our $VERSION = '0.40';
 


### PR DESCRIPTION
* Before overriding the VNC hostname to `127.0.0.1` (to connect to
  `dewebsockify`), save the original hostname.
* When checking whether VNC over WebSockets should be enabled, compare the
  configured `VIRSH_GUEST` with the saved hostname and not the overridden
  one.
* This should fix the problem of the first test mentioned in
  https://progress.opensuse.org/issues/114820