### PR TITLE
Add s390x support to QEMU backend

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -95,7 +95,8 @@ sub configure_controllers ($self, $vars) {
     }
 
     if ($vars->{CDMODEL} eq 'scsi-cd' || $vars->{HDDMODEL} eq 'scsi-hd') {
-        $vars->{SCSICONTROLLER} ||= "virtio-scsi-pci";
+        my $is_s390x = ($vars->{ARCH} // '') eq 's390x';
+        $vars->{SCSICONTROLLER} ||= $is_s390x ? 'virtio-scsi' : 'virtio-scsi-pci';
     }
 
     my $scsi_con = $vars->{SCSICONTROLLER} || 0;

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -245,6 +245,17 @@ subtest qemu_tpm_option => sub {
     like $runcmd, qr|swtpm socket --tpmstate dir=.*mytpm6 --ctrl type=unixio,path=.*mytpm6/swtpm-sock --log level=20 -d|, 'swtpm 1.2 device created';
 };
 
+subtest s390x_options => sub {
+    my $cmdline = qemu_cmdline(ARCH => 's390x', QEMU_VIDEO_DEVICE => 'virtio-gpu', OFW => 0);
+    like $cmdline, qr/-device virtio-gpu,edid=on/, '-device virtio-gpu,edid=on option added';
+    unlike $cmdline, qr/-boot.*/, '-boot options not added';
+    like $cmdline, qr/-device virtio-keyboard/, '-device virtio-keyboard option added';
+    unlike $cmdline, qr/(audiodev|soundhw)/, 'audio options not added';
+    unlike $cmdline, qr/isa-fdc.fdtypeA=none/, 'isa-fdc.fdtypeA=none option is not added';
+    like $cmdline, qr/-device virtio-rng/, '-device virtio-rng option added';
+    like $cmdline, qr/-device virtio-tablet/, '-device virtio-tablet option added';
+};
+
 subtest 'capturing audio' => sub {
     $called{handle_qmp_command} = undef;
     $backend->start_audiocapture({filename => 'foo'});


### PR DESCRIPTION
These virtual devices added for s390x virtualization:

- `virtio-scsi` as alias of `virtio-scsi-ccw` for SCSI controller
- `virtio-gpu` as alias of `virtio-gpu-ccw` for VirtIO GPU Device
- `virtio-rng` as alias of `virtio-rng-ccw` for VirtIO RNG
- `virtio-tablet` as alias of `virtio-tablet-ccw` for input mouse interaction
- `virtio-keyboard` as alias of `virtio-keyboard-ccw` for keyboard interaction

Disabled audio support since there is no audio virtual device available on this architecture (see `qemu-kvm -device help`)