### PR TITLE
Dynamically obtain vmware datastore path

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -522,7 +522,7 @@ __END"
     # define the new domain
     $self->run_cmd("virsh $remote_vmm define $xmlfilename") && die "virsh define failed";
     if ($self->vmm_family eq 'vmware') {
-        my $vmx = sprintf('/vmfs/volumes/datastore1/openQA/%s.vmx', $self->name);
+        my $vmx = sprintf('/vmfs/volumes/%s/openQA/%s.vmx', $bmwqemu::vars{VMWARE_DATASTORE} // 'datastore1', $self->name);
 
         # set default boot delay
         $self->run_cmd("echo bios.bootDelay = \"10000\" >> $vmx", domain => 'sshVMwareServer');

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -217,7 +217,7 @@ VIRSH_INSTANCE;integer;;VM's instance number on VIRSH_HOSTNAME
 VMWARE_USERNAME;string;;Administrator's username ('@' is '%40')
 VMWARE_PASSWORD;string;;Administrator's password
 VMWARE_HOST;string;;VCS server for authentication
-VMWARE_DATASTORE;string;;VMware datastore
+VMWARE_DATASTORE;string;datastore1;VMware datastore
 VMWARE_NFS_DATASTORE;string;;VMware datastore with openQA NFS directories
 VMWARE_SERIAL_PORT;string;;TCP port where is VM's serial port stream to be expected on the ESX server
 VMWARE_BRIDGE;string;;VMware's bridge name (usual default is 'VM Network')


### PR DESCRIPTION
VMware datastore path should not be hardcode as its name is different on each ESXi server. Its value can be obtain from the variable 'VMWARE_DATASTORE'.

Failed job: https://openqa.suse.de/tests/9574488
```
[debug] [run_ssh_cmd(echo bios.bootDelay = "10000" >> /vmfs/volumes/datastore1/openQA/openQA-SUT-4.vmx)] stderr:
  sh: can't create /vmfs/volumes/datastore1/openQA/openQA-SUT-4.vmx: nonexistent directory
```

https://openqa.suse.de/tests/9574488/file/vars.json
`"VMWARE_DATASTORE": "Datastore2",`