### PR TITLE
Export TESSDATA_PREFIX in check phase of os-autoinst.spec

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -212,6 +212,8 @@ export NO_BRP_STALE_LINK_ERROR=yes
 
 %check
 export CI=1
+# set TESSDATA_PREFIX for 02-ocr.t
+export TESSDATA_PREFIX="%{_datadir}/tessdata/"
 # account for sporadic slowness in build environments
 # https://progress.opensuse.org/issues/89059
 export OPENQA_TEST_TIMEOUT_SCALE_CI=20

--- a/ocr.pm
+++ b/ocr.pm
@@ -16,7 +16,8 @@ sub tesseract ($img, $area) {
     }
 
     $img->write($imgfn);
-    system('tesseract', $imgfn, $txtfn);
+    # disable debug output, because new versions by default only reports errors and warnings
+    system("tesseract $imgfn $txtfn quiet");
     $txtfn .= '.txt';
     open(my $fh, '<:encoding(UTF-8)', $txtfn);
     local $/;

--- a/t/02-test_ocr.t
+++ b/t/02-test_ocr.t
@@ -33,13 +33,13 @@ stderr_like { needle::init } qr/loaded.*needles/, 'log output for needle init';
 my $img1 = tinycv::read(needle::needles_dir() . '/bootmenu.test.png');
 my $needle = needle->new('bootmenu-ocr.ref.json');
 my $res;
-stderr_like { $res = $img1->search($needle) } qr/Tesseract.*OCR/, 'log output for OCR';
+$res = $img1->search($needle);
 ok(defined $res, 'ocr match 1');
 
 my $ocr;
 for my $area (@{$res->{needle}->{area}}) {
     next unless $area->{type} eq 'ocr';
-    stderr_like { $ocr .= ocr::tesseract($img1, $area) } qr/Tesseract.*OCR/, 'log output for tesseract call';
+    $ocr .= ocr::tesseract($img1, $area);
 }
 
 ok defined $ocr, 'OCR area found' and

--- a/tools/invoke-tests
+++ b/tools/invoke-tests
@@ -52,6 +52,9 @@ fi
 export OS_AUTOINST_BUILD_DIRECTORY=$build_directory
 export OS_AUTOINST_MAKE_TOOL=$make_path
 
+# set TESSDATA_PREFIX for 02-test_ocr.t
+export TESSDATA_PREFIX='/usr/share/tessdata/'
+
 args=()
 # use unbuffer if it was found so e.g. timestamps on OBS builds will be useful
 # note: When executing tests with prove it seems that the output is only flushed after one test has finished unless there's a terminal.


### PR DESCRIPTION
https://progress.opensuse.org/issues/123193