### PR TITLE
Drop setting of TESSDATA_PREFIX in invoke-tests

### DIFF
--- a/tools/invoke-tests
+++ b/tools/invoke-tests
@@ -52,9 +52,6 @@ fi
 export OS_AUTOINST_BUILD_DIRECTORY=$build_directory
 export OS_AUTOINST_MAKE_TOOL=$make_path
 
-# set TESSDATA_PREFIX for 02-test_ocr.t
-export TESSDATA_PREFIX='/usr/share/tessdata/'
-
 args=()
 # use unbuffer if it was found so e.g. timestamps on OBS builds will be useful
 # note: When executing tests with prove it seems that the output is only flushed after one test has finished unless there's a terminal.


### PR DESCRIPTION
It's not appropriate to do this here. This is not the right path on all distros. Forcing this path here makes it impossible to run the tests successfully on e.g. Fedora, where the tesseract data is in /usr/share/tesseract/tessdata (and there is no need to explicitly specify this, as tesseract is built to find it there without any such specification).