### PR TITLE
Fix uncoverable comments

### DIFF
--- a/t/02-test_ocr.t
+++ b/t/02-test_ocr.t
@@ -25,9 +25,8 @@ cv::init();
 require tinycv;
 
 unless (which('tesseract')) {
-    # uncoverable statement count:2
-    plan skip_all => 'No tesseract installed';
-    exit(0);
+    plan skip_all => 'No tesseract installed';    # uncoverable statement
+    exit(0);    # uncoverable statement
 }
 
 stderr_like { needle::init } qr/loaded.*needles/, 'log output for needle init';


### PR DESCRIPTION
The "count:n" is only for cases where the following line has more than one statement, and n actually means the specific number of the statement, not the count of statements to mark uncoverable, and since there is only one statement, count:2 was targeting statement number 2 which doesn't exist.