### PR TITLE
Remove workaround for broken chromium

### DIFF
--- a/.github/workflows/openqa_fullstack.yml
+++ b/.github/workflows/openqa_fullstack.yml
@@ -33,13 +33,6 @@ jobs:
           git clone --depth 1 https://github.com/os-autoinst/openQA.git ../openQA
       - name: Install dependencies
         run: (cd ../openQA; bash -x tools/ci/build_cache.sh; sudo npm install)
-      - name: Workaround chromium bug
-        run: |
-          # downgrade chromedriver from problematic version to last good version, see
-          # https://progress.opensuse.org/issues/164239
-          # ignore if zypper fails to refresh some repos and try to continue
-          rpm -q chromedriver | grep -v 126.0.6478. || \
-            (sudo zypper -n refresh; sudo zypper --no-refresh -n in --oldpackage chromium-125.0.6422.141-bp156.2.3.1 chromedriver-125.0.6422.141-bp156.2.3.1)
       - name: Build os-autoinst
         run: sudo -u $NORMAL_USER make symlinks
       - name: Run unit tests


### PR DESCRIPTION
This reverts commit 85fadea10b78b9d8c34a0ca4c33af2399cf9901a.

The bug is fixed in version 127 as we can see already in pull requests, as the workaround was only applied for version 126.

Issue: https://progress.opensuse.org/issues/164239