### PR TITLE
Remove extra arguments from testapi::send_key()

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -73,7 +73,7 @@ sub ensure_installed ($self, @pkglist) {
     else {
         die "TODO: implement 'ensure_installed' for your distri " . testapi::get_var('DISTRI', '');
     }
-    if ($testapi::password) { testapi::type_password; testapi::send_key("ret", 1, 0); }
+    if ($testapi::password) { testapi::type_password; testapi::send_key("ret"); }
     testapi::wait_still_screen(7, 90);    # wait for install
 }
 


### PR DESCRIPTION
Related Progress Ticket: https://progress.opensuse.org/issues/167941
- Send only 'key' arg to testapi::send_key() in ensure_installed