### PR TITLE
Fix resolution with virtio backend on new QEMU versions

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -680,7 +680,15 @@ sub start_qemu ($self) {
     elsif ($vars->{OFW}) {
         $use_usb_kbd = $self->qemu_params_ofw;
     }
-    sp('vga', $vars->{QEMUVGA}) if $vars->{QEMUVGA};
+    if (my $qemu_vga = $vars->{QEMUVGA}) {
+        if ($qemu_vga eq 'virtio') {
+            # specify EDID information explicitly to get consistent behavior across different QEMU versions
+            sp('device', "virtio-vga,edid=on,xres=$self->{xres},yres=$self->{yres}");
+        }
+        else {
+            sp('vga', $qemu_vga);
+        }
+    }
 
     my @nicmac;
     my @nicvlan;


### PR DESCRIPTION
The QEMU version 7.0.0 (currently in Tumbleweed) apparently changed the default EDID information when using the virtio backend so now the screen resolution is wrong once the graphical installer is shown. (The video parameter usually specified within GRUB only affects the console but the installer GUI makes its own EDID lookup.)

This change fixes the problem at least when `QEMUVGA` is set manually to `virtio`.

Note that `cirrus` doesn't seem to be affected.