### PR TITLE
Fix 27-consoles-vnc.t for change to endianness conversion logic

### DIFF
--- a/t/27-consoles-vnc.t
+++ b/t/27-consoles-vnc.t
@@ -357,7 +357,7 @@ subtest 'server initialization' => sub {
     $red_shift = 10;
     $green_shift = 5;
     $blue_shift = 0;
-    my @params = ($bits_per_pixel, $depth, $server_is_big_endian != $machine_is_big_endian, $true_colour_flag, $red_max, $green_max, $blue_max, $red_shift, $green_shift, $blue_shift);
+    my @params = ($bits_per_pixel, $depth, ($server_is_big_endian && $machine_is_big_endian), $true_colour_flag, $red_max, $green_max, $blue_max, $red_shift, $green_shift, $blue_shift);
     my @expected = (
         pack(CCCCCCCCnnnCCCCCC => 0, 0, 0, 0, @params, 0, 0, 0),    # setpixelformat
         pack(CCn => 2, 0, 5),    # five supported encodings (no ZRLE due to dell flag)


### PR DESCRIPTION
In e64b7f1 , the condition for doing the VNC endianness conversion in consoles/VNC.pm was changed. However, this test - which has to mirror the condition to ensure the expected values are correct - was not similarly updated. This causes the test to fail on s390x.