### PR TITLE
Fix test/coverage relying on `sudo`

### DIFF
--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -30,10 +30,10 @@ sub git_rev_parse ($dirname, $cmd_prefix = '') {
     chomp(my $version = qx{$cmd_prefix git -C "$dirname" rev-parse HEAD 2>&1});
     return $version if $? == 0;
     return 'UNKNOWN' unless $version =~ /(git config.*safe.directory.*$)/;
-    my $addsafe = 'TMPDIR=$(mktemp -d --tmpdir os-autoinst-git.XXXXX) && HOME=$TMPDIR && ' . $1;
-    $version = qx{$addsafe && git -C "$dirname" rev-parse HEAD && rm -r \$TMPDIR} || '(unreadable git hash)';
-    chomp($version);
-    return $version;
+    my $addsafe = 'TMPDIR=$(mktemp -d --tmpdir os-autoinst-git.XXXXX) && HOME=$TMPDIR && ' . $1;    # uncoverable statement
+    $version = qx{$addsafe && git -C "$dirname" rev-parse HEAD && rm -r \$TMPDIR} || '(unreadable git hash)';    # uncoverable statement
+    chomp($version);    # uncoverable statement
+    return $version;    # uncoverable statement
 }
 
 sub calculate_git_hash ($git_repo_dir) {

--- a/t/20-openqa-isotovideo-utils.t
+++ b/t/20-openqa-isotovideo-utils.t
@@ -14,6 +14,7 @@ use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '10';
 use OpenQA::Isotovideo::Utils qw(git_rev_parse checkout_git_refspec load_test_schedule);
 
+
 my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
 my $pool_dir = "$dir/pool";
 chdir $dir;
@@ -28,8 +29,9 @@ my $toplevel_dir = "$Bin/..";
 my $version = -e "$toplevel_dir/.git" ? qr/[a-f0-9]+/ : qr/UNKNOWN/;
 like git_rev_parse($toplevel_dir), $version, 'can parse working copy version (if it is git)';
 note 'call again git_rev_parse under different user (if available)';
-qx{command -v sudo >/dev/null && sudo -u nobody true};
-like git_rev_parse($toplevel_dir, 'sudo -u nobody'), $version, 'can parse git version as different user' if $? == 0;    # uncoverable statement
+my $sudo_user = $ENV{OS_AUTOINST_TEST_SECOND_USER} // 'nobody';
+qx{command -v sudo >/dev/null && sudo --non-interactive -u $sudo_user true};
+like git_rev_parse($toplevel_dir, "sudo -u $sudo_user"), $version, 'can parse git version as different user' if $? == 0;    # uncoverable statement
 
 subtest 'error handling when loading test schedule' => sub {
     chdir($dir);

--- a/t/20-openqa-isotovideo-utils.t
+++ b/t/20-openqa-isotovideo-utils.t
@@ -29,7 +29,7 @@ my $version = -e "$toplevel_dir/.git" ? qr/[a-f0-9]+/ : qr/UNKNOWN/;
 like git_rev_parse($toplevel_dir), $version, 'can parse working copy version (if it is git)';
 note 'call again git_rev_parse under different user (if available)';
 qx{command -v sudo >/dev/null && sudo -u nobody true};
-like git_rev_parse($toplevel_dir, 'sudo -u nobody'), $version, 'can parse git version as different user' if $? == 0;
+like git_rev_parse($toplevel_dir, 'sudo -u nobody'), $version, 'can parse git version as different user' if $? == 0;    # uncoverable statement
 
 subtest 'error handling when loading test schedule' => sub {
     chdir($dir);


### PR DESCRIPTION
See particular commit messages and https://github.com/os-autoinst/os-autoinst/pull/2413#issuecomment-1845563806.