### PR TITLE
Resume directly after failure in case `assert_script_run` fails

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -366,16 +366,12 @@ sub runtest ($self) {
         $died = 1;
     }
 
-    # pause the test execution if tests are supposed to pause on failures via developer mode
-    if ($error_message) {
-        # hang until the user resumes, possibly ignore the failure
-        my $rsp = autotest::query_isotovideo(pause_test_execution => {due_to_failure => 1, reason => "test died: $error_message"});
-        if (ref $rsp eq 'HASH' && $rsp->{ignore_failure}) {
-            bmwqemu::diag($died
-                ? 'ignoring previously logged failure via developer mode'
-                : "ignoring failure via developer mode: $error_message");
-            $ignore_error = 1;
-        }
+    # pause the test execution if tests are supposed to pause on failures via developer mode, possibly ignore error
+    if ($error_message && autotest::pause_on_failure("test died: $error_message")->{ignore_failure}) {
+        bmwqemu::diag($died
+            ? 'ignoring previously logged failure via developer mode'
+            : "ignoring failure via developer mode: $error_message");
+        $ignore_error = 1;
     }
 
     if (!$ignore_error) {

--- a/testapi.pm
+++ b/testapi.pm
@@ -878,10 +878,10 @@ sub x11_start_program {    # no:style:signatures
 
 sub _handle_script_run_ret {    # no:style:signatures
     my ($ret, $cmd, %args) = @_;
-    croak "command '$cmd' timed out" unless (defined $ret);
+    return autotest::croak assert_script_run => "command '$cmd' timed out" unless defined $ret;
     my $die_msg = "command '$cmd' failed";
     $die_msg .= ": $args{fail_message}" if $args{fail_message};
-    croak $die_msg unless ($ret == 0);
+    return autotest::croak assert_script_run => $die_msg unless $ret == 0;
 }
 
 =head2 assert_script_run


### PR DESCRIPTION
With this change, resuming the test execution ignoring failures will resume the test execution right after the failing `assert_script_run` command (instead on the next module). So far this is only a tweak for `assert_script_run` but it could be extended for other test API functions.

I've been starting with `assert_script_run` because this function was the starting point for the whole "pause on failure" feature.

Related ticket: https://progress.opensuse.org/issues/119380