### PR TITLE
Exclude sub packages with many additional dependencies on SLE

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -31,6 +31,14 @@ Source0:        %{name}-%{version}.tar.xz
 %else
 %define opencv_require pkgconfig(opencv)
 %endif
+# exclude additional sub packages that would pull in a lot of extra dependencies on SLE
+%if 0%{?sle_version} && !0%{?is_opensuse}
+%bcond_with devel_package
+%bcond_with deps_package
+%else
+%bcond_without devel_package
+%bcond_without deps_package
+%endif
 # The following line is generated from dependencies.yaml
 %define build_base_requires %opencv_require gcc-c++ perl(Pod::Html) pkg-config pkgconfig(fftw3) pkgconfig(libpng) pkgconfig(sndfile) pkgconfig(theoraenc)
 # The following line is generated from dependencies.yaml
@@ -150,6 +158,7 @@ automated testing frameworks. However, it can just as well be used
 to test firefox and openoffice operation on top of a newly
 installed OS.
 
+%if %{with devel_package}
 %package devel
 Summary:        Development package pulling in all build+test dependencies
 Group:          Development/Tools/Other
@@ -157,6 +166,7 @@ Requires:       %devel_requires
 
 %description devel
 Development package pulling in all build+test dependencies.
+%endif
 
 %package openvswitch
 Summary:        Openvswitch support for os-autoinst
@@ -199,6 +209,7 @@ Requires:       swtpm
 %description swtpm
 Convenience package providing os-autoinst and swtpm dependencies.
 
+%if %{with deps_package}
 %package s390-deps
 Summary:        Convenience package providing os-autoinst + s390 worker jumphost deps
 Group:          Development/Tools/Other
@@ -216,6 +227,7 @@ Requires:       %ipmi_requires
 
 %description ipmi-deps
 Convenience package providing os-autoinst + ipmi worker jumphost dependencies.
+%endif
 
 
 %prep
@@ -338,13 +350,17 @@ fi
 %config /etc/dbus-1/system.d/org.opensuse.os_autoinst.switch.conf
 %{_sbindir}/rcos-autoinst-openvswitch
 
+%if %{with devel_package}
 %files devel
+%endif
 %ifarch x86_64
 %files qemu-kvm
 %files qemu-x86
 %endif
 %files swtpm
+%if %{with deps_package}
 %files s390-deps
 %files ipmi-deps
+%endif
 
 %changelog


### PR DESCRIPTION
As stated in https://build.suse.de/request/show/343857#comment-4023273 not all sub packages are installable on SLE. This only concerns the `devel` and `deps` sub packages which are really optional. So it makes sense to avoid submitting a huge number of Haskell some utility packages to SLE and exclude those packages instead.

Related ticket: https://progress.opensuse.org/issues/165683