### PR TITLE
Add workaround to prevent `t/29-backend-generalhw.t` being unstable

### DIFF
--- a/backend/generalhw.pm
+++ b/backend/generalhw.pm
@@ -174,9 +174,11 @@ sub start_serial_grab ($self) {
 }
 
 sub stop_serial_grab ($self, @) {
-    return unless $self->{serialpid};
-    kill("-TERM", $self->{serialpid});
-    return waitpid($self->{serialpid}, 0);
+    return 0 unless $self->{serialpid};
+    eval { kill -TERM => $self->{serialpid} };
+    return waitpid($self->{serialpid}, 0) unless my $error = $@;
+    return -1 if $error =~ qr/No such process/i;
+    die "$error\n" if $error;    # uncoverable statement
 }
 
 # serial grab end

--- a/t/29-backend-generalhw.t
+++ b/t/29-backend-generalhw.t
@@ -168,6 +168,7 @@ subtest 'serial grab' => sub {
         $backend->start_serial_grab;
         $backend->stop_serial_grab;
         is waitpid($backend->{serialpid}, WNOHANG), -1, 'process terminated via stop_serial_grab';
+        is $backend->stop_serial_grab, -1, 'returns -1 if process does not exist (but does not die)';
     };
 
     $serialfile->remove;


### PR DESCRIPTION
* Don't die in `stop_serial_grab` if the process does not exist * In this case the process has most likely already terminated anyways so the post-condition of `stop_serial_grab` is still satisfied. * This avoids the corresponding test to sometimes fail with `Can't kill('-TERM', '2481'): No such process at /opt/backend/generalhw.pm line 178` as in the test setup the process might apparently sometimes not be running anymore (not sure why that would be the case, though).
* Related ticket: https://progress.opensuse.org/issues/127532