### PR TITLE
ci: Use PERL_TEST_WARNINGS_ONLY_REPORT_WARNINGS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@
 name: ci
 # yamllint disable-line rule:truthy
 on: [push, pull_request]
+env:
+  # Set to 1 to temporarily ignore warnings
+  PERL_TEST_WARNINGS_ONLY_REPORT_WARNINGS: 0
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/openqa_fullstack.yml
+++ b/.github/workflows/openqa_fullstack.yml
@@ -9,6 +9,9 @@ on:
       stability_test:
         description: 'Set to 1 to fail if any of the RETRY fails'
         default: 0
+env:
+  # Set to 1 to temporarily ignore warnings
+  PERL_TEST_WARNINGS_ONLY_REPORT_WARNINGS: 0
 
 jobs:
   fullstack:

--- a/tools/container_run_ci
+++ b/tools/container_run_ci
@@ -61,7 +61,7 @@ if [[ \"$target\" == \"coverage-codecovbash\" ]]; then
 fi
 cd /opt
 ./tools/install-new-deps.sh
-export CI=1 WITH_COVER_OPTIONS=1 CHECK_GIT_STATUS=1
+export CI=1 WITH_COVER_OPTIONS=1 CHECK_GIT_STATUS=1 PERL_TEST_WARNINGS_ONLY_REPORT_WARNINGS=$PERL_TEST_WARNINGS_ONLY_REPORT_WARNINGS
 cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -S . -B \"$build_dir\"
 cmake --build \"$build_dir\" --verbose --target check
 cmake --build \"$build_dir\" --verbose --target $target


### PR DESCRIPTION
Set to 0 so by default we get fatal warnings.

This makes it easy to quickly set the variable in the workflow settings when
necessary.

Issue: https://progress.opensuse.org/issues/137105

Tested: https://github.com/perlpunk/os-autoinst/actions/runs/6458335529/job/17531841574#step:3:743
```
7: [15:02:30] ./t/24-myjsonrpc-debug.t ................................ ok      856 ms ( 0.00 usr  0.00 sys +  0.78 cusr  0.08 csys =  0.86 CPU)
7: Use of uninitialized value $x in addition (+) at ./t/24-myjsonrpc.t line 32.
7: # Found 1 warnings but allowing them because PERL_TEST_WARNINGS_ONLY_REPORT_WARNINGS is set
7: # Got the following unexpected warnings:
7: #   1: Use of uninitialized value $x in addition (+) at ./t/24-myjsonrpc.t line 32.
7: [15:02:31] ./t/24-myjsonrpc.t ...................................... ok      879 ms ( 0.00 usr  0.00 sys +  0.81 cusr  0.07 csys =  0.88 CPU)
```