### PR TITLE
git/hook: Allow non whitespace in subject message

### DIFF
--- a/.github/workflows/commit_message_checker.yml
+++ b/.github/workflows/commit_message_checker.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Check Subject Begining
         uses: gsactions/commit-message-checker@v1
         with:
-          pattern: '^([A-Z]|[A-Za-z0-9_/.]+:|git subrepo pull)'
+          pattern: '^([A-Z]|\S+:|git subrepo pull)'
           flags: 'g'
           error: 'The subject does not start with a capital or tag.'
           excludeDescription: 'true'


### PR DESCRIPTION
This is a backport of [9463302 ("git: allow non whitespace in subject message")](https://github.com/os-autoinst/os-autoinst-common/commit/94633025dbdc6491ba111e129eef0e286fcfab9d).