### PR TITLE
ci: Improve marking uncoverable statements

### DIFF
--- a/t/04-check_vars_docu.t
+++ b/t/04-check_vars_docu.t
@@ -60,7 +60,7 @@ sub read_doc () {
                 next unless ($var);
                 $default = '' unless (defined $default);
                 $value = '' unless (defined $value);
-                fail "still missing explanation for backend $backend variable $var" unless $explanation;    # uncoverable statement
+                fail "still missing explanation for backend $backend variable $var" unless $explanation;
                 $documented_vars{$backend}{$var} = [$value, $default, $explanation];
             }
         }
@@ -107,12 +107,13 @@ EO_BACKEND_FOOTER
 sub read_backend_pm {    # no:style:signatures
     my ($backend) = $_ =~ /^([^\.]+)\.pm/;
     return unless $backend;
+    # uncoverable statement count:2
     return if (grep { /$backend/i } @backend_blocklist);
     $backend = uc $backend;
     $backend = uc $backend_renames{$backend} if $backend_renames{$backend};
     my $fh;
     eval { open($fh, '<', $File::Find::name) };
-    return fail 'Unable to open ' . $File::Find::name if $@;    # uncoverable statement
+    return fail 'Unable to open ' . $File::Find::name if $@;
     for my $line (<$fh>) {
         my @vars = $line =~ /(?:\$bmwqemu::|\$)vars(?:->)?{["']?([^}"']+)["']?}/g;
         for my $var (@vars) {

--- a/t/07-commands.t
+++ b/t/07-commands.t
@@ -209,6 +209,8 @@ combined_like { eval { $cserver->stop() } } qr/commands process exited/, 'comman
 
 subtest 'decode failure' => sub {
     my $jsonrpc = Test::MockModule->new('myjsonrpc');
+    # uncoverable statement count:2
+    # uncoverable statement count:3
     $jsonrpc->redefine(send_json => sub ($iso, $data) { 1 });
 
     my $oc = Test::MockModule->new('OpenQA::Commands');

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -90,6 +90,7 @@ is($completed, 1, 'start+next+start should complete');
 # Test loading snapshots with always_rollback flag. Have to put it here, before loading
 # runargs test module, as it fails.
 my ($reverts_done, $snapshots_made) = (0, 0);
+# uncoverable statement count:2
 $mock_autotest->redefine(load_snapshot => sub { $reverts_done++ });
 $mock_autotest->redefine(make_snapshot => sub { $snapshots_made++ });
 $mock_autotest->redefine(query_isotovideo => 0);

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -38,8 +38,8 @@ sub isotovideo (%args) {
     note "Starting isotovideo with: @cmd";
     qx(cd $toplevel_dir && @cmd);
     my $res = $?;
-    return fail 'failed to execute isotovideo: ' . $! if $res == -1;    # uncoverable statement
-    return fail 'isotovideo died with signal ' . ($res & 127) if $res & 127;    # uncoverable statement
+    return fail 'failed to execute isotovideo: ' . $! if $res == -1;
+    return fail 'isotovideo died with signal ' . ($res & 127) if $res & 127;
     local $Test::Builder::Level = $Test::Builder::Level + 1;
     return is $res >> 8, $args{exit_code}, 'isotovideo exit code';
 }

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -569,6 +569,9 @@ subtest 'special cases when starting QEMU' => sub {
 
 subtest 'special cases when handling QMP command' => sub {
     my $create_virtio_console_fifo_called;
+    # uncoverable statement count:2
+    # uncoverable statement count:3
+    # uncoverable statement count:4
     $backend_mock->redefine(create_virtio_console_fifo => sub () { ++$create_virtio_console_fifo_called });
     $backend_mock->unmock('handle_qmp_command');
     $bmwqemu::vars{QEMU_ONLY_EXEC} = 1;

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -358,10 +358,10 @@ sub _prepare_video_encoder ($baseclass) {
         my $pipe = IO::Pipe->new;
         my $pid = fork;
         if ($pid) { $pipe->writer }
-        elsif (defined $pid) {    # uncoverable statement
-            $pipe->reader;    # uncoverable statement
-            my @lines = <$pipe>;    # uncoverable statement
-            exit;    # uncoverable statement
+        elsif (defined $pid) {
+            $pipe->reader;
+            my @lines = <$pipe>;
+            exit;
         }    # uncoverable statement
         else { die "Couldn't fork" }    # uncoverable statement
         push @pipes, [$pid => $pipe];
@@ -875,6 +875,8 @@ subtest 'check_asserted_screen takes too long' => sub {
 subtest 'child process handling' => sub {
     throws_ok { $baseclass->_child_process(undef) } qr/without code/, 'starting dies without specifying coderef';
     local $SIG{TERM} = 'DEFAULT';
+    # uncoverable statement count:2
+    # uncoverable statement count:3
     my $pid = $baseclass->_child_process(sub { pause; _exit 0 });
     ok $pid, 'started child, pid returned: ' . ($pid // '?');
     combined_like { $baseclass->_stop_children_processes } qr/waitpid for $pid returned/, 'stopped child again';

--- a/t/27-consoles-local_xvnc.t
+++ b/t/27-consoles-local_xvnc.t
@@ -39,6 +39,7 @@ my $vnc_mock = Test::MockObject->new->set_true('check_vnc_stalls');
 $vnc_base_mock->redefine(connect_remote => $vnc_mock);
 $bmwqemu::scriptdir = "$Bin/..";
 my $local_xvnc_mock = Test::MockModule->new('consoles::localXvnc');
+# uncoverable statement count:2
 $local_xvnc_mock->redefine(start_xvnc => sub { _exit(0) });
 stderr_like { $c->activate } qr/Connected to Xvnc/, 'can call activate';
 is $c->callxterm('true', 'window1'), '', 'can call callxterm';

--- a/t/27-consoles-vmware.t
+++ b/t/27-consoles-vmware.t
@@ -83,6 +83,7 @@ subtest 'request WebSockets URL' => sub {
     my $req_mock = Test::MockModule->new('Mojo::Message::Request');
     my @fake_res = mk_res 200, '<faultstring>some error</faultstring>';
     $user_agent_mock->redefine(start => sub ($ua, $tx) { });
+    # uncoverable statement count:2
     $user_agent_mock->redefine(get => sub { Mojo::Transaction::HTTP->new });
     $http->redefine(result => sub { shift @fake_res });
 
@@ -140,6 +141,7 @@ subtest 'turning WebSocket into normal socket via dewebsockify' => sub {
         sub received_everything ($self) { length $self->received_data >= length 'message sent from raw socket' }
     }
     {
+        # uncoverable statement count:2
         package TestWebSocketApp::Controller::Test;
         use Mojo::Base 'Mojolicious::Controller', -signatures;
         sub start_ws ($self) {
@@ -191,10 +193,10 @@ subtest 'turning WebSocket into normal socket via dewebsockify' => sub {
     $connect_to_dewebsockify = sub ($loop) {
         note "connecting to dewebsockify on port $tcp_port";
         $loop->client({port => $tcp_port} => sub ($loop, $err, $stream) {
-                if ($err) {    # uncoverable statement
-                    if (--$connect_attempts) {    # uncoverable statement
-                        note "unable to connect to dewebsockify on port $tcp_port: $err (will try again $connect_attempts times)";    # uncoverable statement
-                        return $loop->timer(0.1 => $connect_to_dewebsockify);    # uncoverable statement
+                if ($err) {
+                    if (--$connect_attempts) {
+                        note "unable to connect to dewebsockify on port $tcp_port: $err (will try again $connect_attempts times)";
+                        return $loop->timer(0.1 => $connect_to_dewebsockify);
                     }
                     fail "unable to connect to dewebsockify on port $tcp_port: $err";    # uncoverable statement
                     return $loop->stop;    # uncoverable statement
@@ -265,7 +267,6 @@ subtest 'test against real VMWare instance' => sub {
     my $instance_url = $ENV{OS_AUTOINST_TEST_AGAINST_REAL_VMWARE_INSTANCE};
     unless ($instance_url) {
         plan skip_all => 'Set OS_AUTOINST_TEST_AGAINST_REAL_VMWARE_INSTANCE to run this test.';
-        exit(0);    # uncoverable statement
     }
     $vmware->configure_from_url($instance_url);    # uncoverable statement
     note 'host: ' . $vmware->host // '?';    # uncoverable statement

--- a/t/31-sshSerial.t
+++ b/t/31-sshSerial.t
@@ -60,7 +60,9 @@ $mock_channel->mock(read => sub {    # no:style:signatures
         }
 
         if (length($data) > $size) {
-            unshift @{$self->{read_queue}}, substr($data, $size);    # uncoverable statement
+            # uncoverable statement count:1
+            # uncoverable statement count:2
+            unshift @{$self->{read_queue}}, substr($data, $size);
             $data = substr($data, 0, $size);    # uncoverable statement
         }
 
@@ -89,9 +91,12 @@ $mock_ssh->set_always(blocking => $mock_channel->blocking($_[1]));
 $mock_ssh->mock(error => sub ($self) {
         return undef unless defined($self->{error});
         return ${$self->{error}}[0] if ((caller(0))[5]);
-        return @{$self->{error}};    # uncoverable statement
+        # uncoverable statement count:1
+        # uncoverable statement count:2
+        return @{$self->{error}};
 });
 
+# uncoverable statement count:2
 $mock_ssh->mock(die_with_error => sub { die $_[1] });
 
 subtest 'Read test' => sub {


### PR DESCRIPTION
It's only possible to find out which statements are covered or not by having a close look at the HTML report of each file, especially at the number in the "stmt" column.
This will also tell you how many statements a line actually has, as it will add the number of calls in an extra row per statement.

Also if a statement is covered and marked as uncovered, it will decrease the overall percentage (look for lines which are marked as uncoverable but have a call number of greater than 0.
So I removed some of the uncoverable markers and added some elsewhere, where one or more statements on a line aren't covered. Now locally I get 100% for all t/*.t files.

Issue: https://progress.opensuse.org/issues/125237