### PR TITLE
IPMI backend incorrectly handle empty return value

### DIFF
--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -32,7 +32,7 @@ sub ipmitool ($self, $cmd, %args) {
     my @tries = (1 .. $args{tries});
     for (@tries) {
         $ret = IPC::Run::run(\@cmd, \$stdin, \$stdout, \$stderr);
-        if ($ret == 0) {
+        if ($ret) {
             $self->dell_sleep;
             last;
         } else {


### PR DESCRIPTION
Refer to the issue: https://progress.opensuse.org/issues/136226

There is something wrong during handle the return value of IPC::Run::run.

Refer to https://metacpan.org/pod/IPC::Run#RETURN-VALUES: "run() and finish() return TRUE when all subcommands exit with a 0 result code. This is the opposite of perl's system() command."

In my experiments, $ret = IPC::Run::run(), when `$ret = ""` the ipmitool run into failure, `$ret=1` run success.

I need widely verify this change on bare-metal systems.