### PR TITLE
Avoid errors in `get_job_autoinst_vars` due to not using FQDNs

### DIFF
--- a/mmapi.pm
+++ b/mmapi.pm
@@ -183,8 +183,9 @@ sub get_job_autoinst_url ($target_id) {
     my $workers = $tx->res->json('/workers') // [];
     for my $worker (@$workers) {
         if ($worker->{jobid} && $target_id == $worker->{jobid} && $worker->{host} && $worker->{instance} && $worker->{properties}{JOBTOKEN}) {
-            my $hostname = $worker->{host};
-            my $token = $worker->{properties}{JOBTOKEN};
+            my $properties = $worker->{properties};
+            my $hostname = $properties->{WORKER_HOSTNAME} // $worker->{host};
+            my $token = $properties->{JOBTOKEN};
             my $workerport = $worker->{instance} * 10 + 20002 + 1;    # the same as in openqa/script/worker
             my $url = "http://$hostname:$workerport/$token";
             return $url;


### PR DESCRIPTION
* Use FQDN in cross-worker MM-API calls if available
* See https://progress.opensuse.org/issues/158185