### PR TITLE
qemu backend: Use the value of `HDDSIZEGB` var for backing files as well

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -155,7 +155,7 @@ sub configure_blockdevs ($self, $bootfrom, $basedir, $vars) {
         my $backing_file = $vars->{"HDD_$i"};
         my $node_id = 'hd' . ($i - 1);
         my $hdd_serial = $vars->{"HDDSERIAL_$i"} || $node_id;
-        my $size = $vars->{"HDDSIZEGB_$i"};
+        my $size = $vars->{"HDDSIZEGB_$i"} // $vars->{HDDSIZEGB};
         my $num_queues = $vars->{"HDDNUMQUEUES_$i"} || -1;
         my $drive;
 
@@ -174,7 +174,6 @@ sub configure_blockdevs ($self, $bootfrom, $basedir, $vars) {
             $size //= $self->get_img_size($backing_file);
             $drive = $bdc->add_existing_drive($node_id, $backing_file, $hdd_model, $size, $num_queues);
         } else {
-            $size //= $vars->{HDDSIZEGB} . 'G';
             $drive = $bdc->add_new_drive($node_id, $hdd_model, $size, $num_queues);
         }
 


### PR DESCRIPTION
This will fix aarch64 JeOS tests using raw images where only `HDDSIZEGB` is defined and avoid to define an additional `HDDSIZEGB_1` variable.

Example of test where the HDD is not resized when only  `HDDSIZEGB` is defined: https://openqa.opensuse.org/tests/2897239
But it was resized once  `HDDSIZEGB_1` was set: https://openqa.opensuse.org/tests/2897830