### PR TITLE
Move exit_code_from_test_results to Runner.pm

### DIFF
--- a/OpenQA/Isotovideo/Runner.pm
+++ b/OpenQA/Isotovideo/Runner.pm
@@ -3,9 +3,6 @@
 
 package OpenQA::Isotovideo::Runner;
 use Mojo::Base -base, -signatures;
-# Avoid "Subroutine JSON::PP::Boolean::(0+ redefined" warnings
-# Details: https://progress.opensuse.org/issues/90371
-use JSON::PP;
 
 use autodie ':all';
 no autodie 'kill';
@@ -13,6 +10,7 @@ use POSIX qw(:sys_wait_h _exit);
 use Mojo::File qw(path);
 use Mojo::UserAgent;
 use IO::Select;
+use JSON::PP;
 use log qw(diag fctwarn);
 use OpenQA::Isotovideo::Utils qw(checkout_git_repo_and_branch checkout_git_refspec checkout_wheels
   load_test_schedule);

--- a/OpenQA/Isotovideo/Runner.pm
+++ b/OpenQA/Isotovideo/Runner.pm
@@ -3,9 +3,14 @@
 
 package OpenQA::Isotovideo::Runner;
 use Mojo::Base -base, -signatures;
+# Avoid "Subroutine JSON::PP::Boolean::(0+ redefined" warnings
+# Details: https://progress.opensuse.org/issues/90371
+use JSON::PP;
+
 use autodie ':all';
 no autodie 'kill';
 use POSIX qw(:sys_wait_h _exit);
+use Mojo::File qw(path);
 use Mojo::UserAgent;
 use IO::Select;
 use log qw(diag fctwarn);
@@ -28,6 +33,12 @@ has [qw(backend command_handler)];
 
 # the loop status
 has loop => 1;
+
+use constant {
+    EXIT_STATUS_OK => 0,
+    EXIT_STATUS_ERR_NO_TESTS => 100,
+    EXIT_STATUS_ERR_FROM_TEST_RESULTS => 101,
+};
 
 sub run ($self) {
     # now we have everything, give the tests a go
@@ -233,6 +244,23 @@ sub _init_bmwqemu ($, @args) {
             diag("Setting forced test parameter $key -> $2");
         }
     }
+}
+
+sub exit_code_from_test_results ($self) {
+    my @results = glob(path(bmwqemu::result_dir(), "result-*.json"));
+    return EXIT_STATUS_ERR_NO_TESTS if @results == 0;
+
+    my $did_fail = 0;
+    for my $result_file_path (@results) {
+        my $result_file = path($result_file_path);
+        my $test_result = decode_json($result_file->slurp)->{result};
+        diag sprintf("Test result [%s] %s", $result_file->to_string, $test_result);
+        # If a failure (anything different from ok & softfail) is found, keep it.
+        next if $did_fail;
+
+        $did_fail = $test_result !~ m/^(ok|softfail)$/;
+    }
+    return $did_fail ? EXIT_STATUS_ERR_FROM_TEST_RESULTS : EXIT_STATUS_OK;
 }
 
 sub handle_shutdown ($self, $return_code) {

--- a/isotovideo
+++ b/isotovideo
@@ -85,8 +85,6 @@ no autodie 'kill';
 use constant {
     EXIT_STATUS_OK => 0,
     EXIT_STATUS_ERR => 1,
-    EXIT_STATUS_ERR_NO_TESTS => 100,
-    EXIT_STATUS_ERR_FROM_TEST_RESULTS => 101,
 };
 
 # Avoid "Subroutine JSON::PP::Boolean::(0+ redefined" warnings
@@ -113,7 +111,6 @@ Getopt::Long::Configure("no_ignore_case");
 use OpenQA::Isotovideo::Interface;
 use OpenQA::Isotovideo::Runner;
 use OpenQA::Isotovideo::Utils qw(git_rev_parse spawn_debuggers handle_generated_assets);
-use Mojo::File qw(path);
 
 my %options;
 
@@ -129,23 +126,6 @@ sub usage ($r) {
 sub _get_version_string () {
     my $thisversion = git_rev_parse(curfile->dirname);
     return "Current version is $thisversion [interface v$OpenQA::Isotovideo::Interface::version]";
-}
-
-sub _exit_code_from_test_results () {
-    my @results = glob(path(bmwqemu::result_dir(), "result-*.json"));
-    return EXIT_STATUS_ERR_NO_TESTS if @results == 0;
-
-    my $did_fail = 0;
-    for my $result_file_path (@results) {
-        my $result_file = path($result_file_path);
-        my $test_result = decode_json($result_file->slurp)->{result};
-        diag sprintf("Test result [%s] %s", $result_file->to_string, $test_result);
-        # If a failure (anything different from ok & softfail) is found, keep it.
-        next if $did_fail;
-
-        $did_fail = $test_result !~ m/^(ok|softfail)$/;
-    }
-    return $did_fail ? EXIT_STATUS_ERR_FROM_TEST_RESULTS : EXIT_STATUS_OK;
 }
 
 sub version () {
@@ -202,7 +182,7 @@ eval {
     $runner->run;
 
     if ($options{'exit-status-from-test-results'}) {
-        $RETURN_CODE = _exit_code_from_test_results();
+        $RETURN_CODE = $runner->exit_code_from_test_results;
     }
 
     # terminate/kill the command server and let it inform its websocket clients before

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -247,25 +247,6 @@ subtest 'exit status from test results' => sub {
     path('vars.json')->remove if -e 'vars.json';
     path('serial0')->touch;
 
-    subtest 'no test scheduled' => sub {
-        path('testresults/')->remove_tree;
-        my $log = combined_from { isotovideo(
-                default_opts => '--exit-status-from-test-results backend=null',
-                opts => "casedir=$data_dir/empty_test_distribution", exit_code => 100) };
-    };
-
-    subtest 'tests scheduled' => sub {
-        path('testresults/')->remove_tree;
-        my $module_basename = 'failing_module';
-        my $module = "tests/$module_basename";
-        my $log = combined_from { isotovideo(
-                default_opts => '--exit-status-from-test-results backend=null',
-                opts => "casedir=$data_dir/tests schedule=$module", exit_code => 101) };
-
-        like $log, qr/scheduling $module_basename $module\.pm/, 'module scheduled';
-        like $log, qr/Test result \[testresults\/result\-$module_basename\.json\] fail/, 'failed test module report';
-    };
-
     subtest 'softfailed module' => sub {
         path('testresults/')->remove_tree;
         my $module_basename = 'softfail_module';

--- a/t/19-isotovideo-command-processing.t
+++ b/t/19-isotovideo-command-processing.t
@@ -12,11 +12,14 @@ use Test::Warnings ':report_warnings';
 use Test::Fatal;
 use Mojo::JSON 'encode_json';
 use Mojo::File qw(tempdir path);
+use Mojo::Util qw(scope_guard);
 use OpenQA::Isotovideo::CommandHandler;
 use OpenQA::Isotovideo::Interface;
 use OpenQA::Isotovideo::Runner;
 
 my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
+chdir $dir;
+my $cleanup = scope_guard sub { chdir $Bin; undef $dir };
 
 # declare fake file descriptors
 my $cmd_srv_fd = 0;
@@ -399,7 +402,6 @@ subtest signalhandler => sub {
 };
 subtest 'Check exit_code_from_test_results' => sub {
     my $runner = OpenQA::Isotovideo::Runner->new;
-    chdir($dir);
 
     subtest 'no test scheduled' => sub {
         my $path_mock = Test::MockModule->new('Mojo::File');
@@ -450,8 +452,3 @@ subtest 'shutdown handling' => sub {
 };
 
 done_testing;
-
-END {
-    unlink OpenQA::Isotovideo::CommandHandler::AUTOINST_STATUSFILE;
-    unlink bmwqemu::STATE_FILE;
-}

--- a/t/19-isotovideo-command-processing.t
+++ b/t/19-isotovideo-command-processing.t
@@ -10,10 +10,13 @@ use Test::MockModule;
 use Test::Output qw(stderr_like stderr_unlike combined_like);
 use Test::Warnings ':report_warnings';
 use Test::Fatal;
-use Mojo::JSON;
+use Mojo::JSON 'encode_json';
+use Mojo::File qw(tempdir path);
 use OpenQA::Isotovideo::CommandHandler;
 use OpenQA::Isotovideo::Interface;
 use OpenQA::Isotovideo::Runner;
+
+my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
 
 # declare fake file descriptors
 my $cmd_srv_fd = 0;
@@ -393,6 +396,32 @@ subtest signalhandler => sub {
         $runner->_signal_handler('INT');
     } qr/isotovideo received signal INT/, 'Signal logged';
     is($last_signal, 'INT', 'Event emitted');
+};
+subtest 'Check exit_code_from_test_results' => sub {
+    my $runner = OpenQA::Isotovideo::Runner->new;
+    chdir($dir);
+
+    subtest 'no test scheduled' => sub {
+        my $path_mock = Test::MockModule->new('Mojo::File');
+        $path_mock->redefine(path => 0);
+        is($runner->exit_code_from_test_results(), 100, 'EXIT_STATUS_ERR_NO_TESTS returns if no results');
+    };
+
+    subtest 'tests scheduled' => sub {
+        path('testresults/')->make_path;
+        my $json = encode_json({result => 'failing'});
+        my $resfile = path('testresults/result-failed_module.json')->spew($json);
+        is($runner->exit_code_from_test_results(), 101, 'EXIT_STATUS_ERR_FROM_TEST_RESULTS returns if test failed');
+        path('testresults/')->remove_tree;
+    };
+
+    subtest 'softfailed module' => sub {
+        path('testresults/')->make_path;
+        my $json = encode_json({result => 'softfail'});
+        my $resfile = path('testresults/result-softfailed_module.json')->spew($json);
+        is($runner->exit_code_from_test_results(), 0, 'EXIT_STATUS_OK returns if test is not failed');
+        path('testresults/')->remove_tree;
+    };
 };
 
 subtest 'No readable JSON' => sub {


### PR DESCRIPTION
`exit_code_from_test_results` is moved to Runner Class in order to be able                                                                                                                                                                   
to speed the tests up for 14-isotovideo.t.                                                                                                                                                                                                   
14-isotovideo.t is faster by ~3 wallclock.    

https://progress.opensuse.org/issues/157339