### PR TITLE
Make it possible to run more than one python test module

### DIFF
--- a/t/fake/tests/morepython.py
+++ b/t/fake/tests/morepython.py
@@ -2,4 +2,4 @@ from testapi import *
 
 
 def run(self):
-    pass
+    diag("This is morepython.py")

--- a/t/fake/tests/pythontest.py
+++ b/t/fake/tests/pythontest.py
@@ -1,0 +1,6 @@
+from testapi import *
+
+
+def run(self):
+    diag("This is pythontest.py")
+    set_var("HELP", "I am a python script trapped in a perl script!")


### PR DESCRIPTION
Before all functions would be imported to the global namespace.

Issue: https://progress.opensuse.org/issues/132656

I had to rename test.py to pythontest.py because otherwise python was complaining:

    ImportError: Module 'test' is not installed.
