### PR TITLE
Remove non-functional save_storage_drives from testapi

### DIFF
--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -9,7 +9,7 @@ use Mojo::Base -strict, -signatures;
 # -> increment on every change of such APIs
 # -> never move that variable to another place (when refactoring)
 #    because it may be accessed by the tests itself
-our $version = 38;
+our $version = 39;
 
 # major version of the (web socket) API relevant to the developer mode
 # -> increment when making non-backward compatible changes to that API

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -488,8 +488,6 @@ sub switch_network ($self, $args) { $self->notimplemented }
 
 sub save_memory_dump ($self, $args) { $self->notimplemented }
 
-sub save_storage_drives ($self, $args) { $self->notimplemented }
-
 ## MAY be overwritten:
 
 # vm's would return

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -322,20 +322,6 @@ sub save_memory_dump ($self, $args) {
     }
 }
 
-sub save_storage_drives ($self, $args) {
-    diag "Attempting to extract disk #$args->{disk}";
-    $self->do_extract_assets(
-        {
-            hdd_num => $args->{disk},
-            name => sprintf("%s-%d-vm_disk_file.qcow2", $args->{filename}, $args->{disk}),
-            dir => "ulogs",
-            format => "qcow2"
-        });
-
-    diag "Successfully extracted disk #$args->{disk}";
-    return;
-}
-
 sub inflate_balloon ($self) {
     my $vars = \%bmwqemu::vars;
     return unless $vars->{QEMU_BALLOON_TARGET};

--- a/doc/memorydumps.asciidoc
+++ b/doc/memorydumps.asciidoc
@@ -8,8 +8,7 @@ IMPORTANT: Currently only the QEMU backend is supported.
 
 == How to use
 
-Three methods are available to the test writer, `freeze_vm`, `save_memory_dump`,
-and `save_storage_drives`
+Two methods are available to the test writer, `freeze_vm` and `save_memory_dump`
 
 The feature is enabled by calling the aforementioned methods, using
 a https://github.com/os-autoinst/openQA/blob/master/docs/WritingTests.asciidoc#how-to-write-tests[post_fail_hook] and setting the test's flags as fatal. The `save_memory_dump` method can be however
@@ -21,15 +20,6 @@ The method `save_memory_dump` can be called at any point, but it is recommended
 to use it within a post fail hook. Different filenames should be provided if the
 dump is being used within the test itself (or more than one memory dump is being
 created) if no filename is provided, the test's name will be used.
-
-=== save_storage_drives
-
-The method `save_storage_drives` saves all of the SUT drives using a filename
-provided by the user, if not the current test's name will be used  as part of
-the final filename, the default will be the current test's name. The  disk
-number will be always present.
-
-NOTE: Call this method to ensure memory and disk dump refer to the same machine state.
 
 === freeze_vm
 
@@ -48,7 +38,6 @@ A very simple way to use this helpful feature is the following:
 sub post_fail_hook ($self) {
     freeze_vm;
     save_memory_dump(filename => 'my-memory-dump');
-    save_storage_drives('my-disk');
 }
 
 sub test_flags ($) { { fatal => 1 } }

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -1072,7 +1072,6 @@ subtest 'assert/check recorded sound' => sub {
 
 lives_ok { power('on') } 'power can be called';
 lives_ok { save_memory_dump } 'save_memory_dump can be called';
-like(exception { save_storage_drives }, qr/should be called.*post_fail_hook/, 'save_storage_drives should be called special');
 lives_ok { freeze_vm } 'freeze_vm can be called';
 lives_ok { resume_vm } 'resume_vm can be called';
 

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -414,15 +414,6 @@ subtest 'saving memory dump' => sub {
     is $runcmd, 'bzip2 -v6 ulogs/foo-vm-memory-dump', 'expected compression fallback command invoked';
 };
 
-subtest 'saving storage drives' => sub {
-    my @extract_args;
-    my @expected_args = ([$backend, {hdd_num => 42, name => 'foo-42-vm_disk_file.qcow2', dir => 'ulogs', format => 'qcow2'}]);
-    $backend_mock->redefine(do_extract_assets => sub (@args) { push @extract_args, \@args });
-    combined_like { $backend->save_storage_drives({disk => 42, filename => 'foo'}) }
-    qr/Attempting to extract disk #42.*Successfully extracted disk #42/s, 'extraction logged';
-    is_deeply \@extract_args, \@expected_args, 'expected assets extracted' or diag explain \@extract_args;
-};
-
 subtest '"balloon" handling' => sub {
     $fake_qmp_answer = {return => {actual => 1}};
     $$invoked_qmp_cmds = undef;

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -83,7 +83,6 @@ subtest 'not implemented' => sub {
         [do_extract_assets => 23],
         [switch_network => 23],
         [save_memory_dump => 23],
-        [save_storage_drives => 23],
     );
     for my $test (@tests) {
         my ($m, @args) = @$test;

--- a/testapi.pm
+++ b/testapi.pm
@@ -53,7 +53,7 @@ our @EXPORT = qw($realname $username $password $serialdev %cmd %vars
   become_root x11_start_program ensure_installed eject_cd power
 
   switch_network
-  save_memory_dump save_storage_drives freeze_vm resume_vm
+  save_memory_dump freeze_vm resume_vm
 
   diag hashed_string
 
@@ -1922,36 +1922,6 @@ sub save_memory_dump (%nargs) {
     bmwqemu::diag("Trying to save machine state");
 
     query_isotovideo('backend_save_memory_dump', \%nargs);
-}
-
-=head2 save_storage_drives
-
-  save_storage_drives([$filename]);
-
-Saves all of the SUT drives using C<$filename> as part of the final filename,
-the default will be the current test's name. The disk number will be always present.
-
-This method must be called within a post_fail_hook.
-
-I<Currently only qemu backend is supported.>
-
-=cut
-
-sub save_storage_drives ($filename = undef) {
-    $filename //= $autotest::current_test->{name};
-    die "save_storage_drives should be called within a post_fail_hook" unless ((caller(1))[3]) =~ /post_fail_hook/;
-
-    bmwqemu::log_call();
-    bmwqemu::diag("Trying to save machine drives");
-    bmwqemu::load_vars();
-
-    # Right now, we're saving all the disks
-    # sometimes we might not want to. This could be improved.
-    if (my $nd = $bmwqemu::vars{NUMDISKS}) {
-        for my $i (1 .. $nd) {
-            query_isotovideo('backend_save_storage_drives', {disk => $i, filename => $filename});
-        }
-    }
 }
 
 =head2 freeze_vm


### PR DESCRIPTION
https://progress.opensuse.org/issues/130922

`save_storage_drives` never worked and isn't used by any test
(os-autoinst-distri-*) and with high probability in any other instance
of openQA because nobody reported an issue with it.

As for why it can't work --> `qemu-img` works only with offline images, it
can't work on images used by running or paused VM. Any use of this method
will end with:

~~~
qemu-img: Could not open '/var/lib/openqa/pool/2/raid/hd0-overlay0': Failed to get shared "write" lock
  Is another process using the image [/var/lib/openqa/pool/2/raid/hd0-overlay0]?
~~~

A fix for this is non-trivial and there is minimum users for this
functionality is better to remove this method first to prevent users to use
it and also to remove practically dead code from os-autoinst