### PR TITLE
Add SLE16 Backports OBS CI integration

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -9,6 +9,12 @@ pr:
   - configure_repositories:
       project: devel:openQA:GitHub
       repositories:
+      - name: SLE_15_SP6_Backports
+        paths:
+          - target_project: openSUSE:Backports:SLE-15-SP6:Update
+            target_repository: standard
+        architectures:
+          - x86_64
       - name: openSUSE_Tumbleweed
         paths:
           - target_project: openSUSE:Factory


### PR DESCRIPTION
This is the only backports working in building in OBS.