### PR TITLE
Move backend into CommandHandler as well

### DIFF
--- a/OpenQA/Isotovideo/CommandHandler.pm
+++ b/OpenQA/Isotovideo/CommandHandler.pm
@@ -5,6 +5,7 @@ package OpenQA::Isotovideo::CommandHandler;
 use Mojo::Base 'Mojo::EventEmitter', -signatures;
 
 use bmwqemu;
+use autotest ();
 use log qw(diag fctwarn);
 use OpenQA::Isotovideo::Interface;
 use OpenQA::Isotovideo::NeedleDownloader;
@@ -18,6 +19,9 @@ use constant AUTOINST_STATUSFILE => 'autoinst-status.json';
 
 # io handles for sending data to command server and backend
 has [qw(test_fd cmd_srv_fd backend_fd backend_out_fd answer_fd)] => undef;
+
+# the running test process
+has test_process => undef;
 
 # the name of the current test (full name includes category prefix, eg. installation-)
 has [qw(current_test_name current_test_full_name)];
@@ -64,6 +68,10 @@ has [qw(last_check_seconds last_check_microseconds)] => 0;
 sub new ($class, @args) {
     my $self = $class->SUPER::new(@args);
     $self->_update_last_check;
+    my ($test_process, $test_fd) = autotest::start_process;
+    $test_process->once(collected => sub { $self->loop(0) if $self->loop });
+    $self->test_process($test_process);
+    $self->test_fd($test_fd);
     return $self;
 }
 
@@ -77,7 +85,16 @@ sub setup_signal_handler ($self) {
 sub _signal_handler ($self, $sig) {
     bmwqemu::serialize_state(component => 'isotovideo', msg => "isotovideo received signal $sig", log => 1);
     return $self->loop(0) if $self->loop;
+    $self->stop_autotest;
     $self->emit(signal => $sig);
+}
+
+sub stop_autotest ($self) {
+    my $test_process = $self->test_process or return;
+    diag('stopping autotest process ' . $test_process->pid);
+    $test_process->stop() if $test_process->is_running;
+    $self->test_process(undef);
+    diag('done with autotest process');
 }
 
 sub clear_tags_and_timeout ($self) {
@@ -289,6 +306,9 @@ sub _handle_command_set_current_test ($self, $response, @) {
 sub _handle_command_tests_done ($self, $response, @) {
     $self->test_died($response->{died});
     $self->test_completed($response->{completed});
+    CORE::close($self->test_fd);
+    $self->test_fd(undef);
+    $self->stop_autotest;
     $self->emit(tests_done => $response);
     $self->loop(0);
     $self->current_test_name('');

--- a/isotovideo
+++ b/isotovideo
@@ -54,7 +54,6 @@ use JSON::PP;
 
 my $installprefix;    # $bmwqemu::scriptdir
 my $fatal_error;    # the last error message caught by the die handler
-my $backend;
 
 BEGIN {
     # the following line is modified during make install
@@ -80,7 +79,6 @@ use Mojo::UserAgent;
 use Mojo::IOLoop::ReadWriteProcess 'process';
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 Getopt::Long::Configure("no_ignore_case");
-use OpenQA::Isotovideo::Backend;
 use OpenQA::Isotovideo::CommandHandler;
 use OpenQA::Isotovideo::Interface;
 use OpenQA::Isotovideo::Utils qw(git_rev_parse checkout_git_repo_and_branch
@@ -228,22 +226,17 @@ testapi::init();
 needle::init();
 bmwqemu::save_vars();
 
-$backend = OpenQA::Isotovideo::Backend->new;
-
 spawn_debuggers;
 
 # stop main loop as soon as one of the child processes terminates
 my $stop_loop = sub (@) { $command_handler->loop(0) if $command_handler->loop; };
-$backend->process->once(collected => $stop_loop);
 $cmd_srv_process->once(collected => $stop_loop);
 
 $command_handler = OpenQA::Isotovideo::CommandHandler->new(
     cmd_srv_fd => $cmd_srv_fd,
-    backend_fd => $backend->process->channel_in,
-    backend_out_fd => $backend->process->channel_out,
-);
+)->init;
 $command_handler->on(signal => sub ($event, $sig) {
-        $backend->stop if defined $backend;    # uncoverable statement
+        $command_handler->backend->stop if defined $command_handler->backend;    # uncoverable statement
         stop_commands("received signal $sig");    # uncoverable statement
         _exit(1);    # uncoverable statement
 });
@@ -289,7 +282,7 @@ $return_code = handle_generated_assets($command_handler, $clean_shutdown) unless
 $fatal_error = undef;
 
 END {
-    $backend->stop if defined $backend;
+    $command_handler->backend->stop if $command_handler and $command_handler->backend;
     stop_commands('test execution ended through exception');
     $command_handler->stop_autotest if defined $command_handler;
 

--- a/isotovideo
+++ b/isotovideo
@@ -68,7 +68,6 @@ BEGIN {
 
 use log qw(diag);
 use needle;
-use autotest ();
 use commands;
 use distribution;
 use testapi ();
@@ -151,7 +150,6 @@ for my $arg (@ARGV) {
 
 my $cmd_srv_process;
 my $command_handler;
-my $testprocess;
 my $cmd_srv_fd;
 my $cmd_srv_port;
 
@@ -186,15 +184,6 @@ sub stop_commands ($reason) {
     $cmd_srv_process->stop();
     $cmd_srv_process = undef;
     diag('done with command server');
-}
-
-sub stop_autotest () {
-    return unless defined $testprocess;
-
-    diag('stopping autotest process ' . $testprocess->pid);
-    $testprocess->stop() if $testprocess->is_running;
-    $testprocess = undef;
-    diag('done with autotest process');
 }
 
 # make sure all commands coming from the backend will not be in the
@@ -239,34 +228,23 @@ testapi::init();
 needle::init();
 bmwqemu::save_vars();
 
-my $testfd;
-($testprocess, $testfd) = autotest::start_process();
-
 $backend = OpenQA::Isotovideo::Backend->new;
 
 spawn_debuggers;
 
 # stop main loop as soon as one of the child processes terminates
 my $stop_loop = sub (@) { $command_handler->loop(0) if $command_handler->loop; };
-$testprocess->once(collected => $stop_loop);
 $backend->process->once(collected => $stop_loop);
 $cmd_srv_process->once(collected => $stop_loop);
 
 $command_handler = OpenQA::Isotovideo::CommandHandler->new(
     cmd_srv_fd => $cmd_srv_fd,
-    test_fd => $testfd,
     backend_fd => $backend->process->channel_in,
     backend_out_fd => $backend->process->channel_out,
 );
-$command_handler->on(tests_done => sub (@) {
-        CORE::close($testfd);
-        $testfd = undef;
-        stop_autotest;
-});
 $command_handler->on(signal => sub ($event, $sig) {
         $backend->stop if defined $backend;    # uncoverable statement
         stop_commands("received signal $sig");    # uncoverable statement
-        stop_autotest;    # uncoverable statement
         _exit(1);    # uncoverable statement
 });
 $command_handler->setup_signal_handler;
@@ -279,10 +257,10 @@ $command_handler->run;
 # terminate/kill the command server and let it inform its websocket clients before
 stop_commands('test execution ended');
 
-if ($testfd) {
+if ($command_handler->test_fd) {
     $return_code = 1;    # unusual shutdown
-    CORE::close $testfd;
-    stop_autotest;
+    CORE::close($command_handler->test_fd);    # uncoverable statement
+    $command_handler->stop_autotest;    # uncoverable statement
 }
 
 diag 'isotovideo ' . ($return_code ? 'failed' : 'done');
@@ -313,7 +291,7 @@ $fatal_error = undef;
 END {
     $backend->stop if defined $backend;
     stop_commands('test execution ended through exception');
-    stop_autotest;
+    $command_handler->stop_autotest if defined $command_handler;
 
     # in case of early exit, e.g. help display
     $return_code //= 0;

--- a/t/19-isotovideo-command-processing.t
+++ b/t/19-isotovideo-command-processing.t
@@ -371,7 +371,6 @@ subtest signalhandler => sub {
 subtest 'No readable JSON' => sub {
     # We need valid fd's so fileno works but they're never used
     open(my $readable, "$Bin");
-    $command_handler->test_fd($readable);
     $command_handler->cmd_srv_fd($readable);
     stderr_like {
         $command_handler->_read_response(undef, $readable);

--- a/t/19-isotovideo-command-processing.t
+++ b/t/19-isotovideo-command-processing.t
@@ -51,10 +51,19 @@ $rpc_mock->redefine(read_json => sub {
 # setup a CommandHandler instance using the fake file descriptors
 my $command_handler = OpenQA::Isotovideo::CommandHandler->new(
     cmd_srv_fd => $cmd_srv_fd,
-    backend_fd => $backend_fd,
     current_test_name => 'welcome',
     status => 'initial',
 );
+{
+    my $mock = Test::MockModule->new('OpenQA::Isotovideo::CommandHandler');
+    $mock->redefine(start_backend => sub ($self) {
+            $self->backend($bmwqemu::backend);
+            $self->backend_fd($backend_fd);
+            $self->backend_out_fd($answer_fd);
+    });
+    $command_handler->init;
+}
+
 
 sub reset_state () {
     $command_handler->tags(undef);


### PR DESCRIPTION
to keep the right order of initialization (autotest::start_process, backend)

This is based on the reverted #2206 