### PR TITLE
Revert commits from merged PR "Extend t/17-basetest.t"

### DIFF
--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -95,7 +95,6 @@ subtest run_post_fail_test => sub {
     $bmwqemu::vars{_SKIP_POST_FAIL_HOOKS} = 1;
     combined_like { dies_ok { $basetest->runtest } 'behavior persists regardless of _SKIP_POST_FAIL_HOOKS setting' }
     qr/Test died/, 'test died';
-    $basetest->{result} = 'fail'    # make regex to check output with
 };
 
 subtest modules_test => sub {
@@ -284,7 +283,6 @@ subtest record_screenmatch => sub {
             name => 'foo',
             file => 'some/path/foo.json',
         },
-        unregistered => 'yes',
     );
     my @tags = (qw(some tags));
     my @failed_needles = (


### PR DESCRIPTION
These commits from [Extend t/17-basetest.t](https://github.com/os-autoinst/os-autoinst/pull/2207) (ticket: [94952](https://progress.opensuse.org/issues/94952)) are WIP and are therefore being reverted

- 072dd9e04df8948e1f3c1f755c6fa8f10332bcd1
  Extend run_post_fail test (17-basetest.t)

- 746ac6725a944dd324c7456e6713eb7cbf476b48
  Extend record_screenmatch test (17-basetest.t)