### PR TITLE
Fix nr. of keys sent in send_key_until_needlematch

### DIFF
--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -9,7 +9,7 @@ use Mojo::Base -strict, -signatures;
 # -> increment on every change of such APIs
 # -> never move that variable to another place (when refactoring)
 #    because it may be accessed by the tests itself
-our $version = 27;
+our $version = 28;
 
 # major version of the (web socket) API relevant to the developer mode
 # -> increment when making non-backward compatible changes to that API

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -947,7 +947,7 @@ subtest 'send_key_until_needlematch' => sub {
     $mock_testapi->unmock('send_key');
     $fake_needle_found = $fake_needle_found_after_pause = 0;
     $cmds = [];
-    throws_ok(sub { send_key_until_needlematch('tag', 'esc', 2); },
+    throws_ok(sub { send_key_until_needlematch('tag', 'esc', 3); },
         qr/assert_screen reached/,
         'no candidate needle matched tags'
     );

--- a/testapi.pm
+++ b/testapi.pm
@@ -1365,7 +1365,7 @@ sub release_key {
 
   send_key_until_needlematch($tag, $key [, $counter, $timeout]);
 
-Send specific key until needle with C<$tag> is not matched or C<$counter> is 0.
+Send specific key until needle with C<$tag> is matched or C<$counter> is 0.
 C<$tag> can be string or C<ARRAYREF> (C<['tag1', 'tag2']>)
 Default counter is 20 steps, default timeout is 1s
 
@@ -1384,7 +1384,7 @@ sub send_key_until_needlematch {
         wait_screen_change {
             send_key $key;
         };
-        if (!$counter--) {
+        if (--$counter <= 0) {
             assert_screen $tag, 1;
         }
         $real_timeout = $timeout;


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/107749 

the function `send_key_until_needlematch()` is documented to send the key at maximum _n_ times, but is sending the key _n+1_ times before failing. By looking at the test [`03-testapi.t`](https://github.com/os-autoinst/os-autoinst/blob/515dc27b2e6625c01b3a5b6d90b441cda2d5bba2/t/03-testapi.t#L950) , 'esc' key is sent two times and then [checked for three times](https://github.com/os-autoinst/os-autoinst/blob/515dc27b2e6625c01b3a5b6d90b441cda2d5bba2/t/03-testapi.t#L962). 

This is an issue for some scenarios, for example, if an even number of keypresses is required, as is the case of maximizing and unmaximizing a window, by sending an even number of alt-f10.

This PR aims to correct both the unit test and the API behavior. 