### PR TITLE
Revert "Use tempfile TMPDIR option"

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -483,7 +483,7 @@ sub get_remote_vmm ($self) { $bmwqemu::vars{VMWARE_REMOTE_VMM} // '' }
 sub define_and_start ($self) {
     my $remote_vmm = "";
     if ($self->vmm_family eq 'vmware') {
-        my ($fh, $libvirtauthfilename) = File::Temp::tempfile('libvirtauth-XXXX', TMPDIR => 1);
+        my ($fh, $libvirtauthfilename) = File::Temp::tempfile('libvirtauth-XXXX', DIR => "/tmp/");
 
         # The libvirt esx driver supports connection over HTTP(S) only. When
         # asked to authenticate we provide the password via 'authfile'.


### PR DESCRIPTION
This reverts commit 3766bf348dfd9732cd2dc230b712ed0ed339f811.

The problem seems to be that we are setting $ENV{TMPDIR} to the pool directory in openQA, and when $libvirtauthfilename is created in there, it gets removed for some reason.
https://github.com/os-autoinst/os-autoinst/commit/3766bf348dfd9732cd2dc230b712ed0ed339f811#r122622230

I guess we just have to rely on the fact that `/tmp/` will always exist :)