### PR TITLE
Fix video_stream console (ustreamer mode) and make debugging such issues easier

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -254,7 +254,8 @@ sub load_snapshot ($sname) {
     # On VMware VNC console needs to be re-selected after snapshot revert,
     # so the screen is refreshed. Same with serial console.
     return unless ($command // '') eq 'vmware_fixup';
-    testapi::select_console('sut');
+    my $ret = testapi::select_console('sut');    # uncoverable statement
+    die $ret->{error} if $ret->{error};    # uncoverable statement
     query_isotovideo('backend_stop_serial_grab');
     query_isotovideo('backend_start_serial_grab');
 }

--- a/backend/generalhw.pm
+++ b/backend/generalhw.pm
@@ -93,7 +93,8 @@ sub relogin_vnc ($self) {
             jpeg => $bmwqemu::vars{GENERAL_HW_VNC_JPEG} // 0,
         });
     $vnc->backend($self);
-    $self->select_console({testapi_console => 'sut'});
+    my $ret = $self->select_console({testapi_console => 'sut'});
+    die $ret->{error} if $ret->{error};
 
     return 1;
 }
@@ -130,7 +131,8 @@ sub reconnect_video_stream ($self, @) {
             edid => $bmwqemu::vars{GENERAL_HW_EDID},
         });
     $vnc->backend($self);
-    $self->select_console({testapi_console => 'sut'});
+    my $ret = $self->select_console({testapi_console => 'sut'});
+    die $ret->{error} if $ret->{error};
 
     return 1;
 }

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -1033,7 +1033,8 @@ sub start_qemu ($self) {
             description => "QEMU's VNC"});
 
     $vnc->backend($self);
-    $self->select_console({testapi_console => 'sut'});
+    my $ret = $self->select_console({testapi_console => 'sut'});
+    die $ret->{error} if $ret->{error};
 
     if ($vars->{NICTYPE} eq "tap") {
         $self->{allocated_networks} = $num_networks;

--- a/backend/s390x.pm
+++ b/backend/s390x.pm
@@ -20,7 +20,8 @@ sub do_start_vm ($self, @) {
     $self->truncate_serial_file;
     my $console = $testapi::distri->add_console('x3270', 's3270');
     $console->backend($self);
-    $self->select_console({testapi_console => 'x3270'});
+    my $ret = $self->select_console({testapi_console => 'x3270'});
+    die $ret->{error} if $ret->{error};
 
     return 1;
 }

--- a/consoles/video_stream.pm
+++ b/consoles/video_stream.pm
@@ -155,7 +155,7 @@ sub connect_remote_video ($self, $url) {
         $self->{ustreamer_pipe} = $ffmpeg;
         my $timeout = 100;
         while ($timeout && !-f "/dev/shm/$sink_name") {
-            sleep(0.1);    # uncoverable statement
+            usleep(100_000);    # uncoverable statement
             $timeout -= 1;    # uncoverable statement
         }
         die "ustreamer startup timeout" if $timeout <= 0;

--- a/consoles/video_stream.pm
+++ b/consoles/video_stream.pm
@@ -128,6 +128,7 @@ sub _get_ffmpeg_cmd ($self, $url) {
 sub _get_ustreamer_cmd ($self, $url, $sink_name) {
     return [
         'ustreamer', '--device', $url, '-f', '5',
+        '-m', 'UYVY',    # specify preferred format
         '-c', 'NOOP',    # do not produce JPEG stream
         '--raw-sink', $sink_name, '--raw-sink-rm',    # raw memsink
         '--dv-timings',    # enable using DV timings (getting resolution, and reacting to changes)

--- a/t/26-video_stream.t
+++ b/t/26-video_stream.t
@@ -105,6 +105,7 @@ subtest 'connect stream' => sub {
     my $cmd = $mock_console->original('_get_ustreamer_cmd')->($console, '/dev/video0', 'raw-sink-dev-video0');
     is_deeply $cmd, [
         'ustreamer', '--device', '/dev/video0', '-f', '5',
+        '-m', 'UYVY',
         '-c', 'NOOP',
         '--raw-sink', 'raw-sink-dev-video0', '--raw-sink-rm',
         '--dv-timings'], "correct cmd built";

--- a/t/29-backend-s390x.t
+++ b/t/29-backend-s390x.t
@@ -18,6 +18,9 @@ use distribution;
 use testapi;
 
 $bmwqemu::vars{WORKER_HOSTNAME} = 'localhost';
+$bmwqemu::vars{ZVM_HOST} = 'localhost';
+$bmwqemu::vars{ZVM_GUEST} = 'guest';
+$bmwqemu::vars{ZVM_PASSWORD} = 'password';
 ok my $backend = backend::s390x->new(), 'can instantiate backend';
 ok !$backend->check_socket(undef), 'check_socket returns false by default';
 
@@ -27,6 +30,10 @@ my $distri = $testapi::distri = distribution->new;
 my $local_xvnc_mock = Test::MockModule->new('consoles::localXvnc');
 my $local_xvnc_activated;
 $local_xvnc_mock->redefine(activate => sub { $local_xvnc_activated = 1 });
+
+my $s3270_mock = Test::MockModule->new('consoles::s3270');
+$s3270_mock->noop('new_3270_console');
+$s3270_mock->noop('connect_and_login');
 
 
 subtest 'starting VM' => sub {


### PR DESCRIPTION
Two fixes for the ustreamer mode in the video_stream console.
And also do not ignore error in `select_console()` - that would have saved me several hours of debugging.