### PR TITLE
Warn when modifying files under external directly

### DIFF
--- a/.github/checklist.yml
+++ b/.github/checklist.yml
@@ -5,5 +5,5 @@ paths:
     - Consider running manual verification tests on real hardware, especially for non-qemu backends
   "testapi.pm":
     - Consider bumping the version number in OpenQA/Isotovideo/Interface.pm for changes in behaviour
-  "external":
+  "external/**":
     - Consider doing this change in the upstream repository directly, see external/os-autoinst-common/README.md


### PR DESCRIPTION
This is hopefully fixing it; apparently you can't just give it a directory name