### PR TITLE
Introduce VNC_EXTRA_VARS variable

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -931,7 +931,9 @@ sub start_qemu ($self) {
 
         if ($vars->{VNC}) {
             my $vncport = $vars->{VNC} !~ /:/ ? ":$vars->{VNC}" : $vars->{VNC};
-            sp('vnc', [qv "$vncport share=force-shared"]);
+            my $extravars = $vars->{VNC_EXTRA_VARS};
+            $extravars = defined $extravars ? " $extravars" : '';
+            sp('vnc', [qv "$vncport share=force-shared$extravars"]);
             sp('k', $vars->{VNCKB}) if $vars->{VNCKB};
         }
 

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -194,6 +194,7 @@ VDE_PORT;integer;worker instance + 10;number of vde switch port to connect
 VDE_SOCKETDIR;string;.;directory where vde_switch control socket is to be found
 VDE_USE_SLIRP;integer;1;whether to start slirpvde
 VNC;integer;worker instance + 90;Display on which VNC server is running. Actual port is 5900 + VNC
+VNC_EXTRA_VARS;string;;Additional variables passed to the qemu VNC parameter (`-vnc`)
 VNCKB;;;Set the keyboard layout if you are not using en-us
 WORKER_CLASS;string;undef;qemu system types
 WORKER_HOSTNAME;string;undef;Worker hostname


### PR DESCRIPTION
Introduce the `VNC_EXTRA_VARS` variable that allows users to pass additional parameters to the `-vnc` argument of the QEMU backend.

Related ticket: https://progress.opensuse.org/issues/121261

Verification run: [With VNC_EXTRA_VARS](http://unarmed-1.qa.suse.de/tests/985#settings) | [Without VNC_EXTRA_VARS](http://unarmed-1.qa.suse.de/tests/942#settings)