### PR TITLE
Avoid SVT-AV1 when FFmpeg 4 is installed

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -344,11 +344,11 @@ sub _invoke_video_encoder ($self, $pipe_name, $display_name, @cmd) {
     $pipe->blocking(!!$bmwqemu::vars{VIDEO_ENCODER_BLOCKING_PIPE});
 }
 
-sub _ffmpeg_banner () { qx{ffmpeg 2>&1} // '' }
+sub _ffmpeg_banner () { qx{ffmpeg -version} // '' }
 
 sub _auto_detect_external_video_encoder ($self) {
     my $ffmpeg_banner = _ffmpeg_banner;
-    return DEFAULT_FFMPEG_CMD . ' -c:v libsvtav1 -crf 50 -preset 7' if $ffmpeg_banner =~ qr/--enable-libsvtav1(\s|$)/;
+    return DEFAULT_FFMPEG_CMD . ' -c:v libsvtav1 -crf 50 -preset 7' if $ffmpeg_banner =~ qr/--enable-libsvtav1(\s|$)/ and $ffmpeg_banner !~ qr/ffmpeg\sversion\s4\./;
     return DEFAULT_FFMPEG_CMD . ' -c:v libvpx-vp9 -crf 35 -b:v 1500k -cpu-used 1' if $ffmpeg_banner =~ qr/--enable-libvpx(\s|$)/;
 }
 


### PR DESCRIPTION
Full support for SVT-AV is added in FFmpeg 5.1, older versions does not support setting CBR mode.

Reference: https://progress.opensuse.org/issues/163601