### PR TITLE
t: Fix hidden output of 'diag explain'

### DIFF
--- a/t/01-test_needle.t
+++ b/t/01-test_needle.t
@@ -27,7 +27,7 @@ sub _cmp_similarity ($area, $expected_similarity) {
     my $similarity = delete $area->{similarity};
     my $difference = abs($similarity - $expected_similarity);
     cmp_ok $difference, '<', '0.01', 'similarity within tolerance'
-      or diag explain "actual similarity: $similarity, expected similarity: $expected_similarity";
+      or always_explain "actual similarity: $similarity, expected similarity: $expected_similarity";
 }
 
 throws_ok(
@@ -158,9 +158,9 @@ subtest 'handle failure to load image' => sub {
         my ($best_candidate, $candidates) = $image->search([$needle_without_png, $needle_with_png]);
         ok($best_candidate, 'has best candidate');
         is($best_candidate->{needle}, $needle_with_png, 'needle with png is best candidate')
-          or diag explain $best_candidate;
+          or always_explain $best_candidate;
         is_deeply($candidates, [], 'missing needle not even considered as candidate')
-          or diag explain $candidates;
+          or always_explain $candidates;
     }
     qr{.*Could not open image .*$missing_needle_path.*\n.*skipping console\.ref\: missing PNG.*},
       'needle with missing PNG skipped';

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -94,7 +94,7 @@ loadtest 'start';
 loadtest 'next';
 is(keys %autotest::tests, 2, 'two tests have been scheduled');
 loadtest 'start', 'rescheduling same step later';
-is(keys %autotest::tests, 3, 'three steps have been scheduled (one twice)') || diag explain %autotest::tests;
+is(keys %autotest::tests, 3, 'three steps have been scheduled (one twice)') || always_explain %autotest::tests;
 is($autotest::tests{'tests-start1'}->{name}, 'start#1', 'handle duplicate tests');
 is($autotest::tests{'tests-start1'}->{fullname}, 'tests-start#1', 'duplicate test has correct fullname');
 is($autotest::tests{'tests-start1'}->{$_}, $autotest::tests{'tests-start'}->{$_}, "duplicate tests point to the same $_")

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -102,7 +102,7 @@ subtest 'isotovideo with custom git repo parameters specified' => sub {
     # run during a `git rebase -x 'make test'`
     delete @ENV{qw(GIT_DIR GIT_REFLOG_ACTION GIT_WORK_TREE)};
     my $git_init_output = qx{git init -q --bare repo.git 2>&1};
-    is($?, 0, 'initialized test repo') or diag explain $git_init_output;
+    is($?, 0, 'initialized test repo') or always_explain $git_init_output;
     # Ensure the checkout folder does not exist so that git clone tries to
     # create a new checkout on every test run
     remove_tree('repo');

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -94,7 +94,7 @@ subtest run_post_fail_test => sub {
         is_deeply $cmds->[0], \%pause_on_failure, 'failure reported to pause if pausing on failures enabled';
         my %test_name_update = (cmd => 'set_current_test', name => 'foo', full_name => 'foo (post fail hook)');
         is_deeply $cmds->[1], \%test_name_update, 'test name updated (to show post fail hook in developer mode)';
-    } or diag explain $cmds;
+    } or always_explain $cmds;
 
     $bmwqemu::vars{_SKIP_POST_FAIL_HOOKS} = 1;
     combined_like { dies_ok { $basetest->runtest } 'behavior persists regardless of _SKIP_POST_FAIL_HOOKS setting' }
@@ -369,7 +369,7 @@ subtest record_screenmatch => sub {
                 result => 'ok',
             }
     ], 'screenmatch detail recorded as expected')
-      or diag explain $basetest->{details};
+      or always_explain $basetest->{details};
 
     # check a needle has workaround property
     my $basetest_for_workaround = basetest->new();
@@ -427,7 +427,7 @@ subtest record_screenmatch => sub {
                 dent => 1,
             }
     ], 'screenmatch detail with workaround property recorded as expected')
-      or diag explain $basetest_for_workaround->{details};
+      or always_explain $basetest_for_workaround->{details};
 };
 
 subtest 'register_extra_test_results' => sub {
@@ -500,7 +500,7 @@ $mock_bmwqemu->noop('fctres', 'fctinfo');
 subtest verify_sound_image => sub {
     my $test = basetest->new();
     my $res = $test->verify_sound_image("$FindBin::Bin/data/frame1.ppm", 'notapath2', 'check');
-    is_deeply($res->{area}, [{x => 1, y => 2, similarity => 100}], 'area was returned') or diag explain $res->{area};
+    is_deeply($res->{area}, [{x => 1, y => 2, similarity => 100}], 'area was returned') or always_explain $res->{area};
     is($res->{needle}->{file}, 'foundneedle.json', 'needle file was returned');
     is($res->{needle}->{name}, 'foundneedle', 'needle name was returned');
     $suppress_match = 'yes';
@@ -508,11 +508,11 @@ subtest verify_sound_image => sub {
     my $mock_test = Test::MockModule->new('basetest');
     $mock_test->mock(record_screenfail => sub { my ($self, %args) = @_; $details = \%args; });
     $res = $test->verify_sound_image("$FindBin::Bin/data/frame1.ppm", "$FindBin::Bin/data/frame2.ppm", 1);
-    is($res, undef, 'res is undef as expected') or diag explain $res;
-    is($details->{result}, 'unk', 'no needle match: unknown status correct') or diag explain $details;
+    is($res, undef, 'res is undef as expected') or always_explain $res;
+    is($details->{result}, 'unk', 'no needle match: unknown status correct') or always_explain $details;
     $res = $test->verify_sound_image("$FindBin::Bin/data/frame1.ppm", "$FindBin::Bin/data/frame2.ppm", 0);
-    is($details->{result}, 'fail', 'no needle match: status fail') or diag explain $details;
-    is($details->{overall}, 'fail', 'no needle match: overall fail') or diag explain $details;
+    is($details->{result}, 'fail', 'no needle match: status fail') or always_explain $details;
+    is($details->{overall}, 'fail', 'no needle match: overall fail') or always_explain $details;
 };
 
 $mock_bmwqemu->noop('diag', 'modstate');

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -159,38 +159,38 @@ subtest 'setting graphics backend' => sub {
     local *backend::qemu::sp = sub (@args) { @params = @args };
     $bmwqemu::vars{ARCH} = 'x86_64';
     $backend->_set_graphics_backend();
-    is_deeply \@params, [device => 'VGA,edid=on,xres=1024,yres=768'], 'default backend is VGA with EDID info (no QEMUVGA or QEMU_VIDEO_DEVICE set)' or diag explain \@params;
+    is_deeply \@params, [device => 'VGA,edid=on,xres=1024,yres=768'], 'default backend is VGA with EDID info (no QEMUVGA or QEMU_VIDEO_DEVICE set)' or always_explain \@params;
 
     $bmwqemu::vars{ARCH} = 'aarch64';
     $backend->_set_graphics_backend();
-    is_deeply \@params, [device => 'virtio-gpu-pci,edid=on,xres=1024,yres=768'], 'default backend for ARM is virtio with EDID info (no QEMUVGA or QEMU_VIDEO_DEVICE set)' or diag explain \@params;
+    is_deeply \@params, [device => 'virtio-gpu-pci,edid=on,xres=1024,yres=768'], 'default backend for ARM is virtio with EDID info (no QEMUVGA or QEMU_VIDEO_DEVICE set)' or always_explain \@params;
 
     $bmwqemu::vars{QEMU_OVERRIDE_VIDEO_DEVICE_AARCH64} = '1';
     $backend->_set_graphics_backend();
-    is_deeply \@params, [device => 'VGA,edid=on,xres=1024,yres=768'], 'QEMU_OVERRIDE_VIDEO_DEVICE_AARCH64 changes ARM default to VGA' or diag explain \@params;
+    is_deeply \@params, [device => 'VGA,edid=on,xres=1024,yres=768'], 'QEMU_OVERRIDE_VIDEO_DEVICE_AARCH64 changes ARM default to VGA' or always_explain \@params;
     delete $bmwqemu::vars{QEMU_OVERRIDE_VIDEO_DEVICE_AARCH64};
 
     $bmwqemu::vars{ARCH} = 's390x';
     $backend->_set_graphics_backend();
-    is_deeply \@params, [device => 'virtio-gpu,edid=on,xres=1024,yres=768'], 'default backend for s390x sets graphics backend' or diag explain \@params;
+    is_deeply \@params, [device => 'virtio-gpu,edid=on,xres=1024,yres=768'], 'default backend for s390x sets graphics backend' or always_explain \@params;
 
     $bmwqemu::vars{ARCH} = 'x86_64';
     $bmwqemu::vars{QEMUVGA} = 'virtio';
     $backend->_set_graphics_backend();
-    is_deeply \@params, [device => 'virtio-vga,edid=on,xres=1024,yres=768'], 'QEMUVGA=virtio results in device virtio-vga with EDID info' or diag explain \@params;
+    is_deeply \@params, [device => 'virtio-vga,edid=on,xres=1024,yres=768'], 'QEMUVGA=virtio results in device virtio-vga with EDID info' or always_explain \@params;
 
     $bmwqemu::vars{QEMUVGA} = 'cirrus';
     $backend->_set_graphics_backend();
-    is_deeply \@params, [device => 'cirrus-vga'], 'QEMUVGA=cirrus results in device cirrus-vga with no EDID info' or diag explain \@params;
+    is_deeply \@params, [device => 'cirrus-vga'], 'QEMUVGA=cirrus results in device cirrus-vga with no EDID info' or always_explain \@params;
 
     $bmwqemu::vars{QEMU_VIDEO_DEVICE} = 'virtio-vga';
     $backend->_set_graphics_backend();
-    is_deeply \@params, [device => 'virtio-vga,edid=on,xres=1024,yres=768'], 'QEMU_VIDEO_DEVICE wins if both it and QEMUVGA are set' or diag explain \@params;
+    is_deeply \@params, [device => 'virtio-vga,edid=on,xres=1024,yres=768'], 'QEMU_VIDEO_DEVICE wins if both it and QEMUVGA are set' or always_explain \@params;
 
     delete $bmwqemu::vars{QEMUVGA};
     $bmwqemu::vars{QEMU_VIDEO_DEVICE_OPTIONS} = 'foo=bar';
     $backend->_set_graphics_backend();
-    is_deeply \@params, [device => 'virtio-vga,edid=on,xres=1024,yres=768,foo=bar'], 'QEMU_VIDEO_DEVICE_OPTIONS gets appended to EDID values' or diag explain \@params;
+    is_deeply \@params, [device => 'virtio-vga,edid=on,xres=1024,yres=768,foo=bar'], 'QEMU_VIDEO_DEVICE_OPTIONS gets appended to EDID values' or always_explain \@params;
 };
 
 sub qemu_cmdline (%args) {
@@ -317,7 +317,7 @@ subtest 'capturing audio' => sub {
         }, {
             arguments => {'command-line' => 'stopcapture 0'},
             execute => 'human-monitor-command',
-        }], 'expected QMP command called' or diag explain $called{handle_qmp_command};
+        }], 'expected QMP command called' or always_explain $called{handle_qmp_command};
 };
 
 subtest 'wait functions' => sub {
@@ -348,8 +348,8 @@ subtest 'wait functions' => sub {
         $fake_qmp_answer = {return => {status => 'completed', ram => {total => 41, remaining => 15}}};
         $$invoked_qmp_cmds = undef;
         $backend->_wait_for_migrate;
-        is_deeply $$invoked_qmp_cmds, [{execute => 'query-migrate'}], 'migration queried' or diag explain $$invoked_qmp_cmds;
-        is_deeply \@wait_args, [$backend, qr/paused|finish-migrate/], 'waited for status change' or diag explain \@wait_args;
+        is_deeply $$invoked_qmp_cmds, [{execute => 'query-migrate'}], 'migration queried' or always_explain $$invoked_qmp_cmds;
+        is_deeply \@wait_args, [$backend, qr/paused|finish-migrate/], 'waited for status change' or always_explain \@wait_args;
     };
 };
 
@@ -368,7 +368,7 @@ subtest 'migration to file_qemu8' => sub {
         {execute => 'stop'},
         {execute => 'migrate', arguments => {uri => 'fd:dumpfd'}}
     );
-    is_deeply $$invoked_qmp_cmds, \@expected, 'expected QMP commands invoked' or diag explain $$invoked_qmp_cmds;
+    is_deeply $$invoked_qmp_cmds, \@expected, 'expected QMP commands invoked' or always_explain $$invoked_qmp_cmds;
     $backend_mock->unmock('determine_qemu_version');
 };
 
@@ -389,14 +389,14 @@ subtest 'migration to file_qemu9' => sub {
         {execute => 'stop'},
         {execute => 'migrate', arguments => {uri => 'file:dumpfd'}}
     );
-    is_deeply $$invoked_qmp_cmds, \@expected, 'expected QMP commands invoked' or diag explain $$invoked_qmp_cmds;
+    is_deeply $$invoked_qmp_cmds, \@expected, 'expected QMP commands invoked' or always_explain $$invoked_qmp_cmds;
     $backend_mock->unmock('determine_qemu_version');
 };
 
 subtest 'misc functions' => sub {
     $backend->{proc}->_process(Test::MockObject->set_always(pid => $$));
     my $res = $backend->cpu_stat;
-    is scalar @$res, 2, 'cpu_stat returns two values' or diag explain $res;
+    is scalar @$res, 2, 'cpu_stat returns two values' or always_explain $res;
     ok looks_like_number($res->[$_]), "cpu_stat value $_ is a number" for (0, 1);
 
     $bmwqemu::vars{HDDMODEL} = 'nvme';
@@ -407,14 +407,14 @@ subtest 'misc functions' => sub {
     is_deeply $called{handle_qmp_command}, [{
             execute => 'migrate-set-capabilities',
             arguments => {capabilities => [{capability => 'foo', state => Mojo::JSON::false}]},
-    }], 'expected QMP command called for "set_migrate_capability"' or diag explain $called{handle_qmp_command};
+    }], 'expected QMP command called for "set_migrate_capability"' or always_explain $called{handle_qmp_command};
 
     $called{handle_qmp_command} = undef;
     $backend->open_file_and_send_fd_to_qemu("$Bin/$Script", 'foo');
     is_deeply $called{handle_qmp_command}, [{
             execute => 'getfd',
             arguments => {fdname => 'foo'},
-    }], 'expected QMP command called for "open_file_and_send_fd_to_qemu"' or diag explain $called{handle_qmp_command};
+    }], 'expected QMP command called for "open_file_and_send_fd_to_qemu"' or always_explain $called{handle_qmp_command};
 
     @bmwqemu::ovmf_locations = ('does not exist', "$Bin/$Script", 'does not exist either');
     is backend::qemu::find_ovmf, "$Bin/$Script", 'locating ovmf (normally "/usr/share/qemu/ovmf-x86_64-ms-code.bin")';
@@ -446,7 +446,7 @@ subtest 'saving memory dump qemu8' => sub {
         {execute => 'migrate', arguments => {uri => 'fd:dumpfd'}},
         {execute => 'cont'}
     );
-    is_deeply $called{handle_qmp_command}, \@expected, 'expected QMP command called for "save_memory_dump"' or diag explain $called{handle_qmp_command};
+    is_deeply $called{handle_qmp_command}, \@expected, 'expected QMP command called for "save_memory_dump"' or always_explain $called{handle_qmp_command};
     is $runcmd, 'xz --no-warn -T 1 -v6 ulogs/foo-vm-memory-dump', 'expected compression command invoked';
 
     $which_mock->redefine(which => undef);
@@ -502,19 +502,19 @@ subtest '"balloon" handling' => sub {
     $$invoked_qmp_cmds = undef;
     $backend->inflate_balloon;
     $backend->deflate_balloon;
-    is_deeply $$invoked_qmp_cmds, undef, 'no QMP commands invoked without QEMU_BALLOON_TARGET' or diag explain $$invoked_qmp_cmds;
+    is_deeply $$invoked_qmp_cmds, undef, 'no QMP commands invoked without QEMU_BALLOON_TARGET' or always_explain $$invoked_qmp_cmds;
 
     $bmwqemu::vars{QEMU_BALLOON_TARGET} = 1;
     $backend->inflate_balloon;
     is_deeply $$invoked_qmp_cmds, [
         {execute => 'balloon', arguments => {value => 1048576}}, {execute => 'query-balloon'}, {execute => 'query-balloon'}
-    ], 'expected QMP commands invoked when "inflating balloon"' or diag explain $$invoked_qmp_cmds;
+    ], 'expected QMP commands invoked when "inflating balloon"' or always_explain $$invoked_qmp_cmds;
 
     $$invoked_qmp_cmds = undef;
     $backend->deflate_balloon;
     is_deeply $$invoked_qmp_cmds, [
         {execute => 'balloon', arguments => {value => 1073741824}}    # QEMURAM * 1048576
-    ], 'expected QMP commands invoked when "deflating balloon"' or diag explain $$invoked_qmp_cmds;
+    ], 'expected QMP commands invoked when "deflating balloon"' or always_explain $$invoked_qmp_cmds;
 };
 
 subtest 'snapshot handling' => sub {
@@ -537,7 +537,7 @@ subtest 'snapshot handling' => sub {
                 format => 'qcow2', 'node-name' => 'some-id', 'snapshot-file' => "$dir/raid/some-id-overlay1", 'snapshot-node-name' => 'some-id-overlay1'},
         },
         {execute => 'cont'},
-    ], 'expected QMP commands invoked when saving snapshot' or diag explain $$invoked_qmp_cmds;
+    ], 'expected QMP commands invoked when saving snapshot' or always_explain $$invoked_qmp_cmds;
 
     # save the snapshot again again assuming the blockdev-snapshot-sync call fails
     my %first_overlay = (
@@ -554,7 +554,7 @@ subtest 'snapshot handling' => sub {
     combined_like { $backend->save_snapshot({name => 'fakevm'}) } qr/snapshot complete/i, 'completion logged (2)';
     is_deeply $$invoked_qmp_cmds, [
         {execute => 'query-status'}, {execute => 'stop'}, \%first_overlay, \%first_overlay, \%second_overlay, \%second_overlay, {execute => 'cont'},
-    ], 'expected QMP commands invoked when saving snapshot with error' or diag explain $$invoked_qmp_cmds;
+    ], 'expected QMP commands invoked when saving snapshot with error' or always_explain $$invoked_qmp_cmds;
 
     # load snapshot with different mocked qemu versions to test args
     $backend_mock->redefine(determine_qemu_version => sub ($self, $qemubin) { $self->{qemu_version} = '8.2' });
@@ -570,7 +570,7 @@ subtest 'snapshot handling' => sub {
         {execute => 'migrate-incoming', arguments => {uri => 'exec:cat vm-snapshots/fakevm'}},
         {execute => 'cont'}
     );
-    is_deeply $$invoked_qmp_cmds, \@expected, 'expected QMP commands invoked when loading snapshot (qemu 8)' or diag explain $$invoked_qmp_cmds;
+    is_deeply $$invoked_qmp_cmds, \@expected, 'expected QMP commands invoked when loading snapshot (qemu 8)' or always_explain $$invoked_qmp_cmds;
     $$invoked_qmp_cmds = undef;
     $backend_mock->redefine(determine_qemu_version => sub ($self, $qemubin) { $self->{qemu_version} = '9.2' });
     $backend->determine_qemu_version('foo');
@@ -586,7 +586,7 @@ subtest 'snapshot handling' => sub {
         {execute => 'migrate-incoming', arguments => {uri => 'file:dumpfd'}},
         {execute => 'cont'}
     );
-    is_deeply $$invoked_qmp_cmds, \@expected, 'expected QMP commands invoked when loading snapshot (qemu 9)' or diag explain $$invoked_qmp_cmds;
+    is_deeply $$invoked_qmp_cmds, \@expected, 'expected QMP commands invoked when loading snapshot (qemu 9)' or always_explain $$invoked_qmp_cmds;
     $backend_mock->unmock('determine_qemu_version');
 };
 
@@ -642,7 +642,7 @@ subtest 'save storage' => sub {
             },
             execute => 'blockdev-backup'},
         {execute => 'query-jobs'},
-        {execute => 'cont'}], 'excepted QMP commands when saving storage' or diag explain $$invoked_qmp_cmds;
+        {execute => 'cont'}], 'excepted QMP commands when saving storage' or always_explain $$invoked_qmp_cmds;
     # timeout exceeded
     $bmwqemu::vars{SAVE_STORAGE_TIMEOUT} = 2;
     $i = 0;
@@ -704,7 +704,7 @@ subtest 'special cases when starting QEMU' => sub {
         'vdecmd -s ./vde.mgmt port/remove 86', 'vdecmd -s ./vde.mgmt port/create 86', 'vdecmd -s ./vde.mgmt vlan/create foovlan',
         'vdecmd -s ./vde.mgmt port/setvlan 86 foovlan', 'vdecmd -s ./vde.mgmt port/setvlan 87 foovlan',
         "swtpm socket --tpmstate dir=$dir/mytpm6 --ctrl type=unixio,path=$dir/mytpm6/swtpm-sock --log level=20 -d"
-    ], 'vde and swtpm commands invoked' or diag explain \@invoked_cmds;
+    ], 'vde and swtpm commands invoked' or always_explain \@invoked_cmds;
 
     # set different parameters to test more cases
     $bmwqemu::vars{UEFI} = $bmwqemu::vars{UEFI_PFLASH} = 0;
@@ -732,8 +732,8 @@ subtest 'special cases when starting QEMU' => sub {
     is $bmwqemu::vars{BOOTFROM}, 'd', 'BOOTFROM set to "d" for "cdrom"';
     like $qemu_params, qr{canokey,file=canokey}, 'canokey parameter present due to FIDO2=1';
     is scalar @dbus_invocations, 2, 'two D-Bus invocatios made';
-    is_deeply $dbus_invocations[0], [$backend, set_vlan => 'tap2', 'foovlan'], 'vlan set for tap device via D-Bus call' or diag explain \@dbus_invocations;
-    is_deeply $dbus_invocations[1], [$backend, 'show'], 'networking status shown for OVS_DEBUG=1' or diag explain \@dbus_invocations;
+    is_deeply $dbus_invocations[0], [$backend, set_vlan => 'tap2', 'foovlan'], 'vlan set for tap device via D-Bus call' or always_explain \@dbus_invocations;
+    is_deeply $dbus_invocations[1], [$backend, 'show'], 'networking status shown for OVS_DEBUG=1' or always_explain \@dbus_invocations;
     if (is ref $callbacks{cleanup}, 'CODE', 'cleanup callback set') {
         $callbacks{cleanup}->();
         is_deeply $dbus_invocations[2], [$backend, unset_vlan => 'tap2', 'foovlan'], 'vlan unset in cleanup handler via D-Bus call';

--- a/t/18-qemu.t
+++ b/t/18-qemu.t
@@ -418,7 +418,7 @@ subtest 'relative assets' => sub {
         [qw(create -f qcow2 -F raw -b), "$Bin/data/uefi-code.bin", "raid/pflash-code-overlay0", 1966080],
         [qw(create -f qcow2 -F qcow2 -b), "$dir/some.qcow2", "raid/pflash-vars-overlay0", 512],
     );
-    is_deeply(\@gcmdl, \@cmdl, 'find the asset real path') or diag explain \@gcmdl;
+    is_deeply(\@gcmdl, \@cmdl, 'find the asset real path') or always_explain \@gcmdl;
 };
 
 subtest 'qemu was killed due to the system being out of memory' => sub {

--- a/t/21-needle-downloader.t
+++ b/t/21-needle-downloader.t
@@ -97,13 +97,13 @@ subtest 'add relevant downloads' => sub {
     qr/.*skipping downloading new needle: $needles_dir\/foo\.png seems already up-to-date.*/,
       'skipped downloads logged';
     is_deeply($downloader->files_to_download, \@expected_downloads, 'downloads added')
-      or diag explain $downloader->files_to_download;
+      or always_explain $downloader->files_to_download;
 
     subtest 'limit applied' => sub {
         $downloader->download_limit(3);
         $downloader->add_relevant_downloads(\@new_needles);
         is_deeply($downloader->files_to_download, \@expected_downloads, 'no more downloads added')
-          or diag explain $downloader->files_to_download;
+          or always_explain $downloader->files_to_download;
     };
 };
 

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -80,13 +80,13 @@ is_deeply($svirt_sut_console, {
         serial_port_no => 1,
         testapi_console => 'root-sut-serial',
         pty_dev => SERIAL_TERMINAL_DEFAULT_DEVICE,
-}, 'SUT serial console correctly initialized') or diag explain $consoles;
+}, 'SUT serial console correctly initialized') or always_explain $consoles;
 
 sub _is_xml ($actual_xml_data, $expected_xml_file_path) {
     my $diff = XML::SemanticDiff->new(keeplinenums => 1);
     if (my @changes = $diff->compare($actual_xml_data, $expected_xml_file_path)) {
         fail 'XML not as expected';    # uncoverable statement
-        diag explain 'differences:', \@changes;    # uncoverable statement
+        always_explain 'differences:', \@changes;    # uncoverable statement
         note 'produced XML:';    # uncoverable statement
         note $actual_xml_data;    # uncoverable statement
         return 0;    # uncoverable statement
@@ -215,7 +215,7 @@ subtest 'starting VMware console' => sub {
         'echo \'bios.bootDelay = "10000"\' >> /vmfs/volumes/datastore1/openQA/openQA-SUT-1.vmx',
         $s . ' start openQA-SUT-1 2> >(tee /tmp/os-autoinst-openQA-SUT-1-stderr.log >&2)',
         $s . ' dumpxml openQA-SUT-1'
-    ], 'expected commands invoked' or diag explain \@cmds;
+    ], 'expected commands invoked' or always_explain \@cmds;
 };
 
 subtest 'test config encoding' => sub {
@@ -288,7 +288,7 @@ subtest 'starting VMware console with combustion' => sub {
         'echo \'guestinfo.combustion.script = "testingCombustion"\' >> /vmfs/volumes/datastore1/openQA/openQA-SUT-1.vmx',
         $s . ' start openQA-SUT-1 2> >(tee /tmp/os-autoinst-openQA-SUT-1-stderr.log >&2)',
         $s . ' dumpxml openQA-SUT-1'
-    ], 'expected commands invoked' or diag explain \@cmds;
+    ], 'expected commands invoked' or always_explain \@cmds;
 };
 
 subtest 'starting VMware console with ignition' => sub {
@@ -324,7 +324,7 @@ subtest 'starting VMware console with ignition' => sub {
         'echo \'guestinfo.ignition.config.data = "ignitionTEST"\' >> /vmfs/volumes/datastore1/openQA/openQA-SUT-1.vmx',
         $s . ' start openQA-SUT-1 2> >(tee /tmp/os-autoinst-openQA-SUT-1-stderr.log >&2)',
         $s . ' dumpxml openQA-SUT-1'
-    ], 'expected commands invoked' or diag explain \@cmds;
+    ], 'expected commands invoked' or always_explain \@cmds;
 };
 
 subtest 'starting VMware console with cloud-init' => sub {
@@ -362,7 +362,7 @@ subtest 'starting VMware console with cloud-init' => sub {
         'echo \'guestinfo.metadata = "CI_test_CONF"\' >> /vmfs/volumes/datastore1/openQA/openQA-SUT-1.vmx',
         $s . ' start openQA-SUT-1 2> >(tee /tmp/os-autoinst-openQA-SUT-1-stderr.log >&2)',
         $s . ' dumpxml openQA-SUT-1'
-    ], 'expected commands invoked' or diag explain \@cmds;
+    ], 'expected commands invoked' or always_explain \@cmds;
 };
 
 subtest 'SSH credentials' => sub {

--- a/t/27-consoles-vmware.t
+++ b/t/27-consoles-vmware.t
@@ -64,7 +64,7 @@ subtest 'test configuration with fake URL' => sub {
     $fake_vnc->called_pos_ok(6, 'description', 'description assigned');
     $fake_vnc->called_args_pos_is(6, 2, 'VNC over WebSockets server provided by VMWare', 'description set accordingly');
     is_deeply \@dewebsockify_args, [12345, 'wss://foo', 'session'], 'dewebsockify called with expected args'
-      or diag explain \@dewebsockify_args;
+      or always_explain \@dewebsockify_args;
     is $vmware->host, 'foo.bar', 'hostname set';
     is $vmware->vm_id, undef, 'no VM-ID set (as our URL did not include one)';
     is $vmware->username, 'root', 'username set';

--- a/t/29-backend-generalhw.t
+++ b/t/29-backend-generalhw.t
@@ -80,8 +80,8 @@ subtest 'start VM' => sub {
     is_deeply(\@invoked_cmds, [
             [$cmd_ctl, 'poweroff'], [$cmd_ctl, 'flash', 'light', '/hdd', '5G'], [$cmd_ctl, 'poweroff'],
             ['sleep', 3], [$cmd_ctl, 'poweron'], 'start_serial_grab'
-    ], 'poweroff/on commands invoked') or diag explain \@invoked_cmds;
-    is_deeply(\@vnc_logins, [['vnc.server']], 'tried to connect to VNC server') or diag explain \@vnc_logins;
+    ], 'poweroff/on commands invoked') or always_explain \@invoked_cmds;
+    is_deeply(\@vnc_logins, [['vnc.server']], 'tried to connect to VNC server') or always_explain \@vnc_logins;
 };
 
 subtest 'start VM with video' => sub {
@@ -94,8 +94,8 @@ subtest 'start VM with video' => sub {
     is_deeply(\@invoked_cmds, [
             [$cmd_ctl, 'poweroff'], [$cmd_ctl, 'flash', 'light', '/hdd', '5G'], [$cmd_ctl, 'poweroff'],
             ['sleep', 3], [$cmd_ctl, 'poweron'], 'start_serial_grab'
-    ], 'poweroff/on commands invoked') or diag explain \@invoked_cmds;
-    is_deeply(\@video_connects, [['udp://@:5004']], 'tried to connect to video stream') or diag explain \@vnc_logins;
+    ], 'poweroff/on commands invoked') or always_explain \@invoked_cmds;
+    is_deeply(\@video_connects, [['udp://@:5004']], 'tried to connect to video stream') or always_explain \@vnc_logins;
 };
 
 subtest 'hdd args' => sub {
@@ -109,7 +109,7 @@ subtest 'hdd args' => sub {
 subtest 'stop VM' => sub {
     @invoked_cmds = ();
     is_deeply($backend->do_stop_vm, {}, 'return value');
-    is_deeply(\@invoked_cmds, [[$cmd_ctl, 'poweroff']], 'poweroff/on commands invoked') or diag explain \@invoked_cmds;
+    is_deeply(\@invoked_cmds, [[$cmd_ctl, 'poweroff']], 'poweroff/on commands invoked') or always_explain \@invoked_cmds;
 };
 
 subtest 'eject_cd' => sub {
@@ -121,7 +121,7 @@ subtest 'eject_cd' => sub {
             [$cmd_ctl, 'eject'],
             [$cmd_ctl, 'eject', '--id=cd1'],
             [$cmd_ctl, 'eject', '--force'],
-    ], 'eject commands invoked') or diag explain \@invoked_cmds;
+    ], 'eject commands invoked') or always_explain \@invoked_cmds;
 };
 
 subtest 'error handling' => sub {
@@ -156,7 +156,7 @@ subtest 'handling power commands' => sub {
     $mock->redefine(run_cmd => sub ($self, $cmd, @extra_args) { push @invoked_cmds, $cmd });
     $backend->power({action => 'on'});
     $backend->power({action => 'off'});
-    is_deeply \@invoked_cmds, ['GENERAL_HW_POWERON_CMD', 'GENERAL_HW_POWEROFF_CMD'], 'power commands invoked' or diag explain \@invoked_cmds;
+    is_deeply \@invoked_cmds, ['GENERAL_HW_POWERON_CMD', 'GENERAL_HW_POWEROFF_CMD'], 'power commands invoked' or always_explain \@invoked_cmds;
     throws_ok { $backend->power({action => 'foo'}) } qr/not implemented/, 'dies on invalid action';
 };
 
@@ -204,8 +204,8 @@ subtest 'extracting assets' => sub {
     my (@invoked_cmds, @extra_args);
     $mock->redefine(run_cmd => sub ($self, $cmd, @args) { push @invoked_cmds, $cmd; push @extra_args, @args });
     $backend->do_extract_assets({@args});
-    is_deeply \@invoked_cmds, ['GENERAL_HW_IMAGE_CMD'], 'image command invoked' or diag explain \@invoked_cmds;
-    is_deeply \@extra_args, [41, 'bar/foo'], 'image path passed' or diag explain \@extra_args;
+    is_deeply \@invoked_cmds, ['GENERAL_HW_IMAGE_CMD'], 'image command invoked' or always_explain \@invoked_cmds;
+    is_deeply \@extra_args, [41, 'bar/foo'], 'image path passed' or always_explain \@extra_args;
 };
 
 done_testing();

--- a/t/30-mmapi.t
+++ b/t/30-mmapi.t
@@ -50,13 +50,13 @@ sub call ($function_name, @args) {
 # test without a server
 subtest 'mmapi: server not reachable' => sub {
     combined_like { is_deeply call($_), undef, "undef returned ($_)" } qr/Connection error/, "error logged ($_)" for (qw(mmapi::get_children));
-    is_deeply(\@recorded_info, [], 'no info recorded') or diag explain \@recorded_info;
+    is_deeply(\@recorded_info, [], 'no info recorded') or always_explain \@recorded_info;
 };
 
 subtest 'lockapi: server not reachable' => sub {
     combined_like { is call($_, qw(name where info)), 0, "zero returned $_" } qr/Connection error/, "error logged ($_)"
       for (qw(lockapi::mutex_create lockapi::mutex_try_lock lockapi::barrier_create lockapi::barrier_try_wait));
-    is_deeply(\@recorded_info, [], 'no info recorded') or diag explain \@recorded_info;
+    is_deeply(\@recorded_info, [], 'no info recorded') or always_explain \@recorded_info;
 };
 
 # setup a fake server
@@ -164,7 +164,7 @@ subtest 'mmapi: general usage' => sub {
     $mmapi_mock->redefine(get_job_autoinst_url => sub { '/autoinst' });
     is_deeply(mmapi::get_job_autoinst_vars(100), {foo => 'bar'}, 'get autoinst vars');
 
-    is_deeply(\@recorded_info, [], 'no info recorded') or diag explain \@recorded_info;
+    is_deeply(\@recorded_info, [], 'no info recorded') or always_explain \@recorded_info;
 };
 
 subtest 'lockapi: misuse' => sub {
@@ -174,7 +174,7 @@ subtest 'lockapi: misuse' => sub {
       for (qw(lockapi::barrier_create lockapi::barrier_wait lockapi::barrier_destroy));
     combined_like { throws_ok { call($_, 'foo', '') } qr/mydie/, "no task throws ($_)" } qr/missing.*task/, "no task logged ($_)"
       for (qw(lockapi::barrier_create));
-    is_deeply(\@recorded_info, [], 'no info recorded') or diag explain \@recorded_info;
+    is_deeply(\@recorded_info, [], 'no info recorded') or always_explain \@recorded_info;
 };
 
 subtest 'lockapi: server returns error' => sub {
@@ -186,7 +186,7 @@ subtest 'lockapi: server returns error' => sub {
       for (qw(lockapi::mutex_try_lock lockapi::mutex_unlock lockapi::barrier_try_wait));
     combined_like { throws_ok { call($_, 'finished_lock') } qr/mydie/, "owner finished throws ($_)" } qr/owner already finished/, "finished logged ($_)"
       for (qw(lockapi::mutex_try_lock));
-    is_deeply(\@recorded_info, [], 'no info recorded') or diag explain \@recorded_info;
+    is_deeply(\@recorded_info, [], 'no info recorded') or always_explain \@recorded_info;
     # note: Omitting lockapi::mutex_lock and lockapi::barrier_wait here to avoid being blocked infinitely.
 };
 
@@ -204,7 +204,7 @@ subtest 'lockapi: successful use' => sub {
         is lockapi::barrier_try_wait('unblocked'), 1, 'tried waiting for barrier';
         is lockapi::barrier_destroy('deletable'), 1, 'barrier destroyed';
     } qr/mutex create.*mutex lock.*mutex try lock.*mutex unlock.*barrier create.*barrier wait.*barrier try wait.*barrier destroy/s, 'logging';
-    is scalar @recorded_info, 2, 'record info called expected number of times' or diag explain \@recorded_info;
+    is scalar @recorded_info, 2, 'record info called expected number of times' or always_explain \@recorded_info;
 };
 
 subtest 'lockapi::barrier_wait() failures' => sub {

--- a/t/34-git.t
+++ b/t/34-git.t
@@ -176,7 +176,7 @@ subtest 'cloning with caching' => sub {
         is ref $repo_entry, 'HASH', "entry for '$repo_path' exists" or return;
         cmp_ok $repo_entry->{size}, '>', 0, 'valid size assigned';
         cmp_ok $repo_entry->{last_use}, '>=', $start_time, 'valid last use assigned';
-    } or diag explain $index;
+    } or always_explain $index;
 
     subtest 'limit size of cache directory' => sub {
         sleep 10;    # simulate time has passed via "Test::Mock::Time"


### PR DESCRIPTION
The common way to provide additional detailed output about internal data
structures in case of test failures is 'diag explain' from Test::More.
However in Test::Most that behaves different and causes unexpected
issues like a bare '# 0' instead of array content.
https://metacpan.org/pod/Test::Most#explain explains that difference in
behaviour.

This commit changes all according occurences to 'always_explain'.

I used the following command:

```
git grep -l 'diag explain' | xargs sed -i 's/diag explain/always_explain/g'
```