### PR TITLE
Save ipmi sol output as log file

### DIFF
--- a/consoles/sshXtermIPMI.pm
+++ b/consoles/sshXtermIPMI.pm
@@ -17,6 +17,7 @@ sub start_sol ($self) {
     my @command = $self->backend->ipmi_cmdline;
     push(@command, qw(sol activate));
     my $serial = $self->{args}->{serial};
+    push(@command, qw(2>&1 | tee -a ipmisol-log)) if $bmwqemu::vars{IPMI_SOL_LOG};
     my $cstr = join(' ', @command);
 
     # Try to deactivate IPMI SOL before activate

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -94,6 +94,7 @@ IPMI_MC_RESET_PING_COUNT;integer;1;Ping counts that must be successful after mc 
 IPMI_MC_RESET_IPMI_TRIES;integer;3;Maximum number of IPMI command tries that are conducted after mc reset
 IPMI_SOL_PERSISTENT_CONSOLE;boolean;1;Make SOL console persistent and don't reset it, enabled by default
 IPMI_SOL_MAX_RECONNECTS;integer;5;Maximum number of SOL reconnects on connection failure
+IPMI_SOL_LOG;boolean;1;Record IPMI SOL output into ipmisol-log in consoles/sshXtermIPMI.pm, disabled by default
 IPMI_$_;;;Internal iterator variable
 WORKER_HOSTNAME;string;undef;Worker hostname
 |====================


### PR DESCRIPTION
* **IPMI** SOL console output records important information about system under test, including boot-up process, error messages, unexpected abnormal output and etc, detailed texts of which likely might not be recorded by screenshot or even video clip. 

* **By** saving full output of ipmi sol console to a log file, which will be uploaded at the end of test run, investigation and examination work can be executed much more easily and conveniently without losing any information.

* **Introduce** test suite setting ```IPMISOL_LOG``` to determine whether ipmi sol ouptut will be recorded into log file ```ipmisol-log```.

* **Add** entry for setting ```IPMISOL_LOG``` in ```doc/backend_vars.asciidoc```.

* **This** pull request should be merged together with https://github.com/os-autoinst/openQA/pull/5699. 

* **Verification Runs:**
  * [**test run without IPMISOL_LOG and ipmisol-log** link1](http://10.67.18.153/tests/2842) [link2](http://10.100.228.134/tests/2842) [link3](http://10.100.204.18/tests/2842) [link4](http://10.149.193.170/tests/2842)
  * [**test run with IPMISOL_LOG=0 and without ipmisol-log** link1](http://10.67.18.153/tests/2845) [link2](http://10.100.228.134/tests/2845) [link3](http://10.100.204.18/tests/2845) [link4](http://10.149.193.170/tests/2845)
  * [**test run with IPMISOL_LOG=1 passed and ipmisol-log** link1](http://10.67.18.153/tests/2834) [link2](http://10.100.228.134/tests/2834) [link3](http://10.100.204.18/tests/2834) [link4](http://10.149.193.170/tests/2834)
  * [**test run with IPMISOL_LOG=1 cancelled and ipmisol-log** link1](http://10.67.18.153/tests/2835) [link2](http://10.100.228.134/tests/2835) [link3](http://10.100.204.18/tests/2835) [link4](http://10.149.193.170/tests/2835)
  * [**test run with IPMISOL_LOG=1 failed and ipmisol-log** link1](http://10.67.18.153/tests/2843) [link2](http://10.100.228.134/tests/2843) [link3](http://10.100.204.18/tests/2843) [link4](http://10.149.193.170/tests/2843)
  * [**test run with IPMISOL_LOG=1 timed-out and ipmisol-log** link1](http://10.67.18.153/tests/2844) [link2](http://10.100.228.134/tests/2844) [link3](http://10.100.204.18/tests/2844) [link4](http://10.149.193.170/tests/2844)
  * [**ipmisol-log records full installation and boot-up process** link1](http://10.67.18.153/tests/2834) [link2](http://10.100.228.134/tests/2834) [link3](http://10.100.204.18/tests/2834) [link4](http://10.149.193.170/tests/2834)
  * [**ipmisol-log records full call trace** link1](http://10.67.18.153/tests/2847) [link2](http://10.100.228.134/tests/2847) [link3](http://10.100.204.18/tests/2847) [link4](http://10.149.193.170/tests/2847)