### PR TITLE
Move isotovideo to OpenQA::Isotovideo::Runner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ set(PERL_FILES
     OpenQA/Isotovideo/CommandHandler.pm
     OpenQA/Isotovideo/Interface.pm
     OpenQA/Isotovideo/NeedleDownloader.pm
+    OpenQA/Isotovideo/Runner.pm
     OpenQA/Isotovideo/Utils.pm
     OpenQA/NamedIOSelect.pm
     OpenQA/Qemu/BlockDevConf.pm

--- a/OpenQA/Isotovideo/CommandHandler.pm
+++ b/OpenQA/Isotovideo/CommandHandler.pm
@@ -41,8 +41,6 @@ has pause_on_failure => sub { $bmwqemu::vars{PAUSE_ON_FAILURE} // 0 };
 
 # the reason why the test execution has paused or 0 if not paused
 has reason_for_pause => 0;
-# the loop status
-has loop => 1;
 
 # when paused, save the command from autotest which has been postponed to be able to resume
 has postponed_answer_fd => undef;

--- a/OpenQA/Isotovideo/CommandHandler.pm
+++ b/OpenQA/Isotovideo/CommandHandler.pm
@@ -295,7 +295,6 @@ sub _handle_command_tests_done ($self, $response, @) {
     $self->test_died($response->{died});
     $self->test_completed($response->{completed});
     $self->emit(tests_done => $response);
-    $self->loop(0);
     $self->current_test_name('');
     $self->status('finished');
     $self->update_status_file;

--- a/OpenQA/Isotovideo/CommandHandler.pm
+++ b/OpenQA/Isotovideo/CommandHandler.pm
@@ -10,7 +10,6 @@ use OpenQA::Isotovideo::Interface;
 use OpenQA::Isotovideo::NeedleDownloader;
 use Cpanel::JSON::XS;
 use Mojo::File 'path';
-use IO::Select;
 use Time::HiRes qw(gettimeofday tv_interval);
 
 use constant AUTOINST_STATUSFILE => 'autoinst-status.json';

--- a/OpenQA/Isotovideo/CommandHandler.pm
+++ b/OpenQA/Isotovideo/CommandHandler.pm
@@ -69,19 +69,6 @@ sub new ($class, @args) {
     return $self;
 }
 
-sub setup_signal_handler ($self) {
-    my $signal_handler = sub ($sig) { $self->_signal_handler($sig) };
-    $SIG{TERM} = $signal_handler;
-    $SIG{INT} = $signal_handler;
-    $SIG{HUP} = $signal_handler;
-}
-
-sub _signal_handler ($self, $sig) {
-    bmwqemu::serialize_state(component => 'isotovideo', msg => "isotovideo received signal $sig", log => 1);
-    return $self->loop(0) if $self->loop;
-    $self->emit(signal => $sig);
-}
-
 sub clear_tags_and_timeout ($self) {
     $self->tags(undef);
     $self->timeout(undef);

--- a/OpenQA/Isotovideo/CommandHandler.pm
+++ b/OpenQA/Isotovideo/CommandHandler.pm
@@ -446,26 +446,4 @@ sub _read_response ($self, $rsp, $fd) {
     }
 }
 
-sub run ($self) {
-    # now we have everything, give the tests a go
-    $self->test_fd->write("GO\n");
-
-    my $io_select = IO::Select->new();
-    $io_select->add($self->test_fd);
-    $io_select->add($self->cmd_srv_fd);
-    $io_select->add($self->backend_out_fd);
-
-    while ($self->loop) {
-        my ($ready_for_read, $ready_for_write, $exceptions) = IO::Select::select($io_select, undef, $io_select, $self->timeout);
-        for my $readable (@$ready_for_read) {
-            my $rsp = myjsonrpc::read_json($readable);
-            $self->_read_response($rsp, $readable);
-            last unless defined $rsp;
-        }
-        $self->check_asserted_screen if defined($self->tags);
-    }
-    $self->stop_command_processing;
-    return 0;
-}
-
 1;

--- a/OpenQA/Isotovideo/CommandHandler.pm
+++ b/OpenQA/Isotovideo/CommandHandler.pm
@@ -421,15 +421,4 @@ sub check_asserted_screen ($self) {
     }
 }
 
-sub _read_response ($self, $rsp, $fd) {
-    if (!defined $rsp) {
-        fctwarn sprintf("THERE IS NOTHING TO READ %d %d %d", fileno($fd), fileno($self->test_fd), fileno($self->cmd_srv_fd));
-        $self->loop(0);
-    } elsif ($fd == $self->backend_out_fd) {
-        $self->send_to_backend_requester({ret => $rsp->{rsp}});
-    } else {
-        $self->process_command($fd, $rsp);
-    }
-}
-
 1;

--- a/OpenQA/Isotovideo/Runner.pm
+++ b/OpenQA/Isotovideo/Runner.pm
@@ -1,0 +1,59 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package OpenQA::Isotovideo::Runner;
+use Mojo::Base -base, -signatures;
+use autodie ':all';
+no autodie 'kill';
+use log qw(diag);
+
+sub stop_commands ($self, $reason, $cmd_srv_process, $cmd_srv_port) {
+    return unless defined $$cmd_srv_process;
+    return unless $$cmd_srv_process->is_running;
+
+    my $pid = $$cmd_srv_process->pid;
+    diag("stopping command server $pid because $reason");
+
+    if ($$cmd_srv_port && $reason && $reason eq 'test execution ended') {
+        my $job_token = $bmwqemu::vars{JOBTOKEN};
+        my $url = "http://127.0.0.1:$$cmd_srv_port/$job_token/broadcast";
+        diag('isotovideo: informing websocket clients before stopping command server: ' . $url);
+
+        # note: If the job is stopped by the worker because it has been
+        # aborted, the worker will send this command on its own to the command
+        # server and also stop the command server. So this is only done in the
+        # case the test execution just ends.
+
+        my $timeout = 15;
+        # The command server might have already been stopped by the worker
+        # after the user has aborted the job or the job timeout has been
+        # exceeded so no checks for failure done.
+        Mojo::UserAgent->new(request_timeout => $timeout)->post($url, json => {stopping_test_execution => $reason});
+    }
+
+    $$cmd_srv_process->stop();
+    $$cmd_srv_process = undef;
+    diag('done with command server');
+}
+
+
+
+sub _flush_std ($) {
+    select(STDERR);
+    $| = 1;
+    select(STDOUT);    # default
+    $| = 1;
+}
+
+sub _init_vars ($, @args) {
+    for my $arg (@args) {
+        if ($arg =~ /^([[:alnum:]_\[\]\.]+)=(.+)/) {
+            my $key = uc $1;
+            $bmwqemu::vars{$key} = $2;
+            diag("Setting forced test parameter $key -> $2");
+        }
+    }
+}
+
+
+1;

--- a/OpenQA/Isotovideo/Runner.pm
+++ b/OpenQA/Isotovideo/Runner.pm
@@ -89,6 +89,7 @@ sub handle_commands ($self) {
             CORE::close($self->testfd);
             $self->testfd(undef);
             $self->stop_autotest();
+            $command_handler->loop(0);
     });
     $command_handler->on(signal => sub ($event, $sig) {
             $self->backend->stop if defined $self->backend;    # uncoverable statement

--- a/OpenQA/Isotovideo/Runner.pm
+++ b/OpenQA/Isotovideo/Runner.pm
@@ -10,7 +10,7 @@ use Mojo::UserAgent;
 use IO::Select;
 use log qw(diag fctwarn);
 use OpenQA::Isotovideo::Utils qw(checkout_git_repo_and_branch checkout_git_refspec checkout_wheels
-load_test_schedule);
+  load_test_schedule);
 use OpenQA::Isotovideo::Backend;
 use OpenQA::Isotovideo::CommandHandler;
 use bmwqemu ();
@@ -121,6 +121,10 @@ sub handle_commands ($self) {
             $self->stop_autotest();
             $self->loop(0);
     });
+    # uncoverable statement count:1
+    # uncoverable statement count:2
+    # uncoverable statement count:3
+    # uncoverable statement count:4
     $command_handler->on(signal => sub ($event, $sig) {
             $self->backend->stop if defined $self->backend;    # uncoverable statement
             $self->stop_commands("received signal $sig");    # uncoverable statement
@@ -159,7 +163,7 @@ sub stop_commands ($self, $reason) {
 
     if ($self->cmd_srv_port && $reason && $reason eq 'test execution ended') {
         my $job_token = $bmwqemu::vars{JOBTOKEN};
-        my $url = "http://127.0.0.1:".$self->cmd_srv_port."/$job_token/broadcast";
+        my $url = "http://127.0.0.1:" . $self->cmd_srv_port . "/$job_token/broadcast";
         diag('isotovideo: informing websocket clients before stopping command server: ' . $url);
 
         # note: If the job is stopped by the worker because it has been
@@ -188,7 +192,7 @@ sub stop_autotest ($self) {
     diag('done with autotest process');
 }
 
-sub checkout_code($self) {
+sub checkout_code ($self) {
     checkout_git_repo_and_branch('CASEDIR');
 
     # Try to load the main.pm from one of the following in this order:

--- a/OpenQA/Isotovideo/Runner.pm
+++ b/OpenQA/Isotovideo/Runner.pm
@@ -8,8 +8,10 @@ no autodie 'kill';
 use log qw(diag);
 use OpenQA::Isotovideo::Utils qw(checkout_git_repo_and_branch checkout_git_refspec checkout_wheels
 load_test_schedule);
+use OpenQA::Isotovideo::Backend;
 use bmwqemu ();
 use testapi ();
+use autotest ();
 
 sub load_schedule ($self) {
     # set a default distribution if the tests don't have one
@@ -24,6 +26,16 @@ sub start_server ($self) {
     my ($cmd_srv_process, $cmd_srv_fd, $cmd_srv_port);
     ($cmd_srv_process, $cmd_srv_fd) = commands::start_server($cmd_srv_port = $bmwqemu::vars{QEMUPORT} + 1);
     return ($cmd_srv_process, $cmd_srv_fd, $cmd_srv_port);
+}
+
+sub start_autotest ($self) {
+    my ($testprocess, $testfd) = autotest::start_process();
+    return ($testprocess, $testfd);
+}
+
+sub create_backend ($self) {
+    my $backend = OpenQA::Isotovideo::Backend->new;
+    return $backend;
 }
 
 # note: The subsequently defined stop_* functions are used to tear down the process tree.

--- a/OpenQA/Isotovideo/Runner.pm
+++ b/OpenQA/Isotovideo/Runner.pm
@@ -15,6 +15,8 @@ use autotest ();
 
 has [qw(cmd_srv_process cmd_srv_fd cmd_srv_port)];
 
+has [qw(testprocess testfd)];
+
 sub load_schedule ($self) {
     # set a default distribution if the tests don't have one
     $testapi::distri = distribution->new;
@@ -34,7 +36,8 @@ sub start_server ($self) {
 
 sub start_autotest ($self) {
     my ($testprocess, $testfd) = autotest::start_process();
-    return ($testprocess, $testfd);
+    $self->testprocess($testprocess);
+    $self->testfd($testfd);
 }
 
 sub create_backend ($self) {
@@ -75,12 +78,12 @@ sub stop_commands ($self, $reason) {
     diag('done with command server');
 }
 
-sub stop_autotest ($self, $testprocess) {
-    return unless defined $$testprocess;
+sub stop_autotest ($self) {
+    return unless defined $self->testprocess;
 
-    diag('stopping autotest process ' . $$testprocess->pid);
-    $$testprocess->stop() if $$testprocess->is_running;
-    $$testprocess = undef;
+    diag('stopping autotest process ' . $self->testprocess->pid);
+    $self->testprocess->stop() if $self->testprocess->is_running;
+    $self->testprocess(undef);
     diag('done with autotest process');
 }
 

--- a/OpenQA/Isotovideo/Runner.pm
+++ b/OpenQA/Isotovideo/Runner.pm
@@ -17,6 +17,8 @@ has [qw(cmd_srv_process cmd_srv_fd cmd_srv_port)];
 
 has [qw(testprocess testfd)];
 
+has [qw(backend)];
+
 sub load_schedule ($self) {
     # set a default distribution if the tests don't have one
     $testapi::distri = distribution->new;
@@ -42,7 +44,7 @@ sub start_autotest ($self) {
 
 sub create_backend ($self) {
     my $backend = OpenQA::Isotovideo::Backend->new;
-    return $backend;
+    $self->backend($backend);
 }
 
 # note: The subsequently defined stop_* functions are used to tear down the process tree.

--- a/isotovideo
+++ b/isotovideo
@@ -85,10 +85,7 @@ use OpenQA::Isotovideo::Backend;
 use OpenQA::Isotovideo::CommandHandler;
 use OpenQA::Isotovideo::Interface;
 use OpenQA::Isotovideo::Runner;
-use OpenQA::Isotovideo::Utils qw(git_rev_parse
-  spawn_debuggers
-  checkout_wheels
-  handle_generated_assets load_test_schedule);
+use OpenQA::Isotovideo::Utils qw(git_rev_parse spawn_debuggers handle_generated_assets );
 
 my %options;
 
@@ -157,16 +154,9 @@ my $cmd_srv_port;
 
 $runner->checkout_code;
 
-# set a default distribution if the tests don't have one
-$testapi::distri = distribution->new;
+$runner->load_schedule;
 
-$bmwqemu::vars{WHEELS_DIR} ||= $bmwqemu::vars{CASEDIR};
-checkout_wheels($bmwqemu::vars{WHEELS_DIR});
-load_test_schedule;
-
-# start the command fork before we get into the backend, the command child
-# is not supposed to talk to the backend directly
-($cmd_srv_process, $cmd_srv_fd) = commands::start_server($cmd_srv_port = $bmwqemu::vars{QEMUPORT} + 1);
+($cmd_srv_process, $cmd_srv_fd, $cmd_srv_port) = $runner->start_server;
 
 testapi::init();
 needle::init();

--- a/isotovideo
+++ b/isotovideo
@@ -85,10 +85,10 @@ use OpenQA::Isotovideo::Backend;
 use OpenQA::Isotovideo::CommandHandler;
 use OpenQA::Isotovideo::Interface;
 use OpenQA::Isotovideo::Runner;
-use OpenQA::Isotovideo::Utils qw(git_rev_parse checkout_git_repo_and_branch
+use OpenQA::Isotovideo::Utils qw(git_rev_parse
   spawn_debuggers
   checkout_wheels
-  checkout_git_refspec handle_generated_assets load_test_schedule);
+  handle_generated_assets load_test_schedule);
 
 my %options;
 
@@ -130,6 +130,12 @@ my $return_code = 1;
 #       immediately but only in the END block.
 $SIG{__DIE__} = sub ($e) { $fatal_error = $e };
 
+# make sure all commands coming from the backend will not be in the
+# developers's locale - but a defined english one. This is SUSE's
+# default locale
+$ENV{LC_ALL} = 'en_US.UTF-8';
+$ENV{LANG} = 'en_US.UTF-8';
+
 my $runner = OpenQA::Isotovideo::Runner->new;
 
 diag(_get_version_string());
@@ -140,8 +146,7 @@ $log::direct_output = $options{debug};
 $runner->_flush_std;
 
 $bmwqemu::scriptdir = $installprefix;
-bmwqemu::init();
-$runner->_init_vars(@ARGV);
+$runner->_init_bmwqemu(@ARGV);
 
 my $cmd_srv_process;
 my $command_handler;
@@ -149,46 +154,8 @@ my $testprocess;
 my $cmd_srv_fd;
 my $cmd_srv_port;
 
-# note: The subsequently defined stop_* functions are used to tear down the process tree.
-#       However, the worker also ensures that all processes are being terminated (and
-#       eventually killed).
 
-
-sub stop_autotest () {
-    return unless defined $testprocess;
-
-    diag('stopping autotest process ' . $testprocess->pid);
-    $testprocess->stop() if $testprocess->is_running;
-    $testprocess = undef;
-    diag('done with autotest process');
-}
-
-# make sure all commands coming from the backend will not be in the
-# developers's locale - but a defined english one. This is SUSE's
-# default locale
-$ENV{LC_ALL} = 'en_US.UTF-8';
-$ENV{LANG} = 'en_US.UTF-8';
-
-checkout_git_repo_and_branch('CASEDIR');
-
-# Try to load the main.pm from one of the following in this order:
-#  - product dir
-#  - casedir
-#
-# This allows further structuring the test distribution collections with
-# multiple distributions or flavors in one repository.
-$bmwqemu::vars{PRODUCTDIR} ||= $bmwqemu::vars{CASEDIR};
-
-# checkout Git repo NEEDLES_DIR refers to (if it is a URL) and re-assign NEEDLES_DIR to contain the checkout path
-checkout_git_repo_and_branch('NEEDLES_DIR');
-
-bmwqemu::ensure_valid_vars();
-
-# as we are about to load the test modules checkout the specified git refspec,
-# if specified, or simply store the git hash that has been used. If it is not a
-# git repo fail silently, i.e. store an empty variable
-
-$bmwqemu::vars{TEST_GIT_HASH} = checkout_git_refspec($bmwqemu::vars{CASEDIR} => 'TEST_GIT_REFSPEC');
+$runner->checkout_code;
 
 # set a default distribution if the tests don't have one
 $testapi::distri = distribution->new;
@@ -227,12 +194,12 @@ $command_handler = OpenQA::Isotovideo::CommandHandler->new(
 $command_handler->on(tests_done => sub (@) {
         CORE::close($testfd);
         $testfd = undef;
-        stop_autotest;
+        $runner->stop_autotest(\$testprocess);
 });
 $command_handler->on(signal => sub ($event, $sig) {
         $backend->stop if defined $backend;    # uncoverable statement
         $runner->stop_commands("received signal $sig", \$cmd_srv_process, \$cmd_srv_port);    # uncoverable statement
-        stop_autotest;    # uncoverable statement
+        $runner->stop_autotest(\$testprocess);    # uncoverable statement
         _exit(1);    # uncoverable statement
 });
 $command_handler->setup_signal_handler;
@@ -248,7 +215,7 @@ $runner->stop_commands('test execution ended', \$cmd_srv_process, \$cmd_srv_port
 if ($testfd) {
     $return_code = 1;    # unusual shutdown
     CORE::close $testfd;
-    stop_autotest;
+    $runner->stop_autotest(\$testprocess);
 }
 
 diag 'isotovideo ' . ($return_code ? 'failed' : 'done');
@@ -279,7 +246,7 @@ $fatal_error = undef;
 END {
     $backend->stop if defined $backend;
     $runner and $runner->stop_commands('test execution ended through exception', \$cmd_srv_process, \$cmd_srv_port);
-    stop_autotest;
+    $runner and $runner->stop_autotest(\$testprocess);
 
     # in case of early exit, e.g. help display
     $return_code //= 0;

--- a/isotovideo
+++ b/isotovideo
@@ -152,7 +152,7 @@ needle::init();
 bmwqemu::save_vars();
 
 $runner->start_autotest;
-my $backend = $runner->create_backend;
+$runner->create_backend;
 
 spawn_debuggers;
 my $command_handler;
@@ -160,14 +160,14 @@ my $command_handler;
 # stop main loop as soon as one of the child processes terminates
 my $stop_loop = sub (@) { $command_handler->loop(0) if $command_handler->loop; };
 $runner->testprocess->once(collected => $stop_loop);
-$backend->process->once(collected => $stop_loop);
+$runner->backend->process->once(collected => $stop_loop);
 $runner->cmd_srv_process->once(collected => $stop_loop);
 
 $command_handler = OpenQA::Isotovideo::CommandHandler->new(
     cmd_srv_fd => $runner->cmd_srv_fd,
     test_fd => $runner->testfd,
-    backend_fd => $backend->process->channel_in,
-    backend_out_fd => $backend->process->channel_out,
+    backend_fd => $runner->backend->process->channel_in,
+    backend_out_fd => $runner->backend->process->channel_out,
 );
 $command_handler->on(tests_done => sub (@) {
         CORE::close($runner->testfd);
@@ -175,7 +175,7 @@ $command_handler->on(tests_done => sub (@) {
         $runner->stop_autotest();
 });
 $command_handler->on(signal => sub ($event, $sig) {
-        $backend->stop if defined $backend;    # uncoverable statement
+        $runner->backend->stop if defined $runner->backend;    # uncoverable statement
         $runner->stop_commands("received signal $sig");    # uncoverable statement
         $runner->stop_autotest();    # uncoverable statement
         _exit(1);    # uncoverable statement
@@ -222,7 +222,7 @@ $return_code = handle_generated_assets($command_handler, $clean_shutdown) unless
 $fatal_error = undef;
 
 END {
-    $backend->stop if defined $backend;
+    $runner->backend->stop if $runner and $runner->backend;
     $runner and $runner->stop_commands('test execution ended through exception');
     $runner and $runner->stop_autotest();
 

--- a/isotovideo
+++ b/isotovideo
@@ -73,7 +73,6 @@ use distribution;
 use testapi ();
 use Getopt::Long;
 require IPC::System::Simple;
-use POSIX qw(:sys_wait_h _exit);
 use Try::Tiny;
 use Mojo::File qw(curfile);
 use Mojo::UserAgent;
@@ -155,32 +154,8 @@ $runner->start_autotest;
 $runner->create_backend;
 
 spawn_debuggers;
-my $command_handler;
 
-# stop main loop as soon as one of the child processes terminates
-my $stop_loop = sub (@) { $command_handler->loop(0) if $command_handler->loop; };
-$runner->testprocess->once(collected => $stop_loop);
-$runner->backend->process->once(collected => $stop_loop);
-$runner->cmd_srv_process->once(collected => $stop_loop);
-
-$command_handler = OpenQA::Isotovideo::CommandHandler->new(
-    cmd_srv_fd => $runner->cmd_srv_fd,
-    test_fd => $runner->testfd,
-    backend_fd => $runner->backend->process->channel_in,
-    backend_out_fd => $runner->backend->process->channel_out,
-);
-$command_handler->on(tests_done => sub (@) {
-        CORE::close($runner->testfd);
-        $runner->testfd(undef);
-        $runner->stop_autotest();
-});
-$command_handler->on(signal => sub ($event, $sig) {
-        $runner->backend->stop if defined $runner->backend;    # uncoverable statement
-        $runner->stop_commands("received signal $sig");    # uncoverable statement
-        $runner->stop_autotest();    # uncoverable statement
-        _exit(1);    # uncoverable statement
-});
-$command_handler->setup_signal_handler;
+my $command_handler = $runner->handle_commands;
 
 $return_code = 0;
 

--- a/isotovideo
+++ b/isotovideo
@@ -151,7 +151,7 @@ testapi::init();
 needle::init();
 bmwqemu::save_vars();
 
-my ($testprocess, $testfd) = $runner->start_autotest;
+$runner->start_autotest;
 my $backend = $runner->create_backend;
 
 spawn_debuggers;
@@ -159,25 +159,25 @@ my $command_handler;
 
 # stop main loop as soon as one of the child processes terminates
 my $stop_loop = sub (@) { $command_handler->loop(0) if $command_handler->loop; };
-$testprocess->once(collected => $stop_loop);
+$runner->testprocess->once(collected => $stop_loop);
 $backend->process->once(collected => $stop_loop);
 $runner->cmd_srv_process->once(collected => $stop_loop);
 
 $command_handler = OpenQA::Isotovideo::CommandHandler->new(
     cmd_srv_fd => $runner->cmd_srv_fd,
-    test_fd => $testfd,
+    test_fd => $runner->testfd,
     backend_fd => $backend->process->channel_in,
     backend_out_fd => $backend->process->channel_out,
 );
 $command_handler->on(tests_done => sub (@) {
-        CORE::close($testfd);
-        $testfd = undef;
-        $runner->stop_autotest(\$testprocess);
+        CORE::close($runner->testfd);
+        $runner->testfd(undef);
+        $runner->stop_autotest();
 });
 $command_handler->on(signal => sub ($event, $sig) {
         $backend->stop if defined $backend;    # uncoverable statement
         $runner->stop_commands("received signal $sig");    # uncoverable statement
-        $runner->stop_autotest(\$testprocess);    # uncoverable statement
+        $runner->stop_autotest();    # uncoverable statement
         _exit(1);    # uncoverable statement
 });
 $command_handler->setup_signal_handler;
@@ -190,10 +190,10 @@ $command_handler->run;
 # terminate/kill the command server and let it inform its websocket clients before
 $runner->stop_commands('test execution ended');
 
-if ($testfd) {
+if ($runner->testfd) {
     $return_code = 1;    # unusual shutdown
-    CORE::close $testfd;
-    $runner->stop_autotest(\$testprocess);
+    CORE::close $runner->testfd;
+    $runner->stop_autotest();
 }
 
 diag 'isotovideo ' . ($return_code ? 'failed' : 'done');
@@ -224,7 +224,7 @@ $fatal_error = undef;
 END {
     $backend->stop if defined $backend;
     $runner and $runner->stop_commands('test execution ended through exception');
-    $runner and $runner->stop_autotest(\$testprocess);
+    $runner and $runner->stop_autotest();
 
     # in case of early exit, e.g. help display
     $return_code //= 0;

--- a/isotovideo
+++ b/isotovideo
@@ -84,13 +84,11 @@ Getopt::Long::Configure("no_ignore_case");
 use OpenQA::Isotovideo::Backend;
 use OpenQA::Isotovideo::CommandHandler;
 use OpenQA::Isotovideo::Interface;
+use OpenQA::Isotovideo::Runner;
 use OpenQA::Isotovideo::Utils qw(git_rev_parse checkout_git_repo_and_branch
   spawn_debuggers
   checkout_wheels
   checkout_git_refspec handle_generated_assets load_test_schedule);
-
-session->enable;
-session->enable_subreaper;
 
 my %options;
 
@@ -113,6 +111,9 @@ GetOptions(\%options, 'debug|d', 'workdir=s', 'color=s', 'help|h|?', 'version|v'
 usage(0) if $options{help};
 version() if $options{version};
 
+session->enable;
+session->enable_subreaper;
+
 my $color = $options{color} // 'yes';
 # User setting has preference, see https://no-color.org/
 delete $ENV{NO_COLOR} if $color eq 'yes';
@@ -129,25 +130,18 @@ my $return_code = 1;
 #       immediately but only in the END block.
 $SIG{__DIE__} = sub ($e) { $fatal_error = $e };
 
+my $runner = OpenQA::Isotovideo::Runner->new;
+
 diag(_get_version_string());
 
 # enable debug default when started from a tty
 $log::direct_output = $options{debug};
 
-select(STDERR);
-$| = 1;
-select(STDOUT);    # default
-$| = 1;
+$runner->_flush_std;
 
 $bmwqemu::scriptdir = $installprefix;
 bmwqemu::init();
-for my $arg (@ARGV) {
-    if ($arg =~ /^([[:alnum:]_\[\]\.]+)=(.+)/) {
-        my $key = uc $1;
-        $bmwqemu::vars{$key} = $2;
-        diag("Setting forced test parameter $key -> $2");
-    }
-}
+$runner->_init_vars(@ARGV);
 
 my $cmd_srv_process;
 my $command_handler;
@@ -159,34 +153,6 @@ my $cmd_srv_port;
 #       However, the worker also ensures that all processes are being terminated (and
 #       eventually killed).
 
-sub stop_commands ($reason) {
-    return unless defined $cmd_srv_process;
-    return unless $cmd_srv_process->is_running;
-
-    my $pid = $cmd_srv_process->pid;
-    diag("stopping command server $pid because $reason");
-
-    if ($cmd_srv_port && $reason && $reason eq 'test execution ended') {
-        my $job_token = $bmwqemu::vars{JOBTOKEN};
-        my $url = "http://127.0.0.1:$cmd_srv_port/$job_token/broadcast";
-        diag('isotovideo: informing websocket clients before stopping command server: ' . $url);
-
-        # note: If the job is stopped by the worker because it has been
-        # aborted, the worker will send this command on its own to the command
-        # server and also stop the command server. So this is only done in the
-        # case the test execution just ends.
-
-        my $timeout = 15;
-        # The command server might have already been stopped by the worker
-        # after the user has aborted the job or the job timeout has been
-        # exceeded so no checks for failure done.
-        Mojo::UserAgent->new(request_timeout => $timeout)->post($url, json => {stopping_test_execution => $reason});
-    }
-
-    $cmd_srv_process->stop();
-    $cmd_srv_process = undef;
-    diag('done with command server');
-}
 
 sub stop_autotest () {
     return unless defined $testprocess;
@@ -265,7 +231,7 @@ $command_handler->on(tests_done => sub (@) {
 });
 $command_handler->on(signal => sub ($event, $sig) {
         $backend->stop if defined $backend;    # uncoverable statement
-        stop_commands("received signal $sig");    # uncoverable statement
+        $runner->stop_commands("received signal $sig", \$cmd_srv_process, \$cmd_srv_port);    # uncoverable statement
         stop_autotest;    # uncoverable statement
         _exit(1);    # uncoverable statement
 });
@@ -277,7 +243,7 @@ $return_code = 0;
 $command_handler->run;
 
 # terminate/kill the command server and let it inform its websocket clients before
-stop_commands('test execution ended');
+$runner->stop_commands('test execution ended', \$cmd_srv_process, \$cmd_srv_port);
 
 if ($testfd) {
     $return_code = 1;    # unusual shutdown
@@ -312,7 +278,7 @@ $fatal_error = undef;
 
 END {
     $backend->stop if defined $backend;
-    stop_commands('test execution ended through exception');
+    $runner and $runner->stop_commands('test execution ended through exception', \$cmd_srv_process, \$cmd_srv_port);
     stop_autotest;
 
     # in case of early exit, e.g. help display

--- a/isotovideo
+++ b/isotovideo
@@ -146,9 +146,10 @@ $runner->run;
 $runner->stop_commands('test execution ended');
 
 if ($runner->testfd) {
-    $return_code = 1;    # unusual shutdown
-    CORE::close $runner->testfd;
-    $runner->stop_autotest();
+    # unusual shutdown
+    $return_code = 1;    # uncoverable statement
+    CORE::close $runner->testfd;    # uncoverable statement
+    $runner->stop_autotest();    # uncoverable statement
 }
 
 diag 'isotovideo ' . ($return_code ? 'failed' : 'done');

--- a/isotovideo
+++ b/isotovideo
@@ -54,7 +54,6 @@ use JSON::PP;
 
 my $installprefix;    # $bmwqemu::scriptdir
 my $fatal_error;    # the last error message caught by the die handler
-my $backend;
 
 BEGIN {
     # the following line is modified during make install
@@ -81,7 +80,6 @@ use Mojo::UserAgent;
 use Mojo::IOLoop::ReadWriteProcess 'process';
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 Getopt::Long::Configure("no_ignore_case");
-use OpenQA::Isotovideo::Backend;
 use OpenQA::Isotovideo::CommandHandler;
 use OpenQA::Isotovideo::Interface;
 use OpenQA::Isotovideo::Runner;
@@ -144,30 +142,20 @@ $runner->_flush_std;
 
 $bmwqemu::scriptdir = $installprefix;
 $runner->_init_bmwqemu(@ARGV);
-
-my $cmd_srv_process;
-my $command_handler;
-my $testprocess;
-my $cmd_srv_fd;
-my $cmd_srv_port;
-
-
 $runner->checkout_code;
-
 $runner->load_schedule;
 
-($cmd_srv_process, $cmd_srv_fd, $cmd_srv_port) = $runner->start_server;
+my ($cmd_srv_process, $cmd_srv_fd, $cmd_srv_port) = $runner->start_server;
 
 testapi::init();
 needle::init();
 bmwqemu::save_vars();
 
-my $testfd;
-($testprocess, $testfd) = autotest::start_process();
-
-$backend = OpenQA::Isotovideo::Backend->new;
+my ($testprocess, $testfd) = $runner->start_autotest;
+my $backend = $runner->create_backend;
 
 spawn_debuggers;
+my $command_handler;
 
 # stop main loop as soon as one of the child processes terminates
 my $stop_loop = sub (@) { $command_handler->loop(0) if $command_handler->loop; };

--- a/isotovideo
+++ b/isotovideo
@@ -66,23 +66,13 @@ BEGIN {
 }
 
 use log qw(diag);
-use needle;
-use autotest ();
-use commands;
-use distribution;
-use testapi ();
 use Getopt::Long;
-require IPC::System::Simple;
-use Try::Tiny;
 use Mojo::File qw(curfile);
-use Mojo::UserAgent;
-use Mojo::IOLoop::ReadWriteProcess 'process';
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 Getopt::Long::Configure("no_ignore_case");
-use OpenQA::Isotovideo::CommandHandler;
 use OpenQA::Isotovideo::Interface;
 use OpenQA::Isotovideo::Runner;
-use OpenQA::Isotovideo::Utils qw(git_rev_parse spawn_debuggers handle_generated_assets );
+use OpenQA::Isotovideo::Utils qw(git_rev_parse spawn_debuggers handle_generated_assets);
 
 my %options;
 
@@ -130,32 +120,22 @@ $SIG{__DIE__} = sub ($e) { $fatal_error = $e };
 $ENV{LC_ALL} = 'en_US.UTF-8';
 $ENV{LANG} = 'en_US.UTF-8';
 
-my $runner = OpenQA::Isotovideo::Runner->new;
-
 diag(_get_version_string());
 
 # enable debug default when started from a tty
 $log::direct_output = $options{debug};
 
-$runner->_flush_std;
-
 $bmwqemu::scriptdir = $installprefix;
+
+my $runner = OpenQA::Isotovideo::Runner->new;
 $runner->_init_bmwqemu(@ARGV);
-$runner->checkout_code;
-$runner->load_schedule;
-
-$runner->start_server;
-
-testapi::init();
-needle::init();
-bmwqemu::save_vars();
-
+$runner->prepare;
 $runner->start_autotest;
 $runner->create_backend;
 
 spawn_debuggers;
 
-my $command_handler = $runner->handle_commands;
+$runner->handle_commands;
 
 $return_code = 0;
 
@@ -191,7 +171,7 @@ if (!$return_code) {
 # read calculated variables from backend and tests
 bmwqemu::load_vars();
 
-$return_code = handle_generated_assets($command_handler, $clean_shutdown) unless $return_code;
+$return_code = handle_generated_assets($runner->command_handler, $clean_shutdown) unless $return_code;
 
 # clear any previously recorded die message; it was not fatal after all if the execution came this far
 $fatal_error = undef;

--- a/isotovideo
+++ b/isotovideo
@@ -145,7 +145,7 @@ $runner->_init_bmwqemu(@ARGV);
 $runner->checkout_code;
 $runner->load_schedule;
 
-my ($cmd_srv_process, $cmd_srv_fd, $cmd_srv_port) = $runner->start_server;
+$runner->start_server;
 
 testapi::init();
 needle::init();
@@ -161,10 +161,10 @@ my $command_handler;
 my $stop_loop = sub (@) { $command_handler->loop(0) if $command_handler->loop; };
 $testprocess->once(collected => $stop_loop);
 $backend->process->once(collected => $stop_loop);
-$cmd_srv_process->once(collected => $stop_loop);
+$runner->cmd_srv_process->once(collected => $stop_loop);
 
 $command_handler = OpenQA::Isotovideo::CommandHandler->new(
-    cmd_srv_fd => $cmd_srv_fd,
+    cmd_srv_fd => $runner->cmd_srv_fd,
     test_fd => $testfd,
     backend_fd => $backend->process->channel_in,
     backend_out_fd => $backend->process->channel_out,
@@ -176,7 +176,7 @@ $command_handler->on(tests_done => sub (@) {
 });
 $command_handler->on(signal => sub ($event, $sig) {
         $backend->stop if defined $backend;    # uncoverable statement
-        $runner->stop_commands("received signal $sig", \$cmd_srv_process, \$cmd_srv_port);    # uncoverable statement
+        $runner->stop_commands("received signal $sig");    # uncoverable statement
         $runner->stop_autotest(\$testprocess);    # uncoverable statement
         _exit(1);    # uncoverable statement
 });
@@ -188,7 +188,7 @@ $return_code = 0;
 $command_handler->run;
 
 # terminate/kill the command server and let it inform its websocket clients before
-$runner->stop_commands('test execution ended', \$cmd_srv_process, \$cmd_srv_port);
+$runner->stop_commands('test execution ended');
 
 if ($testfd) {
     $return_code = 1;    # unusual shutdown
@@ -223,7 +223,7 @@ $fatal_error = undef;
 
 END {
     $backend->stop if defined $backend;
-    $runner and $runner->stop_commands('test execution ended through exception', \$cmd_srv_process, \$cmd_srv_port);
+    $runner and $runner->stop_commands('test execution ended through exception');
     $runner and $runner->stop_autotest(\$testprocess);
 
     # in case of early exit, e.g. help display

--- a/isotovideo
+++ b/isotovideo
@@ -160,7 +160,7 @@ my $command_handler = $runner->handle_commands;
 $return_code = 0;
 
 # enter the main loop: process messages from autotest, command server and backend
-$command_handler->run;
+$runner->run;
 
 # terminate/kill the command server and let it inform its websocket clients before
 $runner->stop_commands('test execution ended');

--- a/t/19-isotovideo-command-processing.t
+++ b/t/19-isotovideo-command-processing.t
@@ -381,11 +381,11 @@ subtest signalhandler => sub {
     my $runner = OpenQA::Isotovideo::Runner->new;
     $runner->command_handler($command_handler);
     $command_handler->once(signal => sub ($event, $sig) { $last_signal = $sig });
-    $command_handler->loop(1);
+    $runner->loop(1);
     stderr_like {
         $runner->_signal_handler('TERM');
     } qr/isotovideo received signal TERM/, 'Signal logged';
-    is($command_handler->loop, 0, 'Loop was stopped');
+    is($runner->loop, 0, 'Loop was stopped');
     is($last_signal, undef, 'No event emitted');
 
     stderr_like {
@@ -404,7 +404,7 @@ subtest 'No readable JSON' => sub {
     stderr_like {
         $runner->_read_response(undef, $readable);
     } qr/THERE IS NOTHING TO READ/, 'no response';
-    is($command_handler->loop, 0, 'Loop was stopped');
+    is($runner->loop, 0, 'Loop was stopped');
 };
 
 done_testing;

--- a/t/19-isotovideo-command-processing.t
+++ b/t/19-isotovideo-command-processing.t
@@ -395,12 +395,14 @@ subtest signalhandler => sub {
 };
 
 subtest 'No readable JSON' => sub {
+    my $runner = OpenQA::Isotovideo::Runner->new;
+    $runner->command_handler($command_handler);
     # We need valid fd's so fileno works but they're never used
     open(my $readable, "$Bin");
-    $command_handler->test_fd($readable);
-    $command_handler->cmd_srv_fd($readable);
+    $runner->testfd($readable);
+    $runner->cmd_srv_fd($readable);
     stderr_like {
-        $command_handler->_read_response(undef, $readable);
+        $runner->_read_response(undef, $readable);
     } qr/THERE IS NOTHING TO READ/, 'no response';
     is($command_handler->loop, 0, 'Loop was stopped');
 };

--- a/t/19-isotovideo-command-processing.t
+++ b/t/19-isotovideo-command-processing.t
@@ -13,6 +13,7 @@ use Test::Fatal;
 use Mojo::JSON;
 use OpenQA::Isotovideo::CommandHandler;
 use OpenQA::Isotovideo::Interface;
+use OpenQA::Isotovideo::Runner;
 
 # declare fake file descriptors
 my $cmd_srv_fd = 0;
@@ -377,16 +378,18 @@ subtest check_asserted_screen => sub {
 
 subtest signalhandler => sub {
     my $last_signal;
+    my $runner = OpenQA::Isotovideo::Runner->new;
+    $runner->command_handler($command_handler);
     $command_handler->once(signal => sub ($event, $sig) { $last_signal = $sig });
     $command_handler->loop(1);
     stderr_like {
-        $command_handler->_signal_handler('TERM');
+        $runner->_signal_handler('TERM');
     } qr/isotovideo received signal TERM/, 'Signal logged';
     is($command_handler->loop, 0, 'Loop was stopped');
     is($last_signal, undef, 'No event emitted');
 
     stderr_like {
-        $command_handler->_signal_handler('INT');
+        $runner->_signal_handler('INT');
     } qr/isotovideo received signal INT/, 'Signal logged';
     is($last_signal, 'INT', 'Event emitted');
 };


### PR DESCRIPTION
This moves code from isotovideo and OpenQA::Isotovideo::CommandHandler to OpenQA::Isotovideo::Runner, by small steps.

It was thoroughly tested on some dedicated workers.

Issues: https://progress.opensuse.org/issues/81899 https://progress.opensuse.org/issues/121045