### PR TITLE
PoC - Trace test variables

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -274,6 +274,7 @@ sub run_all () {
         warn $e;
         $died = 1;    # test execution died
     }
+    bmwqemu::debug_vars();
     try {
         bmwqemu::save_vars(no_secret => 1);
         bmwqemu::diag("Sending tests_done");

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -302,6 +302,10 @@ sub random_string ($count) {
 # sleeping for one second should ensure that one more screenshot is taken
 sub wait_for_one_more_screenshot () { sleep 1 }
 
+sub debug_vars () {
+    tied(%bmwqemu::vars)->debug_vars;
+}
+
 package bmwqemu::tiedvars;
 use Tie::Hash;
 use base qw/ Tie::StdHash /;    # no:style prevent style warning regarding use of Mojo::Base and base in this file
@@ -316,6 +320,39 @@ sub TIEHASH ($class, %args) {
 sub STORE ($self, $key, $val) {
     croak("Settings key '$key' is invalid (check your test settings)") unless $key =~ m/^(?:[A-Z0-9_]+)\z/;
     $self->{data}->{$key} = $val;
+    my @stack;
+    for (0 .. 9) {
+        my @caller = caller($_);
+        last unless @caller;
+        my ($package, $file, $line, $sub) = @caller;
+        if ($caller[3] eq 'bmwqemu::load_vars') {
+            $self->{trace}->{load_vars}->{$key} = $val;
+            return;
+        }
+        next if ($package eq 'testapi');
+        last if ($package eq 'basetest' and $sub eq '(eval)');
+        last if $package eq 'main';
+        push @stack, [$package, $line, $sub];
+    }
+    $self->{trace}->{override}->{$key} = {
+        callstack => \@stack,
+        value => $val,
+    };
+}
+
+sub debug_vars ($self) {
+    use YAML::PP;
+    use YAML::PP::Common qw/ PRESERVE_FLOW_STYLE YAML_FLOW_SEQUENCE_STYLE /;
+    my $yp = YAML::PP->new(preserve => PRESERVE_FLOW_STYLE);
+    my $trace = $self->{trace};
+    for my $key (keys %{$trace->{override}}) {
+        my $callstack = $trace->{override}->{$key}->{callstack};
+        for my $row (@$callstack) {
+            $row = $yp->preserved_sequence($row, style => YAML_FLOW_SEQUENCE_STYLE);
+        }
+    }
+    my $dump = $yp->dump_string($trace);
+    log::diag $dump;
 }
 
 sub FIRSTKEY ($self) {


### PR DESCRIPTION
This is just a proof of concept.

Issue: https://progress.opensuse.org/issues/156697

Example output:
```
[2024-03-05T14:53:02.149581+01:00] [debug] [pid:23635] ---
  load_vars:
    ARCH: x86_64
    # ...
  override:
    DUMMY:
      callstack:
      - [boot, 7, testapi::set_var]
      - [basetest, 352, boot::run]
      value: lala
    NEEDLES_GIT_HASH:
      callstack:
      - [needle, 292, bmwqemu::tiedvars::STORE]
      - [OpenQA::Isotovideo::Runner, 72, needle::init]
      value: f39035e15d5d7535b6bc66bbcd9cde565a978945
    NEEDLES_GIT_URL:
      callstack:
      - [needle, 292, bmwqemu::tiedvars::STORE]
      - [OpenQA::Isotovideo::Runner, 72, needle::init]
      value: git@github.com:os-autoinst/os-autoinst-needles-openQA.git
    TEST_GIT_HASH:
      callstack:
      - [OpenQA::Isotovideo::Runner, 215, bmwqemu::tiedvars::STORE]
      - [OpenQA::Isotovideo::Runner, 68, OpenQA::Isotovideo::Runner::checkout_code]
      value: 552780e98a3a1d4881f4b42b6d381848cb980837
    TEST_GIT_URL:
      callstack:
      - [OpenQA::Isotovideo::Runner, 215, bmwqemu::tiedvars::STORE]
      - [OpenQA::Isotovideo::Runner, 68, OpenQA::Isotovideo::Runner::checkout_code]
      value: git@github.com:os-autoinst/os-autoinst-distri-openQA
```