### PR TITLE
Add TEST_GIT_URL/NEEDLES_GIT_URL to vars

### DIFF
--- a/OpenQA/Isotovideo/Runner.pm
+++ b/OpenQA/Isotovideo/Runner.pm
@@ -212,7 +212,7 @@ sub checkout_code ($self) {
     # if specified, or simply store the git hash that has been used. If it is not a
     # git repo fail silently, i.e. store an empty variable
 
-    $bmwqemu::vars{TEST_GIT_HASH} = checkout_git_refspec($bmwqemu::vars{CASEDIR} => 'TEST_GIT_REFSPEC');
+    ($bmwqemu::vars{TEST_GIT_URL}, $bmwqemu::vars{TEST_GIT_HASH}) = checkout_git_refspec($bmwqemu::vars{CASEDIR} => 'TEST_GIT_REFSPEC');
 
     checkout_wheels($bmwqemu::vars{CASEDIR}, $bmwqemu::vars{WHEELS_DIR});
 }

--- a/needle.pm
+++ b/needle.pm
@@ -289,7 +289,7 @@ sub init ($init_needles_dir = $bmwqemu::vars{NEEDLES_DIR} // default_needles_dir
         $needles_dir = path($bmwqemu::vars{CASEDIR}, $needles_dir)->to_string;
         die "Can't init needles from $init_needles_dir; If one doesn't specify NEEDLES_DIR, the needles will be loaded from \$PRODUCTDIR/needles firstly or $needles_dir (\$CASEDIR + $init_needles_dir), check vars.json" unless -d $needles_dir;
     }
-    $bmwqemu::vars{NEEDLES_GIT_HASH} = checkout_git_refspec($needles_dir => 'NEEDLES_GIT_REFSPEC');
+    ($bmwqemu::vars{NEEDLES_GIT_URL}, $bmwqemu::vars{NEEDLES_GIT_HASH}) = checkout_git_refspec($needles_dir => 'NEEDLES_GIT_REFSPEC');
 
     %needles = ();
     %tags = ();


### PR DESCRIPTION
So far we only save the commit hash, but we don't know which repository it actually comes from.

Issue: https://progress.opensuse.org/issues/152681

