### PR TITLE
Add a minor fix for parse_extra_log subtest in 03-testapi.t

### DIFF
--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -639,6 +639,7 @@ subtest 'script_sudo' => sub {
 };
 
 subtest 'parse_extra_log' => sub {
+    $bmwqemu::vars{WORKER_HOSTNAME} = 'my_worker_host';
     my $mock_parser = Test::MockObject->new();
     my $mock_testapi = Test::MockModule->new('testapi');
     $mock_testapi->define(parser => sub { $mock_parser });


### PR DESCRIPTION
- running `prove -I. t/03-testapi.t -v` was throwing warnings:
```
  #   Failed test 'no (unexpected) warnings (via done_testing)'
  #   at t/03-testapi.t line 1290.
  # Got the following unexpected warnings:
  #   1: Use of uninitialized value $hostname in concatenation
         (.) or string at os-autoinst/testapi.pm line 2092.
  #   2: Use of uninitialized value $hostname in concatenation
        (.) or string at os-autoinst/testapi.pm line 2092.
   1..72
```