### PR TITLE
Fix: console reset on milestone loading

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -49,7 +49,6 @@ sub new ($class, $category = undef) {
     $self->{dents} = 0;
     $self->{post_fail_hook_running} = 0;
     $self->{timeoutcounter} = 0;
-    $self->{activated_consoles} = [];
     $self->{name} = $class;
     $self->{serial_failures} = [];
     $self->{autoinst_failures} = [];
@@ -591,27 +590,6 @@ sub verify_sound_image ($self, $imgpath, $mustmatch, $check) {
     else {
         $self->record_screenfail(@needles_params, result => 'fail', overall => 'fail');
     }
-    return;
-}
-
-# this is called if the test failed and the framework loaded a VM
-# snapshot - all consoles activated in the test's run function loose their
-# state
-sub rollback_activated_consoles ($self) {
-    for my $console (@{$self->{activated_consoles}}) {
-        # the backend will only reset its state, and call activate
-        # the next time - the console itself might actually not be
-        # able to activate a 2nd time, but that's up to the console class
-        autotest::query_isotovideo('backend_reset_console', {testapi_console => $console});
-    }
-    $self->{activated_consoles} = [];
-
-    if (defined($autotest::last_milestone_console)) {
-        my $ret = autotest::query_isotovideo('backend_select_console',
-            {testapi_console => $autotest::last_milestone_console});
-        die $ret->{error} if $ret->{error};
-    }
-
     return;
 }
 

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -307,7 +307,7 @@ testapi::set_distribution(distribution->new());
 $autotest::last_milestone = {};
 select_console('a-console');
 is console('a-console')->{console}, 'a-console';
-is_deeply $autotest::last_milestone->{activated_consoles}, ['a-console'], 'Current console is activated';
+is_deeply $autotest::activated_consoles, ['a-console'], 'Current console is activated';
 is(is_serial_terminal, 0, 'Not a serial terminal');
 is(current_console, 'a-console', 'Current console is the a-console');
 is console('b-console')->{console}, 'b-console', 'new console created on the fly';

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -42,7 +42,6 @@ $autotest::isotovideo = 1;
 my $last_screenshot_data;
 my $fake_ignore_failure;
 my $suppress_match;
-my @reset_consoles;
 my @selected_consoles;
 sub fake_send_json ($to_fd, $cmd) { push(@$cmds, $cmd) }
 sub fake_read_json ($fd) {
@@ -56,14 +55,6 @@ sub fake_read_json ($fd) {
     }
     elsif ($cmd eq 'backend_verify_image') {
         return {ret => {found => {needle => {name => 'foundneedle', file => 'foundneedle.json'}, area => [{x => 1, y => 2, similarity => 100}]}, candidates => []}} unless $suppress_match;
-        return {};
-    }
-    elsif ($cmd eq 'backend_reset_console') {
-        push @reset_consoles, $lcmd;
-        return {};
-    }
-    elsif ($cmd eq 'backend_select_console') {
-        push @selected_consoles, $lcmd;
         return {};
     }
     elsif ($cmd eq 'backend_last_screenshot_data') {
@@ -522,16 +513,6 @@ subtest verify_sound_image => sub {
     $res = $test->verify_sound_image("$FindBin::Bin/data/frame1.ppm", "$FindBin::Bin/data/frame2.ppm", 0);
     is($details->{result}, 'fail', 'no needle match: status fail') or diag explain $details;
     is($details->{overall}, 'fail', 'no needle match: overall fail') or diag explain $details;
-};
-
-subtest rollback_activated_consoles => sub {
-    my $test = basetest->new();
-    $test->{activated_consoles} = ['activated_console'];
-    $autotest::last_milestone_console = 'last_milestone_console';
-    $test->rollback_activated_consoles;
-    is_deeply($test->{activated_consoles}, [], 'activated consoles cleared') or diag explain $test->{activated_consoles};
-    is_deeply(\@reset_consoles, [{cmd => 'backend_reset_console', testapi_console => 'activated_console'}], 'activated consoles reset') or diag explain \@reset_consoles;
-    is_deeply(\@selected_consoles, [{cmd => 'backend_select_console', testapi_console => 'last_milestone_console'}], 'last milestone console selected') or diag explain \@selected_consoles;
 };
 
 $mock_bmwqemu->noop('diag', 'modstate');

--- a/testapi.pm
+++ b/testapi.pm
@@ -1678,10 +1678,7 @@ sub select_console ($testapi_console, @args) {
 
     $autotest::selected_console = $testapi_console;
     if ($ret->{activated}) {
-        # we need to store the activated consoles for rollback
-        if ($autotest::last_milestone) {
-            push(@{$autotest::last_milestone->{activated_consoles}}, $testapi_console);
-        }
+        push(@$autotest::activated_consoles, $testapi_console);
         $testapi::distri->activate_console($testapi_console, @args);
     }
     $testapi::distri->console_selected($testapi_console, @args);
@@ -1728,6 +1725,7 @@ if you did something to the system that affects the console (e.g. trigger reboot
 =cut
 
 sub reset_consoles () {
+    $autotest::activated_consoles = [];
     query_isotovideo('backend_reset_consoles');
     return;
 }


### PR DESCRIPTION
When someone is calling `testapi::reset_consoles()`, while there is already a "last_milestone", the activation of a virtio serial console may fail, after loading the `last_good` milestone.

### Explanation

After loading the `last_good` milestone, `autotest` is calling the function `basetest::rollback_activated_consoles()` while the basetest object points to the test where the last milestone was generated.
The method `rollback_activated_consoles()` call's, for each console which was activated during this tests, the RPC function  `backend_reset_console`. Each console has it's own reset handler, **but** important is, that it reset the `consoles::console->{activated}` state which has impact when a console get selected (`testapi::select_console()`), where we call `$testapi::distri->activate_console()` only if the RPC call `backend_select_console` retrieves `{activated => 1}` (see `consoles::console->select()`).

This implementation has an issues with `testapi::reset_consoles()`:
  * When someone call's `testapi::reset_consoles()` (e.g. `lib/serial_terminal::reboot()`), all consoles get deactivated. And if we now `select()` them after successful reboot, they will be also marked to get reset on loading the `last_good` milestone. **But** these consoles may already be activated in the milestone thus the state is not correctly reflected.

### Solution
  * Do not connect the last-milestone with the test-module
  * Collect all activated consoles in `autotest`
  * Clear the list of activated consoles in `testapi::reset_consoles()`

### Reproducer
 * http://openqa.suse.de/t16082302 - console_reset_on_milestone_case1.1 => failed
 * http://openqa.suse.de/t16082300 - console_reset_on_milestone_good_case => passed


```bash
openqa-cli api --host http://openqa.suse.de -X POST jobs ARCH=x86_64 BACKEND=qemu BOOT_HDD_IMAGE=1 TEST=console_reset_on_milestone_case1.1 BUILD=test-reboot 'CASEDIR=https://github.com/cfconrad/os-autoinst-distri-opensuse#clemix_debug_milestone_with_reboot' DESKTOP=textmode DISTRI=sle FLAVOR=CI VERSION=15-SP7 HDDSIZEGB=30 HDD_1=SLES-15-SP7-x86_64-Build43.1-wicked.qcow2 MACHINE=x86_64 NICTYPE=tap NOIMAGES=1 NOVIDEO=1 QEMUCPU=qemu64 QEMURAM=2048 TAPDEV=auto,auto VIDEOMODE=text VIRTIO_CONSOLE=1 VIRTIO_CONSOLE_NUM=2 WORKER_CLASS=tap,qemu_x86_64, _QUIET_SCRIPT_CALLS=1 SCHEDULE=tests/boot/boot_to_desktop,tests/clemix/check_virtio_terminal,tests/clemix/check_console,tests/clemix/milestone,tests/clemix/reboot,tests/clemix/check_virtio_terminal,tests/clemix/always_rollback,tests/clemix/check_virtio_terminal
````

Or this script which I used to play around:
```bash
#!/bin/bash

hdd=${hdd:-SLES-15-SP7-x86_64-Build43.1-wicked.qcow2}
host=${host:-http://openqa.suse.de}
casedir=${casedir:-"https://github.com/cfconrad/os-autoinst-distri-opensuse#clemix_debug_milestone_with_reboot"}

schedule()
{
    local v;
    for arg in "$@"; do
        v="$v,tests/clemix/$arg"
    done
    echo "tests/boot/boot_to_desktop$v"
}

trigger() {
    SCHEDULE=$(schedule "$@")

    echo openqa-cli api --host $host -X POST jobs \
        'ARCH=x86_64' \
        'BACKEND=qemu' \
        'BOOT_HDD_IMAGE=1' \
        "TEST=${TEST:-debug_reboot_and_load_snapshot}" \
        'BUILD=test-reboot' \
        "CASEDIR=$casedir" \
        'DESKTOP=textmode'  \
        'DISTRI=sle' \
        'FLAVOR=CI'  \
        'VERSION=15-SP7' \
        'HDDSIZEGB=30' \
        "HDD_1=$hdd" \
        'MACHINE=x86_64' \
        'NICTYPE=tap'  \
        'NOIMAGES=1' \
        'NOVIDEO=1' \
        'QEMUCPU=qemu64' \
        'QEMURAM=2048' \
        'TAPDEV=auto,auto' \
        'VIDEOMODE=text' \
        'VIRTIO_CONSOLE=1' \
        'VIRTIO_CONSOLE_NUM=2' \
        "WORKER_CLASS=tap,qemu_x86_64,${worker:-}" \
        '_QUIET_SCRIPT_CALLS=1' \
        "SCHEDULE=$SCHEDULE"
}


{
    TEST="console_reset_on_milestone_good_case" trigger \
        check_virtio_terminal add_virtio_terminal1 check_virtio_terminal1 \
        milestone check_virtio_terminal check_virtio_terminal1 \
        always_rollback check_virtio_terminal check_virtio_terminal1 \
        always_rollback check_virtio_terminal check_virtio_terminal1

    TEST="console_reset_on_milestone_case1" trigger \
        check_virtio_terminal add_virtio_terminal1 check_virtio_terminal1 \
        milestone reboot check_virtio_terminal check_virtio_terminal1 \
        always_rollback check_virtio_terminal check_virtio_terminal1

    TEST="console_reset_on_milestone_case1.1" trigger \
        check_virtio_terminal check_console \
        milestone reboot check_virtio_terminal \
        always_rollback check_virtio_terminal

} | openqa-wait-job --host $host
```