### PR TITLE
video_stream: handle HID command confirmations

### DIFF
--- a/container/os-autoinst_dev/Dockerfile
+++ b/container/os-autoinst_dev/Dockerfile
@@ -47,6 +47,7 @@ RUN zypper in -y -C \
        rsync \
        shadow \
        shfmt \
+       socat \
        sshpass \
        sudo \
        tesseract-ocr \

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -105,6 +105,7 @@ test_base_requires:
   xorg-x11-Xvnc:
   icewm:
   xterm:
+  socat:
 
 test_version_only_requires:
   perl(Mojo::IOLoop::ReadWriteProcess): '>= 0.28'

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -91,7 +91,7 @@ Source0:        %{name}-%{version}.tar.xz
 %define test_non_s390_requires %{nil}
 %endif
 # The following line is generated from dependencies.yaml
-%define test_base_requires %main_requires cpio icewm perl(Benchmark) perl(Devel::Cover) perl(FindBin) perl(Pod::Coverage) perl(Test::Fatal) perl(Test::Mock::Time) perl(Test::MockModule) perl(Test::MockObject) perl(Test::MockRandom) perl(Test::Mojo) perl(Test::Most) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 procps python3-setuptools qemu >= 4.0 qemu-tools xorg-x11-Xvnc xterm xterm-console
+%define test_base_requires %main_requires cpio icewm perl(Benchmark) perl(Devel::Cover) perl(FindBin) perl(Pod::Coverage) perl(Test::Fatal) perl(Test::Mock::Time) perl(Test::MockModule) perl(Test::MockObject) perl(Test::MockRandom) perl(Test::Mojo) perl(Test::Most) perl(Test::Output) perl(Test::Pod) perl(Test::Strict) perl(Test::Warnings) >= 0.029 procps python3-setuptools qemu >= 4.0 qemu-tools socat xorg-x11-Xvnc xterm xterm-console
 # The following line is generated from dependencies.yaml
 %define test_version_only_requires perl(Mojo::IOLoop::ReadWriteProcess) >= 0.28
 # The following line is generated from dependencies.yaml

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -329,7 +329,7 @@ GENERAL_HW_FLASH_CMD;string;;Shell Command to flash a disk image on SUT (in CMD_
 GENERAL_HW_FLASH_ARGS;string;;Arguments to pass GENERAL_HW_FLASH_CMD Shell script
 GENERAL_HW_IMAGE_CMD;string;;Shell Command to extract disk image from SUT (in CMD_DIR), optional
 GENERAL_HW_IMAGE_ARGS;string;;Arguments to pass GENERAL_HW_IMAGE_CMD Shell script. The script will get also extra arguments: disk number and file path to save it into.
-GENERAL_HW_INPUT_CMD;string;;Shell Command to control keyboard/mouse of the SUT, should wait for keyboard events on its stdin (in syntax used in 'send_key'), or mouse events as 'mouse_move <x> <y>' or 'mouse_button <buttons-pressed-mask>'. This is used only if GENERAL_HW_VIDEO_STREAM_URL is set.
+GENERAL_HW_INPUT_CMD;string;;Shell Command to control keyboard/mouse of the SUT, should wait for keyboard events on its stdin (in syntax used in 'send_key'), or mouse events as 'mouse_move <x> <y>' or 'mouse_button <buttons-pressed-mask>'. The command should print an "ok" line for each input (or an error message in case of an error). This is used only if GENERAL_HW_VIDEO_STREAM_URL is set.
 GENERAL_HW_INPUT_ARGS;string;;Arguments to pass GENERAL_HW_INPUT_CMD Shell script
 GENERAL_HW_EDID;string;;EDID to be set on relevant /dev/video device (see 'GENERAL_HW_VIDEO_STREAM_URL'), used directly as an argument for 'v4l2-ctl --set-edit'. Example values: 'type=hdmi', 'file=/some/path'.
 HDDSIZEGB;integer;10;Creates HDD with specified size in GiB

--- a/t/26-video_stream.t
+++ b/t/26-video_stream.t
@@ -243,7 +243,7 @@ subtest 'input events' => sub {
     my ($cmds_fh, @cmds);
     my $console = consoles::video_stream->new(undef, {
             url => 'udp://@:5004',
-            input_cmd => 'cat > input-commands',
+            input_cmd => "socat STDIO 'EXEC:yes ok!!CREATE:input-commands'",
     });
     $console->backend($mock_backend);
     $console->activate;


### PR DESCRIPTION
When sending commands to stdin of GENERAL_HW_INPUT_CMD, wait for it to
confirm reception/execution. Not waiting may cause some commands
queueing up, which will break timing in some cases (for example, a sleep
between clicks will not work, if both clicks happen to wait in a stdin
pipe one after another). Normally, HID commands are handled quickly, but
recently I've got a case where mouse_move may take a bit more time
(emulating real mouse with only relative movement, by moving it step by
 step to the desired position, and try to not hit pointer acceleration).

This is a change in the protocol used for GENERAL_HW_INPUT_CMD -
previously it didn't need to print anything to stdout, and now it needs
to print "ok" after handling every command. Scripts not updated to this
new protocol will result in a test hang at the first input. Since this
isn't broadly used feature, this API change hopefully is acceptable.