### PR TITLE
Avoid adding message about termination from myjsonrpc as reason

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -70,8 +70,11 @@ use constant STATE_FILE => 'base_state.json';
 
 # Write a JSON representation of the process termination to disk
 sub serialize_state (%state) {
-    bmwqemu::fctwarn($state{msg}) if delete $state{error};
-    bmwqemu::diag($state{msg}) if delete $state{log};
+    my $message = $state{msg};
+    bmwqemu::fctwarn($message) if delete $state{error};
+    bmwqemu::diag($message) if delete $state{log};
+    # avoid adding message about termination from myjsonrpc as reason, can happen during shutdown and very unlikely about the actual problem
+    return undef if $message =~ m/myjsonrpc: remote end terminated/;
     return undef if -e STATE_FILE;
     eval { path(STATE_FILE)->spew(encode_json(\%state)) };
     bmwqemu::diag("Unable to serialize fatal error: $@") if $@;

--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -172,10 +172,17 @@ is_deeply decode_json(path('new_json_file.json')->slurp), \%new_json, 'JSON file
 
 ok bmwqemu::wait_for_one_more_screenshot, 'wait for one more screenshot is ok';
 
+subtest 'serializing state' => sub {
+    bmwqemu::serialize_state(msg => 'myjsonrpc: remote end terminated');
+    ok !-e bmwqemu::STATE_FILE, 'no statefile created for shutdown-related message';
+    bmwqemu::serialize_state(msg => 'foo');
+    is_deeply decode_json(path(bmwqemu::STATE_FILE)->slurp), {msg => 'foo'}, 'state serialized';
+};
+
 done_testing;
 
 END {
-    unlink for qw(vars.json new_json_file.json);
+    unlink for qw(vars.json new_json_file.json), bmwqemu::STATE_FILE;
 }
 
 1;


### PR DESCRIPTION
This message can happen during shutdown. It only means that one process has existed while another one was still reading from its pipe. This message is very unlikely about the actual problem and rather distracting - so it should not be recorded as reason (even if there is no better reason at this point).

Related ticket: https://progress.opensuse.org/issues/174196