### PR TITLE
Fix error handling when cloning a Git repository

### DIFF
--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -242,6 +242,7 @@ sub checkout_git_repo_and_branch ($dir_variable, %args) {
         $error = $@;
         return $local_abs if $status;
         bmwqemu::diag "Clone failed, retries left: $tries of $retry_count";
+        path($local_path)->remove_tree;
         sleep $retry_interval if $tries;
     } while ($tries-- > 0);
     die $error;

--- a/t/34-git.t
+++ b/t/34-git.t
@@ -42,9 +42,13 @@ subtest 'failure to clone results once' => sub {
 };
 
 subtest 'failure to clone results in repeated attempts' => sub {
+    my $chdir_guard = scope_guard sub { chdir $Bin; };
     my $utils_mock = Test::MockModule->new('OpenQA::Isotovideo::Utils');
     my $failed_once = 0;
-    $utils_mock->redefine(clone_git => sub (@) {
+    chdir $tmpdir;
+    $utils_mock->redefine(clone_git => sub ($dir, @) {
+            ok !-e $dir, "$dir cleaned up" or return 1;
+            path($dir)->make_path;
             bmwqemu::diag "Connection reset by peer";
             die "Unable to clone Git repository";
     });


### PR DESCRIPTION
* Extend tests so the mocked `clone_git` function behaves like the actual function to reproduce https://progress.opensuse.org/issues/164811
* Remove a possibly created repository directory in the error case before the next attempt; otherwise the next attempt will find the existing directory and skip the cloning