### PR TITLE
Add Enterprise Linux support to the QEMU backend

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -609,7 +609,16 @@ sub start_qemu ($self) {
                     last;
                 }
             }
-            $qemubin = find_bin('/usr/bin/', @execs) unless $qemubin;
+            # qemubin_path_generic: Generic path of QEMU
+            # qemubin_path_el: QEMU path on Enterprise Linux
+            # qemubin_exec_el: QEMU executable name on Enterprise Linux
+            # qemubin_path_$DISTRO: QEMU path on $DISTRO
+            # qemubin_exec_$DISTRO: QEMU executable name on $DISTRO
+            my $qemubin_path_generic = '/usr/bin/';
+            my $qemubin_path_el = '/usr/libexec/';
+            my $qemubin_exec_el = 'qemu-kvm';
+            $qemubin = find_bin($qemubin_path_generic, @execs) unless $qemubin;
+            $qemubin = find_bin($qemubin_path_el, $qemubin_exec_el) unless $qemubin;
         }
     }
 


### PR DESCRIPTION
- Unlike other Linux distributions, In Enterprise Linux, QEMU is present in /usr/libexec/qemu-kvm.
Add this path as one of the QEMU executable's path
- Introduce a logic to add QEMU paths for other distributions

Resolves #2267
Also see alternative patch on #2268