### PR TITLE
ssh_screen: Log SSH read errors

### DIFF
--- a/t/31-sshSerial.t
+++ b/t/31-sshSerial.t
@@ -90,7 +90,7 @@ $mock_ssh->set_always(blocking => $mock_channel->blocking($_[1]));
 
 $mock_ssh->mock(error => sub ($self) {
         return undef unless defined($self->{error});
-        return ${$self->{error}}[0] if ((caller(0))[5]);
+        return ${$self->{error}}[0] unless ((caller(0))[5]);
         # uncoverable statement count:1
         # uncoverable statement count:2
         return @{$self->{error}};


### PR DESCRIPTION
OpenQA currently ignores all read errors on SSH channels which makes it difficult to tell apart network failures from plain SUT timeouts. Log each SSH error once into autoinst-log.txt for now. Depending on later analysis, we can turn most SSH read errors into fatal failures.