### PR TITLE
Execute VMWare test on PowerPC again as instability should be fixed

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -181,10 +181,6 @@ done
 rm xt/00-tidy.t
 # Remove test relying on a git working copy
 rm xt/30-make.t
-# https://progress.opensuse.org/issues/114881
-%ifarch ppc64le
-rm t/27-consoles-vmware.t
-%endif
 
 %build
 %define __builder ninja


### PR DESCRIPTION
Hopefully 725152a7d481e0cb7404f683aa22dae093261809 fixed the instability of
that test which lead to sporadic test failures (especially on PowerPC).

See https://progress.opensuse.org/issues/114881