### PR TITLE
log: Print PID

### DIFF
--- a/log.pm
+++ b/log.pm
@@ -27,7 +27,7 @@ sub log_format_callback ($time, $level, @items) {
     # ensure indentation for multi-line output
     $lines =~ s/(?<!\A)^/  /gm;
 
-    return '[' . Time::Moment->now . "] [$level] $lines";
+    return '[' . Time::Moment->now . "] [$level] [pid:$$] $lines";
 }
 
 sub diag (@args) {

--- a/t/10-virtio_terminal.t
+++ b/t/10-virtio_terminal.t
@@ -78,7 +78,7 @@ subtest "Test open_pipe() error condition" => sub {
     my $helper = prepare_pipes($socket_path);
     my $term = consoles::virtio_terminal->new('unit-test-console', {socked_path => $socket_path});
     is $term->is_serial_terminal, 1, 'is a serial terminal';
-    combined_like { dies_ok { $term->open_pipe(); } 'Expect die if pipe_sz fail' } qr/\[debug\] <<<.*open_pipe/, 'log';
+    combined_like { dies_ok { $term->open_pipe(); } 'Expect die if pipe_sz fail' } qr/\[debug\].*open_pipe/, 'log';
     cleanup_pipes($helper);
 
     my $size = 1024;
@@ -124,7 +124,7 @@ subtest "Test open_pipe() error condition" => sub {
 
     $term = consoles::virtio_terminal->new('unit-test-console', {socked_path => $socket_path});
     combined_like { throws_ok { $term->open_pipe() } qr/No such file or directory/, "Throw exception if pipe doesn't exists" }
-    qr/\[debug\] <<<.*open_pipe/, 'log for open_pipe on non-existent pipe';
+    qr/\[debug\].*open_pipe/, 'log for open_pipe on non-existent pipe';
 
     $vterminal_mock = Test::MockModule->new('consoles::virtio_terminal');
     $vterminal_mock->redefine("get_pipe_sz", sub { 1 });


### PR DESCRIPTION
It helps to know which process is printing a message when multiple processes can print the same message. In fact it is often not clear which component some code belongs to. So printing the PID can help identify it even if the message is unique.