### PR TITLE
openvswitch: Ensure a consistent MTU size compatible with GRE tunnels

### DIFF
--- a/script/os-autoinst-setup-multi-machine
+++ b/script/os-autoinst-setup-multi-machine
@@ -68,6 +68,8 @@ setup_multi_machine_with_networkmanager() {
 setup_multi_machine_with_wicked() {
     ovs-vsctl list-br | grep -q "$bridge" && ovs-vsctl del-br "$bridge"
     ovs-vsctl add-br "$bridge"
+    # see https://progress.opensuse.org/issues/151310
+    ovs-vsctl set int $bridge mtu_request=1450
     cat > "/etc/sysconfig/network/ifcfg-$bridge" <<EOF
 BOOTPROTO='static'
 IPADDR='10.0.2.2/15'


### PR DESCRIPTION
So far common multi-machine tests set an MTU size but not always consistently and we want to ensure we have a properly working setup without relying on test maintainers to know the setup of machines.

Related progress issue: https://progress.opensuse.org/issues/151310