### PR TITLE
Make blocking mode configurable for video encoder pipe

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -339,7 +339,7 @@ sub _invoke_video_encoder ($self, $pipe_name, $display_name, @cmd) {
     my $pid = open($self->{$pipe_name}, '|-', @cmd);
     my $pipe = $self->{$pipe_name};
     $self->{video_encoders}->{$pid} = {name => $display_name, pipe => $pipe, cmd => join ' ', @cmd};
-    $pipe->blocking(0);
+    $pipe->blocking(!!$bmwqemu::vars{VIDEO_ENCODER_BLOCKING_PIPE});
 }
 
 sub _start_external_video_encoder_if_configured ($self) {

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -46,6 +46,7 @@ UPLOAD_INACTIVITY_TIMEOUT;integer;300;Specifies the inactivity timeout in second
 NO_DEPRECATE_BACKEND_$backend;boolean;0;Only warn about deprecated backends instead of aborting
 XRES;integer;1024;Resolution of display on x axis. Sets the resolution of the video encoder, and in qemu, the initial console resolution when OFW is set (Power and SPARC), and the EDID resolution for devices that support EDID
 YRES;integer;768;Resolution of display on y axis. Sets the resolution of the video encoder, and in qemu, the initial console resolution when OFW is set (Power and SPARC), and the EDID resolution for devices that support EDID
+VIDEO_ENCODER_BLOCKING_PIPE;boolean;0;Whether the pipe for writing data to the video encoder should be blocking or not. Making it blocking might allow following the live view in realtime despite large screenshot file sizes but it is not a well tested configuration
 
 |====================
 


### PR DESCRIPTION
The pipe for the video encoder was hardcoded to be non-blocking. Some people may prefer to make it blocking for better user experince in the WebUI live view in cases where there are large screenshot file sizes