### PR TITLE
ci: Add SLE 15 SP4 Backports repository

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -9,9 +9,9 @@ pr:
   - configure_repositories:
       project: devel:openQA:GitHub
       repositories:
-      - name: SLE_15_SP4_Backports
+      - name: SLE_15_SP5_Backports
         paths:
-          - target_project: openSUSE:Backports:SLE-15-SP4:Update
+          - target_project: openSUSE:Backports:SLE-15-SP5:Update
             target_repository: standard
         architectures: [ x86_64 ]
       - name: openSUSE_Tumbleweed

--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -9,6 +9,11 @@ pr:
   - configure_repositories:
       project: devel:openQA:GitHub
       repositories:
+      - name: SLE_15_SP4_Backports
+        paths:
+          - target_project: openSUSE:Backports:SLE-15-SP4:Update
+            target_repository: standard
+        architectures: [ x86_64 ]
       - name: openSUSE_Tumbleweed
         paths:
           - target_project: openSUSE:Factory


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/127541?

I had to add the repo to https://build.opensuse.org/package/show/devel:openQA:GitHub:os-autoinst:os-autoinst:PR-2302/os-autoinst manually.
The repos are actually used from what's in the main branch workflow file.