### PR TITLE
testapi/save_screenshot(): Do not act on serial terminal

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -173,7 +173,8 @@ Saves screenshot of current SUT screen.
 
 =cut
 
-sub save_screenshot () { $autotest::current_test->take_screenshot }
+sub is_serial_terminal;
+sub save_screenshot () { $autotest::current_test->take_screenshot unless is_serial_terminal }
 
 =head2 record_soft_failure
 


### PR DESCRIPTION
`save_screenshot()` does not work on serial terminal. Handling it in the function saves many checks in os-autoinst-distri-opensuse git repository.