### PR TITLE
Remove obsolete qemu options

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -544,12 +544,6 @@ sub qemu_params_ofw ($self) {
     $vars->{QEMUMACHINE} //= "usb=off";
     # set the initial resolution on PCC and SPARC
     sp('g', "$self->{xres}x$self->{yres}");
-    # newer qemu needs safe cache capability level quirk settings
-    # https://progress.opensuse.org/issues/75259
-    my $caps = ',cap-cfpc=broken,cap-sbbc=broken,cap-ibs=broken';
-    $vars->{QEMUMACHINE} .= $caps if $vars->{QEMUMACHINE} !~ /$caps/;
-    $caps = ',cap-ccf-assist=off';
-    $vars->{QEMUMACHINE} .= $caps if $self->{qemu_version} >= version->declare(5) && $vars->{QEMUMACHINE} !~ /$caps/;
     return 1;
 }
 

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -194,7 +194,6 @@ sub qemu_cmdline (%args) {
 }
 
 like qemu_cmdline(OFW => 1, XRES => 640, YRES => 480), qr/-g 640x480/, 'res is set for ppc/sparc';
-like qemu_cmdline(OFW => 1), qr/cap-cfpc=broken/, 'OFW workarounds applied';
 
 sub test_boot_options ($boot, $arch, $pxe, $expected) {
     my $cmdline;


### PR DESCRIPTION
These options got introduced based on qemu log warnings. With the most recent firmware (FW860) these options seem to be no longer required.

Related ticket: https://progress.opensuse.org/issues/76951

Verification run: https://openqa.opensuse.org/tests/4060130

History of these options:
- https://github.com/os-autoinst/os-autoinst/pull/1554
- https://github.com/os-autoinst/os-autoinst/pull/1837
- https://github.com/os-autoinst/os-autoinst/pull/1835