### PR TITLE
Allow explicit use of SSH agent after 026c93c broke implicit use

### DIFF
--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -9,7 +9,7 @@ use Mojo::Base -strict, -signatures;
 # -> increment on every change of such APIs
 # -> never move that variable to another place (when refactoring)
 #    because it may be accessed by the tests itself
-our $version = 32;
+our $version = 33;
 
 # major version of the (web socket) API relevant to the developer mode
 # -> increment when making non-backward compatible changes to that API

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -1205,7 +1205,7 @@ sub new_ssh_connection ($self, %args) {
     while ($counter > 0) {
         if ($ssh->connect($args{hostname}, $args{port})) {
 
-            if (defined($args{password})) {
+            if (!$args{use_ssh_agent} && defined($args{password})) {
                 $ssh->auth(username => $args{username}, password => $args{password});
             }
             else {

--- a/consoles/sshSerial.pm
+++ b/consoles/sshSerial.pm
@@ -27,6 +27,7 @@ sub activate ($self) {
     my $hostname = $self->{args}->{hostname} || die('we need a hostname to ssh to');
     my $password = $self->{args}->{password} // $testapi::password;
     my $username = $self->{args}->{username} // 'root';
+    my $use_ssh_agent = $self->{args}->{use_ssh_agent} // 0;
     my $pty_cols = $self->{args}->{pty_cols} // 2048;
     my $port = $self->{args}->{port} // 22;
 
@@ -36,6 +37,7 @@ sub activate ($self) {
         hostname => $hostname,
         password => $password,
         username => $username,
+        use_ssh_agent => $use_ssh_agent,
         port => $port,
     );
     my $chan = $ssh->channel()

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -252,7 +252,9 @@ subtest 'SSH utilities' => sub {
     @agent = ();
     $baseclass->new_ssh_connection(%ssh_creds, password => '');
     is scalar @agent, 0, 'Empty password also accepted, auth_agent not called';
-    $ssh_expect->{password} = 'password';
+
+    $baseclass->new_ssh_connection(%ssh_creds, password => '', use_ssh_agent => 1);
+    is scalar @agent, 1, 'auth_agent called via "use_ssh_agent" despite empty password';
 
     # check run_ssh_cmd() usage
     is($baseclass->run_ssh_cmd('echo -n "foo"', %ssh_creds), 0, 'Command successful exit');
@@ -271,7 +273,7 @@ subtest 'SSH utilities' => sub {
     my @connected_ssh = grep { $_->{connected} } values(%$ssh_obj_data);
     my @disconnected_ssh = grep { !$_->{connected} } values(%$ssh_obj_data);
 
-    is(scalar(@connected_ssh), 7, "Expect 6 connected SSH connections");
+    is(scalar(@connected_ssh), 8, "Expect 8 connected SSH connections");
     is($ssh1->{connected}, 1, "SSH connection ssh1 connected");
     is($ssh2->{connected}, 1, "SSH connection ssh2 connected");
     is($ssh7->{connected}, 1, "SSH connection ssh7 connected");
@@ -286,7 +288,7 @@ subtest 'SSH utilities' => sub {
 
     $baseclass->close_ssh_connections();
     @connected_ssh = grep { $_->{connected} } values(%$ssh_obj_data);
-    is scalar @connected_ssh, 4, 'Expect 4 connected SSH connections (ssh1, ssh2 and ssh9)';
+    is scalar @connected_ssh, 5, 'Expect 5 connected SSH connections (ssh1, ssh2 and ssh9)';
     is($ssh1->{connected}, 1, "SSH connection ssh1 connected");
     is($ssh2->{connected}, 1, "SSH connection ssh2 connected");
     is($ssh9->{connected}, 1, "SSH connection ssh9 connected (user agent auth)");


### PR DESCRIPTION
With 026c93c is is possible use a falsy value as password which broke the ability to use a falsy value to imply SSH agent use. This change adds the possibility to use SSH agent back by explicitly specifying `use_ssh_agent => 1`.

See https://github.com/os-autoinst/os-autoinst/pull/2152#issuecomment-1272407524 and https://progress.opensuse.org/issues/117784