### PR TITLE
testapi: Optimize compat_args()'s handling of one fixed parameter

### DIFF
--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -690,6 +690,7 @@ subtest 'compat_args' => sub {
 
     is_deeply({testapi::compat_args(\%def_args, [], a => 'Y', b => 666, k => 5)}, {a => 'Y', b => 666, c => $def_args{c}, k => 5}, 'Additional parameter 1');
     is_deeply({testapi::compat_args(\%def_args, [], k => 5)}, {a => $def_args{a}, b => $def_args{b}, c => $def_args{c}, k => 5}, 'Additional parameter 2');
+    is_deeply({testapi::compat_args(\%def_args, ['c'], k => 5)}, {a => $def_args{a}, b => $def_args{b}, c => $def_args{c}, k => 5}, 'Additional parameter - one fixed parameter');
     is_deeply({testapi::compat_args(\%def_args, ['c'], 666, k => 5)}, {a => $def_args{a}, b => $def_args{b}, c => 666, k => 5}, 'Additional parameter 3');
 
     like(warning { testapi::compat_args(\%def_args, [], a => 'Z', 'outch') }->[0], qr/^Odd number of arguments/, 'Warned on Odd number 1');

--- a/testapi.pm
+++ b/testapi.pm
@@ -2280,18 +2280,17 @@ A typical call would look like:
 
 =cut
 
-sub compat_args {    # no:style:signatures
-    my ($def_args, $fix_keys) = splice(@_, 0, 2);
+sub compat_args ($def_args, $fix_keys, @args) {
     my %ret;
     if (@$fix_keys == 1) {
-        $ret{$fix_keys->[0]} = shift if ((@_ % 2) != 0);
+        $ret{$fix_keys->[0]} = shift @args if ((@args % 2) != 0);
     } else {
         for my $key (@{$fix_keys}) {
-            $ret{$key} = shift if (@_ >= 1 && (!defined($_[0]) || !exists $def_args->{$_[0]}));
+            $ret{$key} = shift @args if (@args >= 1 && (!defined($args[0]) || !exists $def_args->{$args[0]}));
         }
     }
-    carp("Odd number of arguments") unless ((@_ % 2) == 0);
-    %ret = (%{$def_args}, %ret, @_);
+    carp("Odd number of arguments") unless ((@args % 2) == 0);
+    %ret = (%{$def_args}, %ret, @args);
     map { $ret{$_} //= $def_args->{$_} } keys(%{$def_args});
     return %ret;
 }

--- a/testapi.pm
+++ b/testapi.pm
@@ -2283,8 +2283,12 @@ A typical call would look like:
 sub compat_args {    # no:style:signatures
     my ($def_args, $fix_keys) = splice(@_, 0, 2);
     my %ret;
-    for my $key (@{$fix_keys}) {
-        $ret{$key} = shift if (scalar(@_) >= 1 && (!defined($_[0]) || !grep { $_ eq $_[0] } keys(%{$def_args})));
+    if (@$fix_keys == 1) {
+        $ret{$fix_keys->[0]} = shift if ((@_ % 2) != 0);
+    } else {
+        for my $key (@{$fix_keys}) {
+            $ret{$key} = shift if (@_ >= 1 && (!defined($_[0]) || !exists $def_args->{$_[0]}));
+        }
     }
     carp("Odd number of arguments") unless ((@_ % 2) == 0);
     %ret = (%{$def_args}, %ret, @_);


### PR DESCRIPTION
With only one fixed parameter, the number of arguments specify
if the fixed parameter was given or not.
It makes the check for known named parameter keys obsolete and
allow additional parameters also in the first field (fixed parameter).