### PR TITLE
Check if SSH password is defined explicitly

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -1143,7 +1143,7 @@ sub new_ssh_connection ($self, %args) {
     while ($counter > 0) {
         if ($ssh->connect($args{hostname}, $args{port})) {
 
-            if ($args{password}) {
+            if (defined($args{password})) {
                 $ssh->auth(username => $args{username}, password => $args{password});
             }
             else {


### PR DESCRIPTION
When creating a new SSH connection, if the password is an empty string
the statement `if ($args{password})` will be false

Using `defined()` will instead allow for the correct behaviour, meaning
an empty password can be used correctly