### PR TITLE
Add FIDO2 support for qemu

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -959,6 +959,8 @@ sub start_qemu ($self) {
         sp('device', 'usb-kbd') if $use_usb_kbd;
         sp('device', 'virtio-keyboard') if $use_virtio_kbd;
 
+        sp("device", "canokey,file=canokey") if $vars->{FIDO2};
+
         my $smp_config = [$vars->{QEMUCPUS}];
         for my $key (qw(QEMUSOCKETS QEMUDIES QEMUCLUSTERS QEMUCORES QEMUTHREADS)) {
             my $qkey = lc($key =~ s/^QEMU//r);

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -108,6 +108,7 @@ BOOT_MENU_TIMEOUT;integer;5000;boot menu timeout in ms. Needs BOOT_MENU
 BOOTFROM;chars;undef;Influences order of boot devices. Multi boot order is not supported. This variable can be overriden by `PXEBOOT`. See qemu -boot option and PXEBOOT variable.
 CDMODEL;see qemu -device ?;undef;Storage device for virtualized CD
 DELAYED_START;boolean;;delay vm cpu start until resume_vm() is called
+FIDO2;boolean;0;Enable FIDO2 hardware token
 HDDMODEL;see qemu -device ?;virtio-blk;Storage device for virtualized HDD.
 HDDMODEL_$_;see qemu -device ?;virtio-blk;Storage device for virtualized HDD. Overrides global HDDMODEL for HDD_$i
 HDDSIZEGB;integer;10;Creates HDD with specified size in GiB

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -613,6 +613,7 @@ subtest 'special cases when starting QEMU' => sub {
     $bmwqemu::vars{OVS_DEBUG} = 1;
     $bmwqemu::vars{WORKER_CLASS} = '';
     $bmwqemu::vars{BOOTFROM} = 'cdrom';
+    $bmwqemu::vars{FIDO2} = '1';
 
     my $process_mock = Test::MockObject->new;
     my %callbacks;
@@ -629,6 +630,7 @@ subtest 'special cases when starting QEMU' => sub {
     like $qemu_params, qr{order=}, 'order parameter present due to BOOT_HDD_IMAGE=1 and UEFI=0';
     like $qemu_params, qr{\sbios}, 'bios parameter present due to BIOS=1 and UEFI=0';
     is $bmwqemu::vars{BOOTFROM}, 'd', 'BOOTFROM set to "d" for "cdrom"';
+    like $qemu_params, qr{canokey,file=canokey}, 'canokey parameter present due to FIDO2=1';
     is scalar @dbus_invocations, 2, 'two D-Bus invocatios made';
     is_deeply $dbus_invocations[0], [$backend, set_vlan => 'tap2', 'foovlan'], 'vlan set for tap device via D-Bus call' or diag explain \@dbus_invocations;
     is_deeply $dbus_invocations[1], [$backend, 'show'], 'networking status shown for OVS_DEBUG=1' or diag explain \@dbus_invocations;


### PR DESCRIPTION
Introduce generic FIDO2 variable that indicates that tests should use a hardware FIDO2 token. In the qemu backend that means adding the canokey device.