### PR TITLE
Revert "Fix script_run sanity checks"

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -116,7 +116,6 @@ sub script_run ($self, $cmd, @args) {
             quiet => undef
         }, ['timeout'], @args);
 
-    die "Multiline commands are not supported:\n$cmd;\n" if $cmd =~ m/\n/;
     if (testapi::is_serial_terminal) {
         testapi::wait_serial($self->{serial_term_prompt}, no_regex => 1, quiet => $args{quiet});
     }
@@ -128,8 +127,7 @@ sub script_run ($self, $cmd, @args) {
         my $marker = "; echo $str-\$?-" . ($args{output} ? "Comment: $args{output}" : '');
         if (testapi::is_serial_terminal) {
             testapi::type_string($marker);
-            die 'Command was mistyped'
-              unless testapi::wait_serial($cmd . $marker, no_regex => 1, quiet => $args{quiet});
+            testapi::wait_serial($cmd . $marker, no_regex => 1, quiet => $args{quiet});
             testapi::type_string("\n");
         }
         else {


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst#2342

As seen in the original PR, this caused quite some tests to fail that relied on the unsupported multiline commands.
There is a list of tests collected on the PR that failed in a TW test run - so we have at least something to go on by to fix this for the next round (reverting to not have emergency fixes going left and right - yet we also don't want to block all progress for now)
