### PR TITLE
spec: Use PERL_TEST_WARNINGS_ONLY_REPORT_WARNINGS

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -237,6 +237,8 @@ export TESSDATA_PREFIX="%{_datadir}/tessdata/"
 # account for sporadic slowness in build environments
 # https://progress.opensuse.org/issues/89059
 export OPENQA_TEST_TIMEOUT_SCALE_CI=20
+# We don't want fatal warnings during package building
+export PERL_TEST_WARNINGS_ONLY_REPORT_WARNINGS=1
 # Enable verbose test output as we can not store test artifacts within package
 # build environments in case of needing to investigate failures
 export PROVE_ARGS="--timer -v --nocolor"

--- a/t/04-testapi-python.t
+++ b/t/04-testapi-python.t
@@ -17,6 +17,7 @@ use testapi;
 use Inline Python => "for i in dir(perl): globals()[i] = getattr(perl, i)";
 
 use Inline 'Python';
+pass 'use Inline does not die';
 done_testing;
 __END__
 __Python__


### PR DESCRIPTION
This way warnings won't make our builds and PRs fail.

Issue: https://progress.opensuse.org/issues/137105

It was already verified that this works in #2375 