### PR TITLE
Improve coverage, add tests, ensure all scripts handle invalid options

### DIFF
--- a/check_needles.pl
+++ b/check_needles.pl
@@ -2,11 +2,24 @@
 
 use Mojo::Base -strict, -signatures;
 use File::Basename;
+use Getopt::Long;
 use needle;
 use cv;
 
 cv::init();
 require tinycv;
+
+Getopt::Long::Configure("no_ignore_case");
+
+my %options;
+
+sub usage ($r) {
+    eval { require Pod::Usage; Pod::Usage::pod2usage($r) };
+    die "cannot display help, install perl(Pod::Usage)\n" if $@;    # uncoverable statement
+}
+
+GetOptions(\%options, 'help|h|?') or usage(1);
+usage(0) if $options{help};
 
 my ($res, $needle, $img);
 my $ndir = $ARGV[0] || ".";

--- a/check_qemu_oom
+++ b/check_qemu_oom
@@ -22,12 +22,12 @@ my %options;
 
 sub usage ($r) {
     eval { require Pod::Usage; Pod::Usage::pod2usage($r) };
-    die "cannot display help, install perl(Pod::Usage)\n" if $@;
+    die "cannot display help, install perl(Pod::Usage)\n" if $@;    # uncoverable statement
 }
 
 GetOptions(\%options, 'help|h|?') or usage(1);
 usage(0) if $options{help};
 usage(1) unless @ARGV;
 my $qemu_pid = $ARGV[0] or usage(1);
-
-exit(index(qx{dmesg} // '', "Out of memory: Killed process $qemu_pid") != -1 ? 0 : 1);
+my $oom_log_cmd = $ENV{CHECK_QEMU_OOM_LOG_CMD} // 'dmesg';
+exit(index(qx{$oom_log_cmd} // '', "Out of memory: Killed process $qemu_pid") != -1 ? 0 : 1);

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,14 +4,14 @@ comment:
   behavior: default
   require_changes: true
 coverage:
-  range: 60..95
+  range: 80..100
   round: down
   precision: 2
   status:
     changes: false
     project:
       default:
-        target: 80.0
+        target: 94.0
         threshold: 0.1
       fully_covered:
         target: 100.0

--- a/imgsearch
+++ b/imgsearch
@@ -36,20 +36,21 @@ use needle;
     sub from_paths ($needle_paths, @args) { [map { basic_needle->new($_, @args) } @$needle_paths] }
 }
 
-sub print_usage () {
+sub usage ($r) {
     print "imgsearch [options]
 
 options:
     --needle-images    specifies images to look for
     --haystack-images  specifies images to look in
     --verbose          enables debug output
+    --help             Show this help
 
 example:
 imagesearch \
     --needle-images logo1.png logo2.png \
     --haystack-images asset.png screenshot.png
 ";
-    exit 0;
+    exit $r;
 }
 
 getopt 'needle-images=s@{1,}' => \my @needle_image_paths,
@@ -58,9 +59,11 @@ getopt 'needle-images=s@{1,}' => \my @needle_image_paths,
   'margin=f' => \my $margin,
   'threshold=f' => \my $threshold,
   'search-ratio=f' => \my $search_ratio,
-  'v|verbose' => \my $verbose;
+  'v|verbose' => \my $verbose,
+  'h|help' => \my $help;
 
-print_usage unless @needle_image_paths && @image_paths;
+usage(0) if $help;
+usage(1) unless @needle_image_paths && @image_paths;
 
 # stop opencv logging messages polluting stdout
 $ENV{'OPENCV_LOG_LEVEL'} ||= 'SILENT';

--- a/isotovideo
+++ b/isotovideo
@@ -75,7 +75,11 @@ use OpenQA::Isotovideo::Utils qw(git_rev_parse spawn_debuggers handle_generated_
 
 my %options;
 
+# global exit status
+my $return_code = 1;
+
 sub usage ($r) {
+    $return_code = $r;
     eval { require Pod::Usage; Pod::Usage::pod2usage($r) };
     die "cannot display help, install perl(Pod::Usage)\n" if $@;
 }
@@ -87,6 +91,7 @@ sub _get_version_string () {
 
 sub version () {
     print _get_version_string() . "\n";
+    $return_code = 0;
     exit 0;
 }
 
@@ -104,9 +109,6 @@ delete $ENV{NO_COLOR} if $color eq 'yes';
 $ENV{ANSI_COLORS_DISABLED} = 1 if $color eq 'no';
 
 chdir $options{workdir} if $options{workdir};
-
-# global exit status
-my $return_code = 1;
 
 # abstraction providing many helpers and function to run the select-loop
 my $runner;

--- a/t/40-check_qemu_oom.t
+++ b/t/40-check_qemu_oom.t
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+use Test::Warnings ':report_warnings';
+
+use FindBin '$Bin';
+use lib "$FindBin::Bin/lib", "$Bin/../external/os-autoinst-common/lib";
+use OpenQA::Test::TimeLimit '5';
+
+sub check_qemu_oom () {
+    system("$Bin/../check_qemu_oom 1");
+    return $? >> 8;
+}
+
+$ENV{CHECK_QEMU_OOM_LOG_CMD} = 'true';
+is check_qemu_oom(), 1, 'No OOM condition found on PID 1';
+$ENV{CHECK_QEMU_OOM_LOG_CMD} = 'echo "Out of memory: Killed process 1"';
+is check_qemu_oom(), 0, 'OOM condition found based on special message';
+
+done_testing;

--- a/t/44-scripts.t
+++ b/t/44-scripts.t
@@ -27,6 +27,10 @@ for my $script (sort keys %types) {
     my $out = qx{timeout 8 $Bin/../$script --help 2>&1};
     my $rc = $? >> 8;
     is $rc, 0, "Calling '$script --help' returns exit code 0" or diag "Output($script): $out";
+    $out = qx{$Bin/../$script invalid-command --invalid-flag 2>&1};
+    $rc = $?;
+    isnt($rc, 0, "Calling '$script invalid-command --invalid-flag' returns non-zero exit code")
+      or diag "Output: $out";
 }
 
 done_testing;

--- a/tools/invoke-tests
+++ b/tools/invoke-tests
@@ -44,7 +44,7 @@ db="$build_directory/cover_db"
 # set Perl module include path and coverage options
 export PERL5LIB="$source_directory:$source_directory/ppmclibs/blib/lib:$source_directory/ppmclibs/blib/arch/auto/tinycv:$PERL5LIB"
 if [[ $WITH_COVER_OPTIONS ]]; then
-    ignore="external/|t/data/tests/tests/|/tmp|/CheckGitStatus.pm|$prove_path"
+    ignore="external/|tools/|t/data/tests/tests/|/tmp|/CheckGitStatus.pm|$prove_path"
     # add ' -MOpenQA::Test::PatchDeparse' for older OS versions to avoid warnings
     export PERL5OPT="-I$source_directory/t/lib -I$source_directory/external/os-autoinst-common/lib -MOpenQA::Test::CheckGitStatus -MDevel::Cover=-db,$db,-ignore,$ignore,-coverage,statement"
 fi


### PR DESCRIPTION
tools/update-deps is a symlink to a script in external/ which is already
excluded from coverage analysis as it comes from an external repository.
tools/update-deps should hence also not be included in our coverage
analysis – especially as its statement coverage is not 100% – and as
tools/update-deps is currently the only file within tools/ that ends up
in coverage data anyway as visible in
https://app.codecov.io/gh/os-autoinst/os-autoinst/tree/master/tools
we should consistently exclude the complete tools directory from
analysis.