### PR TITLE
Enable multifd support

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,7 +14,7 @@ coverage:
         target: 94.0
         threshold: 0.1
       fully_covered:
-        target: 100.0
+        target: 99.95
         paths:
           - OpenQA/
           - backend/

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -172,11 +172,12 @@ QEMU_SMBIOS;see qemu -smbios ?;undef;pass this value to qemu -smbios
 QEMU_SOUNDHW;see qemu -soundhw ?;had;pass this value to qemu -soundhw (for qemu < 4.2)
 QEMU_AUDIODEV;see qemu -device ?;intel-hda;Audio device to use with audiodev to qemu -device (for qemu >= 4.2)
 QEMU_AUDIOBACKEND;see qemu -audio-help;none;Audio backend to use with audiodev (for qemu >= 4.2)
-QEMU_COMPRESS_LEVEL;integer;6;Sets the compression level used for memory dumps and snapshots. Zero turns compression off and 9 is the maximum level. Generally there is little improvement in compression ratio by increasing the level, but the CPU time can be high on some platforms.
-QEMU_COMPRESS_THREADS;integer;QEMUCPUS;Number of threads used for compressing memory dumps and snapshots.
+QEMU_COMPRESS_LEVEL;integer;6;Sets the compression level used for memory dumps and snapshots. Zero turns compression off and 9 is the maximum level. Generally there is little improvement in compression ratio by increasing the level, but the CPU time can be high on some platforms. (For qemu < 9.1.0)
+QEMU_COMPRESS_THREADS;integer;QEMUCPUS;Number of threads used for compressing memory dumps and snapshots. (For qemu < 9.1.0)
 QEMU_NON_FATAL_DBUS_CALL;boolean;0;Ignore failed dbus calls and ignore instead of fatal exits
 QEMU_MAX_BANDWIDTH;integer;INT_MAX;Limits the transfer rate during a snapshot.
 QEMU_DUMP_COMPRESS_METHOD;string;xz;The compression to use during a memory dump. Can be set to xz, bzip2 or internal (QEMU's internal compression, not compatible with crash or gdb). If xz is set, but not available, it will fallback to bzip2. Also see QEMU_COMPRESSION_LEVEL.
+QEMU_MULTIFD_CHANNELS;integer;2;Number of channels used to migrate data in parallel (only when multifd is used, which means qemu >= 9.1.0). This is the same number that the number of sockets used for migration. Can be set from 1 to 255.
 QEMU_APPEND;string;;Append parameters on qemu command line. The first item will have '-' prepended to it.
 QEMU_ENABLE_SMBD;boolean;0;Enable QEMU's built-in samba service for user network. Exported worker's pool will be accessible on `\\10.0.2.4\qemu` share. Requires `smbd` to be installed (usually part of the `samba` package).
 VIRTIO_CONSOLE;boolean;1;Enable/disable virtio console. (@see `-device virtconsole` qemu option)

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -359,15 +359,32 @@ subtest 'migration to file' => sub {
     $$invoked_qmp_cmds = undef;
     $backend->_migrate_to_file(filename => 'foo');
     is_deeply \@wait_for_migrate_args, [$backend], 'migration awaited';
-    is_deeply $$invoked_qmp_cmds, [
+    my @expected = (
         {execute => 'migrate-set-capabilities', arguments => {capabilities => [{capability => 'events', state => Mojo::JSON->true}]}},
-        {execute => 'migrate-set-capabilities', arguments => {capabilities => [{capability => 'multifd', state => Mojo::JSON->true}]}},
-        {execute => 'migrate-set-capabilities', arguments => {capabilities => [{capability => 'mapped-ram', state => Mojo::JSON->true}]}},
-        {execute => 'migrate-set-parameters', arguments => {'multifd-channels' => 2, 'direct-io' => Mojo::JSON->true, 'max-bandwidth' => '9223372036854775807'}},
+    );
+    if ($backend->{qemu_version} ge version->declare(9.1)) {
+        push @expected, (
+            {execute => 'migrate-set-capabilities', arguments => {capabilities => [{capability => 'multifd', state => Mojo::JSON->true}]}},
+            {execute => 'migrate-set-capabilities', arguments => {capabilities => [{capability => 'mapped-ram', state => Mojo::JSON->true}]}},
+            {execute => 'migrate-set-parameters', arguments => {'multifd-channels' => 2, 'direct-io' => Mojo::JSON->true, 'max-bandwidth' => '9223372036854775807'}},
+        );
+    }
+    else {
+        push @expected, (
+            {execute => 'migrate-set-parameters', arguments => {'compress-level' => 0, 'compress-threads' => 2, 'max-bandwidth' => '9223372036854775807'}},
+        );
+    }
+    push @expected, (
         {execute => 'getfd', arguments => {fdname => 'dumpfd'}},
         {execute => 'stop'},
-        {execute => 'migrate', arguments => {uri => 'file:dumpfd'}},
-    ], 'expected QMP commands invoked' or diag explain $$invoked_qmp_cmds;
+    );
+    if ($backend->{qemu_version} ge version->declare(9.1)) {
+        push @expected, ({execute => 'migrate', arguments => {uri => 'file:dumpfd'}});
+    }
+    else {
+        push @expected, ({execute => 'migrate', arguments => {uri => 'fd:dumpfd'}});
+    }
+    is_deeply $$invoked_qmp_cmds, \@expected, 'expected QMP commands invoked' or diag explain $$invoked_qmp_cmds;
 };
 
 subtest 'misc functions' => sub {
@@ -404,21 +421,51 @@ subtest 'saving memory dump' => sub {
     $fake_qmp_answer = {return => {status => 'running'}};
     $called{handle_qmp_command} = undef;
     combined_like { $backend->save_memory_dump({filename => 'foo'}) } qr/memory dump completed/i, 'completion logged';
-    is_deeply $called{handle_qmp_command}, [
+    # command varies based on qemu version, so we have to construct the
+    # expected command carefully
+    my @expected = (
         {execute => 'query-status'},
-        {
-            execute => 'migrate-set-parameters',
-            arguments => {'multifd-channels' => 2, 'direct-io' => Mojo::JSON->true, 'max-bandwidth' => '9223372036854775807'},
-        },
         {
             execute => 'migrate-set-capabilities',
             arguments => {capabilities => [{capability => 'events', state => Mojo::JSON->true}]},
-        },
+        }
+    );
+    if ($backend->{qemu_version} ge version->declare(9.1)) {
+        push @expected, (
+            {
+                execute => 'migrate-set-capabilities',
+                arguments => {capabilities => [{capability => 'multifd', state => Mojo::JSON->true}]},
+            },
+            {
+                execute => 'migrate-set-capabilities',
+                arguments => {capabilities => [{capability => 'mapped-ram', state => Mojo::JSON->true}]},
+            },
+            {
+                execute => 'migrate-set-parameters',
+                arguments => {'multifd-channels' => 2, 'direct-io' => Mojo::JSON->true, 'max-bandwidth' => '9223372036854775807'},
+            },
+        );
+    }
+    else {
+        push @expected, (
+            {
+                execute => 'migrate-set-parameters',
+                arguments => {'compress-level' => 0, 'compress-threads' => 1, 'max-bandwidth' => '9223372036854775807'},
+            },
+        );
+    }
+    push @expected, (
         {execute => 'getfd', arguments => {fdname => 'dumpfd'}},
         {execute => 'stop'},
-        {execute => 'migrate', arguments => {uri => 'fd:dumpfd'}},
-        {execute => 'cont'},
-    ], 'expected QMP command called for "save_memory_dump"' or diag explain $called{handle_qmp_command};
+    );
+    if ($backend->{qemu_version} ge version->declare(9.1)) {
+        push @expected, ({execute => 'migrate', arguments => {uri => 'file:dumpfd'}});
+    }
+    else {
+        push @expected, ({execute => 'migrate', arguments => {uri => 'fd:dumpfd'}});
+    }
+    push @expected, ({execute => 'cont'});
+    is_deeply $called{handle_qmp_command}, \@expected, 'expected QMP command called for "save_memory_dump"' or diag explain $called{handle_qmp_command};
     is $runcmd, 'xz --no-warn -T 1 -v6 ulogs/foo-vm-memory-dump', 'expected compression command invoked';
 
     $which_mock->redefine(which => undef);
@@ -487,16 +534,28 @@ subtest 'snapshot handling' => sub {
 
     $$invoked_qmp_cmds = undef;
     combined_like { $backend->load_snapshot({name => 'fakevm'}) } qr/restored snapshot/i, 'restoration logged';
-    is_deeply $$invoked_qmp_cmds, [
+    my @expected = (
         {execute => 'query-status'},
         {execute => 'stop'},
         {execute => 'qmp_capabilities'},
         {execute => 'migrate-set-capabilities', arguments => {capabilities => [{capability => 'events', state => Mojo::JSON->true}]}},
-        {execute => 'migrate-set-capabilities', arguments => {capabilities => [{capability => 'multifd', state => Mojo::JSON->true}]}},
-        {execute => 'migrate-set-capabilities', arguments => {capabilities => [{capability => 'mapped-ram', state => Mojo::JSON->true}]}},
-        {execute => 'migrate-incoming', arguments => {uri => 'exec:cat vm-snapshots/fakevm'}},
-        {execute => 'cont'},
-    ], 'expected QMP commands invoked when loading snapshot' or diag explain $$invoked_qmp_cmds;
+    );
+    if ($backend->{qemu_version} ge version->declare(9.1)) {
+        push @expected, (
+            {execute => 'migrate-set-capabilities', arguments => {capabilities => [{capability => 'multifd', state => Mojo::JSON->true}]}},
+            {execute => 'migrate-set-capabilities', arguments => {capabilities => [{capability => 'mapped-ram', state => Mojo::JSON->true}]}},
+            {execute => 'getfd', arguments => {fdname => 'dumpfd'}},
+            {execute => 'migrate-incoming', arguments => {uri => 'file:dumpfd'}},
+        );
+    }
+    else {
+        push @expected, (
+            {execute => 'migrate-set-capabilities', arguments => {capabilities => [{capability => 'compress', state => Mojo::JSON->true}]}},
+            {execute => 'migrate-incoming', arguments => {uri => 'exec:cat vm-snapshots/fakevm'}},
+        );
+    }
+    push @expected, ({execute => 'cont'});
+    is_deeply $$invoked_qmp_cmds, \@expected, 'expected QMP commands invoked when loading snapshot' or diag explain $$invoked_qmp_cmds;
 };
 
 subtest 'save storage' => sub {


### PR DESCRIPTION
From qemu 9.1.0, the "compress" migration capability has been removed, but multifd migration is able to do compression and can be used instead.

https://progress.opensuse.org/issues/167218