### PR TITLE
Make qemu-img compress file using multiple threads

### DIFF
--- a/OpenQA/Qemu/DriveDevice.pm
+++ b/OpenQA/Qemu/DriveDevice.pm
@@ -112,7 +112,7 @@ sub gen_qemu_img_convert ($self, $img_dir, $name, $qemu_compress_qcow) {
     # Compressing takes longer but the transfer takes shorter amount of time.
     my $compress = $qemu_compress_qcow;
     my @cmd = qw(convert);
-    push @cmd, qw(-c) if $compress;
+    push @cmd, qw(-c -W) if $compress;
     push @cmd, ('-O', QEMU_IMAGE_FORMAT, $self->drive->file, "$img_dir/$name");
     return \@cmd;
 }

--- a/t/18-qemu.t
+++ b/t/18-qemu.t
@@ -48,7 +48,7 @@ is_deeply(\@gcmdl, \@cmdl, 'Generate qemu command line for single new drive');
 is_deeply(\@gcmdl, \@cmdl, 'Generate qemu-img command line for single new drive');
 
 my $compress = 1;
-@cmdl = (['convert', '-c', '-O', 'qcow2', 'raid/hd1', 'images/hd1.qcow2']);
+@cmdl = (['convert', '-c', '-W', '-O', 'qcow2', 'raid/hd1', 'images/hd1.qcow2']);
 @gcmdl = $bdc->gen_qemu_img_convert(qr/^hd/, 'images', 'hd1.qcow2', $compress);
 is_deeply(\@gcmdl, \@cmdl, 'Generate qemu-img convert for single new drive');
 
@@ -110,7 +110,7 @@ is_deeply(\@gcmdl, \@cmdl, 'Generate qemu-img command line for single existing d
 is_deeply(\@cmdl, \@gcmdl, 'Generate unlink list for single existing drive');
 
 $compress = 1;
-@cmdl = (['convert', '-c', '-O', 'qcow2', 'raid/hd1-overlay0', 'images/hd1.qcow2']);
+@cmdl = (['convert', '-c', '-W', '-O', 'qcow2', 'raid/hd1-overlay0', 'images/hd1.qcow2']);
 @gcmdl = $bdc->gen_qemu_img_convert(qr/^hd1/, 'images', 'hd1.qcow2', $compress);
 is_deeply(\@gcmdl, \@cmdl, 'Generate qemu-img convert for single existing drive');
 
@@ -252,7 +252,7 @@ is_deeply(\@gcmdl, \@cmdl, 'Generate reverted snapshot images');
 @gcmdl = $bdc->gen_unlink_list();
 is_deeply(\@gcmdl, \@cmdl, 'Generate unlink list of reverted snapshot images');
 
-@cmdl = (['convert', '-c', '-O', 'qcow2', 'raid/hd0-overlay1', 'images/hd0.qcow2']);
+@cmdl = (['convert', '-c', '-W', '-O', 'qcow2', 'raid/hd0-overlay1', 'images/hd0.qcow2']);
 @gcmdl = $bdc->gen_qemu_img_convert(qr/^hd0$/, 'images', 'hd0.qcow2', $compress);
 is_deeply(\@gcmdl, \@cmdl, 'Generate qemu-img convert with snapshots');
 


### PR DESCRIPTION
qemu-img can compress using up to 4 threads, enable this functionality. In Qubes OS setup, some jobs upload multi-GB disk images, and reducing compress time from 40min (about the same time as the rest of the job) down to 10min makes a huge difference.

This feature is not clearly documented, but I learned about it on QEMU's IRC, and posted findings here:
https://gitlab.com/qemu-project/qemu/-/issues/80#note_1669835297