### PR TITLE
Show in developer mode when test is executing the post fail hook

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -294,6 +294,8 @@ sub post_run_hook ($self) {
 }
 
 sub run_post_fail ($self, $msg) {
+    my $name = $self->{name};
+    autotest::query_isotovideo(set_current_test => {name => $name, full_name => ($self->{fullname} // $name) . ' (post fail hook)'});
     my $post_fail_hook_start_time = time;
     unless ($bmwqemu::vars{_SKIP_POST_FAIL_HOOKS}) {
         $self->{post_fail_hook_running} = 1;

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -66,6 +66,8 @@ subtest run_post_fail_test => sub {
     combined_like { dies_ok { $basetest->runtest } 'run_post_fail end up with die' } qr/Test died/, 'test died';
     combined_like { dies_ok { $basetest->runtest } 'post fail hooks runtime' } qr/post fail hooks runtime:/,
       'Post fail hooks runtime present';
+    my %cmd = (cmd => 'set_current_test', name => 'foo', full_name => 'foo (post fail hook)');
+    is_deeply $cmds->[0], \%cmd, 'test name updated (to show post fail hook in developer mode)';
 
     $bmwqemu::vars{_SKIP_POST_FAIL_HOOKS} = 1;
     combined_like { dies_ok { $basetest->runtest } 'behavior persists regardless of _SKIP_POST_FAIL_HOOKS setting' }


### PR DESCRIPTION
A very simple change I've come up with when trying to debug some other developer mode related changes for https://progress.opensuse.org/issues/119380 (but not really related to that ticket).