### PR TITLE
Apply code review suggestions to loadtestdir subtest

### DIFF
--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -449,12 +449,9 @@ subtest make_snapshot => sub {
 };
 
 subtest loadtestdir => sub {
-    use lib 't/data/tests';
-    $bmwqemu::vars{CASEDIR} = 't/data/tests';
+    $bmwqemu::vars{CASEDIR} = '.';
     stderr_like {
-        like warning {
-            autotest::loadtestdir('tests');
-        }, qr/ARRAY/, 'script found';
+        autotest::loadtestdir('t/data/tests/tests');
     } qr/scheduling/, 'loadscript success';
     ok exists $autotest::tests{'tests-boot'}, 'boot.pm loaded';
 };


### PR DESCRIPTION
Related progress ticket: https://progress.opensuse.org/issues/167926

- remove "use lib 't/data/tests';" from within loadtestdir subtest subroutine
- use relative path for casedir instead of path to test modules directory