### PR TITLE
Improve lib lookup in check_needles.pl

### DIFF
--- a/check_needles.pl
+++ b/check_needles.pl
@@ -3,6 +3,10 @@
 use Mojo::Base -strict, -signatures;
 use File::Basename;
 use Getopt::Long;
+
+use FindBin '$Bin';
+use lib "$Bin";
+
 use needle;
 use cv;
 


### PR DESCRIPTION
Same as in other scripts we can allow check_needles.pl to find libs on
its own as well.