### PR TITLE
[WIP] tools/tidy: Pass checked modules by relative path

### DIFF
--- a/tools/tidy
+++ b/tools/tidy
@@ -24,9 +24,9 @@ EOF
 }
 
 set -eo pipefail
-dir="$(dirname "$0")"
+dir="$(dirname "$(realpath -s "$0")")"
 
-args=""
+args="--conf-file $dir/../.tidyallrc"
 selection='--all'
 [[ -e "$dir/perlfiles" ]] && selection=$("$dir"/perlfiles)
 opts=$(getopt -o hcfol --long help,check,force,only-changed,list -n "$0" -- "$@") || usage
@@ -55,8 +55,8 @@ perltidy_version_expected=$(sed -n "s/^.*Perl::Tidy[^0-9]*\([0-9]*\)['];$/\1/p" 
 # This might be used from another repo like os-autoinst-distri-opensuse
 if [ -z "${perltidy_version_expected}" ]; then
     # No cpanfile in the linked repo, use the one from os-autoinst instead
-    dir="$(dirname "$(readlink -f "$0")")"
-    perltidy_version_expected=$(sed -n "s/^.*Perl::Tidy[^0-9]*\([0-9]*\)['];$/\1/p" "$dir"/../cpanfile)
+    cpanfile_dir="$(dirname "$(readlink -f "$0")")"
+    perltidy_version_expected=$(sed -n "s/^.*Perl::Tidy[^0-9]*\([0-9]*\)['];$/\1/p" "$cpanfile_dir"/../cpanfile)
 fi
 perltidy_version_found=$(perltidy -version | sed -n '1s/^.*perltidy, v\([0-9]*\)\s*$/\1/p')
 if [ "$perltidy_version_found" != "$perltidy_version_expected" ]; then
@@ -68,12 +68,6 @@ if [ "$perltidy_version_found" != "$perltidy_version_expected" ]; then
         exit 1
     fi
 fi
-
-# go to caller directory
-cd "$dir/.."
-
-# just to make sure we are at the right location
-test -e tools/tidy || exit 1
 
 # shellcheck disable=SC2086
 tidyall $args $filename


### PR DESCRIPTION
Previously tidy script did cd to os-autoinst root directory.
This allowed to use path of checked modules from git root directory
(i.e. git ls-files output).

But because this script is symlinked to os-autoinst-distri-opensuse git,
it required to specify full path instead of relative. Removing cd to
root directory allows to always specify relative path from current
working directory, which is convenient, because script is mostly run
from root directory in both git repositories.

Changes:
* Remove cd to upper directory from tools/ and replace it with
  --conf-file $dir/../.tidyallrc. The config file contains
  --profile=$ROOT/.perltidyrc, which is working to locate .perltidyrc
  from any location.
* Remove check -e tools/tidy.


NOTE: this will allow to move `tidy` script to https://github.com/os-autoinst/os-autoinst-common, so that it does not have to be synced over and over again.