### PR TITLE
video_stream: make FPS configurable

### DIFF
--- a/consoles/video_stream.pm
+++ b/consoles/video_stream.pm
@@ -120,14 +120,14 @@ sub connect_remote ($self, $args) {
     $self->connect_remote_input($args->{input_cmd}) if $args->{input_cmd};
 }
 
-# uncoverable statement count:1..6 note:the function is redefined in tests
 sub _get_ffmpeg_cmd ($self, $url) {
     my $fps = $1 if ($url =~ s/\?fps=([0-9]+)//);
     $fps //= 4;
-    my @cmd = split(/ /, $self->{args}->{video_cmd_prefix});    # uncoverable statement
-    push(@cmd, ('ffmpeg', '-loglevel', 'fatal', '-i', $url));    # uncoverable statement
-    push(@cmd, ('-vcodec', 'ppm', '-f', 'rawvideo', '-r', $fps, '-'));    # uncoverable statement
-    return \@cmd;    # uncoverable statement
+    my @cmd;
+    @cmd = split(/ /, $self->{args}->{video_cmd_prefix}) if $self->{args}->{video_cmd_prefix};
+    push(@cmd, ('ffmpeg', '-loglevel', 'fatal', '-i', $url));
+    push(@cmd, ('-vcodec', 'ppm', '-f', 'rawvideo', '-r', $fps, '-'));
+    return \@cmd;
 }
 
 sub _get_ustreamer_cmd ($self, $url, $sink_name) {

--- a/consoles/video_stream.pm
+++ b/consoles/video_stream.pm
@@ -120,17 +120,21 @@ sub connect_remote ($self, $args) {
     $self->connect_remote_input($args->{input_cmd}) if $args->{input_cmd};
 }
 
-# uncoverable statement count:1..4 note:the function is redefined in tests
+# uncoverable statement count:1..6 note:the function is redefined in tests
 sub _get_ffmpeg_cmd ($self, $url) {
+    my $fps = $1 if ($url =~ s/\?fps=([0-9]+)//);
+    $fps //= 4;
     my @cmd = split(/ /, $self->{args}->{video_cmd_prefix});    # uncoverable statement
     push(@cmd, ('ffmpeg', '-loglevel', 'fatal', '-i', $url));    # uncoverable statement
-    push(@cmd, ('-vcodec', 'ppm', '-f', 'rawvideo', '-r', '4', '-'));    # uncoverable statement
+    push(@cmd, ('-vcodec', 'ppm', '-f', 'rawvideo', '-r', $fps, '-'));    # uncoverable statement
     return \@cmd;    # uncoverable statement
 }
 
 sub _get_ustreamer_cmd ($self, $url, $sink_name) {
+    my $fps = $1 if ($url =~ s/\?fps=([0-9]+)//);
+    $fps //= 5;
     return [
-        'ustreamer', '--device', $url, '-f', '5',
+        'ustreamer', '--device', $url, '-f', $fps,
         '-m', 'UYVY',    # specify preferred format
         '-c', 'NOOP',    # do not produce JPEG stream
         '--raw-sink', $sink_name, '--raw-sink-rm',    # raw memsink

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -315,7 +315,7 @@ GENERAL_HW_VNC_PORT;integer;5900;VNC Port number
 GENERAL_HW_VNC_DEPTH;integer;16;Color depth for VNC server
 GENERAL_HW_VNC_JPEG;integer;0;Advertise support for Tight JPEG encoding
 GENERAL_HW_NO_SERIAL;boolean;;Don't use serial
-GENERAL_HW_VIDEO_STREAM_URL;string;;Video stream URL (in ffmpeg's syntax) to receive, for example 'udp://@:5004' or '/dev/video0'. Using 'ustreamer:///dev/videoN' will use ustreamer from PiKVM instead of ffmpeg to read '/dev/videoN'. Ustreamer support requires pack("D") working, which rules out openSUSE 15.5's perl.
+GENERAL_HW_VIDEO_STREAM_URL;string;;Video stream URL (in ffmpeg's syntax) to receive, for example 'udp://@:5004' or '/dev/video0'. Using 'ustreamer:///dev/videoN' will use ustreamer from PiKVM instead of ffmpeg to read '/dev/videoN'. The URL can have '?fps=..' appended to specify desired FPS to capture with. Ustreamer support requires pack("D") working, which rules out openSUSE 15.5's perl.
 GENERAL_HW_VIDEO_CMD_PREFIX;string;;Prefix to prepend to 'ffmpeg' and 'v4l2-ctl' commands, can be used to run them on a different host via SSH. Example: 'ssh root@pikvm'. Note: the value is tokenized on spaces, so avoid their use in command name or any of the parameters.
 VIDEO_STREAM_PIPE_BUFFER_SIZE;integer;1680*1050*3+20;Buffer containing at least a single PPM frame for video capturing
 GENERAL_HW_KEYBOARD_URL;string;;URL to keyboard emulation device. eg. 'http://1.2.3.4/cmd' - see https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/data/generalhw_scripts/rpi_pico_w_keyboard[rpi_pico_w_keyboard]

--- a/t/26-video_stream.t
+++ b/t/26-video_stream.t
@@ -96,6 +96,16 @@ subtest 'connect stream' => sub {
         [('/dev/video0', undef, '--set-dv-bt-timings query')],
         [('/dev/video0', undef, '--get-dv-timings')],
     ], "calls to v4l2-ctl";
+
+    my $cmd = $mock_console->original('_get_ffmpeg_cmd')->($console, 'udp://@:5004');
+    is_deeply $cmd, [
+        'ffmpeg', '-loglevel', 'fatal', '-i', 'udp://@:5004',
+        '-vcodec', 'ppm', '-f', 'rawvideo', '-r', 4, '-'], "correct cmd built for UDP source";
+
+    $cmd = $mock_console->original('_get_ffmpeg_cmd')->($console, '/dev/video0?fps=3');
+    is_deeply $cmd, [
+        'ffmpeg', '-loglevel', 'fatal', '-i', '/dev/video0',
+        '-vcodec', 'ppm', '-f', 'rawvideo', '-r', 3, '-'], "correct cmd built for fps=3";
 };
 
 subtest 'connect stream ustreamer' => sub {

--- a/t/26-video_stream.t
+++ b/t/26-video_stream.t
@@ -113,7 +113,14 @@ subtest 'connect stream ustreamer' => sub {
         '-m', 'UYVY',
         '-c', 'NOOP',
         '--raw-sink', 'raw-sink-dev-video0', '--raw-sink-rm',
-        '--dv-timings'], "correct cmd built";
+        '--dv-timings'], "correct cmd built for ustreamer";
+    $cmd = $mock_console->original('_get_ustreamer_cmd')->($console, '/dev/video0?fps=2', 'raw-sink-dev-video0');
+    is_deeply $cmd, [
+        'ustreamer', '--device', '/dev/video0', '-f', '2',
+        '-m', 'UYVY',
+        '-c', 'NOOP',
+        '--raw-sink', 'raw-sink-dev-video0', '--raw-sink-rm',
+        '--dv-timings'], "correct cmd built for fps=2";
 };
 
 subtest 'frames parsing' => sub {


### PR DESCRIPTION
This is all about balance between compute power on the worker host and
desired latency and video smoothness. Ustreamer is a bit lighter than
ffmpeg, so it can capture more frames (on Raspberry Pi), but then it
puts more stress on the system as more frames are searched for needles
and more frames goes to video encoder. On the other hand, lower FPS may
cause some details to be missed (like quickly dismissed notification).
The optimal value may even differ from test to test, for example based
on the test length and how much backlog for video encoder is acceptable
(amount of available RAM is important in this case too).
Instead of trying to find perfect value that fits all, make it
configurable. Keep the default unchanged.