### PR TITLE
Revert "[RFC] Test OBS CI against SLE_15_SP5_Backports"

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -9,12 +9,6 @@ pr:
   - configure_repositories:
       project: devel:openQA:GitHub
       repositories:
-      - name: SLE_15_SP5_Backports
-        paths:
-          - target_project: openSUSE:Backports:SLE-15-SP5:Update
-            target_repository: standard
-        architectures:
-          - x86_64
       - name: openSUSE_Tumbleweed
         paths:
           - target_project: openSUSE:Factory


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst#2431
as OBS CI checks already fail and show what's missing.