### PR TITLE
Add ipmitool dependencies for openqa-worker-container

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -93,6 +93,7 @@ Source0:        %{name}-%{version}.tar.xz
 # The following line is generated from dependencies.yaml
 %define devel_requires %python_style_requires %test_requires ShellCheck perl(Code::TidyAll) perl(Devel::Cover) perl(Devel::Cover::Report::Codecov) perl(Module::CPANfile) perl(Perl::Tidy) perl(Template::Toolkit) shfmt
 %define s390_zvm_requires /usr/bin/xkbcomp /usr/bin/Xvnc x3270 icewm xterm xterm-console xdotool fonts-config mkfontdir mkfontscale openssh-clients
+%define ipmi_requires ipmitool
 %define qemu_requires qemu-tools e2fsprogs
 BuildRequires:  %test_requires %test_version_only_requires
 # For unbuffered output of Perl testsuite, especially when running it on OBS so timestamps in the log are actually useful
@@ -183,6 +184,15 @@ Requires:       %s390_zvm_requires
 
 %description s390-deps
 Convenience package providing os-autoinst + s390 worker jumphost dependencies.
+
+%package ipmi-deps
+Summary:        Convenience package providing os-autoinst + ipmi worker jumphost deps
+Group:          Development/Tools/Other
+Requires:       os-autoinst
+Requires:       %ipmi_requires
+
+%description ipmi-deps
+Convenience package providing os-autoinst + ipmi worker jumphost dependencies.
 
 
 %prep
@@ -309,5 +319,6 @@ fi
 %endif
 %files swtpm
 %files s390-deps
+%files ipmi-deps
 
 %changelog


### PR DESCRIPTION
Similar to what we do already for s390 we should also provide dependencies for IPMI SUTs.

See https://progress.opensuse.org/issues/153706