### PR TITLE
os-autoinst-openvswitch: Fix running into timeout for slow network init

### DIFF
--- a/os-autoinst-openvswitch
+++ b/os-autoinst-openvswitch
@@ -36,6 +36,8 @@ my %options;
 GetOptions(\%options, 'help|h|?') or usage(1);
 usage(0) if $options{help};
 
+use constant INIT_TIMEOUT => $ENV{OS_AUTOINST_OPENVSWITCH_INIT_TIMEOUT} // (5 * ONE_MINUTE);
+
 sub new ($class, $service) {
     my $self = $class->SUPER::new($service, '/switch');
     bless $self, $class;
@@ -53,7 +55,7 @@ sub init_switch ($self) {
     }
     system('ovs-vsctl', 'br-exists', $self->{BRIDGE});
 
-    for (my $timeout = $ENV{OS_AUTOINST_OPENVSWITCH_INIT_TIMEOUT} // ONE_MINUTE; $timeout > 0; --$timeout) {
+    for (my $timeout = INIT_TIMEOUT; $timeout > 0; --$timeout) {
         my $bridge_conf = qx{ip addr show $self->{BRIDGE}};
         $self->{MAC} = $1 if $bridge_conf =~ /ether\s+(([0-9a-f]{2}:){5}[0-9a-f]{2})\s/;
         $self->{IP} = $1 if $bridge_conf =~ /inet\s+(([0-9]+.){3}[0-9]+\/[0-9]+)\s/;


### PR DESCRIPTION
In case of many openQA worker instances where each instance has one to
multiple TAP devices assigned the network initialization can take
multiple minutes which has been observed in particular when using the
"wicked" network manager. We should account for that and just wait
longer. This is what we did for the openqa.opensuse.org and other openQA
instances already for years with a systemd override setting the
environment variable.

This commit bumps the timeout already within os-autoinst-openvswitch
from 1 to 5 minutes to account for that.

Related progress issue: https://progress.opensuse.org/issues/132134