### PR TITLE
Fix MAX_TEST_STEPS with default value of 50k

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -412,7 +412,7 @@ sub save_test_result ($self) {
     return $result;
 }
 
-sub _increment_test_count ($self, $max = $bmwqemu::vars{MAX_TEST_STEPS} // 50) {
+sub _increment_test_count ($self, $max = $bmwqemu::vars{MAX_TEST_STEPS} // 50000) {
     if ($total_result_count >= $max) {
         my $msg = "Maximum allowed test steps (MAX_TEST_STEPS=$max) exceeded";
         $self->{fatal_failure} = 1;


### PR DESCRIPTION
Seems like previous commits by accident reverted the change from 50 to
50k.