### PR TITLE
Consolidate ignoring of irrelevant test data for coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -32,8 +32,6 @@ coverage:
           - signalblocker.pm
           - t
           - xt
-        ignore:
-          - t/data/tests
     patch:
       default:
         branches: null

--- a/tools/invoke-tests
+++ b/tools/invoke-tests
@@ -44,7 +44,7 @@ db="$build_directory/cover_db"
 # set Perl module include path and coverage options
 export PERL5LIB="$source_directory:$source_directory/ppmclibs/blib/lib:$source_directory/ppmclibs/blib/arch/auto/tinycv:$PERL5LIB"
 if [[ $WITH_COVER_OPTIONS ]]; then
-    ignore="external/|t/data/tests/tests/|/tmp|/CheckGitStatus.pm|$prove_path"
+    ignore="external/|t/data/tests/|/tmp|/CheckGitStatus.pm|$prove_path"
     # add ' -MOpenQA::Test::PatchDeparse' for older OS versions to avoid warnings
     export PERL5OPT="-I$source_directory/t/lib -I$source_directory/external/os-autoinst-common/lib -MOpenQA::Test::CheckGitStatus -MDevel::Cover=-db,$db,-ignore,$ignore,-coverage,statement"
 fi


### PR DESCRIPTION
We already excluded t/data/tests/tests due to unreliable code coverage
analysis in test modules and recently added t/data/tests to the
codecov-specific ignore list. Instead we should ignore everything
irrelevant when calling Devel::Cover and not ignore anything in codecov.