### PR TITLE
setup-multimachine: Retry package installation up to 7 times

### DIFF
--- a/script/os-autoinst-setup-multi-machine
+++ b/script/os-autoinst-setup-multi-machine
@@ -17,7 +17,7 @@ ensure_ip_forwarding() {
 
 install_packages() {
     command -v retry > /dev/null || zypper -n in retry
-    retry -- zypper -n in openvswitch os-autoinst-openvswitch firewalld libcap-progs
+    retry -e -s 30 -r 7 -- sh -c "zypper ref && zypper -n in openvswitch os-autoinst-openvswitch firewalld libcap-progs"
 }
 
 configure_firewall() {


### PR DESCRIPTION
Also do exponential retry and wait 30 seconds.

See: https://progress.opensuse.org/issues/158553