### PR TITLE
autotest/loadtest: Update test fullname along with name when duplicated

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -177,7 +177,9 @@ sub loadtest ($script, %args) {
 
     my $nr = '';
     while (exists $tests{$fullname . $nr}) {
-        $test->{name} = join "#", $name, ++$nr;
+        my $new_name = join "#", $name, ++$nr;
+        $test->{name} = $new_name;
+        $test->{fullname} = "$category-$new_name";
     }
     $test->{name} = $args{name} if $args{name};
 

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -96,8 +96,9 @@ is(keys %autotest::tests, 2, 'two tests have been scheduled');
 loadtest 'start', 'rescheduling same step later';
 is(keys %autotest::tests, 3, 'three steps have been scheduled (one twice)') || diag explain %autotest::tests;
 is($autotest::tests{'tests-start1'}->{name}, 'start#1', 'handle duplicate tests');
+is($autotest::tests{'tests-start1'}->{fullname}, 'tests-start#1', 'duplicate test has correct fullname');
 is($autotest::tests{'tests-start1'}->{$_}, $autotest::tests{'tests-start'}->{$_}, "duplicate tests point to the same $_")
-  for qw(script fullname category class);
+  for qw(script category class);
 
 like warning {
     stderr_like { autotest::run_all } qr/Sending tests_done/, 'tests_done sent';


### PR DESCRIPTION
Currently, if the developer choose to take control of the test and pause at a duplicate, the job will not pause. The issue is that [_handle_command_set_current_test](https://github.com/os-autoinst/os-autoinst/blob/master/OpenQA/Isotovideo/CommandHandler.pm#L282)  in OpenQA/Isotovideo/CommandHandler.pm needs the correct $full_test_name, which might not be accurate anymore. Fix this by also updating the test "fullname" in loadtest.

Test runs (with some extra debugging prints):
- Without patch:
Pause scheduled: https://rmarliere-openqa.qe.prg2.suse.org/tests/1134/logfile?filename=autoinst-log.txt#line-3624
Fullname mismatch impeding pause: https://rmarliere-openqa.qe.prg2.suse.org/tests/1134/logfile?filename=autoinst-log.txt#line-6969
- With patch:
Pause scheduled: https://rmarliere-openqa.qe.prg2.suse.org/tests/1135/logfile?filename=autoinst-log.txt#line-102
Execution paused: https://rmarliere-openqa.qe.prg2.suse.org/tests/1135/logfile?filename=autoinst-log.txt#line-7059

NOTE: fullname is being sent by the [openQA UI](https://github.com/os-autoinst/openQA/blob/master/assets/javascripts/running.js#L811).