### PR TITLE
systemd: Fix too strict os-autoinst-openvswitch init timeout

### DIFF
--- a/systemd/os-autoinst-openvswitch.service.in
+++ b/systemd/os-autoinst-openvswitch.service.in
@@ -11,7 +11,6 @@ Before=openqa-worker.target
 Type=dbus
 BusName=org.opensuse.os_autoinst.switch
 Environment=OS_AUTOINST_USE_BRIDGE=br0
-Environment=OS_AUTOINST_OPENVSWITCH_INIT_TIMEOUT=60
 EnvironmentFile=-/etc/sysconfig/os-autoinst-openvswitch
 ExecStart=@pkglibexecdir@/os-autoinst-openvswitch
 


### PR DESCRIPTION
In
https://github.com/os-autoinst/os-autoinst/pull/1555
commit e3d8163 I added an environment variable with a default but also
overwrote the value in the systemd definition template file for unknown
reasons. In 8e355cc7 subsequently I bumped the default value of the
timeout to 5m but the systemd service file would still overwrite to 1m.
So this commit removes the environment overwrite in the systemd template
so the default of 5m should be effective at least for cases when the
systemd file is deployed again.

Related progress issue: https://progress.opensuse.org/issues/152365