### PR TITLE
testapi: Remove obsolete "do_wait" argument to "send_key"

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -1287,9 +1287,7 @@ Special characters naming:
 =cut
 
 sub send_key {    # no:style:signatures
-    my $key = shift;
-    my %args = (@_ == 1) ? (do_wait => +shift()) : @_;
-    $args{do_wait} //= 0;
+    my ($key, %args) = @_;
     $args{wait_screen_change} //= 0;
     bmwqemu::log_call(key => $key, %args);
     if ($args{wait_screen_change}) {


### PR DESCRIPTION
"do_wait" was made ineffective with 3c7ae92f about three years ago and
can be removed.