### PR TITLE
Reliably locate top directory of isotovideo

### DIFF
--- a/isotovideo
+++ b/isotovideo
@@ -91,16 +91,17 @@ use constant {
 # Details: https://progress.opensuse.org/issues/90371
 use JSON::PP;
 
+use FindBin '$RealBin';
+
 my $installprefix;    # $bmwqemu::topdir
 
 BEGIN {
     # the following line is modified during make install
     $installprefix = undef;
 
-    my ($wd) = $0 =~ m-(.*)/-;
-    $wd ||= '.';
-    $installprefix ||= $wd;
-    unshift @INC, "$installprefix";
+    my $topdir = $RealBin || '.';
+    $installprefix ||= $topdir;
+    unshift @INC, $installprefix;
 }
 
 use log qw(diag);


### PR DESCRIPTION
Before we matched (/some/path/to/)isotovideo to get the top directory. In the future we might also need to support /some/path/to/scripts/isotovideo being symlinked.

When we move isotoideo to scripts/ and symlink it in the top directory, both invocations need to work.

For example, openQA's fullstack test is using:

    perl script/worker --isotovideo=../os-autoinst/isotovideo --verbose

And OpenQA::Worker::Engines::isotovideo is using
abs_path(../os-autoinst/isotovideo) which will return the path to the linked script, not the symlink itself.

So we should get the real path of the script, which $FindBin::RealBin is realiably doing, and then add '..' to go to the top. Just calling realpath() on it again to get rid of .. in the path for readaibility.