### PR TITLE
Avoid shellcheck warnings

### DIFF
--- a/tools/container_run_ci
+++ b/tools/container_run_ci
@@ -30,7 +30,7 @@ eval set -- "$opts"
 while true; do
   case "$1" in
     -v | --verbose ) set -x; shift ;;
-    -h | --help ) usage 0; shift ;;
+    -h | --help ) usage 0 ;;
     -t | --target ) target="$2"; shift 2 ;;
     -- ) shift; break ;;
     * ) break ;;

--- a/tools/invoke-tests
+++ b/tools/invoke-tests
@@ -25,7 +25,7 @@ opts=$(getopt \
 eval set -- "$opts"
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    -h | --help               ) usage;                     shift   ;;
+    -h | --help               ) usage                              ;;
     --coverage                ) WITH_COVER_OPTIONS=1;      shift   ;;
     --skip-if-cover-db-exists ) SKIP_IF_COVER_DB_EXISTS=1; shift   ;;
     --prove-tool              ) prove_path=$2;             shift 2 ;;

--- a/tools/tidy
+++ b/tools/tidy
@@ -34,7 +34,7 @@ opts=$(getopt -o hcqfol --long help,check,quiet,force,only-changed,list -n "$0" 
 eval set -- "$opts"
 while true; do
   case "$1" in
-    -h | --help ) usage; shift ;;
+    -h | --help ) usage ;;
     -c | --check ) args+=' --check-only'; shift ;;
     -q | --quiet ) args+=' --quiet'; shift ;;
     -f | --force ) force=true; shift ;;


### PR DESCRIPTION
The shift is not reachable in those cases because usage() exits

issue: https://progress.opensuse.org/issues/123445