### PR TITLE
Cover deprecation logging

### DIFF
--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -894,6 +894,8 @@ subtest 'child process handling' => sub {
 
 subtest 'deprecate backend' => sub {
     throws_ok { backend::baseclass::handle_deprecate_backend('AMT') } qr/is unsupported and planned to be\nremoved from os-autoinst eventually/, 'deprecated message is displayed';
+    $bmwqemu::vars{NO_DEPRECATE_BACKEND_TESTBACKEND} = 1;
+    stderr_like { backend::baseclass::handle_deprecate_backend('TESTBACKEND') } qr/DEPRECATED: 'backend::TESTBACKEND' is unsupported/, 'deprecation message is logged';
 };
 
 done_testing;


### PR DESCRIPTION
This should deal with https://app.codecov.io/gh/os-autoinst/os-autoinst/pull/2573/blob/backend/baseclass.pm#L1367