### PR TITLE
Disable merge commit message length check

### DIFF
--- a/.github/workflows/commit_message_checker.yml
+++ b/.github/workflows/commit_message_checker.yml
@@ -27,6 +27,7 @@ jobs:
           error: 'The maximum subject line length of 72 characters is exceeded.'
           excludeDescription: 'true'    # excludes the description body of a pull request
           excludeTitle: 'true'    # excludes the title of a pull request
+          excludeMergeCommits: 'true'    # optional: this excludes merge commits
           checkAllCommitMessages: 'true'    # checks all commits associated with a pull request
           accessToken: ${{ secrets.GITHUB_TOKEN }}    # only required if checkAllCommitMessages is true
       - name: Check Empty Line


### PR DESCRIPTION
If branch names are too long, the tests would fail.
This will only come into action when this is merged:
https://github.com/GsActions/commit-message-checker/pull/79

See https://progress.opensuse.org/issues/119464