### PR TITLE
Lower GIT_CACHE_DIR_LIMIT used in the tests

### DIFF
--- a/t/34-git.t
+++ b/t/34-git.t
@@ -191,7 +191,7 @@ subtest 'cloning with caching' => sub {
             ok -d $repo_cache_dir, 'no cleanup has happened yet';
         };
         subtest 'over limit' => sub {
-            $bmwqemu::vars{GIT_CACHE_DIR_LIMIT} = 100;
+            $bmwqemu::vars{GIT_CACHE_DIR_LIMIT} = 50;
             combined_like { limit_git_cache_dir($git_cache_dir, $fake_checkout2, $fake_checkout_relative2, $handle_du) }
             qr|removing.*$orga/$repo$suffix|i, 'cleanup was logged';
             ok !-d $repo_cache_dir, 'the repo that was cloned first has been cleaned up';


### PR DESCRIPTION
On Fedora, the test fails when this is set to 100; the expected cleanup does not happen. If I drop it to 50, though, the cleanup happens and the test passes. I'm not sure why the difference.