### PR TITLE
Disable SVIRT_WORKER_CACHE by default

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -357,7 +357,7 @@ sub _system (@cmd) { system @cmd }    # uncoverable statement
 
 sub _copy_image_else ($self, $file, $file_basename, $basedir) {
     # utilize asset possibly cached by openQA worker, otherwise sync locally on svirt host (usually relying on NFS mount)
-    if (($bmwqemu::vars{SVIRT_WORKER_CACHE} // 1) && -e $file_basename && defined which 'rsync') {
+    if (($bmwqemu::vars{SVIRT_WORKER_CACHE} // 0) && -e $file_basename && defined which 'rsync') {
         my %c = $self->get_ssh_credentials;
         my $abs = path($file_basename)->to_abs;    # pass abs path so it can contain a colon
         bmwqemu::diag "Syncing '$file_basename' directly from worker host to $c{hostname}";

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -237,7 +237,7 @@ HYPERV_VIRTUAL_SWITCH;string;;Name of Hyper-V's External Virtual Switch
 NUMDISKS;integer;1;Number of disks to be created and attached to VM, can be 0 to disable disks, if using RAIDLEVEL, will be set to 4
 RAIDLEVEL;integer;undef;Sets the raid level, affects NUMDISKS.
 SVIRT_KEEP_VM_RUNNING;boolean;undef;Keep VM running after execution, disabled by default
-SVIRT_WORKER_CACHE;boolean;1;Use the openQA worker cache if possible to copy images to the svirt host - this means the path specified when invoking `add_disk` is **not** fully regarded, e.g. if the specified path points into the `fixed`-subdirectory but the openQA worker cached the same asset under the regular directory (which it prefers over the `fixed`-subdirectory) then the asset from the regular directory will be used
+SVIRT_WORKER_CACHE;boolean;0;Use the openQA worker cache if possible to copy images to the svirt host - this means the path specified when invoking `add_disk` is **not** fully regarded, e.g. if the specified path points into the `fixed`-subdirectory but the openQA worker cached the same asset under the regular directory (which it prefers over the `fixed`-subdirectory) then the asset from the regular directory will be used
 WORKER_HOSTNAME;string;undef;Worker hostname
 |====================
 

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -31,6 +31,7 @@ bmwqemu::init_logger;
 set_var(WORKER_HOSTNAME => 'foo');
 set_var(VIRSH_HOSTNAME => 'bar');
 set_var(VIRSH_PASSWORD => 'password');
+set_var(SVIRT_WORKER_CACHE => 1);
 
 my $ssh_xterm_vt_mock = Test::MockModule->new('consoles::sshXtermVt');
 $ssh_xterm_vt_mock->noop('activate');


### PR DESCRIPTION
This feature is a nice optimization but has the caveat mentioned in the documentation and might also otherwise behave slightly different leading to issues like https://progress.opensuse.org/issues/138746. So it is likely best to only enable it in cases when it is safe to use.