### PR TITLE
Set tesseract to quiet mode and remove 'stderr_like' checks

### DIFF
--- a/ocr.pm
+++ b/ocr.pm
@@ -16,7 +16,8 @@ sub tesseract ($img, $area) {
     }
 
     $img->write($imgfn);
-    system('tesseract', $imgfn, $txtfn);
+    # disable debug output, because new versions by default only reports errors and warnings
+    system("tesseract $imgfn $txtfn quiet");
     $txtfn .= '.txt';
     open(my $fh, '<:encoding(UTF-8)', $txtfn);
     local $/;

--- a/t/02-test_ocr.t
+++ b/t/02-test_ocr.t
@@ -33,13 +33,13 @@ stderr_like { needle::init } qr/loaded.*needles/, 'log output for needle init';
 my $img1 = tinycv::read(needle::needles_dir() . '/bootmenu.test.png');
 my $needle = needle->new('bootmenu-ocr.ref.json');
 my $res;
-stderr_like { $res = $img1->search($needle) } qr/Tesseract.*OCR/, 'log output for OCR';
+$res = $img1->search($needle);
 ok(defined $res, 'ocr match 1');
 
 my $ocr;
 for my $area (@{$res->{needle}->{area}}) {
     next unless $area->{type} eq 'ocr';
-    stderr_like { $ocr .= ocr::tesseract($img1, $area) } qr/Tesseract.*OCR/, 'log output for tesseract call';
+    $ocr .= ocr::tesseract($img1, $area);
 }
 
 ok defined $ocr, 'OCR area found' and


### PR DESCRIPTION
https://progress.opensuse.org/issues/123193

New tesseract-ocr in tumbleweed removed debug output and now reports only warnings and errors.