### PR TITLE
Increase bootindex of network devices if PXEBOOT is enabled

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -179,7 +179,7 @@ sub configure_blockdevs ($self, $bootfrom, $basedir, $vars) {
             $drive = $bdc->add_new_drive($node_id, $hdd_model, $size, $num_queues);
         }
 
-        if ($i == 1 && $bootfrom eq 'disk') {
+        if ($i == 1 && ($bootfrom eq 'disk' || $vars->{PXEBOOT})) {
             $drive->bootindex(0);
         }
 

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -897,7 +897,7 @@ sub start_qemu ($self) {
             else {
                 die "unknown NICTYPE $vars->{NICTYPE}\n";
             }
-            my $bootorder = $vars->{PXEBOOT} ? "bootindex=$i" : '';
+            my $bootorder = $vars->{PXEBOOT} ? "bootindex=" . ($i + 1) : '';
             sp('device', [qv "$vars->{NICMODEL} netdev=qanet$i mac=$nicmac[$i] $bootorder"]);
         }
 

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -229,10 +229,14 @@ subtest 'qemu_net_boot' => sub {
     throws_ok { $backend->start_qemu } qr{unsupported boot order: nc}, 'dies on multi boot order as os-autoinst doesnt supported';
     delete $bmwqemu::vars{BOOTFROM};
     delete $bmwqemu::vars{BOOT_MENU};
-    subtest('Test boot with n on x86_64', \&test_boot_options, 0, 'x86_64', 1, qr|mac=.*,bootindex=\d|);
-    subtest('Test boot with n on aarch64', \&test_boot_options, 0, 'aarch64', 1, qr|mac=.*,bootindex=\d|);
-    subtest('Test boot with n on s390x', \&test_boot_options, 0, 's390x', 1, qr|mac=.*,bootindex=\d|);
-    subtest('Test boot with n on ppc64le', \&test_boot_options, 0, 'ppc64le', 1, qr|mac=.*,bootindex=\d|);
+    subtest('Test boot with n on x86_64', \&test_boot_options, 0, 'x86_64', 1, qr|mac=52:54:00:12:34:56,bootindex=1|);
+    subtest('Test boot with set c to bootindex=0 on x86_64', \&test_boot_options, 0, 'x86_64', 1, qr|drive=hd0,bootindex=0|);
+    subtest('Test boot with n on aarch64', \&test_boot_options, 0, 'aarch64', 1, qr|mac=52:54:00:12:34:56,bootindex=1|);
+    subtest('Test boot with set c to bootindex=0 on aarch64', \&test_boot_options, 0, 'aarch64', 1, qr|drive=hd0,bootindex=0|);
+    subtest('Test boot with n on s390x', \&test_boot_options, 0, 's390x', 1, qr|mac=52:54:00:12:34:56,bootindex=1|);
+    subtest('Test boot with set c to bootindex=0 on s390x', \&test_boot_options, 0, 's390x', 1, qr|drive=hd0,bootindex=0|);
+    subtest('Test boot with n on ppc64le', \&test_boot_options, 0, 'ppc64le', 1, qr|mac=52:54:00:12:34:56,bootindex=1|);
+    subtest('Test boot with set c to bootindex=0 on ppc64le', \&test_boot_options, 0, 'ppc64le', 1, qr|drive=hd0,bootindex=0|);
     delete $bmwqemu::vars{PXEBOOT};
     delete $bmwqemu::vars{ARCH};
 };


### PR DESCRIPTION
https://progress.opensuse.org/issues/151258

As discussed here https://gitlab.com/qemu-project/qemu/-/issues/1995 qemu firmware should skip empty bootdisk and boot from next bootindex device (PXE) and then after reboot use disk with bootindex=0