### PR TITLE
Disable VMWare test for all archs as it is generally unstable

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -182,9 +182,7 @@ rm xt/00-tidy.t
 # Remove test relying on a git working copy
 rm xt/30-make.t
 # https://progress.opensuse.org/issues/114881
-%ifarch ppc64le
 rm t/27-consoles-vmware.t
-%endif
 
 %build
 %define __builder ninja


### PR DESCRIPTION
The test has also timed out a few times on x86_64 builds. The logs are not
very helpful so for now it is likely best to disable the test to keep the
CI going.

See https://progress.opensuse.org/issues/114881