### PR TITLE
Remove sub standstill_detected from basetest.pm

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -591,19 +591,6 @@ Return a listref containing hashrefs like this:
 
 sub ocr_checklist () { [] }
 
-sub standstill_detected ($self, $lastscreenshot) {
-    $self->record_screenfail(
-        img => $lastscreenshot,
-        result => 'fail',
-        overall => 'fail'
-    );
-
-    testapi::send_key('alt-sysrq-w');
-    testapi::send_key('alt-sysrq-l');
-    testapi::send_key('alt-sysrq-d');    # only available with CONFIG_LOCKDEP
-    return;
-}
-
 # this is called if the test failed and the framework loaded a VM
 # snapshot - all consoles activated in the test's run function loose their
 # state


### PR DESCRIPTION
While increasing code coverage for basetest.pm ([Ticket: 94952](https://progress.opensuse.org/issues/94952)) i've found this function `standstill_detected` which seems to not be called anywhere within openqa/os-autoinst:

```
╭─░▒▓    ~/Code/tools/repos ·················································· ✔  2.5.8   at 14:34:11  ▓▒░─╮
╰─ ls                                                                                                              ─╯
openQA  openQA-helper  os-autoinst  os-autoinst-distri-opensuse

╭─░▒▓    ~/Code/tools/repos ·················································· ✔  2.5.8   at 14:34:12  ▓▒░─╮
╰─ grep -r 'standstill_detected' ./                                                                                ─╯
grep: ./os-autoinst/build/cover_db/structure/4c742895140b66adb3e1a588e8bae0d2: binary file matches
./os-autoinst/basetest.pm:sub standstill_detected ($self, $lastscreenshot) {
```
Anyone know if this might be used externally or if it is safe to remove ?