### PR TITLE
Make Python support optional in fullstack test

### DIFF
--- a/t/data/tests/main.pm
+++ b/t/data/tests/main.pm
@@ -29,8 +29,8 @@ my $integration_tests = get_var('INTEGRATION_TESTS');
 autotest::loadtest "tests/freeze.pm" unless $integration_tests;
 
 # Add import path for local test python modules from pool directory
-unless ($integration_tests) {
-    use Inline Python => "import os.path, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.curdir, '../..')))";
+if (!$integration_tests && eval { require Inline::Python }) {
+    Inline::Python::py_eval("import os.path, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.curdir, '../..')))");
     autotest::loadtest "tests/pre_boot.py";
 }
 


### PR DESCRIPTION
* Follow-up on abb1808b0f to cover the fullstack test as well
* Avoid hard dependency on `Inline::Python` by turning `use` into `require`
* See https://progress.opensuse.org/issues/128318#note-38

---

With this change I still get
```
||| starting pre_boot tests/pre_boot.py

<<< testapi::send_key(key="esc", wait_screen_change=0)
…
```
when running the fullstack test with the `Inline::Python` installed but the test can also run without it (then `pre_boot.py` is not scheduled).