### PR TITLE
sshVirtsh: Show virsh stderr output on virsh start failure

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -543,7 +543,7 @@ __END"
     $ret = $self->run_cmd("virsh $remote_vmm start " . $self->name . ' 2> >(tee /tmp/os-autoinst-' . $self->name . '-stderr.log >&2)');
     bmwqemu::diag("Dump actually used libvirt configuration file " . ($ret ? "(broken)" : "(working)"));
     my $config = $self->get_cmd_output("virsh $remote_vmm dumpxml " . $self->name);
-    die "virsh start failed, virsh domain XML:\n$config" if $ret;
+    die "virsh start failed: $ret\n\nvirsh domain XML:\n$config" if $ret;
     my $config_domain = Mojo::DOM->new($config)->at('domain');
     my $vm_id = $config_domain ? $config_domain->attr('id') : '';
     die "virsh domain XML does not specify VM ID which is required from VNC over WebSockets:\n$config" if !$vm_id && $bmwqemu::vars{VMWARE_VNC_OVER_WS};


### PR DESCRIPTION
Svirt backends sometimes fail to start and the error message shown in webUI is useless most of the time. The real error can be found only in autoinst-log.txt. Print the real error into the test failure box.