### PR TITLE
container: Provide jq for convenience in downstream jobs

### DIFF
--- a/container/isotovideo/Dockerfile.qemu-kvm-jq
+++ b/container/isotovideo/Dockerfile.qemu-kvm-jq
@@ -1,0 +1,6 @@
+#!BuildTag: isotovideo:qemu-kvm
+
+FROM opensuse/tumbleweed
+# Provide "jq" as convenience to work with the os-autoinst output
+RUN zypper -n in os-autoinst-qemu-kvm jq && zypper clean
+ENTRYPOINT ["/usr/bin/isotovideo"]

--- a/container/isotovideo/Dockerfile.qemu-x86-jq
+++ b/container/isotovideo/Dockerfile.qemu-x86-jq
@@ -1,0 +1,6 @@
+#!BuildTag: isotovideo:qemu-x86
+
+FROM opensuse/tumbleweed
+# Provide "jq" as convenience to work with the os-autoinst output
+RUN zypper -n in os-autoinst-qemu-x86 jq && zypper clean
+ENTRYPOINT ["/usr/bin/isotovideo"]


### PR DESCRIPTION
https://github.com/os-autoinst/os-autoinst-distri-example/actions/runs/4562594649/jobs/8050016153?pr=15
shows how jq is tried to be installed but fails due to problems in the
repositories which we can avoid by providing all dependencies in the
container already.