### PR TITLE
WIP: Virsh VMware image cp from hdd/fixed

### DIFF
--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -600,6 +600,22 @@ subtest 'Method consoles::sshVirtsh::add_disk()' => sub {
             set_var(VMWARE_NFS_DATASTORE => 'nfs_data_store');
             @last_ssh_commands = ();
             $svirt->add_disk({cdrom => 1, dev_id => $dev_id, file => '/my/path/to/this/file/' . $filename});
+            like($last_ssh_commands[0], qr%cp\s+/my/path/to/this/file/$filename\s+$vmware_openqa_datastore\s*;%, "Copy iso to $vmware_openqa_datastore");
+
+            svirt_xml_validate($svirt,
+                disk_device => 'cdrom',
+                dev => 'hd' . $dev_id,
+                bus => 'ide',
+                source_file => '[my_vmware_datastore] openQA/' . $filename
+            );
+        };
+
+        subtest 'vmware cdrom=1 file_basename' => sub {
+            my $dev_id = 'dev_id_033';
+            my $filename = 'my_cdrom_file_' . $dev_id . '.iso';
+            set_var(VMWARE_NFS_DATASTORE => 'nfs_data_store');
+            @last_ssh_commands = ();
+            $svirt->add_disk({cdrom => 1, dev_id => $dev_id, file => $filename});
             like($last_ssh_commands[0], qr%cp\s+/vmfs/volumes/nfs_data_store/iso/$filename\s+$vmware_openqa_datastore\s*;%, "Copy iso to $vmware_openqa_datastore");
 
             svirt_xml_validate($svirt,


### PR DESCRIPTION
The [SL-M6.0 prod.increment ](https://openqa.suse.de/group_overview/572) tests don't manage **VMware** images in hdd/iso _subolders_, so images in `hdd/fixed/*` are not copied in the expected final destination. This because `_copy_image_to_vm_host` receives the full path file coming from `add_disk` call args, but then it passes  to `_copy_image_vmware` [the basename only](https://github.com/os-autoinst/os-autoinst/blob/63a0bfd0a773cb90202ce8edb5ff0d10443ffd3b/consoles/sshVirtsh.pm#L380).

Note that test can proceed if image already is present transferred by other processes.

Here I change the file_basename input parameters both in `_copy_image_to_vm_host` and `_copy_image_vmware`, with the `full path source file` coming from previous parent calls.

This way, the code is able to manage also images in subfoldes like 'fixed/', running the first bash snippet in `_copy_image_vmware`.

ticket: https://progress.opensuse.org/issues/166748
