### PR TITLE
Extend sshVirtsh console test coverage

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -440,7 +440,7 @@ sub _handle_disk_type ($vmm_family, $cdrom, $dev_id) {
     return ("hd$dev_id", 'ide') if $vmm_family eq 'vmware';
     return ("hd$dev_id", 'ide') if $cdrom && $vmm_family eq 'kvm';
     return ("vd$dev_id", 'virtio') if $vmm_family eq 'kvm';
-    return (undef, undef);
+    return (undef, undef);    # uncoverable statement
 }
 
 sub _bootorder_elem ($doc, $bootorder) {

--- a/t/22-svirt-virsh-config.xml
+++ b/t/22-svirt-virsh-config.xml
@@ -15,7 +15,7 @@
   </features>
   <on_reboot>destroy</on_reboot>
   <devices>
-    <graphics type="vnc" port="5901" autoport="no" listen="0.0.0.0" sharePolicy="force-shared">
+    <graphics type="vnc" port="5901" autoport="no" listen="0.0.0.0" sharePolicy="force-shared" passwd="secret">
       <listen type="address" address="0.0.0.0"/>
     </graphics>
     <console type="pty">


### PR DESCRIPTION
Introduced a subtest to verify `add_input`, `add_interface` and `add_pty`. 
Some statements marked as uncovered

https://progress.opensuse.org/issues/168370