### PR TITLE
 Remove _typing_limit subroutine because it's never used 

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -28,6 +28,7 @@ coverage:
           - consoles/sshVirtsh.pm
           - consoles/sshIucvconn.pm
           - consoles/virtio_terminal.pm
+          - consoles/vnc_base.pm
           - myjsonrpc.pm
           - lockapi.pm
           - basetest.pm

--- a/consoles/vnc_base.pm
+++ b/consoles/vnc_base.pm
@@ -66,8 +66,6 @@ sub current_screen ($self) {
     return $self->{vnc}->_framebuffer;
 }
 
-sub _typing_limit () { $bmwqemu::vars{VNC_TYPING_LIMIT} // VNC_TYPING_LIMIT_DEFAULT || 1 }
-
 sub send_key_event ($self, $key, $press_release_delay) {
     $self->{vnc}->map_and_send_key($key, undef, $press_release_delay);
 }


### PR DESCRIPTION
https://progress.opensuse.org/issues/174271