### PR TITLE
Fall back to manual fetch when checking out branch/ref of Git repo

### DIFF
--- a/t/34-git.t
+++ b/t/34-git.t
@@ -58,9 +58,7 @@ my $case_dir_ok = "file://$git_dir#$head";
 my $case_dir = "file://$git_dir#abcdef";
 
 subtest 'failing clone' => sub {
-    %bmwqemu::vars = (
-        CASEDIR => $case_dir,
-    );
+    %bmwqemu::vars = (CASEDIR => $case_dir);
     my $path;
     my $out = combined_from {
         eval { $path = checkout_git_repo_and_branch('CASEDIR', retry_count => 0) };
@@ -74,27 +72,17 @@ cleanup();
 
 subtest 'successful clone' => sub {
     my $path;
-    %bmwqemu::vars = (
-        CASEDIR => $case_dir_ok,
-    );
-    my $out = combined_from {
-        $path = checkout_git_repo_and_branch('CASEDIR');
-    };
+    %bmwqemu::vars = (CASEDIR => $case_dir_ok);
+    my $out = combined_from { $path = checkout_git_repo_and_branch('CASEDIR') };
     is $path, $clone_dir, 'checkout_git_repo_and_branch returned correct path';
     like $out, qr{Cloning git URL.*Fetching more remote objects}s, 'git clone was called again to fetch a git hash';
 
-    %bmwqemu::vars = (
-        CASEDIR => $case_dir_ok,
-    );
-    $out = combined_from {
-        $path = checkout_git_repo_and_branch('CASEDIR');
-    };
+    %bmwqemu::vars = (CASEDIR => $case_dir_ok);
+    $out = combined_from { $path = checkout_git_repo_and_branch('CASEDIR') };
     is $path, $clone_dir, 'checkout_git_repo_and_branch with existing local directory returned correct path';
     like $out, qr{Skipping to clone.*tmpgitrepo already exists}, 'Log says that local directory already exists';
 
-    eval {
-        bmwqemu::save_vars(no_secret => 1);
-    };
+    eval { bmwqemu::save_vars(no_secret => 1) };
     is($@, '', 'serialization successful');
 };
 

--- a/t/34-git.t
+++ b/t/34-git.t
@@ -38,7 +38,7 @@ subtest 'failure to clone results once' => sub {
     combined_like { checkout_git_repo_and_branch('test', repo => 'https://github.com/foo/bar.git', retry_count => 3) } qr@Clone failed, retries left: 3 of 3@;
 };
 
-subtest 'failure to clone results in repeated attemps' => sub {
+subtest 'failure to clone results in repeated attempts' => sub {
     my $utils_mock = Test::MockModule->new('OpenQA::Isotovideo::Utils');
     my $failed_once = 0;
     $utils_mock->redefine(clone_git => sub (@) {


### PR DESCRIPTION
We have already code in-place that is acting as fallback if `git clone` with `--branch…` does not work. However, it seems rather complicated and doesn't handle the case when the branch is actually just a ref like `refs/pull/<pr_number>/merge` which is used by GitHub actions¹. This change adds a new fallback (before the current one) that simply fetches the missing ref and checks it out. If that fails the previous fallback is still attempted because I'm not sure whether it might still be better in certain cases.

Related issue: https://progress.opensuse.org/issues/124502

---

¹ See documentation of `GITHUB_REF` on
https://docs.github.com/en/actions/learn-github-actions/variables. Note that using `GITHUB_REF_NAME` instead does *not* help as it is just a ref like `<pr_number>/merge` which our current fallback code cannot resolve as well.