### PR TITLE
Clarify test fail message to distinguish errors

### DIFF
--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -589,7 +589,7 @@ subtest 'validate_script_output' => sub {
     } qr/output not validating/, 'Die on output not match';
     throws_ok {
         validate_script_output('script', qr/error/)
-    } qr/output not validating/, 'Die on output not match';
+    } qr/output not validating/, 'Die on output not match for regex';
     throws_ok {
         validate_script_output('script', ['Invalid parameter'])
     } qr/coderef or regexp/, 'Die on invalid parameter';


### PR DESCRIPTION
Make the test output unique to be able to tell what exactly went wrong.