### PR TITLE
dist: Fix unresolved dependency on chattr in OBS

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -93,7 +93,7 @@ Source0:        %{name}-%{version}.tar.xz
 # The following line is generated from dependencies.yaml
 %define devel_requires %python_style_requires %test_requires ShellCheck perl(Code::TidyAll) perl(Devel::Cover) perl(Devel::Cover::Report::Codecov) perl(Perl::Tidy) perl(Template::Toolkit)
 %define s390_zvm_requires /usr/bin/xkbcomp /usr/bin/Xvnc x3270 icewm xterm xterm-console xdotool fonts-config mkfontdir mkfontscale
-%define qemu_requires qemu-tools %{_bindir}/chattr
+%define qemu_requires qemu-tools e2fsprogs
 BuildRequires:  %test_requires %test_version_only_requires
 # For unbuffered output of Perl testsuite, especially when running it on OBS so timestamps in the log are actually useful
 BuildRequires:  expect


### PR DESCRIPTION
https://build.opensuse.org/package/show/devel:openQA/isotovideo-qemu-x86-jq
shows that os-autoinst-qemu-x86 is unresolvable due to "nothing provides
/usr/bin/chattr". As explained by DimStar zypper would have no problem
to resolve but for a build project in OBS the project config would need
to define a "FileProvides". As the build project config is not
automatically synced for different build products we likely have a more
scalable solution with specifying the package that supplies chattr
directly.