### PR TITLE
Show initialization errors of `isotovideo` again

### DIFF
--- a/isotovideo
+++ b/isotovideo
@@ -158,7 +158,10 @@ eval {
 
     $return_code = handle_generated_assets($runner->command_handler, $clean_shutdown) unless $return_code;
 };
-bmwqemu::serialize_state(component => 'isotovideo', msg => $@) if $@;
+if (my $error = $@) {
+    log::fctwarn $error, 'main';
+    bmwqemu::serialize_state(component => 'isotovideo', msg => $error);
+}
 
 END {
     $runner->backend->stop if $runner and $runner->backend;

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -60,6 +60,12 @@ subtest 'color output can be configured via the command-line' => sub {
     is($out, colorstrip($out), 'no colors in logs');
 };
 
+subtest 'standalone isotovideo without any parameters' => sub {
+    chdir $pool_dir;
+    unlink 'vars.json' if -e 'vars.json';
+    combined_like { isotovideo(opts => '') } qr{CASEDIR variable not set, unknown test case directory}, 'initialization error printed to user';
+};
+
 subtest 'standalone isotovideo without vars.json file and only command line parameters' => sub {
     chdir($pool_dir);
     unlink('vars.json') if -e 'vars.json';


### PR DESCRIPTION
Some refactoring of `isotovideo` meant that initialization errors are only written to the state file but not normally logged anymore. This change restores the old behavior so, e.g. "CASEDIR variable not set, unknown test case directory" is printed again in case this variable is missing.

Related ticket: https://progress.opensuse.org/issues/128216