### PR TITLE
Fix missing quotes output in vmx file

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -525,7 +525,7 @@ __END"
         my $vmx = sprintf('/vmfs/volumes/%s/openQA/%s.vmx', $bmwqemu::vars{VMWARE_DATASTORE} // 'datastore1', $self->name);
 
         # set default boot delay
-        $self->run_cmd("echo bios.bootDelay = \"10000\" >> $vmx", domain => 'sshVMwareServer');
+        $self->run_cmd(qq{echo 'bios.bootDelay = "10000"' >> $vmx}, domain => 'sshVMwareServer');
 
         # inject cloud init metadata and userdata required for the image if there are any
         my $ci_meta = $bmwqemu::vars{CLOUD_INIT_META};
@@ -533,10 +533,10 @@ __END"
         my $ci_encoding = $bmwqemu::vars{CLOUD_INIT_ENCODING};
 
         if ($ci_meta && $ci_user && $ci_encoding) {
-            $self->run_cmd("echo guestinfo.metadata = \"$ci_meta\" >> $vmx", domain => 'sshVMwareServer');
-            $self->run_cmd("echo guestinfo.metadata.encoding = \"$ci_encoding\" >> $vmx", domain => 'sshVMwareServer');
-            $self->run_cmd("echo guestinfo.userdata = \"$ci_user\" >> $vmx", domain => 'sshVMwareServer');
-            $self->run_cmd("echo guestinfo.userdata.encoding = \"$ci_encoding\" >> $vmx", domain => 'sshVMwareServer');
+            $self->run_cmd(qq{echo 'guestinfo.metadata = "$ci_meta"' >> $vmx}, domain => 'sshVMwareServer');
+            $self->run_cmd(qq{echo 'guestinfo.metadata.encoding = "$ci_encoding"' >> $vmx}, domain => 'sshVMwareServer');
+            $self->run_cmd(qq{echo 'guestinfo.userdata = "$ci_user"' >> $vmx}, domain => 'sshVMwareServer');
+            $self->run_cmd(qq{echo 'guestinfo.userdata.encoding = "$ci_encoding"' >> $vmx}, domain => 'sshVMwareServer');
         }
     }
 

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -129,7 +129,7 @@ subtest 'starting VMware console' => sub {
         $s . ' destroy openQA-SUT-1 |& grep -v "\\(failed to get domain\\|Domain not found\\)"',
         $s . ' undefine --snapshots-metadata openQA-SUT-1 |& grep -v "\\(failed to get domain\\|Domain not found\\)"',
         $s . ' define /var/lib/libvirt/images/openQA-SUT-1.xml',
-        'echo bios.bootDelay = "10000" >> /vmfs/volumes/datastore1/openQA/openQA-SUT-1.vmx',
+        'echo \'bios.bootDelay = "10000"\' >> /vmfs/volumes/datastore1/openQA/openQA-SUT-1.vmx',
         $s . ' start openQA-SUT-1 2> >(tee /tmp/os-autoinst-openQA-SUT-1-stderr.log >&2)',
         $s . ' dumpxml openQA-SUT-1'
     ], 'expected commands invoked' or diag explain \@cmds;
@@ -162,11 +162,11 @@ subtest 'starting VMware console with Cloud Init' => sub {
         $s . ' destroy openQA-SUT-1 |& grep -v "\\(failed to get domain\\|Domain not found\\)"',
         $s . ' undefine --snapshots-metadata openQA-SUT-1 |& grep -v "\\(failed to get domain\\|Domain not found\\)"',
         $s . ' define /var/lib/libvirt/images/openQA-SUT-1.xml',
-        'echo bios.bootDelay = "10000" >> /vmfs/volumes/datastore1/openQA/openQA-SUT-1.vmx',
-        'echo guestinfo.metadata = "test@meta" >> /vmfs/volumes/datastore1/openQA/openQA-SUT-1.vmx',
-        'echo guestinfo.metadata.encoding = "gzip+base64" >> /vmfs/volumes/datastore1/openQA/openQA-SUT-1.vmx',
-        'echo guestinfo.userdata = "test%user" >> /vmfs/volumes/datastore1/openQA/openQA-SUT-1.vmx',
-        'echo guestinfo.userdata.encoding = "gzip+base64" >> /vmfs/volumes/datastore1/openQA/openQA-SUT-1.vmx',
+        'echo \'bios.bootDelay = "10000"\' >> /vmfs/volumes/datastore1/openQA/openQA-SUT-1.vmx',
+        'echo \'guestinfo.metadata = "test@meta"\' >> /vmfs/volumes/datastore1/openQA/openQA-SUT-1.vmx',
+        'echo \'guestinfo.metadata.encoding = "gzip+base64"\' >> /vmfs/volumes/datastore1/openQA/openQA-SUT-1.vmx',
+        'echo \'guestinfo.userdata = "test%user"\' >> /vmfs/volumes/datastore1/openQA/openQA-SUT-1.vmx',
+        'echo \'guestinfo.userdata.encoding = "gzip+base64"\' >> /vmfs/volumes/datastore1/openQA/openQA-SUT-1.vmx',
         $s . ' start openQA-SUT-1 2> >(tee /tmp/os-autoinst-openQA-SUT-1-stderr.log >&2)',
         $s . ' dumpxml openQA-SUT-1'
     ], 'expected commands invoked' or diag explain \@cmds;


### PR DESCRIPTION
Since vmware 7.0 has more strict inspection on vmx file, we need to ensure the quotation mark output around the value while adding a new property in vmx file.

To resolve https://progress.opensuse.org/issues/117196, adding backslash to output quotation mark.