### PR TITLE
Fix rsync command when asset name contains a colon

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -358,7 +358,7 @@ sub _copy_image_else ($self, $file, $file_basename, $basedir) {
     # utilize asset possibly cached by openQA worker, otherwise sync locally on svirt host (usually relying on NFS mount)
     if (($bmwqemu::vars{SVIRT_WORKER_CACHE} // 1) && -e $file_basename && defined which 'rsync') {
         my %c = $self->get_ssh_credentials;
-        bmwqemu::diag "Syncing '$file' directly from worker host to $c{hostname}";
+        bmwqemu::diag "Syncing '$file_basename' directly from worker host to $c{hostname}";
         _system("sshpass -p '$c{password}' rsync -e 'ssh -o StrictHostKeyChecking=no' -av '$file_basename' '$c{username}\@$c{hostname}:$basedir/$file_basename'");
     }
     else {

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -237,7 +237,7 @@ HYPERV_VIRTUAL_SWITCH;string;;Name of Hyper-V's External Virtual Switch
 NUMDISKS;integer;1;Number of disks to be created and attached to VM, can be 0 to disable disks, if using RAIDLEVEL, will be set to 4
 RAIDLEVEL;integer;undef;Sets the raid level, affects NUMDISKS.
 SVIRT_KEEP_VM_RUNNING;boolean;undef;Keep VM running after execution, disabled by default
-SVIRT_WORKER_CACHE;boolean;1;Use the openQA worker cache if possible to copy images to the svirt host
+SVIRT_WORKER_CACHE;boolean;1;Use the openQA worker cache if possible to copy images to the svirt host - this means the path specified when invoking `add_disk` is **not** fully regarded, e.g. if the specified path points into the `fixed`-subdirectory but the openQA worker cached the same asset under the regular directory (which it prefers over the `fixed`-subdirectory) then the asset from the regular directory will be used
 WORKER_HOSTNAME;string;undef;Worker hostname
 |====================
 

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -750,7 +750,7 @@ subtest 'Method consoles::sshVirtsh::add_disk()' => sub {
             @last_ssh_commands = ();
             @ssh_cmd_return = (0, 0);
             $svirt->add_disk({cdrom => 1, dev_id => $dev_id, file => $file_path});
-            is $last_system_calls[0], "sshpass -p 'password_svirt' rsync -e 'ssh -o StrictHostKeyChecking=no' -av '$file' 'root\@hostname_svirt:$basedir/$file'", 'file copied with rsync';
+            is $last_system_calls[0], "sshpass -p 'password_svirt' rsync -e 'ssh -o StrictHostKeyChecking=no' -av '$dir/$file' 'root\@hostname_svirt:$basedir/$file'", 'file copied with rsync';
             like $last_ssh_commands[0], qr%unxz%, 'file uncompressed with unxz';
 
             svirt_xml_validate($svirt,


### PR DESCRIPTION
This fixes the rsync command for using worker cache via svirt backend in
the case the asset name contains a colon. Before this change the following
happens:

```
sshpass … rsync … -av 'sle-12-SP5-s390x-:31152:kgraft-…' 'root@…:/var…'
The source and destination cannot both be remote.
rsync error: syntax or usage error (code 1) at main.c(1436) [Receiver=3.2.3]
```

With this change the first part of the asset name is no longer wrongly
treated as host specification:

```
sshpass … rsync … -av '/var/lib/openqa/factory/hdd/sle-12-SP5-s390x-:31152:kgraft-…' 'root@…:/var/…'
Warning: Permanently added …
sending incremental file list
sle-12-SP5-s390x-:31152:kgraft-…

sent …
total size is …
```

---

Based on https://github.com/os-autoinst/os-autoinst/pull/2391 because the PRs would conflict.