### PR TITLE
Improve error message about JSON encoding

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -272,7 +272,11 @@ sub mydie ($cause_of_death) {
 # store the obj as json into the given filename
 sub save_json_file ($result, $fn) {
     open(my $fd, ">", "$fn.new");
-    my $json = Cpanel::JSON::XS->new->pretty->canonical->encode($result);
+    my $json = eval { Cpanel::JSON::XS->new->pretty->canonical->encode($result) };
+    if (my $err = $@) {
+        my $dump = Data::Dumper->Dump([$result], ['result']);
+        croak "Cannot encode input: $@\n$dump";
+    }
     print $fd $json;
     close($fd);
     return rename("$fn.new", $fn);

--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -164,7 +164,9 @@ subtest 'invalid vars characters' => sub {
     is exists $bmwqemu::vars{LOWERCASE_NOT_ACCEPTED}, 1, 'exists $vars{...} works';
 };
 
-my %new_json = (foo => 'bar', baz => 42);
+my %new_json = (foo => 'bar', baz => 42, object => bless {this => "cannot be encoded"}, 'Foo');
+throws_ok { bmwqemu::save_json_file(\%new_json, 'new_json_file.json') } qr{Cannot encode input.*encountered object.*bless.*cannot be encoded}s;
+delete $new_json{object};
 ok bmwqemu::save_json_file(\%new_json, 'new_json_file.json'), 'JSON file can be saved with save_json_file';
 is_deeply decode_json(path('new_json_file.json')->slurp), \%new_json, 'JSON file written with correct content';
 


### PR DESCRIPTION
If there is an object in `$result`, we are seeing an error message like this in the log which is not helpful to find the problematic code:

    encountered object 'needle=HASH(0x55579f60d460)', but neither
    allow_blessed, convert_blessed nor allow_tags settings are enabled (or
    TO_JSON/FREEZE method missing) at /usr/lib/os-autoinst/bmwqemu.pm line 274.

Seeing the content can lead to the original broken code (in this case a hash was passed to `record_info` which contained a needle object.

Output will look like this now:
```
# Cannot encode input:                                                                                                 
# $result = {                                                                                                                
#               'foo' => 'bar',                                                                                               
#               'baz' => 42,                                                                                                  
#               'object' => bless( {                           
#                                    'this' => 'cannot be encoded'                                                            
#                                  }, 'Foo' )                                                                                 
#             };                                                                                                              
#  at t/12-bmwqemu.t line 168.                                                                                                
```