### PR TITLE
Add yamltidy config

### DIFF
--- a/.github/workflows/ci_extended.yml
+++ b/.github/workflows/ci_extended.yml
@@ -7,7 +7,7 @@ on:
       - master
   pull_request:
     paths:
-      - 'container/**'
+      - container/**
 jobs:
   test-containers:
     runs-on: ubuntu-latest

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,27 +2,27 @@ pull_request_rules:
   - name: automatic merge
     conditions:
       - and: &base_checks
-        - base=master
-        - -label~=^acceptance-tests-needed|not-ready
-        # wait explicitly for one of the final checks to show up to be on the
-        # safe side even in case of checks not reporting back at all
-        - "check-success=codecov/project"
-        - "check-success=codecov/patch"
-        # Multibuild results will not report the "pending" status, so we
-        # need to require them explicitly, see
-        # https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.scm_ci_workflow_integration.html#sec.obs.obs_scm_ci_workflow_integration.setup.status_reporting
-        # "unresolvable" is not reported in general:
-        # https://trello.com/c/0N3jHq5M/2257-report-back-to-scm-when-build-results-arent-failed-and-succeeded
-        # So we need to require the number of tests explicitly:
-        - "#check-success>=15"
-        - "#check-failure=0"
-        - "#check-pending=0"
-        - linear-history
+          - base=master
+          - -label~=^acceptance-tests-needed|not-ready
+          # wait explicitly for one of the final checks to show up to be on the
+          # safe side even in case of checks not reporting back at all
+          - check-success=codecov/project
+          - check-success=codecov/patch
+          # Multibuild results will not report the "pending" status, so we
+          # need to require them explicitly, see
+          # https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.scm_ci_workflow_integration.html#sec.obs.obs_scm_ci_workflow_integration.setup.status_reporting
+          # "unresolvable" is not reported in general:
+          # https://trello.com/c/0N3jHq5M/2257-report-back-to-scm-when-build-results-arent-failed-and-succeeded
+          # So we need to require the number of tests explicitly:
+          - "#check-success>=15"
+          - "#check-failure=0"
+          - "#check-pending=0"
+          - linear-history
       - and:
-        - "#approved-reviews-by>=2"
-        - "#changes-requested-reviews-by=0"
-        # https://doc.mergify.io/examples.html#require-all-requested-reviews-to-be-approved
-        - "#review-requested=0"
+          - "#approved-reviews-by>=2"
+          - "#changes-requested-reviews-by=0"
+          # https://doc.mergify.io/examples.html#require-all-requested-reviews-to-be-approved
+          - "#review-requested=0"
     actions: &merge
       merge:
         method: merge
@@ -30,10 +30,10 @@ pull_request_rules:
     conditions:
       - and: *base_checks
       - and:
-        # mergify config checks needs at least two rules in "and" so we repeat
-        # one from the base checks
-        - base=master
-        - "label=merge-fast"
+          # mergify config checks needs at least two rules in "and" so we repeat
+          # one from the base checks
+          - base=master
+          - label=merge-fast
     actions: *merge
   - name: ask to resolve conflict
     conditions:

--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -1,30 +1,30 @@
 ---
 pr:
   steps:
-  - branch_package:
-      source_project: devel:openQA
-      source_package: os-autoinst
-      target_project: devel:openQA:GitHub
-      add_repositories: disabled
-  - configure_repositories:
-      project: devel:openQA:GitHub
-      repositories:
-      - name: SLE_15_SP6_Backports
-        paths:
-          - target_project: openSUSE:Backports:SLE-15-SP6:Update
-            target_repository: standard
-        architectures:
-          - x86_64
-      - name: openSUSE_Tumbleweed
-        paths:
-          - target_project: openSUSE:Factory
-            target_repository: snapshot
-        architectures: [ x86_64 ]
-      - name: openSUSE_Leap_15.5
-        paths:
-          - target_project: devel:openQA:Leap:15.5
-            target_repository: openSUSE_Leap_15.5
-        architectures: [ x86_64 ]
+    - branch_package:
+        source_project: devel:openQA
+        source_package: os-autoinst
+        target_project: devel:openQA:GitHub
+        add_repositories: disabled
+    - configure_repositories:
+        project: devel:openQA:GitHub
+        repositories:
+          - name: SLE_15_SP6_Backports
+            paths:
+              - target_project: openSUSE:Backports:SLE-15-SP6:Update
+                target_repository: standard
+            architectures:
+              - x86_64
+          - name: openSUSE_Tumbleweed
+            paths:
+              - target_project: openSUSE:Factory
+                target_repository: snapshot
+            architectures: [ x86_64 ]
+          - name: openSUSE_Leap_15.5
+            paths:
+              - target_project: devel:openQA:Leap:15.5
+                target_repository: openSUSE_Leap_15.5
+            architectures: [ x86_64 ]
   filters:
     event: pull_request
 

--- a/.yamllint
+++ b/.yamllint
@@ -4,7 +4,7 @@ rules:
     max: 160
   document-start: disable
   indentation:
-    indent-sequences: whatever
+    indent-sequences: true
 
   # Allows aligning subsequent lines with [] sequences
   brackets:

--- a/.yamltidy
+++ b/.yamltidy
@@ -1,0 +1,8 @@
+---
+v: v0.1
+indentation:
+  spaces: 2
+  block-sequence-in-mapping: 2
+trailing-spaces: fix
+scalar-style:
+  default: plain


### PR DESCRIPTION
And change .yamllint config to always indent block sequences

I would like to run yamltidy before committing YAML files, and I think we profit from a common indentation.