### PR TITLE
Allow debugging JSON RPC per job

### DIFF
--- a/myjsonrpc.pm
+++ b/myjsonrpc.pm
@@ -28,12 +28,12 @@ sub send_json ($to_fd, $cmd) {
     $cmdcopy{json_cmd_token} ||= bmwqemu::random_string(8);
 
     my $json = $cjx->encode(\%cmdcopy);
-    if (DEBUG_JSON) {
+    if (DEBUG_JSON || $bmwqemu::vars{DEBUG_JSON_RPC}) {
         my $copy = $json;
         # shorten long content
         $copy =~ s/"([^"]{30})[^"]+"/"$1"/g;
         my $fd = fileno($to_fd);
-        bmwqemu::diag("($$) send_json($fd) JSON=$copy");
+        bmwqemu::diag("send_json($fd) JSON=$copy");
     }
     $json .= "\n";
 
@@ -54,7 +54,7 @@ sub read_json ($socket, $cmd_token = undef, $multi = undef) {
     my $cjx = Cpanel::JSON::XS->new;
 
     my $fd = fileno($socket);
-    bmwqemu::diag("($$) read_json($fd)") if DEBUG_JSON;
+    bmwqemu::diag("read_json($fd)") if DEBUG_JSON || $bmwqemu::vars{DEBUG_JSON_RPC};
     if (exists $sockets->{$fd}) {
         # start with the trailing text from previous call
         my $buffer = delete $sockets->{$fd};
@@ -74,9 +74,9 @@ sub read_json ($socket, $cmd_token = undef, $multi = undef) {
         # remember the trailing text
         if ($hash) {
             $sockets->{$fd} = $cjx->incr_text();
-            if (DEBUG_JSON) {
+            if (DEBUG_JSON || $bmwqemu::vars{DEBUG_JSON_RPC}) {
                 my $token = $hash->{json_cmd_token} // 'no-token';
-                bmwqemu::diag("($$) read_json($fd) json_cmd_token=$token");
+                bmwqemu::diag("read_json($fd) json_cmd_token=$token");
             }
             if ($hash->{QUIT}) {
                 bmwqemu::diag("received magic close");
@@ -101,14 +101,14 @@ sub read_json ($socket, $cmd_token = undef, $multi = undef) {
             my $error = $!;
             confess "ERROR: unable to wait for JSON reply: $error\n" unless $!{EINTR};
             # try again if can_read's underlying system call has been interrupted as suggested by the perlipc documentation
-            bmwqemu::diag("($$) read_json($fd): can_read's underlying system call has been interrupted, trying again\n") if DEBUG_JSON;
+            bmwqemu::diag("read_json($fd): can_read's underlying system call has been interrupted, trying again\n") if DEBUG_JSON || $bmwqemu::vars{DEBUG_JSON_RPC};
             @res = $s->can_read;
         }
 
         my $qbuffer;
         my $bytes = sysread($socket, $qbuffer, READ_BUFFER);
         if (!$bytes) {
-            bmwqemu::fctwarn("sysread failed: $!") if DEBUG_JSON;
+            bmwqemu::fctwarn("sysread failed: $!") if DEBUG_JSON || $bmwqemu::vars{DEBUG_JSON_RPC};
             return;
         }
         $cjx->incr_parse($qbuffer);

--- a/t/24-myjsonrpc-debug-var.t
+++ b/t/24-myjsonrpc-debug-var.t
@@ -1,0 +1,51 @@
+#!/usr/bin/perl
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+
+use Test::Most;
+use Mojo::Base -strict, -signatures;
+use FindBin '$Bin';
+use lib "$Bin/../external/os-autoinst-common/lib";
+use OpenQA::Test::TimeLimit '5';
+use Socket;
+
+$bmwqemu::vars{DEBUG_JSON_RPC} = 1;
+
+use myjsonrpc;
+
+use Test::Warnings qw(warnings :report_warnings);
+
+no warnings 'redefine';
+sub bmwqemu::diag ($text) { warn $text }
+
+
+my ($child, $isotovideo);
+socketpair($child, $isotovideo, AF_UNIX, SOCK_STREAM, PF_UNSPEC);
+
+$child->autoflush(1);
+$isotovideo->autoflush(1);
+
+my $send1 = {a => 1};
+my $send2 = {b => 12, json_cmd_token => 'dummy'};
+
+$send1->{json_cmd_token} = 'dummy';
+
+sub debug () {
+    myjsonrpc::send_json($child, $send1);
+    my $read = myjsonrpc::read_json($isotovideo);
+    is_deeply($read, $send1, "read_json returns what send_json sent");
+}
+subtest debug_json => sub {
+    my @warnings = warnings { debug() };
+    like($warnings[0], qr{send_json}, "debug send_json");
+    like($warnings[1], qr{read_json}, "debug read_json");
+    like($warnings[2], qr{read_json.*json_cmd_token=dummy}, "debug json_cmd_token");
+    is(scalar @warnings, 3, "Correct number of warnings");
+};
+
+close $isotovideo;
+close $child;
+
+done_testing;


### PR DESCRIPTION
Occasionally it appears that the wait_serial command is sent by the testapi frontend, but never received by the backend. This has only been observed on a single job after a single LTP test.

It is not easily reproducible and so we need to start debugging in production.

We need to confirm or rule out that the JSON RPC is being lost. Meanwhile we do not want to enable debugging for all jobs that a worker runs.

With this change we can enable debugging JSON RPC on a single job.

https://progress.opensuse.org/issues/121774