### PR TITLE
ci: Add slash to directories in codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -16,8 +16,8 @@ coverage:
       fully_covered:
         target: 100.0
         paths:
-          - OpenQA
-          - backend
+          - OpenQA/
+          - backend/
           - consoles/VMWare.pm
           - consoles/VNC.pm
           - consoles/localXvnc.pm
@@ -30,10 +30,8 @@ coverage:
           - mmapi.pm
           - osutils.pm
           - signalblocker.pm
-          - t/data
-          - t/fake
-          - t/*.t
-          - xt
+          - t/
+          - xt/
     patch:
       default:
         branches: null


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/125237                                 
                                                                                   
Apparently if one only specifies `t` then it counts all files                      
starting with t including testapi.pm and tools/update-deps etc.                    
                                                                                   
It would be really good if there was a page on the codecov report where            
it says which files it considered for the several groups.                          
