### PR TITLE
backend/qemu: Preserve case when modifying OVMF file names

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -671,7 +671,7 @@ sub start_qemu ($self) {
     }
     elsif ($vars->{UEFI} && (($vars->{ARCH} // '') eq 'x86_64')) {
         $vars->{UEFI_PFLASH_CODE} //= find_ovmf;
-        $vars->{UEFI_PFLASH_VARS} //= $vars->{UEFI_PFLASH_CODE} =~ s/code/vars/r;
+        $vars->{UEFI_PFLASH_VARS} //= $vars->{UEFI_PFLASH_CODE} =~ s/code/$&=~tr,CcOoDdEe,VvAaRrSs,r/eir;
         die "No UEFI firmware can be found! Please specify UEFI_PFLASH_CODE/UEFI_PFLASH_VARS or BIOS or UEFI_BIOS or install an appropriate package" unless $vars->{UEFI_PFLASH_CODE};
     }
     if ($vars->{UEFI_PFLASH} || $vars->{BIOS}) {

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -647,6 +647,7 @@ subtest 'special cases when starting QEMU' => sub {
     like $qemu_params, qr{once=n}, 'once=n parameter present due to PXEBOOT';
 
     subtest 'various error cases' => sub {
+        my %initial_vars = %bmwqemu::vars;
         $bmwqemu::vars{NICTYPE} = 'foo';
         combined_like { throws_ok { $backend->start_qemu } qr/unknown NICTYPE foo/, 'dies on unknown NICTYPE' }
           qr/qemu version.*Initializing block device images/si, 'expected logs until exception thrown (1)';
@@ -667,6 +668,10 @@ subtest 'special cases when starting QEMU' => sub {
         $bmwqemu::vars{UEFI_PFLASH_CODE} = 0;
         combined_like { throws_ok { $backend->start_qemu } qr{No UEFI firmware can be found}, 'dies if UEFI firmware not found' }
           qr/qemu version/si, 'expected logs until exception thrown (6)';
+        %bmwqemu::vars = %initial_vars;
+        combined_like { qemu_cmdline(UEFI => 1, UEFI_PFLASH_CODE => '/OVMF_CODE.fd') }
+        qr/qemu version/si, 'expected logs until exception thrown (7)';
+        is $bmwqemu::vars{UEFI_PFLASH_VARS}, '/OVMF_VARS.fd', 'default UEFI_PFLASH_VARS was guessed correctly';
     };
 };
 


### PR DESCRIPTION
I've set up a RHEL-based OpenQA environment, and the default OVMF vars file also points to the code file which prevents UEFI VMs from starting.  It can be worked around by explicitly setting the paths, but this change will fix the default behavior by preserving uppercase file names.  It shouldn't affect other distros since the other paths in `@ovmf_locations` don't contain "code" in their directories.  (Feel free to rewrite this if it's too ugly--I don't know if there is a prettier Perl way to preserve case in substitutions.)