### PR TITLE
setup-multimachine: Retry package installation up to 3 times

### DIFF
--- a/script/os-autoinst-setup-multi-machine
+++ b/script/os-autoinst-setup-multi-machine
@@ -16,7 +16,8 @@ ensure_ip_forwarding() {
 }
 
 install_packages() {
-    zypper -n in openvswitch os-autoinst-openvswitch firewalld libcap-progs
+    command -v retry > /dev/null || zypper -n in retry
+    retry -- zypper -n in openvswitch os-autoinst-openvswitch firewalld libcap-progs
 }
 
 configure_firewall() {


### PR DESCRIPTION
We already use retry in tests which rely on this script so it should be available. Failing that install it anyway.

See: https://progress.opensuse.org/issues/158245