### PR TITLE
Virsh VMware image script debugging

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -16,7 +16,6 @@ use Mojo::File qw(path);
 use Mojo::JSON qw(decode_json);
 use Mojo::Util;
 use Carp 'croak';
-
 use backend::svirt;
 
 has [qw(instance name vmm_family vmm_type vmm_firmware)];
@@ -330,8 +329,10 @@ sub _copy_image_vmware ($self, $name, $backingfile, $file_basename, $vmware_open
     # otherwise copy image from NFS datastore.
     my $nfs_dir = $backingfile ? 'hdd' : 'iso';
     my $vmware_nfs_datastore = $bmwqemu::vars{VMWARE_NFS_DATASTORE} or die 'Need variable VMWARE_NFS_DATASTORE';
+    # cmd debugging activable by setting VMWARE_NFS_DATASTORE_DEBUG=1
+    my $ds_debug = ($bmwqemu::vars{VMWARE_NFS_DATASTORE_DEBUG} // 0) ? "set -x;" : "";
     my $cmd =
-      "if test -e $vmware_openqa_datastore$file_basename; then " .
+      "$ds_debug if test -e $vmware_openqa_datastore$file_basename; then " .
       "while lsof | grep 'cp.*$file_basename'; do " .
       "echo File $file_basename is being copied by other process, sleeping for 60 seconds; sleep 60;" .
       'done;' .


### PR DESCRIPTION
The [SL Micro 6.0 Product Increments - Containers](https://openqa.suse.de/group_overview/572) VMware test revealed an issue in the
[failed job](https://openqa.suse.de/tests/15040545#step/bootloader_svirt/16), where images in `hdd/fixed` folder are included in initial file search, but then only images in `hdd` folder are managed.

This PR started with scope of adding also `subfolders` management, now focused to only add debugging of a script output.

ticket: https://progress.opensuse.org/issues/162941#note-14
