### PR TITLE
Avoid CMake deprecation warning by bumping version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.17.0)
 project(os-autoinst CXX)
 
 # list non-C++ source files

--- a/cmake/pkg-config.cmake
+++ b/cmake/pkg-config.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.17.0)
 
 include(FindPkgConfig)
 

--- a/cmake/test-targets.cmake
+++ b/cmake/test-targets.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.17.0)
 
 enable_testing()
 

--- a/debugviewer/CMakeLists.txt
+++ b/debugviewer/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(debugviewer)
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.17.0)
 
 add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE opencv_core opencv_imgcodecs opencv_highgui)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(doc CXX)
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.17.0)
 
 find_program(POD2HTML_PATH pod2html)
 if (NOT POD2HTML_PATH)

--- a/ppmclibs/CMakeLists.txt
+++ b/ppmclibs/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(ppmclibs CXX)
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.17.0)
 
 # find perl
 find_program(PERL_PATH perl)

--- a/snd2png/CMakeLists.txt
+++ b/snd2png/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(snd2png CXX)
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.17.0)
 
 add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE opencv_core opencv_imgcodecs)

--- a/systemd/CMakeLists.txt
+++ b/systemd/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(systemd)
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.17.0)
 
 set(pkglibexecdir "${CMAKE_INSTALL_PREFIX}/${OS_AUTOINST_DATA_DIR}")
 configure_file(


### PR DESCRIPTION
Avoid warnings like

```
CMake Deprecation Warning at ppmclibs/CMakeLists.txt:2 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

after the recent CMake update on Tumbleweed by bumping the version to 3.17.0 which is the CMake version provided by Leap 15.3 (so this change should be ok with regard to compatibility).

It looks like we don't rely on any legacy behavior of that old CMake version so not other changes are required.