### PR TITLE
spec: Exclude t/27-consoles-vmware.t on OBS

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -173,8 +173,9 @@ Convenience package providing os-autoinst + s390 worker jumphost dependencies.
 # and exclude known flaky tests in OBS check
 # https://progress.opensuse.org/issues/52652
 # 07-commands: https://progress.opensuse.org/issues/60755
+# 27-consoles-vmware: https://progress.opensuse.org/issues/114881
 # 29-backend-driver: https://progress.opensuse.org/issues/105061
-for i in 07-commands 13-osutils 14-isotovideo 18-qemu-options 18-backend-qemu 29-backend-driver 99-full-stack; do
+for i in 07-commands 13-osutils 14-isotovideo 18-qemu-options 18-backend-qemu 27-consoles-vmware 29-backend-driver 99-full-stack; do
     rm t/$i.t
 done
 # exclude unnecessary author tests


### PR DESCRIPTION
This unit test runs into the timeout on OBS very early and it doesn't look like a longer timeout would help.

See: https://progress.opensuse.org/issues/114881