### PR TITLE
Fix build condition for Python support

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -68,7 +68,7 @@ Source0:        %{name}-%{version}.tar.xz
 %bcond_with black
 %endif
 # SLE is missing Python support requirements
-%if !0%{?is_opensuse}
+%if 0%{?is_opensuse}
 %bcond_without python_support
 %else
 %bcond_with python_support


### PR DESCRIPTION
This commit is part of https://github.com/os-autoinst/os-autoinst/pull/2532 but since that PR needs further fixing I extracted the second commit which is a follow-up of https://github.com/os-autoinst/os-autoinst/pull/2531.

---

The macro `%bcond_without` needs to be used in the case where we want to build with that feature by default. That the current code is wrong can be observed in the build logs after 0aff9e8 was merged:

```
[   97s] 3: 1..0 # SKIP Inline::Python is not available
```

Related ticket: https://progress.opensuse.org/issues/128318