### PR TITLE
Fix script_run sanity checks

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -127,7 +127,8 @@ sub script_run ($self, $cmd, @args) {
         my $marker = "; echo $str-\$?-" . ($args{output} ? "Comment: $args{output}" : '');
         if (testapi::is_serial_terminal) {
             testapi::type_string($marker);
-            testapi::wait_serial($cmd . $marker, no_regex => 1, quiet => $args{quiet});
+            die 'Command was mistyped'
+              unless testapi::wait_serial($cmd . $marker, no_regex => 1, quiet => $args{quiet});
             testapi::type_string("\n");
         }
         else {

--- a/distribution.pm
+++ b/distribution.pm
@@ -116,6 +116,7 @@ sub script_run ($self, $cmd, @args) {
             quiet => undef
         }, ['timeout'], @args);
 
+    die "Multiline commands are not supported:\n$cmd;\n" if $cmd =~ m/\n/;
     if (testapi::is_serial_terminal) {
         testapi::wait_serial($self->{serial_term_prompt}, no_regex => 1, quiet => $args{quiet});
     }


### PR DESCRIPTION
The `script_run()` function checks for mistyped commands on serial terminal but the check does nothing except for slowing down the job when it fails. Make the mistype check failures clearly visible.

In addition, add special error message for command strings containing newline characters because these will cause mistype check failures. Use the newline check even on VNC console so that all invalid usage gets fixed now and switching from VNC to serial console works seamlessly in the future.

Mutually exclusive with #2295.