### PR TITLE
Add UEFI boot support for vmware tests

### DIFF
--- a/t/22-svirt-virsh-config-uefi.xml
+++ b/t/22-svirt-virsh-config-uefi.xml
@@ -4,9 +4,8 @@
   <description>openQA WebUI: no-webui-set (1): 0-no-scenario</description>
   <memory unit="MiB">1024</memory>
   <vcpu>1</vcpu>
-  <os>
-    <type>hvm</type>
-    <loader>/usr/share/qemu/ovmf-x86_64-ms-code.bin</loader>
+  <os firmware="efi">
+    <type arch="x86_64">hvm</type>
   </os>
   <features><acpi/><apic/><pae/></features>
   <devices/>

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -112,7 +112,7 @@ subtest 'XML config with UEFI loader and VMware' => sub {
 
     my $console_mock = Test::MockModule->new('consoles::sshVirtsh');
     $console_mock->redefine(run_cmd => 1);
-    throws_ok { $svirt_console->_init_xml } qr/No UEFI firmware can be found on hypervisor/, 'dies if UEFI firmware missing';
+    lives_ok { $svirt_console->_init_xml } 'UEFI firmware can be found on hypervisor';
 
     $console_mock->redefine(run_cmd => 0);
     $svirt_console->_init_xml;


### PR DESCRIPTION
Due to UEFI becoming the mainstream system boot option for user OS installation, it should also support UEFI boot in VMware tests. From VMware ESXi 7.0 guest installation, the boot option switches from BIOS to UEFI as default, and it will help to workaround bsc#1216655. For VMware guests, the firmware attribute is set to efi when the guest uses UEFI, and it is not set when using BIOS.

The libvirt XML format described as below.

```
Legacy boot (BIOS)
------
  <os>
    <type>hvm</type>
  </os>

UEFI boot
------
  <os firmware='efi'>
    <type>hvm</type>
  </os>
```

- Related ticket: https://progress.opensuse.org/issues/152917
- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18378
- Verification run: