### PR TITLE
Isotovideo/Utils: Fix "Use of uninitialized value $name"

### DIFF
--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -329,13 +329,13 @@ sub handle_generated_assets ($command_handler, $clean_shutdown) {
             my $name = $bmwqemu::vars{"STORE_HDD_$i"} || undef;
             unless ($name) {
                 $name = $bmwqemu::vars{"PUBLISH_HDD_$i"} || undef;
+                next unless $name;
                 if ($name =~ /none/i) {
                     bmwqemu::log_call("Asset upload is skipped for PUBLISH_HDD_$i=$name");
                     next;
                 }
                 $dir = 'assets_public';
             }
-            next unless $name;
             push @toextract, _store_asset($i, $name, $dir);
         }
         if ($bmwqemu::vars{UEFI} && $bmwqemu::vars{PUBLISH_PFLASH_VARS}) {


### PR DESCRIPTION
If both `$bmwqemu::vars{"STORE_HDD_$i"}` and `$bmwqemu::vars{"PUBLISH_HDD_$i"}` aren't defined `m//` searches on undefined variable:

```
Use of uninitialized value $name in pattern match (m//) at /usr/lib/os-autoinst/OpenQA/Isotovideo/Utils.pm line 332.
	OpenQA::Isotovideo::Utils::handle_generated_assets(OpenQA::Isotovideo::CommandHandler=HASH(0x564c1ee52a28), "") called at /usr/bin/isotovideo line 152
	main::handle_shutdown() called at /usr/bin/isotovideo line 187
	eval {...} called at /usr/bin/isotovideo line 176
```

Although code added in 38974891 expects at least `$bmwqemu::vars{"PUBLISH_HDD_$i"}` is always set when running this code, obviously there are some jobs with *neither* of these two variables set, e.g. LTP or xfstests jobs (see qam-klp_xfstests_btrfs [1] or ltp_crypto [2]).

Move `next unless $name;` after second assignment, because after unless `$name` should be always set therefore not needed.

[1] https://openqa.suse.de/tests/15038370/file/autoinst-log.txt
[2] https://openqa.suse.de/tests/15038272/file/autoinst-log.txt

Fixes: 38974891 ("Extract 'handle_generated_assets' function from isotovideo for easier testing")