### PR TITLE
Make actually use of `%python_support_requires` for Python support

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -128,6 +128,7 @@ test_requires:
   '%yamllint_requires':
   '%ocr_requires':
   '%test_non_s390_requires':
+  '%python_support_requires':
   python3-Pillow-tk:
   ffmpeg:
 

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -118,7 +118,7 @@ Source0:        %{name}-%{version}.tar.xz
 # The following line is generated from dependencies.yaml
 %define test_version_only_requires perl(Mojo::IOLoop::ReadWriteProcess) >= 0.28
 # The following line is generated from dependencies.yaml
-%define test_requires %build_requires %ocr_requires %spellcheck_requires %test_base_requires %test_non_s390_requires %yamllint_requires ffmpeg python3-Pillow-tk
+%define test_requires %build_requires %ocr_requires %python_support_requires %spellcheck_requires %test_base_requires %test_non_s390_requires %yamllint_requires ffmpeg python3-Pillow-tk
 # The following line is generated from dependencies.yaml
 %define devel_requires %python_style_requires %test_requires ShellCheck file perl(Code::TidyAll) perl(Devel::Cover) perl(Module::CPANfile) perl(Perl::Tidy) perl(Template::Toolkit) sed shfmt
 %define s390_zvm_requires /usr/bin/xkbcomp /usr/bin/Xvnc x3270 icewm xterm xterm-console xdotool fonts-config mkfontdir mkfontscale openssh-clients
@@ -136,7 +136,7 @@ Recommends:     qemu >= 4.0.0
 Recommends:     %qemu_requires
 %if %{with python_support}
 # Optional dependency for Python test API support
-Recommends:     perl(Inline::Python)
+Recommends:     %python_support_requires
 %endif
 # Optional dependency for crop.py
 Recommends:     python3-Pillow-tk


### PR DESCRIPTION
* Add `%python_support_requires` to `%test_requires` so we actually run tests for Python support if enabled
* Use `%python_support_requires` also in `Recommends:` to avoid repeating the dependency name
* Address https://github.com/os-autoinst/os-autoinst/pull/2531#issuecomment-2494903699