### PR TITLE
invoke-tests: Allow PERL5OPT with coverage

### DIFF
--- a/tools/invoke-tests
+++ b/tools/invoke-tests
@@ -67,7 +67,7 @@ export PERL5LIB="$source_directory:$source_directory/ppmclibs/blib/lib:$source_d
 if [[ $WITH_COVER_OPTIONS ]]; then
     ignore="external/|tools/|t/data/tests/tests/|t/data/wheels_dir|/tmp|/CheckGitStatus.pm|$prove_path"
     # add ' -MOpenQA::Test::PatchDeparse' for older OS versions to avoid warnings
-    export PERL5OPT="-I$source_directory/t/lib -I$source_directory/external/os-autoinst-common/lib -MOpenQA::Test::CheckGitStatus -MDevel::Cover=-db,$db,-ignore,$ignore,-coverage,statement"
+    export PERL5OPT="$PERL5OPT -I$source_directory/t/lib -I$source_directory/external/os-autoinst-common/lib -MOpenQA::Test::CheckGitStatus -MDevel::Cover=-db,$db,-ignore,$ignore,-coverage,statement"
 fi
 # set variables for tests which need to invoke the make tool
 export OS_AUTOINST_BUILD_DIRECTORY=$build_directory


### PR DESCRIPTION
Currently options are always overridden when enabling coverage.

For example:

    PERL5OPT=-d:NYTProf ./tools/invoke-tests --coverage t/14-isotovideo.t