### PR TITLE
Improve unit test coverage of test API code handling timeouts

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -301,7 +301,7 @@ sub _check_backend_response ($rsp, $check, $timeout, $mustmatch) {
         }) and return 'try_again';
 
         # only care for the last one
-        $failed_screens = [$final_mismatch] if $check;
+        $failed_screens = [$final_mismatch] if $check && defined $final_mismatch;
         for my $l (@$failed_screens) {
             my $img = tinycv::from_ppm(decode_base64($l->{image}));
             my $result = $check ? 'unk' : 'fail';


### PR DESCRIPTION
* Extend tests
* Avoid Perl warning when there are no failed screens
* See https://progress.opensuse.org/issues/130420