### PR TITLE
Update backend_vars.asciidoc

### DIFF
--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -143,7 +143,7 @@ QEMUCPU;see qemu -cpu ?;undef;CPU to emulate
 QEMUCPUS;integer;1;Number of CPUs to assign to VM
 QEMUDIES;integer;undef;Number of CPU dies used by VM
 QEMUMACHINE;see qemu -machine ?;undef;Machine and chipset to emulate
-QEMUPORT;integer;20003 + worker instance * 10;Port on which QEMU monitor should listen
+QEMUPORT;integer;20002 + worker instance * 10;Port on which QEMU monitor should listen
 QEMURAM;integer;1024;Size of RAM of VM in MiB
 QEMUSOCKETS;integer;undef;Number of CPU sockets used by VM
 QEMUTHREADS;integer;undef;Number of CPU threads used by VM

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -37,7 +37,7 @@ TIMEOUT_SCALE;integer;1;This scale parameter can be used based on performance of
 PAUSE_AT;string;;Test module (name or fullname) to pause test execution at. To be used together with the openQA developer mode which also allows to continue test execution again. Note that this does not start a developer mode session. So you still need to confirm taking control over the test to access the developer mode controls.
 PAUSE_ON_SCREEN_MISMATCH;boolean;0;Pause test execution on the next screen mismatch. Same notes as for `PAUSE_AT` apply.
 PAUSE_ON_NEXT_COMMAND;boolean;0;Pause test execution on the next test API command. Same notes as for `PAUSE_AT` apply.
-PAUSE_ON_FAILURE:boolean;0;Pause test execution on a test failure (instead of invoking the post-fail hook and terminating). Same notes as for `PAUSE_AT` apply.
+PAUSE_ON_FAILURE;boolean;0;Pause test execution on a test failure (instead of invoking the post-fail hook and terminating). Same notes as for `PAUSE_AT` apply.
 _QUIET_SCRIPT_CALLS;boolean;0;Add quiet flag to all the calls to script_run, script_output and validate_script_output. It will omit all the squares "wait_serial expected" on the Details view of the test case. This option might be useful for serial terminal tests.
 _WAIT_STILL_SCREEN_ON_HERE_DOC_INPUT;float;0;If this value is greater then 0, it is used by `wait_still_screen` before starting to write the script into the here document used in `testapi::script_output()` function (see: poo#60566). By default this depends on the backend.
 AUTOINST_URL_HOSTNAME;string;;hostname or IP address of host running the autoinst webserver endpoint, defaults to the local IP address within the qemu network for the qemu backend or the `WORKER_HOSTNAME` otherwise.
@@ -143,7 +143,7 @@ QEMUCPU;see qemu -cpu ?;undef;CPU to emulate
 QEMUCPUS;integer;1;Number of CPUs to assign to VM
 QEMUDIES;integer;undef;Number of CPU dies used by VM
 QEMUMACHINE;see qemu -machine ?;undef;Machine and chipset to emulate
-QEMUPORT;integer;20002 + worker instance * 10;Port on which QEMU monitor should listen
+QEMUPORT;integer;20003 + worker instance * 10;Port on which QEMU monitor should listen
 QEMURAM;integer;1024;Size of RAM of VM in MiB
 QEMUSOCKETS;integer;undef;Number of CPU sockets used by VM
 QEMUTHREADS;integer;undef;Number of CPU threads used by VM


### PR DESCRIPTION
Simple typo fix. 

* First one for markdown table alignment
* Second for port listen, log below for sample

```log
[2023-01-11T15:59:33.346235Z] [info] cmdsrv: daemon reachable under http://*:20013/_kAZUTRYVbxZFm3E/
[2023-01-11T15:59:33.347694Z] [info] Listening at "http://0.0.0.0:20013"
Web application available at http://0.0.0.0:20013
```