### PR TITLE
Allow package builds without `Inline::Python`

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -8,14 +8,15 @@
 #######################################################
 ---
 targets:
-  cpanfile: [                    cover, devel,         main,             lint,           test_base, test, test_version_only                    ]
-  spec:     [ build_base, build,        devel,         main, spellcheck,       yamllint, test_base, test, test_version_only, python_style, ocr, test_non_s390 ]
-  docker:   [ build_base, build,        devel, docker, main, spellcheck, lint, yamllint, test_base, test,                    python_style, ocr, test_non_s390 ]
+  cpanfile: [ cover, devel, main, lint, test_base, test, test_version_only, python_support ]
+  spec:     [ build_base, build, devel, main, spellcheck, yamllint, test_base, test, test_version_only, python_style, ocr, test_non_s390, python_support ]
+  docker:   [ build_base, build, devel, docker, main, spellcheck, lint, yamllint, test_base, test, python_style, ocr, test_non_s390, python_support ]
   cpanfile-targets:
     # target: cpanfile target type (default main)
     devel: develop
     cover: cover
     test_base: test
+    python_support: test
     test: test
     test_version_only: test
     lint: test
@@ -71,6 +72,9 @@ lint_requires:
 python_style_requires:
   python3-black:
 
+python_support_requires:
+  perl(Inline::Python):
+
 ocr_requires:
   tesseract-ocr:
   tesseract-ocr-traineddata-english:
@@ -120,7 +124,6 @@ test_requires:
   '%yamllint_requires':
   '%ocr_requires':
   '%test_non_s390_requires':
-  perl(Inline::Python):
   python3-Pillow-tk:
 
 main_requires:

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -67,6 +67,18 @@ Source0:        %{name}-%{version}.tar.xz
 %else
 %bcond_with black
 %endif
+# SLE is missing Python support requirements
+%if !0%{?is_opensuse}
+%bcond_without python_support
+%else
+%bcond_with python_support
+%endif
+%if %{with python_support}
+# The following line is generated from dependencies.yaml
+%define python_support_requires perl(Inline::Python)
+%else
+%define python_support_requires %{nil}
+%endif
 %if %{with black}
 # The following line is generated from dependencies.yaml
 %define python_style_requires python3-black
@@ -95,7 +107,7 @@ Source0:        %{name}-%{version}.tar.xz
 # The following line is generated from dependencies.yaml
 %define test_version_only_requires perl(Mojo::IOLoop::ReadWriteProcess) >= 0.28
 # The following line is generated from dependencies.yaml
-%define test_requires %build_requires %ocr_requires %spellcheck_requires %test_base_requires %test_non_s390_requires %yamllint_requires perl(Inline::Python) python3-Pillow-tk
+%define test_requires %build_requires %ocr_requires %spellcheck_requires %test_base_requires %test_non_s390_requires %yamllint_requires python3-Pillow-tk
 # The following line is generated from dependencies.yaml
 %define devel_requires %python_style_requires %test_requires ShellCheck perl(Code::TidyAll) perl(Devel::Cover) perl(Devel::Cover::Report::Codecov) perl(Module::CPANfile) perl(Perl::Tidy) perl(Template::Toolkit) shfmt
 %define s390_zvm_requires /usr/bin/xkbcomp /usr/bin/Xvnc x3270 icewm xterm xterm-console xdotool fonts-config mkfontdir mkfontscale openssh-clients
@@ -111,8 +123,10 @@ Recommends:     tesseract-ocr
 Recommends:     dumponlyconsole %s390_zvm_requires
 Recommends:     qemu >= 4.0.0
 Recommends:     %qemu_requires
+%if %{with python_support}
 # Optional dependency for Python test API support
 Recommends:     perl(Inline::Python)
+%endif
 # Optional dependency for crop.py
 Recommends:     python3-Pillow-tk
 # Optional dependency for QEMU's built-in samba service (enabled via QEMU_ENABLE_SMBD=1)

--- a/t/04-testapi-python.t
+++ b/t/04-testapi-python.t
@@ -1,12 +1,15 @@
 #!/usr/bin/perl
 
 use Test::Most;
-use Mojo::Base -strict, -signatures;
+use Test::Exception;
 use Test::Warnings;
+use Mojo::Base -strict, -signatures;
 
 BEGIN {
     unshift @INC, '..';
 }
+
+plan skip_all => 'Inline::Python is not available' unless eval { require Inline::Python };
 
 # This test merely shows how perl objects and modules can be accessed from
 # python
@@ -14,13 +17,13 @@ BEGIN {
 # import all test API methods into global scope of python test modules so that
 # we do not need to write any prefix on each call like "perl.get_var"
 use testapi;
-use Inline Python => "for i in dir(perl): globals()[i] = getattr(perl, i)";
+Inline::Python::py_eval('for i in dir(perl): globals()[i] = getattr(perl, i)');
 
-use Inline 'Python';
-pass 'use Inline does not die';
-done_testing;
-__END__
-__Python__
+my $python_code = <<~'EOM';
 print(get_var('FOO', 'foo'))
 set_var('MY_PYTHON_VARIABLE', 42)
 assert get_required_var('MY_PYTHON_VARIABLE') == 42, "Could not find get_var/set_var variable"
+EOM
+
+lives_ok { Inline::Python::py_eval($python_code) } 'simple use of test API does not crash';
+done_testing;

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -315,7 +315,11 @@ subtest 'load test successfully when CASEDIR is a relative path' => sub {
     like warning { loadtest 'start' }, qr{Subroutine run redefined}, 'We get a warning for loading a test a second time';
 };
 
+my $has_python = eval { require Inline::Python };
+
 subtest python => sub {
+    plan skip_all => 'Inline::Python is not available' unless $has_python;
+
     combined_like {
         lives_ok { autotest::loadtest('tests/pythontest.py') } 'can load test module'
     } qr{Using python version.*scheduling pythontest tests/pythontest}s, 'python pythontest module referenced';
@@ -335,6 +339,8 @@ subtest python => sub {
 };
 
 subtest 'python run_args' => sub {
+    plan skip_all => 'Inline::Python is not available' unless $has_python;
+
     %autotest::tests = ();
     my $targs = OpenQA::Test::RunArgs->new();
     $targs->{data} = 23;
@@ -344,6 +350,8 @@ subtest 'python run_args' => sub {
 };
 
 subtest 'python with bad run method' => sub {
+    plan skip_all => 'Inline::Python is not available' unless $has_python;
+
     %autotest::tests = ();
     my $targs = OpenQA::Test::RunArgs->new();
     $targs->{data} = 23;


### PR DESCRIPTION
The dependency is already just recommended by our spec file. However, the code uses it unconditionally. This change removes that. It also allows tests to run without the dependency.

This will also ease submitting packages to SLE because `Inline::Python` and some of its dependencies are not in SLE.

Related ticket: https://progress.opensuse.org/issues/128318