### PR TITLE
container: Distinguish jq and non-jq variants in BuildTag

### DIFF
--- a/container/isotovideo/Dockerfile.qemu-kvm-jq
+++ b/container/isotovideo/Dockerfile.qemu-kvm-jq
@@ -1,4 +1,4 @@
-#!BuildTag: isotovideo:qemu-kvm
+#!BuildTag: isotovideo:qemu-kvm-jq
 
 FROM opensuse/tumbleweed
 # Provide "jq" as convenience to work with the os-autoinst output

--- a/container/isotovideo/Dockerfile.qemu-x86-jq
+++ b/container/isotovideo/Dockerfile.qemu-x86-jq
@@ -1,4 +1,4 @@
-#!BuildTag: isotovideo:qemu-x86
+#!BuildTag: isotovideo:qemu-x86-jq
 
 FROM opensuse/tumbleweed
 # Provide "jq" as convenience to work with the os-autoinst output


### PR DESCRIPTION
Likely this prevents mutual overwriting of container images. Related to
https://github.com/os-autoinst/os-autoinst/pull/2289.