### PR TITLE
Add Enterprise Linux support to the QEMU backend

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -609,7 +609,7 @@ sub start_qemu ($self) {
                     last;
                 }
             }
-            $qemubin = find_bin('/usr/bin/', @execs) unless $qemubin;
+            $qemubin = find_bin('/usr/bin/', @execs) // find_bin('/usr/libexec/', @execs) unless $qemubin;
         }
     }
 


### PR DESCRIPTION
Unlike other Linux distributions, In Enterprise Linux, QEMU is present in /usr/libexec/qemu-kvm.
Add this path as one of the QEMU executable's path

Resolves #2267

Also see alternative patch on #2269