### PR TITLE
Avoid configuring ACPI on s390x for compat with newer libvirt/qemu

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -113,8 +113,7 @@ sub _init_xml ($self, $args = {}) {
     # Following 'features' are required for VM to correctly shutdown
     my $features = $doc->createElement('features');
     $root->appendChild($features);
-    $elem = $doc->createElement('acpi');
-    $features->appendChild($elem);
+    $features->appendChild($doc->createElement('acpi')) if ($bmwqemu::vars{ARCH} // '') ne 's390x';
     $elem = $doc->createElement('apic');
     $features->appendChild($elem);
     $elem = $doc->createElement('pae');

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -114,10 +114,7 @@ sub _init_xml ($self, $args = {}) {
     my $features = $doc->createElement('features');
     $root->appendChild($features);
     $features->appendChild($doc->createElement('acpi')) if ($bmwqemu::vars{ARCH} // '') ne 's390x';
-    $elem = $doc->createElement('apic');
-    $features->appendChild($elem);
-    $elem = $doc->createElement('pae');
-    $features->appendChild($elem);
+    $features->appendChild($doc->createElement($_)) for qw(apic pae);
 
     if ($self->vmm_family eq 'xen' and $self->vmm_type eq 'linux') {
         $elem = $doc->createElement('kernel');

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -103,6 +103,12 @@ subtest 'XML config for VNC and serial console' => sub {
     _is_xml $svirt_console->{domainxml}->toString(2), "$Bin/22-svirt-virsh-config.xml";
 };
 
+subtest 's390x specifics' => sub {
+    $bmwqemu::vars{ARCH} = 's390x';
+    $svirt_console->_init_xml;
+    unlike $svirt_console->{domainxml}->toString, qr/acpi/i, 'ACPI support is not configured for s390x';
+};
+
 # assume VMware for further testing
 $svirt_console->vmm_family($bmwqemu::vars{VIRSH_VMM_FAMILY} = 'vmware');
 


### PR DESCRIPTION
As mentioned in upstream commit https://github.com/libvirt/libvirt/commit/4ba4f659e42a30c3fa8ece414616a23a992acfaa this configuration was never supported. In commit https://github.com/libvirt/libvirt/commit/d8e95ab6b7c45acc121746e2e24edcfca3d8d8a0 upstream also remove the corresponding tag from their tests.

Related ticket: https://progress.opensuse.org/issues/162683