### PR TITLE
Isotovideo/Utils.pm: Fix undefined NUMDISKS for generalhw

### DIFF
--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -197,7 +197,7 @@ sub handle_generated_assets ($command_handler, $clean_shutdown) {
     # mark hard disks for upload if test finished
     return unless $bmwqemu::vars{BACKEND} =~ m/^(qemu|generalhw)$/;
     my @toextract;
-    my $nd = $bmwqemu::vars{NUMDISKS};
+    my $nd = $bmwqemu::vars{NUMDISKS} // 1;
     if ($command_handler->test_completed) {
         for my $i (1 .. $nd) {
             my $dir = 'assets_private';

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -230,7 +230,6 @@ subtest 'load test success when casedir and productdir are relative path' => sub
 
 subtest 'publish assets' => sub {
     $bmwqemu::vars{BACKEND} = 'qemu';
-    $bmwqemu::vars{NUMDISKS} = 1;
     $bmwqemu::backend = FakeBackendDriver->new('qemu');
     my $publish_asset = $pool_dir . '/assets_public/publish_test.qcow2';
 


### PR DESCRIPTION
`NUMDISKS` variable is total number of disks in QEMU, thus not defined in generalhw, which leads to error in e.g.:


```
Use of uninitialized value $nd in foreach loop entry at /usr/lib/os-autoinst/OpenQA/Isotovideo/Utils.pm line 223.

OpenQA::Isotovideo::Utils::handle_generated_assets(OpenQA::Isotovideo::CommandHandler=HASH(0xaaab184add00), -1) called at /usr/bin/isotovideo line 159
	eval {...} called at /usr/bin/isotovideo line 120
```

Fixes: ee31682e ("Enable assets collection for generalhw backend too")