### PR TITLE
Add s390x support via QEMU backend

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -610,6 +610,9 @@ sub start_qemu ($self) {
         }
     }
 
+# fallback check for RHEL variants of qemu-kvm
+    $qemubin = find_bin('/usr/libexec/', qw(kvm qemu-kvm)) unless $qemubin;
+
     die "no kvm-img/qemu-img found\n" unless $qemuimg;
     die "no Qemu/KVM found\n" unless $qemubin;
 


### PR DESCRIPTION
@kalikiana With this proposed change, emulation goes to the boot point. I have given my machine config below, along with the Qemu log. 

I think, Need a few more additional config adjustments to make it final. Any advise is greatly appreciated.

Resloves #2246 

```log
ARCH_BASE_MACHINE=s390x
PART_TABLE_TYPE=mbr
QEMU=s390x
QEMUMACHINE=s390-ccw-virtio
QEMURAM=4096
QEMU_APPEND=bios /usr/share/qemu/390-ccw.img -boot once=cd0
QEMU_MAX_MIGRATION_TIME=480
QEMU_NO_KVM=1
QEMU_VIDEO_DEVICE=virtio-gpu
WORKER_CLASS=qemu_s390x
```

```log
[2023-01-17T02:54:57.946729Z] [debug] started mgmt loop with pid 10408
[2023-01-17T02:54:57.985342Z] [debug] qemu version detected: 7.0.0
[2023-01-17T02:54:57.988036Z] [debug] running `/usr/bin/chattr +C /var/lib/openqa/pool/1/raid`
[2023-01-17T02:54:57.997916Z] [debug] Fatal error in command `/usr/bin/chattr +C /var/lib/openqa/pool/1/raid`: open3: exec of /usr/bin/chattr +C /var/lib/openqa/pool/1/raid failed: No such file or directory at /usr/share/perl5/vendor_perl/Mojo/IOLoop/ReadWriteProcess.pm line 127.
  
[2023-01-17T02:54:57.998072Z] [debug] Configuring storage controllers and block devices
[2023-01-17T02:54:57.998795Z] [debug] running `/usr/bin/qemu-img info --output=json /var/lib/openqa/pool/1/AlmaLinux-8.7-update-1-s390x-minimal.iso`
[2023-01-17T02:54:58.012165Z] [debug] Initializing block device images
[2023-01-17T02:54:58.012504Z] [debug] running `/usr/bin/qemu-img create -f qcow2 /var/lib/openqa/pool/1/raid/hd0 14G`
[2023-01-17T02:54:58.034805Z] [debug] Formatting '/var/lib/openqa/pool/1/raid/hd0', fmt=qcow2 cluster_size=65536 extended_l2=off compression_type=zlib size=15032385536 lazy_refcounts=off refcount_bits=16
[2023-01-17T02:54:58.035021Z] [debug] running `/usr/bin/qemu-img create -f qcow2 -F raw -b /var/lib/openqa/pool/1/AlmaLinux-8.7-update-1-s390x-minimal.iso /var/lib/openqa/pool/1/raid/cd0-overlay0 1449914368`
[2023-01-17T02:54:58.058215Z] [debug] Formatting '/var/lib/openqa/pool/1/raid/cd0-overlay0', fmt=qcow2 cluster_size=65536 extended_l2=off compression_type=zlib size=1449914368 backing_file=/var/lib/openqa/pool/1/AlmaLinux-8.7-update-1-s390x-minimal.iso backing_fmt=raw lazy_refcounts=off refcount_bits=16
[2023-01-17T02:54:58.058373Z] [debug] init_blockdev_images: Finished creating block devices
[2023-01-17T02:54:58.059814Z] [debug] starting: /usr/bin/qemu-system-s390x -device virtio-gpu -chardev ringbuf,id=serial0,logfile=serial0,logappend=on -serial chardev:serial0 -m 4096 -machine s390-ccw-virtio -netdev user,id=qanet0 -device virtio-net,netdev=qanet0,mac=52:54:00:12:34:56 -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-pci,rng=rng0 -boot once=d -smp 1 -no-shutdown -vnc :91,share=force-shared -device virtio-serial -chardev pipe,id=virtio_console,path=virtio_console,logfile=virtio_console.log,logappend=on -device virtconsole,chardev=virtio_console,name=org.openqa.console.virtio_console -chardev pipe,id=virtio_console1,path=virtio_console1,logfile=virtio_console1.log,logappend=on -device virtconsole,chardev=virtio_console1,name=org.openqa.console.virtio_console1 -chardev socket,path=qmp_socket,server=on,wait=off,id=qmp_socket,logfile=qmp_socket.log,logappend=on -qmp chardev:qmp_socket -S -bios /usr/share/qemu/390-ccw.img -boot once=cd0 -device virtio-scsi-pci,id=scsi0 -blockdev driver=file,node-name=hd0-file,filename=/var/lib/openqa/pool/1/raid/hd0,cache.no-flush=on -blockdev driver=qcow2,node-name=hd0,file=hd0-file,cache.no-flush=on,discard=unmap -device virtio-blk,id=hd0-device,drive=hd0,serial=hd0 -blockdev driver=file,node-name=cd0-overlay0-file,filename=/var/lib/openqa/pool/1/raid/cd0-overlay0,cache.no-flush=on -blockdev driver=qcow2,node-name=cd0-overlay0,file=cd0-overlay0-file,cache.no-flush=on,discard=unmap -device scsi-cd,id=cd0-device,drive=cd0-overlay0,serial=cd0
[2023-01-17T02:54:58.065648Z] [debug] Waiting for 0 attempts
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
	LANGUAGE = (unset),
	LC_ALL = "en_US.UTF-8",
	LANG = "en_US.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
[2023-01-17T02:54:58.343636Z] [debug] Waiting for 1 attempts
[2023-01-17T02:54:58.343929Z] [info] ::: backend::baseclass::die_handler: Backend process died, backend errors are reported below in the following lines:
  QEMU terminated before QMP connection could be established. Check for errors below
[2023-01-17T02:54:58.344299Z] [info] ::: OpenQA::Qemu::Proc::save_state: Saving QEMU state to qemu_state.json
[2023-01-17T02:54:58.345355Z] [debug] Passing remaining frames to the video encoder
[2023-01-17T02:54:58.421654Z] [debug] Waiting for video encoder to finalize the video
[2023-01-17T02:54:58.421820Z] [debug] The built-in video encoder (pid 10431) terminated
[2023-01-17T02:54:58.423708Z] [debug] QEMU: QEMU emulator version 7.0.0 (qemu-7.0.0-2.el9)
[2023-01-17T02:54:58.423813Z] [debug] QEMU: Copyright (c) 2003-2022 Fabrice Bellard and the QEMU Project developers
[2023-01-17T02:54:58.423962Z] [warn] !!! : qemu-system-s390x: Invalid boot device '0'
[2023-01-17T02:54:58.425701Z] [debug] sending magic and exit
[2023-01-17T02:54:58.426176Z] [debug] received magic close
[2023-01-17T02:54:58.434931Z] [debug] backend process exited: 0
```

Signed-off-by: Bala Raman <srbala@gmail.com>