### PR TITLE
Migrate from codecov action v2 to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
       - name: Static checks, unit- and integration tests
         run: tools/container_run_ci
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
-          file: ./build/cover_db/codecov.json
+          files: ./build/cover_db/codecov.json
           fail_ci_if_error: true
           verbose: true
       - run: |


### PR DESCRIPTION
Noticed that there is already a v3 of the codecov uploader while investigating a problem with v2.

Progress: https://progress.opensuse.org/issues/120175