### PR TITLE
Test the changed version, not the released one

### DIFF
--- a/dist/rpm/os-autoinst-openvswitch-test.spec
+++ b/dist/rpm/os-autoinst-openvswitch-test.spec
@@ -5,7 +5,7 @@ Version:        4.6
 Release:        0
 Summary:        test package for %{short_name}
 License:        GPL-2.0-or-later
-BuildRequires:  %{short_name}
+BuildRequires:  %{short_name} == %{version}
 ExcludeArch:    %{ix86}
 
 %description

--- a/dist/rpm/os-autoinst-test.spec
+++ b/dist/rpm/os-autoinst-test.spec
@@ -5,8 +5,7 @@ Version:        4.6
 Release:        0
 Summary:        test package for os-autoinst
 License:        GPL-2.0-or-later
-#BuildRequires:  %{short_name} == %{version}
-BuildRequires:  %{short_name}
+BuildRequires:  %{short_name} == %{version}
 ExcludeArch:    %{ix86}
 
 %description


### PR DESCRIPTION
Test sub-package is pulling any version, not the one currently in build.
That makes tests in PR useless. This should remedy the issue.

Reference: https://progress.opensuse.org/issues/153340