### PR TITLE
Avoid Perl warning about when handling tags to assert

### DIFF
--- a/OpenQA/Isotovideo/CommandHandler.pm
+++ b/OpenQA/Isotovideo/CommandHandler.pm
@@ -311,11 +311,8 @@ sub _handle_command_check_screen ($self, $response, @) {
             check_screen => \%arguments,
             current_api_function => $current_api_function,
     });
-    $self->tags($bmwqemu::backend->_send_json(
-            {
-                cmd => 'set_tags_to_assert',
-                arguments => \%arguments,
-            })->{tags});
+    my $tags_resp = $bmwqemu::backend->_send_json({cmd => 'set_tags_to_assert', arguments => \%arguments});
+    $self->tags(($tags_resp // {})->{tags} // []);
     $self->current_api_function($current_api_function);
 }
 


### PR DESCRIPTION
Sometimes we see the following log messages:

```
[2024-12-12T07:40:42.466285Z] [debug] [pid:106451] backend process exited: 0
[2024-12-12T07:40:42.467509Z] [warn] [pid:106451] !!! main: Can't use an undefined value as a HASH reference at /usr/lib/os-autoinst/OpenQA/Isotovideo/CommandHandler.pm line 318.
…
[2024-12-12T07:40:42.933081Z] [info] [pid:76182] Isotovideo exit status: 0
```

The Perl warning is problematic as it distracts users even though it is not meaningful. It is just a consequence of the backend process exiting when isotovideo still handles a response from an `set_tags_to_assert` backend query (which is empty as the backend has just exited).

This change simply suppresses the warning because isotovideo will exit anyway in this situation. Note that is is not clear yet what problem with the SUT/backend exactly leads to this situation (maybe the VNC client code) but this warning is definitely not helpful to debug this in any case.

Related ticket: https://progress.opensuse.org/issues/174196