### PR TITLE
Deal with "append" options for QEMU backend

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -918,7 +918,16 @@ sub start_qemu ($self) {
     if ($vars->{QEMU_APPEND}) {
         # Split multiple options, if needed
         my @spl = split(' -', $vars->{QEMU_APPEND});
-        sp(split(' ', $_)) for @spl;
+        # Deal with multiple "append" options
+        foreach my $i (@spl) {
+            if (index($i, 'append') != -1) {
+                my @append_split = split('append', $i);
+                sp('append', $append_split[1]);
+             }
+             else {
+                sp(split(' ', $i));
+            }
+        }
     }
 
     create_virtio_console_fifo();


### PR DESCRIPTION
Currently only the first option to "append" passed via QEMU_APPEND will be passed to the kernel, so check for this and correctly app all command line appends