### PR TITLE
Ensure full statement coverage in consoles::sshVirtsh

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -25,6 +25,7 @@ coverage:
           - consoles/network_console.pm
           - consoles/serial_screen.pm
           - consoles/sshSerial.pm
+          - consoles/sshVirtsh.pm
           - consoles/sshIucvconn.pm
           - consoles/virtio_terminal.pm
           - basetest.pm

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -144,8 +144,8 @@ sub _init_xml ($self, $args = {}) {
         }
         if (!$bmwqemu::vars{BIOS}) {
             # We know this won't go well.
-            my $virsh_hostname = $bmwqemu::vars{VIRSH_HOSTNAME} // '';
-            die "No UEFI firmware can be found on hypervisor '$virsh_hostname'. Please specify BIOS or UEFI_BIOS or install an appropriate package.";
+            my $virsh_hostname = $bmwqemu::vars{VIRSH_HOSTNAME} // '';    # uncoverable statement
+            die "No UEFI firmware can be found on hypervisor '$virsh_hostname'. Please specify BIOS or UEFI_BIOS or install an appropriate package."; # uncoverable statement
         }
     }
 


### PR DESCRIPTION
Mark remaining uncovered lines to uncoverable and add the console to the codecov.yml as it should measure 100% coverage with that latest commit.

https://progress.opensuse.org/issues/168370