### PR TITLE
backend: Allow to configure IPMI options

### DIFF
--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -17,7 +17,8 @@ sub new ($class) {
 
 sub ipmi_cmdline ($self) {
     $bmwqemu::vars{"IPMI_$_"} or die "Need variable IPMI_$_" for qw(HOSTNAME USER PASSWORD);
-    return ('ipmitool', '-I', 'lanplus', '-H', $bmwqemu::vars{IPMI_HOSTNAME}, '-U', $bmwqemu::vars{IPMI_USER}, '-P', $bmwqemu::vars{IPMI_PASSWORD});
+    my $ipmi_options = $bmwqemu::vars{IPMI_OPTIONS} // '-I lanplus';
+    return ('ipmitool', split(' ', $ipmi_options), '-H', $bmwqemu::vars{IPMI_HOSTNAME}, '-U', $bmwqemu::vars{IPMI_USER}, '-P', $bmwqemu::vars{IPMI_PASSWORD});
 }
 
 sub ipmitool ($self, $cmd, %args) {

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -82,6 +82,7 @@ HARDWARE_CONSOLE_LOG;boolean;undef;Enable direct log capture of sol console, dis
 IPMI_HOSTNAME;string;undef;Hostname/IP for IPMI interface
 IPMI_PASSWORD;string;undef;Password for the IPMI interface
 IPMI_USER;string;undef;Username for the IPMI interface
+IPMI_OPTIONS;string;-I lanplus;Additional options for the IPMI interface
 IPMI_DO_NOT_POWER_OFF;boolean;undef;Don't power off the machine after test
 IPMI_DO_NOT_RESTART_HOST;boolean;undef;Don't restart the machine before test
 IPMI_BACKEND_MC_RESET;boolean;undef;Reset ipmi main board before test for sol console stability


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/168556