### PR TITLE
Add python binding/import/wrapper for mmapi and lockapi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ set(PERL_FILES
 set(MISC_FILES
     consoles/icewm.cfg
     crop.py
+    lockapi.py
     mmapi.py
     testapi.py
     dmidata/dell_e6330/smbios_type_1.bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ set(PERL_FILES
 set(MISC_FILES
     consoles/icewm.cfg
     crop.py
+    mmapi.py
     testapi.py
     dmidata/dell_e6330/smbios_type_1.bin
     dmidata/dell_e6330/smbios_type_2.bin

--- a/lockapi.py
+++ b/lockapi.py
@@ -1,0 +1,7 @@
+# publish all lock API methods over perl into the modules context.
+# Use with `import lockapi; lockapi.method()` or `from lockapi import *`
+import perl
+
+perl.use("lockapi")
+for i in dir(perl.testapi):
+    locals()[i] = getattr(perl.lockapi, i)

--- a/mmapi.py
+++ b/mmapi.py
@@ -1,0 +1,7 @@
+# publish all mm API methods over perl into the modules context.
+# Use with `import mmapi; mmapi.method()` or `from mmapi import *`
+import perl
+
+perl.use("mmapi")
+for i in dir(perl.mmapi):
+    locals()[i] = getattr(perl.mmapi, i)


### PR DESCRIPTION
Adding python bindings for lockapi and mmapi allows for managing multi machine tests in python.
 
An example test could look like this
``` python
import lockapi
import mmapi

def run(self):
    lockapi.mutex_create('foomutex')
    lockapi.mutex_lock('foomutex')
    lockapi.mutex_unlock('foomutex')
    lockapi.mutex_wait('foomutex')

    # wait for child jobs to be done
    mmapi.wait_for_children()
```
