### PR TITLE
ustreamer: restrict to aarch64 and x86_64

### DIFF
--- a/consoles/video_stream.pm
+++ b/consoles/video_stream.pm
@@ -9,6 +9,7 @@ use Mojo::UserAgent;
 use Mojo::URL;
 use Mojo::Util 'scope_guard';
 
+use Config;
 use List::Util 'max';
 use Time::HiRes qw(usleep clock_gettime CLOCK_MONOTONIC);
 use Fcntl;
@@ -146,6 +147,7 @@ sub connect_remote_video ($self, $url) {
     }
 
     if ($url =~ m^ustreamer://^) {
+        die 'unsupported arch' unless ($Config{archname} =~ /^aarch64|x86_64/);
         my $dev = ($url =~ m^ustreamer://(.*)^)[0];
         my $sink_name = "raw-sink$dev";
         $sink_name =~ s^/^-^g;


### PR DESCRIPTION
The use of `unpack` in the ustreamer code assumes a 64-bit, little-endian environment. It fails on s390x (because it's big- endian) and i686 (because it's 32-bit). In practice, ustreamer is really only used on aarch64. Let's bail unless we're running on aarch64 or x86_64, and similarly disable the tests outside of those arches. We keep x86_64 for the convenience of testing in CI environments and on developers' local machines.

Related progress issue: https://progress.opensuse.org/issues/161969