### PR TITLE
Replace Perl::Critic::{Freenode,Community}

### DIFF
--- a/container/os-autoinst_dev/Dockerfile
+++ b/container/os-autoinst_dev/Dockerfile
@@ -96,7 +96,7 @@ RUN zypper in -y -C \
        'perl(Net::SSH2)' \
        'perl(POSIX)' \
        'perl(Perl::Critic)' \
-       'perl(Perl::Critic::Freenode)' \
+       'perl(Perl::Critic::Community)' \
        'perl(Perl::Critic::Policy)' \
        'perl(Perl::Critic::Utils)' \
        'perl(Perl::Tidy)' \

--- a/cpanfile
+++ b/cpanfile
@@ -80,7 +80,7 @@ on 'test' => sub {
     requires 'Inline::Python';
     requires 'Mojo::IOLoop::ReadWriteProcess', '>= 0.28';
     requires 'Perl::Critic';
-    requires 'Perl::Critic::Freenode';
+    requires 'Perl::Critic::Community';
     requires 'Perl::Critic::Policy';
     requires 'Perl::Critic::Utils';
     requires 'Pod::Coverage';

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -62,7 +62,7 @@ spellcheck_requires:
 
 lint_requires:
   perl(Perl::Critic):
-  perl(Perl::Critic::Freenode):
+  perl(Perl::Critic::Community):
   perl(Perl::Critic::Policy):
   perl(Perl::Critic::Utils):
 


### PR DESCRIPTION
The distribution was renamed. It's available in Leap >= 15.3

Loosely related ticket: https://progress.opensuse.org/issues/127541