### PR TITLE
Fix assert_script_sudo invocation

### DIFF
--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -334,33 +334,26 @@ subtest 'script_run' => sub {
     is(background_script_run('sleep 10', output => 'foo'), '1234', 'background_script_run with output returns valid PID');
 };
 
-sub assert_script_sudo_test () {
+sub assert_script_sudo_test ($waittime, $is_serial_terminal) {
     my $mock_testapi = Test::MockModule->new('testapi');
     $mock_testapi->redefine(_handle_found_needle => sub { return $_[0] });
     $mock_testapi->noop(qw(send_key enter_cmd));
+    my $script_sudo = '';
     $mock_testapi->redefine(hashed_string => 'XXX');
     $mock_testapi->redefine(wait_serial => 'XXX-0-');
-    my $script_sudo = '';
-    $mock_testapi->redefine(script_sudo => sub { $script_sudo = "$_[0]" });
-    $mock_testapi->redefine(_set_assert_marker => 'marker');
-    is assert_script_sudo('echo foo'), undef, 'successful assertion of script_sudo (1)';
-    is $script_sudo, 'echo foo; marker', 'script_sudo called like expected(1)';
-    is assert_script_sudo('bash'), undef, 'successful assertion of script_sudo (2)';
-    is $script_sudo, 'bash; marker', 'script_sudo called like expected(2)';
-}
-
-sub set_assert_marker_test ($is_serial_terminal) {
-    my $mock_testapi = Test::MockModule->new('testapi');
-    $mock_testapi->redefine(_handle_found_needle => sub { return $_[0] });
     $mock_testapi->redefine(is_serial_terminal => $is_serial_terminal);
-    my $expected_output = $is_serial_terminal ? ' > /dev/null' : '';
-    is testapi::_set_assert_marker('XXX'), "echo XXX-\$?-$expected_output", 'marker setter returns correct string to the serial';
+    $mock_testapi->redefine(script_sudo => sub { $script_sudo = "$_[0]"; return "XXX-0-" });
+    is assert_script_sudo('echo foo', $waittime), undef, 'successful assertion of script_sudo (1)';
+    is $script_sudo, 'echo foo', 'script_sudo called like expected(1)';
+    is assert_script_sudo('bash', $waittime), undef, 'successful assertion of script_sudo (2)';
+    is $script_sudo, 'bash', 'script_sudo called like expected(2)';
 }
 
 subtest 'assert_script_sudo' => sub {
-    subtest('_set_assert_marker redirects to serial devices on serial terminal', \&set_assert_marker_test, 0);
-    subtest('_set_assert_marker returns correct marker on non-serial terminal', \&set_assert_marker_test, 1);
-    subtest('Test assert_script_sudo', \&assert_script_sudo_test);
+    subtest('Test assert_script_sudo', \&assert_script_sudo_test, 0, 0);
+    subtest('Test assert_script_sudo', \&assert_script_sudo_test, 0, 1);
+    subtest('Test assert_script_sudo', \&assert_script_sudo_test, 10, 0);
+    subtest('Test assert_script_sudo', \&assert_script_sudo_test, 10, 1);
 };
 
 subtest 'check_assert_screen' => sub {

--- a/testapi.pm
+++ b/testapi.pm
@@ -1013,11 +1013,6 @@ sub background_script_run {    # no:style:signatures
     return $distri->background_script_run($cmd, %args);
 }
 
-sub _set_assert_marker ($hashed_string) {
-    my $redirect_to_serial_console = is_serial_terminal() ? " > /dev/$serialdev" : '';
-    return "echo $hashed_string-\$?-$redirect_to_serial_console";
-}
-
 =head2 assert_script_sudo
 
   assert_script_sudo($command [, $wait]);
@@ -1035,10 +1030,10 @@ C<$serialdev>.
 
 sub assert_script_sudo {    # no:style:signatures
     my ($cmd, $wait) = @_;
+    # Keep in mind C<str> needs to agree with the corresponding C<str> marker
+    # defined on C<$distri->script_sudo> itself.
     my $str = hashed_string("ASS$cmd");
-    my $marker = _set_assert_marker($str);
-    script_sudo("$cmd; $marker", 0);
-    my $ret = wait_serial("$str-\\d+-", $wait);
+    my $ret = script_sudo("$cmd", $wait);
     $ret = ($ret =~ /$str-(\d+)-/)[0] if $ret;
     _handle_script_run_ret($ret, $cmd);
     return;


### PR DESCRIPTION
`assert_script_sudo` tries to assert the output from `script_sudo`. However they use their own marker in each case. Moreover it tries to assert the output from invalid flow. That is because the `assert_script_run` has static $wait time when `script_sudo` involves conditions which gives different output depending on that variable.
Fix consists:
- pass the same arguments between the functions
- simplify `assert_script_sudo` and let `script_sudo` set the marker

Signed-off-by: ybonatakis <ybonatakis@suse.com>