### PR TITLE
WIP: IPMI_HW=dell:Enable dell_sleep for each ipmitool run whenever successfully or failure 

### DIFF
--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -32,8 +32,8 @@ sub ipmitool ($self, $cmd, %args) {
     my @tries = (1 .. $args{tries});
     for (@tries) {
         $ret = IPC::Run::run(\@cmd, \$stdin, \$stdout, \$stderr);
+        $self->dell_sleep;
         if ($ret == 0) {
-            $self->dell_sleep;
             last;
         } else {
             sleep 4;


### PR DESCRIPTION
Currently dell_sleep only works when ipmitool successfully, but not in failure case. Enable dell_sleep in failure case can gain more opportunity in retries.

Issue ticket: https://progress.opensuse.org/issues/136232

Verified URL: http://10.67.129.4/tests/62583#live

The MR code depends on https://github.com/os-autoinst/os-autoinst/pull/2364

