### PR TITLE
os-autoinst-setup-multi-machine: Fix missing dir for gre-up-script

### DIFF
--- a/script/os-autoinst-setup-multi-machine
+++ b/script/os-autoinst-setup-multi-machine
@@ -60,6 +60,7 @@ EOF
   <masquerade/>
 </zone>
 EOF
+    mkdir -p /etc/wicked/scripts/
     cat > /etc/wicked/scripts/gre_tunnel_preup.sh <<EOF
 #!/bin/sh
 action="\$1"


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/133025