### PR TITLE
Get the python code to snitch it's version

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -126,6 +126,8 @@ sub loadtest ($script, %args) {
             sys.path.append("$inc")
             sys.path.append("$script_dir")
             import $name
+            #print("Using python version: %s" % sys.version)
+            perl.diag("Using python version: %s" % sys.version)
             END_OF_PYTHON_CODE
             # Bind the python functions to the perl $name package
             my %info = py_study_package("$name");

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -6,7 +6,7 @@ use Mojo::Base -strict, -signatures;
 use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
-use Test::Output qw(stderr_like combined_from);
+use Test::Output qw(stderr_like combined_from output_like combined_like);
 use Test::Exception;
 use Test::Fatal;
 use Test::Warnings qw(:report_warnings warning);
@@ -316,9 +316,13 @@ subtest 'load test successfully when CASEDIR is a relative path' => sub {
 };
 
 subtest python => sub {
-    stderr_like {
+    my $python_module_regex = qr{scheduling pythontest tests/pythontest};
+    my $python_version_regex = qr{Using python version};
+
+    combined_like {
         lives_ok { autotest::loadtest('tests/pythontest.py') } 'can load test module'
-    } qr{scheduling pythontest tests/pythontest.py}, 'python pythontest module referenced';
+    } qr{(?|scheduling pythontest tests/pythontest|Using python version)}, 'python pythontest module referenced';
+
     %autotest::tests = ();
     loadtest 'pythontest.py';
     loadtest 'morepython.py';

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -316,9 +316,6 @@ subtest 'load test successfully when CASEDIR is a relative path' => sub {
 };
 
 subtest python => sub {
-    my $python_module_regex = qr{scheduling pythontest tests/pythontest};
-    my $python_version_regex = qr{Using python version};
-
     combined_like {
         lives_ok { autotest::loadtest('tests/pythontest.py') } 'can load test module'
     } qr{(?|scheduling pythontest tests/pythontest|Using python version)}, 'python pythontest module referenced';


### PR DESCRIPTION
Ensure there's evidence of the Python version that is embedded in the perl extension

While looking at Inline-Perl with @josegomezr, we realized that there's no information about the python version the extension is compiled with