### PR TITLE
Enable external video encoder by default if available

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -343,7 +343,7 @@ sub _invoke_video_encoder ($self, $pipe_name, $display_name, @cmd) {
     $pipe->blocking(!!$bmwqemu::vars{VIDEO_ENCODER_BLOCKING_PIPE});
 }
 
-sub _ffmpeg_banner () { `ffmpeg 2>&1` // '' }
+sub _ffmpeg_banner () { qx{ffmpeg 2>&1} // '' }
 
 sub _auto_detect_external_video_encoder ($self) {
     my $ffmpeg_banner = _ffmpeg_banner;

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -620,7 +620,7 @@ sub start_qemu ($self) {
     $self->{proc}->qemu_img_bin($qemuimg);
 
     # Get qemu version
-    my $qemu_version = `$qemubin -version`;
+    my $qemu_version = qx{$qemubin -version};
     $qemu_version =~ /([0-9]+([.][0-9]+)+)/;
     $qemu_version = $1;
     $self->{qemu_version} = $qemu_version;

--- a/os-autoinst-openvswitch
+++ b/os-autoinst-openvswitch
@@ -54,7 +54,7 @@ sub init_switch ($self) {
     system('ovs-vsctl', 'br-exists', $self->{BRIDGE});
 
     for (my $timeout = $ENV{OS_AUTOINST_OPENVSWITCH_INIT_TIMEOUT} // ONE_MINUTE; $timeout > 0; --$timeout) {
-        my $bridge_conf = `ip addr show $self->{BRIDGE}`;
+        my $bridge_conf = qx{ip addr show $self->{BRIDGE}};
         $self->{MAC} = $1 if $bridge_conf =~ /ether\s+(([0-9a-f]{2}:){5}[0-9a-f]{2})\s/;
         $self->{IP} = $1 if $bridge_conf =~ /inet\s+(([0-9]+.){3}[0-9]+\/[0-9]+)\s/;
         last if $self->{IP};
@@ -132,7 +132,7 @@ sub _ovs_check ($tap, $vlan, $bridge) {
         return ($return_code, $return_output);
     }
 
-    my $check_bridge = `ovs-vsctl port-to-br $tap`;
+    my $check_bridge = qx{ovs-vsctl port-to-br $tap};
     chomp $check_bridge;
     if ($check_bridge ne $bridge) {
         $return_output = "'$tap' is not connected to bridge '$bridge'";
@@ -159,7 +159,7 @@ sub _cmd (@args) {
 }
 
 sub check_min_ovs_version ($min_ver) {
-    my $out = `ovs-vsctl --version`;
+    my $out = qx{ovs-vsctl --version};
     return if ($out !~ /\(Open vSwitch\)\s+(\d+\.\d+\.\d+)/m);
     my @ver = split(/\./, $1);
     my @min_ver = split(/\./, $min_ver);

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -168,7 +168,7 @@ subtest 'SSH utilities' => sub {
                             $self->{cmd} = $cmd;
                             $self->{eof} = 0;
                             if ($cmd =~ /^(echo|test)/) {
-                                $self->{stdout} = `$cmd`;
+                                $self->{stdout} = qx{$cmd};
                                 $self->{exit_status} = $?;
                                 $self->{stderr} = '';
                             }

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -671,6 +671,7 @@ subtest 'corner cases of do_capture/run_capture_loop' => sub {
 };
 
 subtest 'starting external video encoder and enqueuing screenshot data for it' => sub {
+    ok !$baseclass->_start_external_video_encoder_if_configured, 'external video encoder not used by default';
     my $video_encoders = $baseclass->{video_encoders} = {};
     $bmwqemu::vars{EXTERNAL_VIDEO_ENCODER_CMD} = 'true -o %OUTPUT_FILE_NAME% "trailing arg"';
     $log::logger->level('info');

--- a/t/28-signalblocker.t
+++ b/t/28-signalblocker.t
@@ -26,7 +26,7 @@ no warnings 'redefine';
 my $no_signal_blocker = $ENV{OS_AUTOINST_TEST_NO_SIGNAL_BLOCKER};
 
 # define a helper to find the number of threads spawned by this test
-sub thread_count () { scalar split("\n", `ps huH p $$`) }
+sub thread_count () { scalar split("\n", qx{ps huH p $$}) }
 is(my $last_thread_count = thread_count, 1, 'initially one thread');
 
 # count SIGTERMs we receive; those handlers should work after creating/destroying the signal blocker


### PR DESCRIPTION
* Enable the use of an external video encoder by default if it
  one is available; the following options are tested and the
  first one wins:
    * Use EXTERNAL_VIDEO_ENCODER_CMD if it is non-empty (as before)
    * Use the built-in encoder if EXTERNAL_VIDEO_ENCODER_CMD is
      present but empty (as before)
    * Use SVT-AV1 if a version of ffmpeg supporting it is in path
    * Use VP9 if a version of ffmpeg supporting it is in path
    * Use the built-in encoder (as before)
* See https://progress.opensuse.org/issues/129955

---

I tested this locally when:
1. ffmpeg is not present in path
2. ffmpeg is present in path but not executable
3. an empty `EXTERNAL_VIDEO_ENCODER_CMD` is configured
4. a non-empty `EXTERNAL_VIDEO_ENCODER_CMD` is configured
5. ffmpeg is present and executable and supports SVT-AV1

In cases 1. to 3. the internal video encoder is used. In 4. and 5. the external video encoder is invoked with expected arguments.