### PR TITLE
Add VNC depth support to the generalhw backend

### DIFF
--- a/backend/generalhw.pm
+++ b/backend/generalhw.pm
@@ -88,7 +88,7 @@ sub relogin_vnc ($self) {
             hostname => $bmwqemu::vars{GENERAL_HW_VNC_IP} || die('Need variable GENERAL_HW_VNC_IP'),
             port => $bmwqemu::vars{GENERAL_HW_VNC_PORT} // 5900,
             password => $bmwqemu::vars{GENERAL_HW_VNC_PASSWORD},
-            depth => 16,
+            depth => $bmwqemu::vars{GENERAL_HW_VNC_DEPTH} // 16,
             connect_timeout => 50
         });
     $vnc->backend($self);

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -305,6 +305,7 @@ Variable;Values allowed;Default value;Explanation
 GENERAL_HW_VNC_IP;string;;Hostname of the gadget's network. If not set, SSH consoles will be used
 GENERAL_HW_VNC_PASSWORD;string;;Password for VNC server
 GENERAL_HW_VNC_PORT;integer;5900;VNC Port number
+GENERAL_HW_VNC_DEPTH;integer;16;Color depth for VNC server
 GENERAL_HW_NO_SERIAL;boolean;;Don't use serial
 GENERAL_HW_VIDEO_STREAM_URL;string;;Video stream URL (in ffmpeg's syntax) to receive, for example 'udp://@:5004' or '/dev/video0'.
 VIDEO_STREAM_PIPE_BUFFER_SIZE;integer;1680*1050*3+20;Buffer containing at least a single PPM frame for video capturing


### PR DESCRIPTION
When working with the generalhw backend, it is not possible to set depth for vnc connections. This fix adds the GENERAL_HW_VNC_DEPTH variable. The default value, 16, remains unchanged.
Added a description to the documentation.