### PR TITLE
ci: Add OBS helper workflow

### DIFF
--- a/.github/workflows/obs-helper.yaml
+++ b/.github/workflows/obs-helper.yaml
@@ -1,0 +1,27 @@
+---
+# yamllint disable rule:line-length
+name: OBS Helper
+
+on: [pull_request_target]
+
+jobs:
+  obs-url:
+    name: Report OBS URL
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: debug
+        run: |
+          env | sort
+      - name: Create Status
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN_FOR_ACTIONS }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/os-autoinst/os-autoinst/statuses/${{ github.event.pull_request.head.sha }} \
+            -f "state=success" -f "target_url=https://build.opensuse.org/project/show/devel:openQA:GitHub:os-autoinst:os-autoinst:PR-${{ github.event.pull_request.number }}" -f "description=Check OBS SCM URL" -f "context=continuous-integration/obs-helper"


### PR DESCRIPTION
This workflow will simply add another check in a PR with the URL to the OBS project that should be created by the OBS scm integration, so you can click on it and delete it if it is broken and needs to get recreated.

Also it's quicker to check for already running tests, because OBS only reports URLS when the build has finished.

I also increased the number of passing tests we require in mergify. We never adapted the number when we added new tests.

Issue: https://progress.opensuse.org/issues/165144

See also:
* https://github.com/os-autoinst/openQA/pull/5879

This will only be visible in the first pull request after the merge.