### PR TITLE
tests: Drop unused Test::MockModule

### DIFF
--- a/t/20-openqa-isotovideo-utils.t
+++ b/t/20-openqa-isotovideo-utils.t
@@ -2,7 +2,6 @@
 
 use Test::Most;
 use Test::Warnings qw(warning :report_warnings);
-use Test::MockModule;
 use autodie ':all';
 use Test::Output qw(combined_like stderr_like);
 use File::Path qw(remove_tree rmtree);


### PR DESCRIPTION
This is an accidental left-over from a new subtest that ended up by moved to t/34-git.t.