### PR TITLE
os-autoinst-setup-multi-machine: Fix tap group discrepancy

### DIFF
--- a/script/os-autoinst-setup-multi-machine
+++ b/script/os-autoinst-setup-multi-machine
@@ -66,7 +66,7 @@ setup_multi_machine_with_networkmanager() {
     # Create tap interfaces
     for i in 0 $(seq 1 "$instances"; seq 64 $((64+instances)); seq 128 $((128+instances))); do
         nmcli con add type ovs-port con.int "tap$i" con.master "$bridge"
-        nmcli con add type tun mode tap owner "$(id -u _openqa-worker)" group "$(getent group nobody | cut -f3 -d:)" con.int "tap$i" master "tap$i"
+        nmcli con add type tun mode tap owner "$(id -u _openqa-worker)" group "$(getent group nogroup | cut -f3 -d:)" con.int "tap$i" master "tap$i"
     done
     create_gre_preup_script /etc/NetworkManager/dispatcher.d/gre_tunnel_preup.sh
 }


### PR DESCRIPTION
Always use "nogroup" (even for NetworkManager)