### PR TITLE
Enable VNC endian conversion when worker is big-endian

### DIFF
--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -378,7 +378,7 @@ sub _server_initialization ($self) {
     $self->_pixinfo(\%pixinfo);
     $self->_bpp($supported_depths{$self->depth}->{bpp});
     $self->_true_colour($supported_depths{$self->depth}->{true_colour});
-    $self->_do_endian_conversion($self->no_endian_conversion ? 0 : $server_is_big_endian != $client_is_big_endian);
+    $self->_do_endian_conversion($self->no_endian_conversion ? 0 : ($server_is_big_endian && $client_is_big_endian));
 
     if ($name_length) {
         $socket->read(my $name_string, $name_length)


### PR DESCRIPTION
When a worker is big-endian (`s390x`), the colors are broken on a little-endian based WebUIs (`x86_64`, `AArch64` and `ppc64le`). Do the endian conversion when `$server_is_big_endian` and `$client_is_big_endian` values returns `true`.

Fixes

![openQA_s390x_broken_colors](https://user-images.githubusercontent.com/10092215/235250450-a06abff7-465a-4e55-b166-e5dcc26cc7f4.png)

Tested in these combinations

`x86_64` Worker with `x86_64` WebUI:
```
server_is_big_endian: 0

client_is_big_endian: 0

_do_endian_conversion: 0
```

`s390x` Worker with `s390x` WebUI:

```
server_is_big_endian: 1

client_is_big_endian: 1

_do_endian_conversion: 1
```

`s390x` Worker with `x86_64` WebUI:

```
server_is_big_endian: 1

client_is_big_endian: 1

_do_endian_conversion: 1
```