### PR TITLE
Implement QEMU backend support for arbitrary CPU topology

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -872,7 +872,14 @@ sub start_qemu ($self) {
         }
 
         sp('device', 'usb-kbd') if $use_usb_kbd;
-        sp('smp', $vars->{QEMUTHREADS} ? [qv "$vars->{QEMUCPUS} threads=$vars->{QEMUTHREADS}"] : $vars->{QEMUCPUS});
+
+        my $smp_config = [$vars->{QEMUCPUS}];
+        for my $key (qw(QEMUSOCKETS QEMUDIES QEMUCLUSTERS QEMUCORES QEMUTHREADS)) {
+            my $qkey = lc($key =~ s/^QEMU//r);
+            push @$smp_config, "$qkey=$vars->{$key}" if exists $vars->{$key};
+        }
+        sp('smp', $smp_config);
+
         if ($vars->{QEMU_NUMA}) {
             for my $i (0 .. ($vars->{QEMUCPUS} - 1)) {
                 my $m = int($vars->{QEMURAM} / $vars->{QEMUCPUS});

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -135,12 +135,16 @@ QEMU_QMP_CONNECT_ATTEMPTS;integer;20;The number of attempts to connect to qemu q
 PATHCNT;integer;2;Number of paths in MULTIPATH scenario
 PXEBOOT;boolean or 'once';0;Boot VM from network, on every boot or only once if set to 'once'
 QEMU;QEMU binary filename;undef;Filename of QEMU binary to use
+QEMUCLUSTERS;integer;undef;Number of CPU clusters used by VM
+QEMUCORES;integer;undef;Number of CPU cores used by VM
 QEMUCPU;see qemu -cpu ?;undef;CPU to emulate
 QEMUCPUS;integer;1;Number of CPUs to assign to VM
+QEMUDIES;integer;undef;Number of CPU dies used by VM
 QEMUMACHINE;see qemu -machine ?;undef;Machine and chipset to emulate
 QEMUPORT;integer;20002 + worker instance * 10;Port on which QEMU monitor should listen
 QEMURAM;integer;1024;Size of RAM of VM in MiB
-QEMUTHREADS;integer;0;Number of cpu threads used by VM
+QEMUSOCKETS;integer;undef;Number of CPU sockets used by VM
+QEMUTHREADS;integer;undef;Number of CPU threads used by VM
 QEMUTPM;'instance' or appropriate value for local swtpm config;undef;Configure VM to use a TPM emulator device, with appropriate args for the arch. If a TPM device is available at QEMUTPM_PATH_PREFIX + X, where X is the value of QEMUTPM or the worker instance number if QEMUTPM is set to 'instance', it will be used. Otherwise it will be created at test startup. See QEMUTPM_VER in the latter case.
 QEMUTPM_VER;'1.2' or '2.0' depending on which TPM chip should be emulated;'2.0';If no TPM device has been setup otherwise, swtpm will be used internally to create one with a socket at /tmp/mytpmX
 QEMUTPM_PATH_PREFIX;string;'/tmp/mytpm';Path prefix to use or create TPM emulator device in


### PR DESCRIPTION
Add job settings `QEMUSOCKETS`, `QEMUDIES`, `QEMUCLUSTERS` and `QEMUCORES` for configuring arbitrary CPU topology.

It turns out that PR #2140 was not sufficient to fix the NUMA issues. It helped on PPC64LE but now other archs are complaining about invalid NUMA configuration during boot. The underlying cause is that [QEMU 6.2 changed the default CPU topology](https://www.qemu.org/docs/master/system/invocation.html) from creating multiple CPU sockets to creating multiple cores on the same socket. So let's add the necessary configuration options to create the CPU topology we need in NUMA tests.