### PR TITLE
Allow following Perl testsuite output during package builds

### DIFF
--- a/cmake/test-targets.cmake
+++ b/cmake/test-targets.cmake
@@ -79,8 +79,9 @@ endif ()
 
 # add targets for invoking Perl test suite
 find_program(PROVE_PATH prove)
+find_program(UNBUFFER_PATH unbuffer)
 if (PROVE_PATH)
-    set(INVOKE_TEST_ARGS --prove-tool "${PROVE_PATH}" --make-tool "${CMAKE_MAKE_PROGRAM}" --build-directory "${CMAKE_CURRENT_BINARY_DIR}")
+    set(INVOKE_TEST_ARGS --prove-tool "${PROVE_PATH}" --make-tool "${CMAKE_MAKE_PROGRAM}" --unbuffer-tool "${UNBUFFER_PATH}" --build-directory "${CMAKE_CURRENT_BINARY_DIR}")
     add_test(
         NAME test-perl-testsuite
         COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tools/invoke-tests" ${INVOKE_TEST_ARGS}

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -83,6 +83,8 @@ Source0:        %{name}-%{version}.tar.xz
 %define devel_requires %python_style_requires %test_requires ShellCheck perl(Code::TidyAll) perl(Devel::Cover) perl(Devel::Cover::Report::Codecov) perl(Perl::Tidy) perl(Template::Toolkit)
 %define s390_zvm_requires /usr/bin/xkbcomp /usr/bin/Xvnc x3270 icewm xterm xterm-console xdotool fonts-config mkfontdir mkfontscale
 BuildRequires:  %test_requires %test_version_only_requires
+# For unbuffered output of Perl testsuite, especially when running it on OBS so timestamps in the log are actually useful
+BuildRequires:  expect
 Requires:       %main_requires
 Recommends:     tesseract-ocr
 Recommends:     dumponlyconsole %s390_zvm_requires
@@ -214,7 +216,7 @@ export CI=1
 export OPENQA_TEST_TIMEOUT_SCALE_CI=20
 # Enable verbose test output as we can not store test artifacts within package
 # build environments in case of needing to investigate failures
-export PROVE_ARGS="--timer -v"
+export PROVE_ARGS="--timer -v --nocolor"
 cd %{__builddir}
 %cmake_build check-pkg-build
 

--- a/tools/invoke-tests
+++ b/tools/invoke-tests
@@ -11,15 +11,16 @@ options:
     --coverage         record test coverage
     --prove-tool       prove tool to use (defaults to prove)
     --make-tool        make tool to use (defaults to make)
+    --unbuffer-tool    unbuffer tool to use (defaults to unbuffer)
     --build-directory  build directory (defaults to $source_directory)"
     exit
 }
 
 # parse arguments
-prove_path=prove make_path=make build_directory=$source_directory
+prove_path=prove make_path=make unbuffer_path=unbuffer build_directory=$source_directory
 opts=$(getopt \
     --options h \
-    --longoptions help,coverage,skip-if-cover-db-exists,prove-tool:,make-tool:,build-directory: \
+    --longoptions help,coverage,skip-if-cover-db-exists,prove-tool:,make-tool:,unbuffer-tool:,build-directory: \
     --name "$(basename "$0")" -- "$@") || usage
 eval set -- "$opts"
 while [[ $# -gt 0 ]]; do
@@ -29,6 +30,7 @@ while [[ $# -gt 0 ]]; do
     --skip-if-cover-db-exists ) SKIP_IF_COVER_DB_EXISTS=1; shift   ;;
     --prove-tool              ) prove_path=$2;             shift 2 ;;
     --make-tool               ) make_path=$2;              shift 2 ;;
+    --unbuffer-tool           ) unbuffer_path=$2;          shift 2 ;;
     --build-directory         ) build_directory=$2;        shift 2 ;;
     --                        ) shift; break ;;
     *                         ) break ;;
@@ -50,6 +52,11 @@ fi
 export OS_AUTOINST_BUILD_DIRECTORY=$build_directory
 export OS_AUTOINST_MAKE_TOOL=$make_path
 
+args=()
+# use unbuffer if it was found so e.g. timestamps on OBS builds will be useful
+# note: When executing tests with prove it seems that the output is only flushed after one test has finished unless there's a terminal.
+[[ $unbuffer_path ]] && [[ $unbuffer_path != 'UNBUFFER_PATH-NOTFOUND' ]] && args+=("$unbuffer_path")
 # split TESTS on white-spaces to allow specifying multiple tests as documented
-# shellcheck disable=SC2086
-(cd "$source_directory" && "$prove_path" $PROVE_ARGS ${TESTS:-"-r"})
+# shellcheck disable=SC2206
+args+=("$prove_path" $PROVE_ARGS ${TESTS:-"-r"})
+(cd "$source_directory" && "${args[@]}")


### PR DESCRIPTION
Turns out that this is only a problem of `prove` when it is not running within a terminal. New commit message:

When running the Perl testsuite via `prove` then output will be buffered
when a pipe is used, e.g. making timestamps on OBS useless.

One can easily see the difference locally by invoking e.g.
```
TESTS="t/27-consoles-vmware.t" PROVE_ARGS=-v  ninja check-pkg-build | ts
```
before and after this change.

---

Old commit message (not really relevant anymore):

So far the Perl testsuite is invoked via CTest when the `check-pkg-build` target is invoked. This unfortunately doesn't allow following the Perl testsuite output and CTest is only emitting the Perl testsuite output as one big chunk at the end, making the timestamps in OBS logs useless.

This change will invoke such tests not within CTest. Since we're using Perl's own test framework here anyways this should be fine. Now, the Perl testsuite is always executed first. If it fails no other tests are executed and the failure summary of the Perl testsuite is clearly visible. If the Perl testsuite succeeds, other tests on CMake level are executed via CTest as usual.

---

This will hopefull help debugging issues like
https://progress.opensuse.org/issues/114881 where it is otherwise not clear whether and at which point a test hangs or is slow.