### PR TITLE
Explicitly specify backingfile format

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -389,7 +389,7 @@ sub _copy_image_to_vm_host ($self, $args, $vmware_openqa_datastore, $file, $name
         my (undef, $json) = $self->run_cmd("qemu-img info --output=json $args->{file}", wantarray => 1);
         my $image_vsize = decode_json($json)->{'virtual-size'};
         $size = (($size * 1024 * 1024 * 1024) <= $image_vsize) ? $image_vsize : $size . 'G';
-        $self->run_cmd(sprintf("qemu-img create '${file}' -f qcow2 -b '$basedir/%s' ${size}", $file_basename))
+        $self->run_cmd(sprintf("qemu-img create '${file}' -f qcow2 -F qcow2 -b '$basedir/%s' ${size}", $file_basename))
           && die 'qemu-img create with backing file failed';
     }
     return $file;

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -573,7 +573,7 @@ subtest 'Method consoles::sshVirtsh::add_disk()' => sub {
                     size => 12
             });
             like($last_ssh_commands[0], qr%^rsync.*/my/path/to/this/file/$file.*$basedir/$file%, 'Use rsync to copy file');
-            is($last_ssh_commands[-1], "qemu-img create '${basedir}openQA-SUT-1$dev_id.img' -f qcow2 -b '$basedir/$file' 12G", 'Used image size > backingfile size');
+            is($last_ssh_commands[-1], "qemu-img create '${basedir}openQA-SUT-1$dev_id.img' -f qcow2 -F qcow2 -b '$basedir/$file' 12G", 'Used image size > backingfile size');
         };
 
         subtest 'family svirt-xen-hvm backingfile=1 size smaller backingfile-size' => sub {
@@ -588,7 +588,7 @@ subtest 'Method consoles::sshVirtsh::add_disk()' => sub {
                     size => 5
             });
             like($last_ssh_commands[0], qr%^rsync.*/my/path/to/this/file/$file.*$basedir/$file%, 'Use rsync to copy file');
-            is($last_ssh_commands[-1], "qemu-img create '${basedir}openQA-SUT-1$dev_id.img' -f qcow2 -b '$basedir/$file' $_10gb", 'Used image size <= backingfile size');
+            is($last_ssh_commands[-1], "qemu-img create '${basedir}openQA-SUT-1$dev_id.img' -f qcow2 -F qcow2 -b '$basedir/$file' $_10gb", 'Used image size <= backingfile size');
 
             svirt_xml_validate($svirt,
                 dev => 'xvd' . $dev_id,
@@ -677,7 +677,7 @@ subtest 'Method consoles::sshVirtsh::add_disk()' => sub {
                     size => 12
             });
             like($last_ssh_commands[0], qr%^rsync.*/my/path/to/this/file/$file.*$basedir/$file%, 'Use rsync to copy file');
-            is($last_ssh_commands[-1], "qemu-img create '${basedir}openQA-SUT-1$dev_id.img' -f qcow2 -b '$basedir/$file' 12G", 'Used image size > backingfile size');
+            is($last_ssh_commands[-1], "qemu-img create '${basedir}openQA-SUT-1$dev_id.img' -f qcow2 -F qcow2 -b '$basedir/$file' 12G", 'Used image size > backingfile size');
         };
 
         subtest 'family kvm backingfile=1 size smaller then backingfile' => sub {
@@ -692,7 +692,7 @@ subtest 'Method consoles::sshVirtsh::add_disk()' => sub {
                     size => 5
             });
             like($last_ssh_commands[0], qr%^rsync.*/my/path/to/this/file/$file.*$basedir/$file%, 'Use rsync to copy file');
-            is($last_ssh_commands[-1], "qemu-img create '${basedir}openQA-SUT-1$dev_id.img' -f qcow2 -b '$basedir/$file' $_10gb", 'Used image size <= backingfile size');
+            is($last_ssh_commands[-1], "qemu-img create '${basedir}openQA-SUT-1$dev_id.img' -f qcow2 -F qcow2 -b '$basedir/$file' $_10gb", 'Used image size <= backingfile size');
 
             svirt_xml_validate($svirt,
                 dev => 'vd' . $dev_id,


### PR DESCRIPTION
Use `-F qcow2` when creating a backing file.

```
openqaw5-xen:~ # qemu-img create
'/var/lib/libvirt/images/openQA-SUT-5a.img' -f qcow2 -b
'/var/lib/libvirt/images//SLES15-SP4-Minimal-VM.x86_64-kvm-and-xen-GM.qcow2'
25769803776
qemu-img: /var/lib/libvirt/images/openQA-SUT-5a.img: Backing file
specified without backing format
Detected format of qcow2.
openqaw5-xen:~ # echo $?
1
```

- ticket: https://progress.opensuse.org/issues/125591