### PR TITLE
Avoid having devel package depend on CI-specific Perl module

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -101,7 +101,6 @@ on 'test' => sub {
 on 'develop' => sub {
     requires 'Code::TidyAll';
     requires 'Devel::Cover';
-    requires 'Devel::Cover::Report::Codecov';
     requires 'Module::CPANfile';
     requires 'Perl::Tidy', '== 20240511.0.0';
     requires 'Template::Toolkit';

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -8,13 +8,14 @@
 #######################################################
 ---
 targets:
-  cpanfile: [ cover, devel, main, lint, test_base, test, test_version_only, python_support ]
+  cpanfile: [ cover, ci, devel, main, lint, test_base, test, test_version_only, python_support ]
   spec:     [ build_base, build, devel, main, spellcheck, yamllint, test_base, test, test_version_only, python_style, ocr, test_non_s390, python_support ]
-  docker:   [ build_base, build, devel, docker, main, spellcheck, lint, yamllint, test_base, test, python_style, ocr, test_non_s390, python_support ]
+  docker:   [ build_base, build, ci, devel, docker, main, spellcheck, lint, yamllint, test_base, test, python_style, ocr, test_non_s390, python_support ]
   cpanfile-targets:
     # target: cpanfile target type (default main)
     devel: develop
     cover: cover
+    ci: cover
     test_base: test
     python_support: test
     test: test
@@ -38,6 +39,8 @@ build_requires:
 
 cover_requires:
   perl(Devel::Cover):
+
+ci_requires:
   perl(Devel::Cover::Report::Codecov):
 
 devel_requires:
@@ -45,7 +48,6 @@ devel_requires:
   '%python_style_requires':
   perl(Code::TidyAll):
   perl(Devel::Cover):
-  perl(Devel::Cover::Report::Codecov):
   perl(Module::CPANfile):
   perl(Template::Toolkit):
   perl(Perl::Tidy): == 20240511.0.0

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -112,7 +112,7 @@ Source0:        %{name}-%{version}.tar.xz
 # The following line is generated from dependencies.yaml
 %define test_requires %build_requires %ocr_requires %spellcheck_requires %test_base_requires %test_non_s390_requires %yamllint_requires python3-Pillow-tk
 # The following line is generated from dependencies.yaml
-%define devel_requires %python_style_requires %test_requires ShellCheck perl(Code::TidyAll) perl(Devel::Cover) perl(Devel::Cover::Report::Codecov) perl(Module::CPANfile) perl(Perl::Tidy) perl(Template::Toolkit) shfmt
+%define devel_requires %python_style_requires %test_requires ShellCheck perl(Code::TidyAll) perl(Devel::Cover) perl(Module::CPANfile) perl(Perl::Tidy) perl(Template::Toolkit) shfmt
 %define s390_zvm_requires /usr/bin/xkbcomp /usr/bin/Xvnc x3270 icewm xterm xterm-console xdotool fonts-config mkfontdir mkfontscale openssh-clients
 %define ipmi_requires ipmitool
 %define qemu_requires qemu-tools e2fsprogs


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/165683