### PR TITLE
[WIP] Fix script_run waiting for escape sequences

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -126,9 +126,8 @@ sub script_run ($self, $cmd, @args) {
         my $str = testapi::hashed_string("SR" . $cmd . $args{timeout});
         my $marker = "; echo $str-\$?-" . ($args{output} ? "Comment: $args{output}" : '');
         if (testapi::is_serial_terminal) {
-            testapi::type_string($marker);
-            testapi::wait_serial($cmd . $marker, no_regex => 1, quiet => $args{quiet});
-            testapi::type_string("\n");
+            testapi::type_string("$marker\n");
+            testapi::wait_serial($marker, no_regex => 1, quiet => $args{quiet});
         }
         else {
             testapi::type_string "$marker > /dev/$testapi::serialdev\n";


### PR DESCRIPTION
`$cmd` can contain escape sequences, mostly new line \n, but on serial console are escape sequences expanded thus do not match, this could be solved with some magic, but I don't think it's needed
We don't wait for `$cmd` and marker in other consoles, no reason to do it in serial console which is more robust AFAIK
Optionally moved "\n" into same type_string with `$marker`, one line less in log

This line is gone with `testapi::type_string($marker . "\n");`
```
[2023-04-03T16:55:06.082436+02:00] [debug] [pid:10170] <<< consoles::serial_screen::type_string(cmd="backend_type_string", json_cmd_token="YAlbgaMk", text="\n")
```
e.g. zypper_lifecycle
before: https://dzedro.suse.cz/tests/934#step/zypper_lifecycle/52 3m 43s
after:
https://dzedro.suse.cz/tests/931#step/zypper_lifecycle/52 47s
https://openqa.suse.de/tests/10854031#step/zypper_lifecycle/52 s390x
https://openqa.suse.de/tests/overview?distri=sle&build=lifecycle s390x