### PR TITLE
testapi: Fix 'snd2png' call arguments introduced in 264fcd83

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -1778,7 +1778,7 @@ sub _check_or_assert_sound ($mustmatch, $check = undef) {
     my $result = $autotest::current_test->stop_audiocapture();
     my $wavfile = join('/', bmwqemu::result_dir(), $result->{audio});
     my $imgpath = "$result->{audio}.png";
-    _snd2png($wavfile, $result);
+    _snd2png($wavfile, $imgpath);
     return $autotest::current_test->verify_sound_image($imgpath, $mustmatch, $check);
 }
 


### PR DESCRIPTION
Fixes an issue observed in
https://openqa.opensuse.org/tests/overview?distri=opensuse&groupid=1&version=Tumbleweed
affecting multiple scenarios.

Related progress issue: https://progress.opensuse.org/issues/99663