### PR TITLE
Use named constant for 4k magic values

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -36,6 +36,7 @@ use OpenQA::NamedIOSelect;
 use constant FULL_SCREEN_SEARCH_FREQUENCY => $ENV{OS_AUTOINST_FULL_SCREEN_SEARCH_FREQUENCY} // 5;
 use constant FULL_UPDATE_REQUEST_FREQUENCY => $ENV{OS_AUTOINST_FULL_UPDATE_REQUEST_FREQUENCY} // 5;
 use constant DEFAULT_FFMPEG_CMD => 'ffmpeg -y -hide_banner -nostats -r 24 -f image2pipe -vcodec ppm -i - -pix_fmt yuv420p';
+use constant SSH_SERIAL_READ_BUFFER_SIZE => 4096;
 
 # should be a singleton - and only useful in backend process
 our $backend;
@@ -1271,7 +1272,7 @@ sub check_ssh_serial ($self, $fh = undef, $write = undef) {
     # read from SSH channel (receiving extended data channel as well via `$chan->ext_data('merge')`)
     my $chan = $self->{serial_chan};
     my $buffer;
-    while (defined(my $bytes_read = $chan->read($buffer, 4096))) {
+    while (defined(my $bytes_read = $chan->read($buffer, SSH_SERIAL_READ_BUFFER_SIZE))) {
         return 1 unless $bytes_read > 0;
         print $buffer;
         open(my $serial, '>>', $self->{serialfile});

--- a/consoles/serial_screen.pm
+++ b/consoles/serial_screen.pm
@@ -9,6 +9,8 @@ use English -no_match_vars;
 use Time::HiRes qw(clock_gettime CLOCK_MONOTONIC);
 use Carp 'croak';
 
+use constant SOCKET_READ_BUFFER_SIZE => 4096;
+
 our $VERSION;
 
 =head1 TESTING
@@ -192,7 +194,7 @@ on failure.
 =cut
 sub read_until ($self, $pattern, $timeout, %nargs) {
     my $fd = $self->{fd_read};
-    my $buflen = $nargs{buffer_size} || 4096;
+    my $buflen = $nargs{buffer_size} || SOCKET_READ_BUFFER_SIZE;
     my $overflow = $nargs{record_output} ? '' : undef;
     my $sttime = thetime();
     my ($rbuf, $buf) = ($self->{carry_buffer}, '');
@@ -266,7 +268,7 @@ no information available about what data is expected to be available.
 
 =cut
 sub peak ($self, %nargs) {
-    my $buflen = $nargs{buffer_size} || 4096;
+    my $buflen = $nargs{buffer_size} || SOCKET_READ_BUFFER_SIZE;
     my $total_read = 0;
     my $buf = '';
     my $read;

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -307,12 +307,12 @@ subtest 'SSH utilities' => sub {
         is($ssh->blocking(), 0, 'We run SSH in none blocking mode');
 
         $baseclass->truncate_serial_file();
-        my $expect_output = "FOO$/" x 4096;
+        my $expect_output = "FOO$/" x backend::baseclass::SSH_SERIAL_READ_BUFFER_SIZE;
         my $channel_read_string = $expect_output;
         $chan->mock(read => sub {
                 my ($self, undef, $max) = @_;
                 return unless (defined($channel_read_string));
-                $max //= 4096;
+                $max //= backend::baseclass::SSH_SERIAL_READ_BUFFER_SIZE;
                 $_[1] = substr($channel_read_string, 0, $max);
                 my $ret = length($_[1]);
                 $channel_read_string = substr($channel_read_string, $ret);


### PR DESCRIPTION
* Use named constant for serial_screen read buffer size
* Use properly named constant for "ssh serial read buffer size"