### PR TITLE
Allow a needle to have multiple click points

### DIFF
--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -9,7 +9,7 @@ use Mojo::Base -strict, -signatures;
 # -> increment on every change of such APIs
 # -> never move that variable to another place (when refactoring)
 #    because it may be accessed by the tests itself
-our $version = 38;
+our $version = 39;
 
 # major version of the (web socket) API relevant to the developer mode
 # -> increment when making non-backward compatible changes to that API

--- a/needle.pm
+++ b/needle.pm
@@ -73,6 +73,7 @@ sub new ($classname, $jsonfile) {
 
     my $gotmatch;
     my $got_click_point;
+    my $got_click_point_with_id;
     for my $area_from_json (@{$json->{area}}) {
         my $area = {};
         for my $tag (qw(xpos ypos width height)) {
@@ -86,14 +87,22 @@ sub new ($classname, $jsonfile) {
         $area->{margin} = $area_from_json->{margin} || 50;
         if (my $click_point = $area_from_json->{click_point}) {
             if ($got_click_point) {
-                warn "$jsonfile has more than one area with a click point\n";
+                warn "$jsonfile has more than one area with a click point without assigning IDs to each\n";
                 return;
             }
             if (!is_click_point_valid($click_point)) {
                 warn "$jsonfile has an area with invalid click point\n";
                 return;
             }
-            $got_click_point = 1;
+            if (ref $click_point ne 'HASH' || !defined $click_point->{id}) {
+                $got_click_point = 1;
+            } else {
+                $got_click_point_with_id = 1;
+            }
+            if ($got_click_point && $got_click_point_with_id) {
+                warn "$jsonfile has more than one area with a click point without assigning IDs to each\n";
+                return;
+            }
             $area->{click_point} = $click_point;
         }
 

--- a/t/01-test_needle.t
+++ b/t/01-test_needle.t
@@ -434,10 +434,24 @@ subtest 'click point' => sub {
     $needle = needle->new('click-point-center.json');
     is_deeply($needle->{area}->[0]->{click_point}, 'center', 'click point "center" parsed');
 
+    $needle = needle->new('click-point-multiple-ids.json');
+    is_deeply($needle->{area}->[0]->{click_point}, {xpos => 2, ypos => 4, id => "first"}, 'first click point parsed');
+    is_deeply($needle->{area}->[1]->{click_point}, {xpos => 1, ypos => 3, id => "second"}, 'second click point parsed');
+
     like(warning {
             $needle = needle->new('click-point-multiple.json');
-    }, qr/click-point-multiple\.json has more than one area with a click point/, 'warning shown');
-    is_deeply($needle, undef, 'multiple click points not accepted');
+    }, qr/click-point-multiple\.json has more than one area with a click point without assigning IDs to each/, 'warning shown');
+    is_deeply($needle, undef, 'multiple click points without IDs not accepted');
+
+    like(warning {
+            $needle = needle->new('click-point-multiple-mixed-1.json');
+    }, qr/click-point-multiple-mixed-1\.json has more than one area with a click point without assigning IDs to each/, 'warning shown');
+    is_deeply($needle, undef, 'multiple click points without IDs not accepted');
+
+    like(warning {
+            $needle = needle->new('click-point-multiple-mixed-2.json');
+    }, qr/click-point-multiple-mixed-2\.json has more than one area with a click point without assigning IDs to each/, 'warning shown');
+    is_deeply($needle, undef, 'multiple click points without IDs not accepted');
 };
 
 subtest 'workaround property' => sub {

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -321,9 +321,9 @@ subtest 'script_run' => sub {
     is(script_run('false', die_on_timeout => 1, output => 'foo'), '1', 'script_run with no check of success and output, returns exit code');
     is(script_run('false', 0, die_on_timeout => 1), undef, 'script_run with no check of success, returns undef when not waiting');
     $fake_matched = 0;
-    throws_ok { script_run('sleep 13', timeout => 10, die_on_timeout => 1, quiet => 1) } qr/command.*timed out/, 'exception occured on script_run() timeout';
+    throws_ok { script_run('sleep 13', timeout => 10, die_on_timeout => 1, quiet => 1) } qr/command.*timed out/, 'exception occurred on script_run() timeout';
     $testapi::distri->{script_run_die_on_timeout} = 1;
-    throws_ok { script_run('sleep 13', timeout => 10, quiet => 1) } qr/command.*timed out/, 'exception occured on script_run() timeout';
+    throws_ok { script_run('sleep 13', timeout => 10, quiet => 1) } qr/command.*timed out/, 'exception occurred on script_run() timeout';
 
     throws_ok { assert_script_run('sleep 13', timeout => 10, quiet => 1) } qr/command.*timed out/, 'exception occurs on assert_script_run() timeout by default';
     my $autotest_mock = Test::MockModule->new('autotest');
@@ -532,7 +532,25 @@ subtest 'assert_and_click' => sub {
             cmd => 'backend_mouse_set',
             x => 61,
             y => 70,
-    }, 'assert_and_click clicks at the  click point specified as "center"') or diag explain $cmds;
+    }, 'assert_and_click clicks at the click point specified as "center"') or diag explain $cmds;
+
+    $cmds = [];
+    @areas = ({x => 50, y => 60, w => 22, h => 20, click_point => {xpos => 5, ypos => 7, id => 'first'}}, {x => 0, y => 0, w => 10, h => 10, click_point => {xpos => 5, ypos => 7, id => 'second'}});
+    ok(assert_and_click('foo', point_id => 'first'));
+    is_deeply($cmds->[1], {
+            cmd => 'backend_mouse_set',
+            x => 55,
+            y => 67,
+    }, 'assert_and_click clicks at the click point with ID "first"') or diag explain $cmds;
+
+    $cmds = [];
+    @areas = ({x => 50, y => 60, w => 22, h => 20, click_point => {xpos => 5, ypos => 7, id => 'first'}}, {x => 0, y => 0, w => 10, h => 10, click_point => {xpos => 5, ypos => 7, id => 'second'}});
+    ok(assert_and_click('foo', point_id => 'second'));
+    is_deeply($cmds->[1], {
+            cmd => 'backend_mouse_set',
+            x => 5,
+            y => 7,
+    }, 'assert_and_click clicks at the click point with ID "second"') or diag explain $cmds;
 
     is_deeply($cmds->[-1], {cmd => 'backend_mouse_set', x => 100, y => 100}, 'assert_and_click succeeds and move to old mouse set');
 

--- a/t/misc_needles/click-point-multiple-ids.json
+++ b/t/misc_needles/click-point-multiple-ids.json
@@ -1,0 +1,36 @@
+{
+    "area": [
+        {
+            "height": 250,
+            "match": 95,
+            "max_offset": 0,
+            "processing_flags": "t",
+            "type": "match",
+            "width": 800,
+            "xpos": 5,
+            "ypos": 10,
+            "click_point": {
+                "xpos": 2,
+                "ypos": 4,
+                "id": "first"
+            }
+        },
+        {
+            "height": 250,
+            "match": 95,
+            "max_offset": 0,
+            "processing_flags": "t",
+            "type": "match",
+            "width": 800,
+            "xpos": 5,
+            "ypos": 10,
+            "click_point": {
+                "xpos": 1,
+                "ypos": 3,
+                "id": "second"
+            }
+        }
+    ],
+    "tags": ["click-point"],
+    "properties": ["glossy"]
+}

--- a/t/misc_needles/click-point-multiple-ids.png
+++ b/t/misc_needles/click-point-multiple-ids.png
@@ -1,0 +1,1 @@
+click-point-multiple-ids.json

--- a/t/misc_needles/click-point-multiple-mixed-1.json
+++ b/t/misc_needles/click-point-multiple-mixed-1.json
@@ -1,0 +1,35 @@
+{
+    "area": [
+        {
+            "height": 250,
+            "match": 95,
+            "max_offset": 0,
+            "processing_flags": "t",
+            "type": "match",
+            "width": 800,
+            "xpos": 5,
+            "ypos": 10,
+            "click_point": {
+                "xpos": 2,
+                "ypos": 4,
+                "id": "first"
+            }
+        },
+        {
+            "height": 250,
+            "match": 95,
+            "max_offset": 0,
+            "processing_flags": "t",
+            "type": "match",
+            "width": 800,
+            "xpos": 5,
+            "ypos": 10,
+            "click_point": {
+                "xpos": 1,
+                "ypos": 3
+            }
+        }
+    ],
+    "tags": ["click-point"],
+    "properties": ["glossy"]
+}

--- a/t/misc_needles/click-point-multiple-mixed-1.png
+++ b/t/misc_needles/click-point-multiple-mixed-1.png
@@ -1,0 +1,1 @@
+click-point-multiple-mixed-1.json

--- a/t/misc_needles/click-point-multiple-mixed-2.json
+++ b/t/misc_needles/click-point-multiple-mixed-2.json
@@ -1,0 +1,35 @@
+{
+    "area": [
+        {
+            "height": 250,
+            "match": 95,
+            "max_offset": 0,
+            "processing_flags": "t",
+            "type": "match",
+            "width": 800,
+            "xpos": 5,
+            "ypos": 10,
+            "click_point": {
+                "xpos": 2,
+                "ypos": 4
+            }
+        },
+        {
+            "height": 250,
+            "match": 95,
+            "max_offset": 0,
+            "processing_flags": "t",
+            "type": "match",
+            "width": 800,
+            "xpos": 5,
+            "ypos": 10,
+            "click_point": {
+                "xpos": 1,
+                "ypos": 3,
+                "id": "second"
+            }
+        }
+    ],
+    "tags": ["click-point"],
+    "properties": ["glossy"]
+}

--- a/t/misc_needles/click-point-multiple-mixed-2.png
+++ b/t/misc_needles/click-point-multiple-mixed-2.png
@@ -1,0 +1,1 @@
+click-point-multiple-mixed-2.json

--- a/testapi.pm
+++ b/testapi.pm
@@ -446,7 +446,7 @@ sub match_has_tag ($tag) { $last_matched_needle ? $last_matched_needle->{needle}
 
 =head2 assert_and_click
 
-  assert_and_click($mustmatch [, timeout => $timeout] [, button => $button] [, clicktime => $clicktime ] [, dclick => 1 ] [, mousehide => 1 ]);
+  assert_and_click($mustmatch [, timeout => $timeout] [, button => $button] [, clicktime => $clicktime ] [, dclick => 1 ] [, mousehide => 1 ] [, point_id => $id ]);
 
 Wait for needle with C<$mustmatch> tag to appear on SUT screen. Then click
 C<$button> at the "click_point" position as defined in the needle JSON file,
@@ -455,7 +455,9 @@ needle area. If C<$dclick> is set, do double click instead.  C<$mustmatch> can
 be string or C<ARRAYREF> of strings (C<['tag1', 'tag2']>).  C<$button> is by
 default C<'left'>. C<'left'> and C<'right'> is supported. If C<$mousehide> is
 true then always move mouse to the 'hidden' position after clicking to prevent
-to hide the area where user wants to assert/click in second step.
+to hide the area where the user wants to assert/click in the second step. If
+C<$point_id> is specified, the clickpoint used will be the one with a matching
+ID.
 
 Throws C<FailedNeedle> exception if C<$timeout> timeout is hit. Default timeout is 30s.
 
@@ -467,22 +469,23 @@ sub assert_and_click ($mustmatch, %args) {
     $last_matched_needle = assert_screen($mustmatch, $args{timeout});
     bmwqemu::log_call(mustmatch => $mustmatch, %args);
 
-    my %click_args = map { $_ => $args{$_} } qw(button clicktime dclick mousehide);
+    my %click_args = map { $_ => $args{$_} } qw(button clicktime dclick mousehide point_id);
     return click_lastmatch(%click_args);
 }
 
 =head2 click_lastmatch
 
-  click_lastmatch([, button => $button] [, clicktime => $clicktime ] [, dclick => 1 ] [, mousehide => 1 ]);
+  click_lastmatch([, button => $button] [, clicktime => $clicktime ] [, dclick => 1 ] [, mousehide => 1 ] [, point_id => $id ]);
 
 Click C<$button> at the "click_point" position as defined in the needle JSON file
 of the last matched needle, or - if the JSON has not explicit "click_point" -
 in the middle of the last match area. If C<$dclick> is set, do double click
 instead. Supported values for C<$button> are C<'left'> and C<'right'>, C<'left'>
 is the default. If C<$mousehide> is true then always move mouse to the 'hidden'
-position after clicking to prevent to disturb the area where user wants to
-assert/click in second step, otherwise move the mouse back to its previous
-position.
+position after clicking to prevent to disturb the area where the user wants to
+assert/click in the second step, otherwise move the mouse back to its previous
+position. If C<$point_id> is specified, the clickpoint used will be the one
+with a matching ID.
 
 =cut
 
@@ -490,6 +493,7 @@ sub click_lastmatch (%args) {
     $args{button} //= 'left';
     $args{dclick} //= 0;
     $args{mousehide} //= 0;
+    $args{point_id} //= undef;
 
     return unless $last_matched_needle;
 
@@ -500,6 +504,7 @@ sub click_lastmatch (%args) {
     my $relative_click_point;
     for my $area (reverse @{$last_matched_needle->{area}}) {
         next unless ($relative_click_point = $area->{click_point});
+        next if defined $args{point_id} && $relative_click_point->{id} ne $args{point_id};
         $relevant_area = $area;
         last;
     }


### PR DESCRIPTION
Needles will now be able to have multiple click points, provided that each is given an ID. If no ID is specified when calling click_lastmatch, the first click point found will be used