### PR TITLE
Ensure Git URL variables are pointing to actual remote despite caching

### DIFF
--- a/t/34-git.t
+++ b/t/34-git.t
@@ -11,7 +11,7 @@ use File::Path qw(rmtree);
 use FindBin '$Bin';
 use Test::Output qw(combined_from combined_like);
 use Test::Mock::Time;
-use OpenQA::Isotovideo::Utils qw(checkout_git_repo_and_branch);
+use OpenQA::Isotovideo::Utils qw(checkout_git_repo_and_branch git_remote_url);
 use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use Test::Warnings ':report_warnings';
@@ -133,6 +133,7 @@ subtest 'cloning with caching' => sub {
         ok -f $working_tree_dir->child('README.md'), 'working tree has been created';
         my $working_tree_config = $working_tree_dir->child('.git/config')->slurp;
         ok index($working_tree_config, $repo_cache_dir), 'working tree config refers to cache dir';
+        is git_remote_url($working_tree_dir), $url, 'remote URL still computed as before';
     };
     subtest 'first clone' => sub {
         my $out = $clone->();


### PR DESCRIPTION
When using caching via `GIT_CACHE_DIR` the function `git_remote_url` so far returns only a local path and not the actual remote URL anymore. With this change the actual remote URL is looked up so the variables `TEST_GIT_URL` and `NEEDLES_GIT_URL` (which are used by external tooling) are still populated as before.

Related ticket: https://progress.opensuse.org/issues/154156