### PR TITLE
Revert "Move stop_autotest into CommandHandler"

### DIFF
--- a/isotovideo
+++ b/isotovideo
@@ -68,6 +68,7 @@ BEGIN {
 
 use log qw(diag);
 use needle;
+use autotest ();
 use commands;
 use distribution;
 use testapi ();
@@ -150,6 +151,7 @@ for my $arg (@ARGV) {
 
 my $cmd_srv_process;
 my $command_handler;
+my $testprocess;
 my $cmd_srv_fd;
 my $cmd_srv_port;
 
@@ -184,6 +186,15 @@ sub stop_commands ($reason) {
     $cmd_srv_process->stop();
     $cmd_srv_process = undef;
     diag('done with command server');
+}
+
+sub stop_autotest () {
+    return unless defined $testprocess;
+
+    diag('stopping autotest process ' . $testprocess->pid);
+    $testprocess->stop() if $testprocess->is_running;
+    $testprocess = undef;
+    diag('done with autotest process');
 }
 
 # make sure all commands coming from the backend will not be in the
@@ -228,23 +239,34 @@ testapi::init();
 needle::init();
 bmwqemu::save_vars();
 
+my $testfd;
+($testprocess, $testfd) = autotest::start_process();
+
 $backend = OpenQA::Isotovideo::Backend->new;
 
 spawn_debuggers;
 
 # stop main loop as soon as one of the child processes terminates
 my $stop_loop = sub (@) { $command_handler->loop(0) if $command_handler->loop; };
+$testprocess->once(collected => $stop_loop);
 $backend->process->once(collected => $stop_loop);
 $cmd_srv_process->once(collected => $stop_loop);
 
 $command_handler = OpenQA::Isotovideo::CommandHandler->new(
     cmd_srv_fd => $cmd_srv_fd,
+    test_fd => $testfd,
     backend_fd => $backend->process->channel_in,
     backend_out_fd => $backend->process->channel_out,
 );
+$command_handler->on(tests_done => sub (@) {
+        CORE::close($testfd);
+        $testfd = undef;
+        stop_autotest;
+});
 $command_handler->on(signal => sub ($event, $sig) {
         $backend->stop if defined $backend;    # uncoverable statement
         stop_commands("received signal $sig");    # uncoverable statement
+        stop_autotest;    # uncoverable statement
         _exit(1);    # uncoverable statement
 });
 $command_handler->setup_signal_handler;
@@ -257,10 +279,10 @@ $command_handler->run;
 # terminate/kill the command server and let it inform its websocket clients before
 stop_commands('test execution ended');
 
-if ($command_handler->test_fd) {
+if ($testfd) {
     $return_code = 1;    # unusual shutdown
-    CORE::close($command_handler->test_fd);    # uncoverable statement
-    $command_handler->stop_autotest;    # uncoverable statement
+    CORE::close $testfd;
+    stop_autotest;
 }
 
 diag 'isotovideo ' . ($return_code ? 'failed' : 'done');
@@ -291,7 +313,7 @@ $fatal_error = undef;
 END {
     $backend->stop if defined $backend;
     stop_commands('test execution ended through exception');
-    $command_handler->stop_autotest if defined $command_handler;
+    stop_autotest;
 
     # in case of early exit, e.g. help display
     $return_code //= 0;

--- a/t/19-isotovideo-command-processing.t
+++ b/t/19-isotovideo-command-processing.t
@@ -371,6 +371,7 @@ subtest signalhandler => sub {
 subtest 'No readable JSON' => sub {
     # We need valid fd's so fileno works but they're never used
     open(my $readable, "$Bin");
+    $command_handler->test_fd($readable);
     $command_handler->cmd_srv_fd($readable);
     stderr_like {
         $command_handler->_read_response(undef, $readable);


### PR DESCRIPTION
Reverts #2206 which causes local CI failures and affects behavior of failure hooks.

See: https://progress.opensuse.org/issues/120786