### PR TITLE
Don't require selected console for wait_serial

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -860,8 +860,7 @@ sub wait_serial ($self, $args) {
     my $matched = 0;
     my $str;
 
-    confess '\'current_console\' is not set' unless $self->{current_console};
-    if ($self->{current_console}->is_serial_terminal) {
+    if ($self->{current_console} && $self->{current_console}->is_serial_terminal) {
         return $self->{current_screen}->read_until($regexp, $timeout, %$args);
     }
 


### PR DESCRIPTION
This would prevent usecases where a console can only be selected
after making sure the SUT booted up by checking serial output for
login prompt. Especially related to generalhw backend.