### PR TITLE
Switch OBS SCM/CI Workflow to branch_package

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -1,10 +1,11 @@
 ---
 pr:
   steps:
-  - link_package:
+  - branch_package:
       source_project: devel:openQA
       source_package: os-autoinst
       target_project: devel:openQA:GitHub
+      add_repositories: disabled
   - configure_repositories:
       project: devel:openQA:GitHub
       repositories:


### PR DESCRIPTION
The OBS changed how it decides if a service should run for a package. Services in modes that would not run server side are filtered out.

This means packages created with `link_package` steps stopped running services a while ago. 

Using the `branch_package` step with `add_repositories: disabled` is a replacement for having a package with services but only selected repositories in the test build.