### PR TITLE
Fix character encoding of JSON result file

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -272,7 +272,7 @@ sub mydie ($cause_of_death) {
 # store the obj as json into the given filename
 sub save_json_file ($result, $fn) {
     open(my $fd, ">", "$fn.new");
-    my $json = eval { Cpanel::JSON::XS->new->pretty->canonical->encode($result) };
+    my $json = eval { Cpanel::JSON::XS->new->utf8->pretty->canonical->encode($result) };
     if (my $err = $@) {
         my $dump = Data::Dumper->Dump([$result], ['result']);
         croak "Cannot encode input: $@\n$dump";


### PR DESCRIPTION
The JSON files were not encoded in UTF-8 previously. Instead the Perl character encoding was used. This became visible during the implementation of the feature of text based needles in the backend.

Important: This bugfix has the potential to introduce issues, if in some other place, the encoding was "fixed" where it should not be.