### PR TITLE
Add dependencies of `tools/check-shellcheck` explicitly, fix CI checks

### DIFF
--- a/container/os-autoinst_dev/Dockerfile
+++ b/container/os-autoinst_dev/Dockerfile
@@ -29,6 +29,7 @@ RUN zypper in -y -C \
        aspell-spell \
        cmake \
        cpio \
+       file \
        gcc-c++ \
        git-core \
        icewm \
@@ -45,6 +46,7 @@ RUN zypper in -y -C \
        qemu-tools \
        qemu-x86 \
        rsync \
+       sed \
        shadow \
        shfmt \
        socat \

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -46,6 +46,8 @@ ci_requires:
 devel_requires:
   '%test_requires':
   '%python_style_requires':
+  file:
+  sed:
   perl(Code::TidyAll):
   perl(Devel::Cover):
   perl(Module::CPANfile):

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -120,7 +120,7 @@ Source0:        %{name}-%{version}.tar.xz
 # The following line is generated from dependencies.yaml
 %define test_requires %build_requires %ocr_requires %spellcheck_requires %test_base_requires %test_non_s390_requires %yamllint_requires python3-Pillow-tk
 # The following line is generated from dependencies.yaml
-%define devel_requires %python_style_requires %test_requires ShellCheck perl(Code::TidyAll) perl(Devel::Cover) perl(Module::CPANfile) perl(Perl::Tidy) perl(Template::Toolkit) shfmt
+%define devel_requires %python_style_requires %test_requires ShellCheck file perl(Code::TidyAll) perl(Devel::Cover) perl(Module::CPANfile) perl(Perl::Tidy) perl(Template::Toolkit) sed shfmt
 %define s390_zvm_requires /usr/bin/xkbcomp /usr/bin/Xvnc x3270 icewm xterm xterm-console xdotool fonts-config mkfontdir mkfontscale openssh-clients
 %define ipmi_requires ipmitool
 %define qemu_requires qemu-tools e2fsprogs


### PR DESCRIPTION
The author tests are currently failing with:

```
 4: /__w/os-autoinst/os-autoinst/tools/check-shellcheck: line 3: file: command not found
4: No files specified.
4:
4: Usage: shellcheck [OPTIONS...] FILES...
```

This is because `file` is no longer implicitly installed in the development container. This change adds dependencies of the `check-shellcheck` script explicitly to avoid running into errors like this.