### PR TITLE
video_stream: Fix uninitialized cmd_prefix

### DIFF
--- a/consoles/video_stream.pm
+++ b/consoles/video_stream.pm
@@ -61,7 +61,7 @@ sub disable ($self, @) {
 
 # uncoverable statement count:1..5 note:the function is redefined in tests
 sub _v4l2_ctl ($device, $cmd_prefix, $cmd) {
-    my @cmd = split(/ /, $cmd_prefix);    # uncoverable statement
+    my @cmd = split(/ /, $cmd_prefix // '');    # uncoverable statement
     push(@cmd, ("v4l2-ctl", "--device", $device, "--concise"));    # uncoverable statement
     push(@cmd, split(/ /, $cmd));    # uncoverable statement
 


### PR DESCRIPTION
Fix this warning:
Use of uninitialized value $cmd_prefix in split at /usr/lib/os-autoinst/consoles/video_stream.pm line 64.