### PR TITLE
Extend tests of IPMI backend or mark lines as uncoverable

### DIFF
--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -128,7 +128,7 @@ sub do_mc_reset ($self) {
     }
 
     # during the eval execution of following commands, SIG{__DIE__} will definitely be triggered, let it go
-    local $SIG{__DIE__} = {};
+    local $SIG{__DIE__} = sub { };
 
     # mc reset cmd should return immediately, try maximum 5 times to ensure cmd executed
     my $max_tries = $bmwqemu::vars{IPMI_MC_RESET_MAX_TRIES} // 5;

--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -157,10 +157,10 @@ sub do_mc_reset ($self) {
                         return;
                     }
                 }
-                sleep 3;
+                sleep 3;    # uncoverable statement
             }
         }
-        sleep 3;
+        sleep 3;    # uncoverable statement
     }
 
     die "IPMI mc reset failure after $max_tries tries! Exit...";


### PR DESCRIPTION
* Mark lines with sleep as uncoverable as it is likely not worth extending
  the tests for these cases
* Extend tests to cover otherwise uncovered lines
* See https://progress.opensuse.org/issues/111254