### PR TITLE
Add support for serial device of s390x in testapi

### DIFF
--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -968,6 +968,12 @@ subtest init => sub {
     testapi::init;
     is $testapi::serialdev, 'hvc0', 'init sets serial device for OFW/PPC';
     set_var('OFW', 0);
+    set_var('ARCH', 's390x');
+    set_var('BACKEND', 'qemu');
+    testapi::init;
+    is $testapi::serialdev, 'ttysclp0', 'init sets serial device for s390x on QEMU backend';
+    set_var('ARCH', '');
+    set_var('BACKEND', '');
     set_var('SERIALDEV', 'foo');
     testapi::init;
     is $testapi::serialdev, 'foo', 'custom serial device can be set';

--- a/testapi.pm
+++ b/testapi.pm
@@ -135,6 +135,7 @@ Used for internal initialization, do not call from tests.
 
 sub _serialdev () {
     return 'hvc0' if get_var('OFW') || get_var('BACKEND', '') =~ /s390x|pvm_hmc/;
+    return 'ttysclp0' if (check_var('ARCH', 's390x') && check_var('BACKEND', 'qemu'));
     return get_var('SERIALDEV', 'ttyS0');
 }
 


### PR DESCRIPTION
Use `/dev/ttysclp0` as a serial device for s390x architecture