### PR TITLE
Automatically reconnect graphical IPMI SOL console on error

### DIFF
--- a/consoles/localXvnc.pm
+++ b/consoles/localXvnc.pm
@@ -39,8 +39,11 @@ sub callxterm ($self, $command, $window_name) {
         mkpath 'ulogs';
         $command = "script -af ulogs/hardware-console-log.txt -c \"$command\"";
     }
-    eval { system("DISPLAY=$display $xterm_vt_cmd -title $window_name -e bash -c '$command' & echo \"xterm PID is \$!\""); };
-    die "cant' start xterm on $display (err: $! retval: $?)" if $@;
+    my $pid = fork();
+    exec("DISPLAY=$display $xterm_vt_cmd -title $window_name -e bash -c '$command'")    # uncoverable statement
+      unless $pid;
+    bmwqemu::diag("Xterm PID: $pid");
+    return $pid;
 }
 
 sub fullscreen ($self, $args) {

--- a/consoles/localXvnc.pm
+++ b/consoles/localXvnc.pm
@@ -37,7 +37,7 @@ sub callxterm ($self, $command, $window_name) {
     die('Missing "xterm"') unless which('xterm');
     if ($self->{args}->{log}) {
         mkpath 'ulogs';
-        $command = "script -f ulogs/hardware-console-log.txt -c \"$command\"";
+        $command = "script -af ulogs/hardware-console-log.txt -c \"$command\"";
     }
     eval { system("DISPLAY=$display $xterm_vt_cmd -title $window_name -e bash -c '$command' & echo \"xterm PID is \$!\""); };
     die "cant' start xterm on $display (err: $! retval: $?)" if $@;

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -93,6 +93,7 @@ IPMI_MC_RESET_TIMEOUT;integer;60;Counts to try to reach IPMI interface after mc 
 IPMI_MC_RESET_PING_COUNT;integer;1;Ping counts that must be successful after mc reset
 IPMI_MC_RESET_IPMI_TRIES;integer;3;Maximum number of IPMI command tries that are conducted after mc reset
 IPMI_SOL_PERSISTENT_CONSOLE;boolean;1;Make SOL console persistent and don't reset it, enabled by default
+IPMI_SOL_MAX_RECONNECTS;integer;5;Maximum number of SOL reconnects on connection failure
 IPMI_$_;;;Internal iterator variable
 WORKER_HOSTNAME;string;undef;Worker hostname
 |====================

--- a/t/27-consoles-local_xvnc.t
+++ b/t/27-consoles-local_xvnc.t
@@ -22,6 +22,7 @@ chdir $dir;
 my $cleanup = scope_guard sub { chdir $Bin; undef $dir };
 
 BEGIN { *consoles::localXvnc::system = sub { 1 } }
+BEGIN { *consoles::localXvnc::exec = sub { _exit(0) } }
 BEGIN { *CORE::GLOBAL::sleep = sub { 1 } }
 
 # mock external tool for testing
@@ -42,11 +43,11 @@ my $local_xvnc_mock = Test::MockModule->new('consoles::localXvnc');
 # uncoverable statement count:2
 $local_xvnc_mock->redefine(start_xvnc => sub { _exit(0) });
 stderr_like { $c->activate } qr/Connected to Xvnc/, 'can call activate';
-is $c->callxterm('true', 'window1'), '', 'can call callxterm';
+ok $c->callxterm('true', 'window1'), 'can call callxterm';
 $vnc_mock->called_pos_ok(0, 'check_vnc_stalls', 'VNC stall detection configured');
 $vnc_mock->called_args_pos_is(0, 2, 0, 'VNC stall detection disabled');
 $c->{args}->{log} = 1;
-is $c->callxterm('true', 'window1'), '', 'can call callxterm';
+ok $c->callxterm('true', 'window1'), 'can call callxterm';
 is $c->fullscreen({window_name => 'foo'}), 1, 'can call fullscreen';
 is $c->disable, undef, 'can call disable';
 


### PR DESCRIPTION
Connecting SOL console on some IPMI workers randomly fails:
https://openqa.suse.de/tests/13602258#step/bootloader_start/1
https://openqa.suse.de/tests/13602258/logfile?filename=hardware-console-log.txt

Check SOL connection process on every screen buffer update and restart it if necessary.

Also open hardware console log in append mode to preserve log contents between SOL reconnects.