### PR TITLE
Fix CMake warning about ordering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(os-autoinst CXX)
 cmake_minimum_required(VERSION 3.3.0)
+project(os-autoinst CXX)
 
 # list non-C++ source files
 set(DOC_FILES


### PR DESCRIPTION
Fix the following CMake warning (by changing the order of the `project` and `cmake_minimum_required` commands):

```
CMake Warning (dev) at CMakeLists.txt:1 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.
```