### PR TITLE
Properly fix coverage of qemu codepaths that depend on version (see https://progress.opensuse.org/issues/167218 )

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -251,7 +251,6 @@ sub _migrate_to_file ($self, %args) {
 
     # Internally compressed dumps can't be opened by crash. They need to be
     # fed back into QEMU as an incoming migration.
-    # uncoverable branch false
     if ($migration_use_multifd) {
         $self->set_migrate_capability('multifd', 1);
         $self->set_migrate_capability('mapped-ram', 1);
@@ -267,10 +266,22 @@ sub _migrate_to_file ($self, %args) {
             },
             fatal => 1
         );
-    } else {
-        $self->set_migrate_capability('compress', 1) if $compress_level > 0;    # uncoverable statement
-        my $cmd = {execute => 'migrate-set-parameters', arguments => {'compress-level' => $compress_level + 0, 'compress-threads' => $compress_threads + 0, 'max-bandwidth' => $max_bandwidth + 0}}; # uncoverable statement
-        $self->handle_qmp_command($cmd, fatal => 1);    # uncoverable statement
+    }
+    else {
+        $self->set_migrate_capability('compress', 1) if $compress_level > 0;
+        $self->handle_qmp_command(
+            {
+                execute => 'migrate-set-parameters',
+                arguments => {
+                    # This is ignored if the compress capability is not set
+                    'compress-level' => $compress_level + 0,
+                    'compress-threads' => $compress_threads + 0,
+                    # Ensure slow dump times are not due to a transfer rate cap
+                    'max-bandwidth' => $max_bandwidth + 0,
+                }
+            },
+            fatal => 1
+        );
     }
 
     $self->open_file_and_send_fd_to_qemu($filename, $fdname);
@@ -502,18 +513,19 @@ sub load_snapshot ($self, $args) {
 
     $self->set_migrate_capability('events', 1);
 
-    # uncoverable branch false
     if ($migration_use_multifd) {
         $self->set_migrate_capability('multifd', 1);
         $self->set_migrate_capability('mapped-ram', 1) if (version->declare($self->{qemu_version}) ge version->declare(9.0));
         $self->open_file_and_send_fd_to_qemu(VM_SNAPSHOTS_DIR . '/' . $snapshot->name,
             $fdname);
-        my $cmd = {execute => 'migrate-incoming', arguments => {uri => "file:$fdname"}};
-        $rsp = $self->handle_qmp_command($cmd, fatal => 1);
+        $rsp = $self->handle_qmp_command({execute => 'migrate-incoming',
+                arguments => {uri => "file:$fdname"}},
+            fatal => 1);
     } else {
-        $self->set_migrate_capability('compress', 1);    # uncoverable statement
-        my $cmd = {execute => 'migrate-incoming', arguments => {uri => 'exec:cat ' . VM_SNAPSHOTS_DIR . '/' . $snapshot->name}};    # uncoverable statement
-        $rsp = $self->handle_qmp_command($cmd, fatal => 1);    # uncoverable statement
+        $self->set_migrate_capability('compress', 1);
+        $rsp = $self->handle_qmp_command({execute => 'migrate-incoming',
+                arguments => {uri => 'exec:cat ' . VM_SNAPSHOTS_DIR . '/' . $snapshot->name}},
+            fatal => 1);
     }
 
     $self->load_console_snapshots($vmname);

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -369,12 +369,20 @@ subtest 'migration to file' => sub {
             {execute => 'migrate-set-parameters', arguments => {'multifd-channels' => 2, 'direct-io' => Mojo::JSON->true, 'max-bandwidth' => '9223372036854775807'}},
         );
     }
+    else {
+        push @expected, (
+            {execute => 'migrate-set-parameters', arguments => {'compress-level' => 0, 'compress-threads' => 2, 'max-bandwidth' => '9223372036854775807'}},
+        );
+    }
     push @expected, (
         {execute => 'getfd', arguments => {fdname => 'dumpfd'}},
         {execute => 'stop'},
     );
     if ($backend->{qemu_version} ge version->declare(9.1)) {
         push @expected, ({execute => 'migrate', arguments => {uri => 'file:dumpfd'}});
+    }
+    else {
+        push @expected, ({execute => 'migrate', arguments => {uri => 'fd:dumpfd'}});
     }
     is_deeply $$invoked_qmp_cmds, \@expected, 'expected QMP commands invoked' or diag explain $$invoked_qmp_cmds;
 };
@@ -438,12 +446,23 @@ subtest 'saving memory dump' => sub {
             },
         );
     }
+    else {
+        push @expected, (
+            {
+                execute => 'migrate-set-parameters',
+                arguments => {'compress-level' => 0, 'compress-threads' => 1, 'max-bandwidth' => '9223372036854775807'},
+            },
+        );
+    }
     push @expected, (
         {execute => 'getfd', arguments => {fdname => 'dumpfd'}},
         {execute => 'stop'},
     );
     if ($backend->{qemu_version} ge version->declare(9.1)) {
         push @expected, ({execute => 'migrate', arguments => {uri => 'file:dumpfd'}});
+    }
+    else {
+        push @expected, ({execute => 'migrate', arguments => {uri => 'fd:dumpfd'}});
     }
     push @expected, ({execute => 'cont'});
     is_deeply $called{handle_qmp_command}, \@expected, 'expected QMP command called for "save_memory_dump"' or diag explain $called{handle_qmp_command};
@@ -527,6 +546,12 @@ subtest 'snapshot handling' => sub {
             {execute => 'migrate-set-capabilities', arguments => {capabilities => [{capability => 'mapped-ram', state => Mojo::JSON->true}]}},
             {execute => 'getfd', arguments => {fdname => 'dumpfd'}},
             {execute => 'migrate-incoming', arguments => {uri => 'file:dumpfd'}},
+        );
+    }
+    else {
+        push @expected, (
+            {execute => 'migrate-set-capabilities', arguments => {capabilities => [{capability => 'compress', state => Mojo::JSON->true}]}},
+            {execute => 'migrate-incoming', arguments => {uri => 'exec:cat vm-snapshots/fakevm'}},
         );
     }
     push @expected, ({execute => 'cont'});


### PR DESCRIPTION
This reverts @Wabri 's changes from https://github.com/os-autoinst/os-autoinst/pull/2608 ,which I think were wrong, and instead addresses the missing coverage by mocking the qemu version discovery code so we can always test both paths regardless of what qemu is installed.