### PR TITLE
Make assert_script_sudo work properly in serial terminal

### DIFF
--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -334,15 +334,19 @@ subtest 'script_run' => sub {
     is(background_script_run('sleep 10', output => 'foo'), '1234', 'background_script_run with output returns valid PID');
 };
 
-sub assert_script_sudo_test ($is_serial_terminal) {
+sub assert_script_sudo_test () {
     my $mock_testapi = Test::MockModule->new('testapi');
     $mock_testapi->redefine(_handle_found_needle => sub { return $_[0] });
     $mock_testapi->noop(qw(send_key enter_cmd));
     $mock_testapi->redefine(hashed_string => 'XXX');
-    $mock_testapi->redefine(wait_serial => "XXX-0-");
-    my $info = $is_serial_terminal ? 'with serial_terminal' : 'without serial_terminal';
-    is(assert_script_sudo('echo foo'), undef, 'successfull assertion of script_sudo $info');
-    is(assert_script_sudo('bash'), undef, 'successfull assertion of script_sudo $info');
+    $mock_testapi->redefine(wait_serial => 'XXX-0-');
+    my $script_sudo = '';
+    $mock_testapi->redefine(script_sudo => sub { $script_sudo = "$_[0]" });
+    $mock_testapi->redefine(_set_assert_marker => 'marker');
+    is assert_script_sudo('echo foo'), undef, 'successful assertion of script_sudo (1)';
+    is $script_sudo, 'echo foo; marker', 'script_sudo called like expected(1)';
+    is assert_script_sudo('bash'), undef, 'successful assertion of script_sudo (2)';
+    is $script_sudo, 'bash; marker', 'script_sudo called like expected(2)';
 }
 
 sub set_assert_marker_test ($is_serial_terminal) {
@@ -350,15 +354,13 @@ sub set_assert_marker_test ($is_serial_terminal) {
     $mock_testapi->redefine(_handle_found_needle => sub { return $_[0] });
     $mock_testapi->redefine(is_serial_terminal => $is_serial_terminal);
     my $expected_output = $is_serial_terminal ? ' > /dev/null' : '';
-    require testapi;
-    is(testapi::_set_assert_marker('XXX'), "echo XXX-\$?-$expected_output", 'marker setter return correct string to the serial');
+    is testapi::_set_assert_marker('XXX'), "echo XXX-\$?-$expected_output", 'marker setter returns correct string to the serial';
 }
 
 subtest 'assert_script_sudo' => sub {
     subtest('_set_assert_marker redirects to serial devices on serial terminal', \&set_assert_marker_test, 0);
     subtest('_set_assert_marker returns correct marker on non-serial terminal', \&set_assert_marker_test, 1);
-    subtest('Test with is_serial_terminal==0', \&assert_script_sudo_test, 0);
-    subtest('Test with is_serial_terminal==1', \&assert_script_sudo_test, 1);
+    subtest('Test assert_script_sudo', \&assert_script_sudo_test);
 };
 
 subtest 'check_assert_screen' => sub {

--- a/testapi.pm
+++ b/testapi.pm
@@ -1012,6 +1012,12 @@ sub background_script_run {    # no:style:signatures
     return $distri->background_script_run($cmd, %args);
 }
 
+sub _set_assert_marker {
+    my ($hashed_string) = @_;
+    my $redirect_to_serial_console = is_serial_terminal() ? " > /dev/$serialdev" : '';
+    return "echo $hashed_string-\$?-$redirect_to_serial_console";
+}
+
 =head2 assert_script_sudo
 
   assert_script_sudo($command [, $wait]);
@@ -1030,7 +1036,8 @@ C<$serialdev>.
 sub assert_script_sudo {    # no:style:signatures
     my ($cmd, $wait) = @_;
     my $str = hashed_string("ASS$cmd");
-    script_sudo("$cmd; echo $str-\$?- > /dev/$serialdev", 0);
+    my $marker = _set_assert_marker($str);
+    script_sudo("$cmd; $marker", 0);
     my $ret = wait_serial("$str-\\d+-", $wait);
     $ret = ($ret =~ /$str-(\d+)-/)[0] if $ret;
     _handle_script_run_ret($ret, $cmd);

--- a/testapi.pm
+++ b/testapi.pm
@@ -1012,8 +1012,7 @@ sub background_script_run {    # no:style:signatures
     return $distri->background_script_run($cmd, %args);
 }
 
-sub _set_assert_marker {
-    my ($hashed_string) = @_;
+sub _set_assert_marker ($hashed_string) {
     my $redirect_to_serial_console = is_serial_terminal() ? " > /dev/$serialdev" : '';
     return "echo $hashed_string-\$?-$redirect_to_serial_console";
 }


### PR DESCRIPTION
When `is_serial_terminal` is used the output doesnt need redirection to the serial device. This causes the assertion to fail when the serial terminal is used.

Signed-off-by: ybonatakis <ybonatakis@suse.com>