### PR TITLE
codecov: Mark basetest as completely covered

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -27,6 +27,7 @@ coverage:
           - consoles/sshSerial.pm
           - consoles/sshIucvconn.pm
           - consoles/virtio_terminal.pm
+          - basetest.pm
           - bmwqemu.pm
           - cv.pm
           - log.pm


### PR DESCRIPTION
With 8da68a4 basetest.pm is fully covered.

Related progress issue: https://progress.opensuse.org/issues/167950