### PR TITLE
Clarify behavior of the `SVIRT_WORKER_CACHE` setting

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -358,7 +358,7 @@ sub _copy_image_else ($self, $file, $file_basename, $basedir) {
     # utilize asset possibly cached by openQA worker, otherwise sync locally on svirt host (usually relying on NFS mount)
     if (($bmwqemu::vars{SVIRT_WORKER_CACHE} // 1) && -e $file_basename && defined which 'rsync') {
         my %c = $self->get_ssh_credentials;
-        bmwqemu::diag "Syncing '$file' directly from worker host to $c{hostname}";
+        bmwqemu::diag "Syncing '$file_basename' directly from worker host to $c{hostname}";
         _system("sshpass -p '$c{password}' rsync -e 'ssh -o StrictHostKeyChecking=no' -av '$file_basename' '$c{username}\@$c{hostname}:$basedir/$file_basename'");
     }
     else {

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -237,7 +237,7 @@ HYPERV_VIRTUAL_SWITCH;string;;Name of Hyper-V's External Virtual Switch
 NUMDISKS;integer;1;Number of disks to be created and attached to VM, can be 0 to disable disks, if using RAIDLEVEL, will be set to 4
 RAIDLEVEL;integer;undef;Sets the raid level, affects NUMDISKS.
 SVIRT_KEEP_VM_RUNNING;boolean;undef;Keep VM running after execution, disabled by default
-SVIRT_WORKER_CACHE;boolean;1;Use the openQA worker cache if possible to copy images to the svirt host
+SVIRT_WORKER_CACHE;boolean;1;Use the openQA worker cache if possible to copy images to the svirt host - this means the path specified when invoking `add_disk` is **not** fully regarded, e.g. if the specified path points into the `fixed`-subdirectory but the openQA worker cached the same asset under the regular directory (which it prefers over the `fixed`-subdirectory) then the asset from the regular directory will be used
 WORKER_HOSTNAME;string;undef;Worker hostname
 |====================
 


### PR DESCRIPTION
* See particular commit messages.
* This came up in the context of https://progress.opensuse.org/issues/137807.