### PR TITLE
Remove obsolete basetest::ocr_checklist

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -600,24 +600,6 @@ sub verify_sound_image ($self, $imgpath, $mustmatch, $check) {
     return;
 }
 
-=head2 ocr_checklist
-
-Optical Character Recognition matching.
-
-Return a listref containing hashrefs like this:
-
-  {
-    screenshot=>2,      # nr of screenshot for the test to OCR
-    x=>104, y=>201,     # position
-    xs=>380, ys=>150,   # size
-    pattern=>"H ?ello", # regex to match the OCR result
-    result=>"OK"        # or "fail"
-  }
-
-=cut
-
-sub ocr_checklist () { [] }
-
 # this is called if the test failed and the framework loaded a VM
 # snapshot - all consoles activated in the test's run function loose their
 # state


### PR DESCRIPTION
ocr_checklist is unused since 75678433.

Related progress issue: https://progress.opensuse.org/issues/167950