### PR TITLE
CI minor cleanup

### DIFF
--- a/tools/container_run_ci
+++ b/tools/container_run_ci
@@ -55,7 +55,10 @@ if [[ \"$cre\" == \"docker\" && \"$ID\" == \"opensuse-leap\" ]]; then
     zypper -n --gpg-auto-import-keys --no-gpg-checks refresh
     zypper -n in --from qemu qemu qemu-x86 qemu-tools qemu-ipxe qemu-sgabios qemu-seabios
 fi
-[[ \"$target\" == \"coverage-codecovbash\" ]] && zypper -n in perl-App-cpanminus && cpanm -nq 'Devel::Cover::Report::Codecovbash'
+if [[ \"$target\" == \"coverage-codecovbash\" ]]; then
+	zypper -n in perl-App-cpanminus
+	cpanm -nq 'Devel::Cover::Report::Codecovbash'
+fi
 cd /opt
 ./tools/install-new-deps.sh
 export CI=1 WITH_COVER_OPTIONS=1 CHECK_GIT_STATUS=1

--- a/tools/container_run_ci
+++ b/tools/container_run_ci
@@ -47,7 +47,7 @@ $cre images | grep opensuse
 
 # shellcheck disable=SC2086
 $cre run --env "QEMU_QMP_CONNECT_ATTEMPTS=10" \
-  $CI_ENV --rm --entrypoint '' -v "$PWD":/opt $IMAGE sh -ec "
+  $CI_ENV --rm --entrypoint '' -v "$PWD":/opt $IMAGE bash -ec "
 . /etc/os-release
 if [[ \"$cre\" == \"docker\" && \"$ID\" == \"opensuse-leap\" ]]; then
     echo 'Newer docker versions need a patched qemu with disabled membarrier'

--- a/tools/tidy
+++ b/tools/tidy
@@ -55,8 +55,8 @@ perltidy_version_expected=$(sed -n "s/^.*Perl::Tidy[^0-9]*\([0-9]*\)['];$/\1/p" 
 # This might be used from another repo like os-autoinst-distri-opensuse
 if [ -z "${perltidy_version_expected}" ]; then
     # No cpanfile in the linked repo, use the one from os-autoinst instead
-    dir="$(dirname "$(readlink -f "$0")")"
-    perltidy_version_expected=$(sed -n "s/^.*Perl::Tidy[^0-9]*\([0-9]*\)['];$/\1/p" "$dir"/../cpanfile)
+    cpanfile_dir="$(dirname "$(readlink -f "$0")")"
+    perltidy_version_expected=$(sed -n "s/^.*Perl::Tidy[^0-9]*\([0-9]*\)['];$/\1/p" "$cpanfile_dir"/../cpanfile)
 fi
 perltidy_version_found=$(perltidy -version | sed -n '1s/^.*perltidy, v\([0-9]*\)\s*$/\1/p')
 if [ "$perltidy_version_found" != "$perltidy_version_expected" ]; then


### PR DESCRIPTION
* tools/container_run_ci: Always run cpanm
Fix occasional error `Error: codecovbash is not a recognised output format`.

* tools/tidy: Do not overwrite path to root dir
Fix unwanted cd to os-autoinst directory

@perlpunk @Martchus @kalikiana FYI
