### PR TITLE
ci: Add helper for reporting OBS url

### DIFF
--- a/.github/workflows/obs-helper.yaml
+++ b/.github/workflows/obs-helper.yaml
@@ -1,0 +1,20 @@
+---
+# yamllint disable rule:line-length
+name: OBS Helper
+
+on: [pull_request]
+
+jobs:
+  obs-url:
+    runs-on: ubuntu-latest
+    name: Report OBS Url
+    steps:
+      - uses: actions/checkout@v4
+      - name: Comment
+        # Only run once on pull request creation
+        if: github.run_number == 1
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment ${{ github.event.pull_request.number }} \
+            --body "You might want to check the OBS project created for this PR: https://build.opensuse.org/project/show/devel:openQA:GitHub:os-autoinst:os-autoinst:${{ github.event.pull_request.number }}"$'\n'"Here you can find all pull requests: https://build.opensuse.org/project/subprojects/devel:openQA:GitHub"$'\n'"_(This is just a little helper in case the OBS workflow fails and does not report the URL yet.)_"


### PR DESCRIPTION
Sometimes the OBS webhook fails and we need to find out the URL to the broken OBS project manually.
This will write a comment onthe PR with the URL.

Issue: https://progress.opensuse.org/issues/165144

Demo: https://github.com/perlpunk/os-autoinst/pull/15#issuecomment-2299076322


Note: Waiting for https://github.com/os-autoinst/openQA/pull/5872 and see if it works