### PR TITLE
t: Split author tests and build test

### DIFF
--- a/.github/workflows/author-tests.yaml
+++ b/.github/workflows/author-tests.yaml
@@ -1,0 +1,18 @@
+---
+name: Author tests
+
+on: [push, pull_request]
+
+jobs:
+  author-tests:
+    runs-on: ubuntu-latest
+    name: Author tests
+    container:
+      image: registry.opensuse.org/devel/openqa/containers/os-autoinst_dev
+    steps:
+      - uses: actions/checkout@v4
+      - name: make test-local
+        run: |
+          git config --global --add safe.directory '*'
+          make
+          make test-local

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -287,6 +287,16 @@ Run individual tests by specifying them explicitly:
 make test-perl-testsuite TESTS="t/15-logging.t t/28-signalblocker.t"
 ----
 
+Run perl author tests:
+----
+make test-local-author-perl
+----
+
+Run all author tests:
+----
+make test-local
+----
+
 Notice that the user needs to include the test directory for each test (either t for normal or
 xt for developer-centric tests) when specifying individual tests.
 

--- a/cmake/test-targets.cmake
+++ b/cmake/test-targets.cmake
@@ -93,10 +93,15 @@ endif ()
 find_program(PROVE_PATH prove)
 find_program(UNBUFFER_PATH unbuffer)
 if (PROVE_PATH)
-    set(INVOKE_TEST_ARGS --prove-tool "${PROVE_PATH}" --make-tool "${CMAKE_MAKE_PROGRAM}" --unbuffer-tool "${UNBUFFER_PATH}" --build-directory "${CMAKE_CURRENT_BINARY_DIR}")
+    set(INVOKE_TEST_ARGS --prove-tool "${PROVE_PATH}" --make-tool "${CMAKE_MAKE_PROGRAM}" --unbuffer-tool "${UNBUFFER_PATH}" --build-directory "${CMAKE_CURRENT_BINARY_DIR}" t)
     add_test(
         NAME test-perl-testsuite
         COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tools/invoke-tests" ${INVOKE_TEST_ARGS}
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+    add_test(
+        NAME test-local-author-perl
+        COMMAND "${PROVE_PATH}" xt
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
 else ()
@@ -104,6 +109,7 @@ else ()
 endif ()
 
 # add build system targets for invoking specific tests
+add_custom_target(test-local-author-perl COMMAND ${CMAKE_CTEST_COMMAND} -R "test-local-author-perl" WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
 add_custom_target(test-local COMMAND ${CMAKE_CTEST_COMMAND} -R "test-local-.*" WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
 add_custom_target(test-doc COMMAND ${CMAKE_CTEST_COMMAND} -R "test-doc-.*" WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
 add_custom_target(test-installed-files COMMAND ${CMAKE_CTEST_COMMAND} -R "test-installed-files" WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -208,7 +208,7 @@ for i in 07-commands 13-osutils 14-isotovideo 18-qemu-options 18-backend-qemu 29
     rm t/$i.t
 done
 # exclude unnecessary author tests
-rm xt/00-tidy.t
+rm xt/00-tidy.t tools/tidyall
 # Remove test relying on a git working copy
 rm xt/30-make.t
 # https://progress.opensuse.org/issues/114881

--- a/tools/container_run_ci
+++ b/tools/container_run_ci
@@ -72,6 +72,6 @@ cd /opt
 ./tools/install-new-deps.sh
 export CI=1 WITH_COVER_OPTIONS=1 CHECK_GIT_STATUS=1 PERL_TEST_WARNINGS_ONLY_REPORT_WARNINGS=$PERL_TEST_WARNINGS_ONLY_REPORT_WARNINGS
 cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -S . -B \"$build_dir\"
-cmake --build \"$build_dir\" --verbose --target check
+cmake --build \"$build_dir\" --verbose --target check-pkg-build
 cmake --build \"$build_dir\" --verbose --target $target
 cover -report html_minimal \"$build_dir\"/cover_db"

--- a/tools/tidyall
+++ b/tools/tidyall
@@ -1,0 +1,1 @@
+../external/os-autoinst-common/tools/tidyall


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/155062

Add test-local-author-perl target and workflow for test-local 

This way we have some of the static tests in its own workflow. Faster and clearer feedback from github.

