### PR TITLE
Update codecov action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Static checks, unit- and integration tests
         run: tools/container_run_ci
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           # should not be necessary for public repos, but might help avoid sporadic upload token errors
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The documentation is very confusing, but it seems to me that the new version supports tokenless uploads in a better way.

It says everywhere that a token is really required, but then it also says that PRs from forks are an exception to that (but that is how it has been in the past anyway).

So let's see if this helps.

* https://docs.codecov.com/docs/codecov-uploader#supporting-tokenless-uploads
* https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954/22 
* https://github.com/codecov/feedback/issues/126
* https://github.com/codecov/engineering-team/issues/665
*  https://github.com/codecov/codecov-action