### PR TITLE
Fix resolution for std/virtio backend on new QEMU versions

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -680,7 +680,15 @@ sub start_qemu ($self) {
     elsif ($vars->{OFW}) {
         $use_usb_kbd = $self->qemu_params_ofw;
     }
-    sp('vga', $vars->{QEMUVGA}) if $vars->{QEMUVGA};
+    if (my $qemu_vga = $vars->{QEMUVGA}) {
+        if ($qemu_vga eq 'virtio') {
+            # specify EDID information explicitly to get consistent behavior across different QEMU versions
+            sp('device', "virtio-vga,edid=on,xres=$self->{xres},yres=$self->{yres}");
+        }
+        else {
+            sp('vga', $qemu_vga);
+        }
+    }
 
     my @nicmac;
     my @nicvlan;

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -683,9 +683,10 @@ sub start_qemu ($self) {
     my $use_usb_kbd;
     my $arch = $vars->{ARCH} // '';
     $arch = 'arm' if ($arch =~ /armv6|armv7/);
+    my $is_arm = $arch eq 'aarch64' || $arch eq 'arm';
     my $custom_video_device = $vars->{QEMU_VIDEO_DEVICE} // 'virtio-gpu-pci';
 
-    if ($arch eq 'aarch64' || $arch eq 'arm') {
+    if ($is_arm) {
         my $video_device = ($vars->{QEMU_OVERRIDE_VIDEO_DEVICE_AARCH64}) ? 'VGA' : "${custom_video_device},xres=$self->{xres},yres=$self->{yres}";
         sp('device', $video_device);
         $arch_supports_boot_order = 0;
@@ -694,7 +695,7 @@ sub start_qemu ($self) {
     elsif ($vars->{OFW}) {
         $use_usb_kbd = $self->qemu_params_ofw;
     }
-    $self->_set_graphics_backend;
+    $self->_set_graphics_backend unless $is_arm;
 
     my @nicmac;
     my @nicvlan;

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -680,14 +680,17 @@ sub start_qemu ($self) {
     elsif ($vars->{OFW}) {
         $use_usb_kbd = $self->qemu_params_ofw;
     }
-    if (my $qemu_vga = $vars->{QEMUVGA}) {
-        if ($qemu_vga eq 'virtio') {
-            # specify EDID information explicitly to get consistent behavior across different QEMU versions
-            sp('device', "virtio-vga,edid=on,xres=$self->{xres},yres=$self->{yres}");
-        }
-        else {
-            sp('vga', $qemu_vga);
-        }
+
+    # set graphics backend
+    # note: Specifying EDID information explicitly for std/virtio backends to get consistent behavior across different QEMU
+    #       versions (as of QEMU 7.0.0 the default resolution is no longer 1024x768).
+    my $qemu_vga = $vars->{QEMUVGA};
+    if (!$qemu_vga || $qemu_vga eq 'std') {
+        sp('device', "VGA,edid=on,xres=$self->{xres},yres=$self->{yres}");
+    } elsif ($qemu_vga eq 'virtio') {
+        sp('device', "virtio-vga,edid=on,xres=$self->{xres},yres=$self->{yres}");
+    } else {
+        sp('vga', $qemu_vga);    # adding this only if not specifying a device; otherwise we'd end up with two graphic cards
     }
 
     my @nicmac;

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -111,6 +111,21 @@ subtest 'switch_network' => sub {
     $called{handle_qmp_command} = undef;
 };
 
+subtest 'setting graphics backend' => sub {
+    my @params;
+    local *backend::qemu::sp = sub (@args) { @params = @args };
+    $backend->_set_graphics_backend;
+    is_deeply \@params, [device => 'VGA,edid=on,xres=1024,yres=768'], 'consistent EDID info set for std backend (no QEMUVGA set)' or diag explain \@params;
+
+    $bmwqemu::vars{QEMUVGA} = 'virtio';
+    $backend->_set_graphics_backend;
+    is_deeply \@params, [device => 'virtio-vga,edid=on,xres=1024,yres=768'], 'consistent EDID info set for virtio backend' or diag explain \@params;
+
+    $bmwqemu::vars{QEMUVGA} = 'cirrus';
+    $backend->_set_graphics_backend;
+    is_deeply \@params, [vga => 'cirrus'], 'other backends passes as-is via "-vga" parameter' or diag explain \@params;
+};
+
 subtest 'execute arbitrary QMP command' => sub {
     my %query = (execute => 'foo', arguments => {bar => 1});
     $called{handle_qmp_command} = undef;


### PR DESCRIPTION
Based on #2170 but also covers the default graphics backend (`QEMUVGA` is `std` or not present at all). Also includes a test.