### PR TITLE
Make default click times configurable via variables

### DIFF
--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -48,6 +48,8 @@ NO_DEPRECATE_BACKEND_$backend;boolean;0;Only warn about deprecated backends inst
 XRES;integer;1024;Resolution of display on x axis. Sets the resolution of the video encoder, and in qemu, the initial console resolution when OFW is set (Power and SPARC), and the EDID resolution for devices that support EDID
 YRES;integer;768;Resolution of display on y axis. Sets the resolution of the video encoder, and in qemu, the initial console resolution when OFW is set (Power and SPARC), and the EDID resolution for devices that support EDID
 VIDEO_ENCODER_BLOCKING_PIPE;boolean;0;Whether the pipe for writing data to the video encoder should be blocking or not. Making it blocking might allow following the live view in realtime despite large screenshot file sizes but it is not a well tested configuration
+DEFAULT_CLICK_SLEEP;float;0.15;Default single click time in seconds
+DEFAULT_DCLICK_SLEEP;float;0.10;Default double/triple click time in seconds (both press time and interval between clicks)
 
 |====================
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -1489,6 +1489,7 @@ Default hold time is 0.15s
 
 sub mouse_click ($button = undef, $time = undef) {
     $button //= 'left';
+    $time //= $bmwqemu::vars{DEFAULT_CLICK_SLEEP};
     $time //= 0.15;
     bmwqemu::log_call(button => $button, cursor_down => $time);
     query_isotovideo('backend_mouse_button', {button => $button, bstate => 1});
@@ -1506,6 +1507,7 @@ Same as mouse_click only for double click.
 
 sub mouse_dclick ($button = undef, $time = undef) {
     $button //= 'left';
+    $time //= $bmwqemu::vars{DEFAULT_DCLICK_SLEEP};
     $time //= 0.10;
     bmwqemu::log_call(button => $button, cursor_down => $time);
     query_isotovideo('backend_mouse_button', {button => $button, bstate => 1});
@@ -1527,6 +1529,7 @@ Same as mouse_click only for triple click.
 
 sub mouse_tclick ($button = undef, $time = undef) {
     $button //= 'left';
+    $time //= $bmwqemu::vars{DEFAULT_DCLICK_SLEEP};
     $time //= 0.10;
     bmwqemu::log_call(button => $button, cursor_down => $time);
     query_isotovideo('backend_mouse_button', {button => $button, bstate => 1});


### PR DESCRIPTION
Make the default changeable globally via a variable, instead of changing
each invocation of mouse_click/assert_and_click etc. Useful if a backend
introduce some latency already (to not cause "long click" by default),
but also when testing with changed mouse settings.