### PR TITLE
Rewrite s390 console to work with arbitrary IP and Hostname combinations

### DIFF
--- a/consoles/s3270.pm
+++ b/consoles/s3270.pm
@@ -321,7 +321,8 @@ sub _connect_3270 ($self, $host) {
 }
 
 sub _login_guest ($self, $guest, $password) {
-    $self->send_3270("String($guest)");
+    my ($username) = $guest =~ /(.*?)\..*$/;
+    $self->send_3270("String($username)");
     $self->send_3270("String($password)");
     $self->send_3270("ENTER");
     $self->send_3270("Wait(InputField)");

--- a/consoles/sshIucvconn.pm
+++ b/consoles/sshIucvconn.pm
@@ -12,6 +12,7 @@ use autodie ':all';
 sub connect_remote ($self, $args) {
     my $hostname = $args->{hostname};
     my $zvmguest = $bmwqemu::vars{ZVM_GUEST};
+    ($zvmguest) = $zvmguest =~ /(.*?)\..*$/;
 
     # ssh connection to SUT for agetty
     my $ttyconn = $self->backend->new_ssh_connection(hostname => $hostname, password => $args->{password}, username => 'root');
@@ -31,7 +32,7 @@ sub connect_remote ($self, $args) {
     # ssh connection to SUT for iucvconn
     my ($ssh, $serialchan) = $self->backend->start_ssh_serial(hostname => $args->{hostname}, password => $args->{password}, username => 'root');
     # start iucvconn
-    bmwqemu::diag('ssh iucvconn: grabbing serial console');
+    bmwqemu::diag("ssh iucvconn: grabbing serial console for guest: $zvmguest");
     $ssh->blocking(1);
     if (!$serialchan->exec("iucvconn $zvmguest lnxhvc0")) {
         bmwqemu::fctwarn('ssh iucvconn: unable to grab serial console at this point: ' . ($ssh->error // 'unknown SSH error'));


### PR DESCRIPTION
As explained in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18176 we now use the `ZVM_GUEST`-variable as FQDN and derive the username based on the first component in this FQDN. This change ensures we log into the according consoles with a correct username.

- Related ticket: https://progress.opensuse.org/issues/132152
- Verification run: https://openqa.suse.de/tests/12858025