### PR TITLE
Use double quotes for URLs

### DIFF
--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -76,7 +76,7 @@ sub _clone_bare_repo ($clone_url, $clone_depth, $clone_cmd, $cache_dir, $handle_
 }
 
 sub _fetch_new_refs ($clone_url, $cache_dir, $branch_arg, $handle_output) {
-    bmwqemu::fctinfo "Updating Git cache for '$clone_url' under '$cache_dir'";
+    bmwqemu::fctinfo qq{Updating Git cache for "$clone_url" under '$cache_dir'};
     if ($branch_arg eq '') {
         # get default branch (usually "main" or "master") from remote repo if $branch_arg is empty
         my $cmd = "env GIT_SSH_COMMAND='ssh -oBatchMode=yes' git ls-remote --symref '$clone_url' HEAD 2>&1";


### PR DESCRIPTION
Single quotes can be part of a URL.

Issue: https://progress.opensuse.org/issues/166676