### PR TITLE
Improve performance of `wait_still_screen`

### DIFF
--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -27,13 +27,14 @@ use Test::MockModule;
 my $mod = Test::MockModule->new('myjsonrpc');
 my $fake_exit = 0;
 my $fake_matched = 1;
-my $fake_timeout = 0;
 
 # define variables for 'fake_read_json'
 my $report_timeout_called = 0;
 my $fake_pause_on_timeout = 0;
 my $fake_needle_found = 1;
 my $fake_needle_found_after_pause = 0;
+my $fake_timeout = 0;
+my $fake_similarity = 42;
 
 # define 'write_with_thumbnail' to fake image
 sub write_with_thumbnail (@) { }
@@ -88,8 +89,8 @@ sub fake_read_json ($fd) {
     elsif ($cmd eq 'backend_get_wait_still_screen_on_here_doc_input' || $cmd eq 'backend_set_reference_screenshot') {
         return {ret => 0};
     }
-    elsif ($cmd eq 'backend_wait_screen_change') {
-        return {ret => {sim => 42, elapsed => 5, timed_out => $fake_timeout}};
+    elsif ($cmd eq 'backend_wait_screen_change' || $cmd eq 'backend_wait_still_screen') {
+        return {ret => {sim => $fake_similarity, elapsed => 5, timed_out => $fake_timeout}};
     }
     else {
         note "mock method not implemented \$cmd: $cmd\n";
@@ -616,7 +617,8 @@ subtest save_tmp_file => sub {
 };
 
 subtest 'wait_still_screen & assert_still_screen' => sub {
-    $mod->redefine(read_json => {ret => {sim => 999}});
+    $fake_similarity = 999;
+    $fake_timeout = 0;
     $mock_bmwqemu->noop('log_call');
     ok(wait_still_screen, 'default arguments');
     ok(wait_still_screen(3), 'still time specified');
@@ -632,6 +634,8 @@ subtest 'wait_still_screen & assert_still_screen' => sub {
     $testapi->redefine(wait_still_screen => sub { die "wait_still_screen(@_)" });
     like(exception { assert_still_screen similarity_level => 9999; }, qr/wait_still_screen\(similarity_level 9999\)/,
         'assert_still_screen forwards arguments to wait_still_screen');
+    $fake_timeout = 1;
+    ok !wait_still_screen, 'falsy return value on timeout';
 };
 
 subtest 'test console::console argument settings' => sub {

--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -59,7 +59,7 @@ unlike $log, qr/script_run: DEPRECATED call of script_run.+die_on_timeout/, 'no 
 like $log, qr/do not wait_still_screen/, 'test type string and do not wait';
 like $log, qr/wait_still_screen: detected same image for 0.2 seconds/, 'test type string and wait for .2 seconds';
 like $log, qr/wait_still_screen: detected same image for 1 seconds/, 'test type string and wait for 1 seconds';
-like $log, qr/wait_still_screen: detected same image for 0.1 seconds/, 'test type string and wait for .1 seconds';
+like $log, qr/wait_still_screen: detected same image for 0\.1 seconds/, 'test type string and wait for .1 seconds';
 like $log, qr/.*event.*STOP/, 'Machine properly paused';
 like $log, qr/.*event.*RESUME/, 'Machine properly resumed';
 like $log, qr/get_test_data returned expected file/, 'get_test_data test';


### PR DESCRIPTION
* Move the loop in autotest polling the backend into the backend itself
  removing the sleep in autotest completely (similar to 05aa5cd)
* Lower the update frequency of the backend when `no_wait` is used (instead
  of just polling the backend more often)
* See https://progress.opensuse.org/issues/116554