### PR TITLE
Call SYNC_ASSETS_HOOK before downloading fresh needles too

### DIFF
--- a/OpenQA/Isotovideo/NeedleDownloader.pm
+++ b/OpenQA/Isotovideo/NeedleDownloader.pm
@@ -124,6 +124,11 @@ sub download ($self) { $self->_download_file($_) for (@{$self->files_to_download
 # downloads missing needles considering $new_needles
 # (see t/21-needle-downloader.t for an example of $new_needles)
 sub download_missing_needles ($self, $new_needles) {
+    if ($new_needles && $bmwqemu::vars{SYNC_ASSETS_HOOK}) {
+        bmwqemu::diag("Running SYNC_ASSETS_HOOK");
+        my $ret = system($bmwqemu::vars{SYNC_ASSETS_HOOK});
+        return if ($ret == (32 << 8));
+    }
     $self->add_relevant_downloads($new_needles);
     $self->download();
 }

--- a/t/21-needle-downloader.t
+++ b/t/21-needle-downloader.t
@@ -149,6 +149,40 @@ subtest '_download_file' => sub {
     like $stderr, qr{internal error occurred when downloading.*oops}, 'internal error was logged';
 };
 
+subtest 'sync assets hook used at the right time' => sub {
+    $downloader = OpenQA::Isotovideo::NeedleDownloader->new;
+    $bmwqemu::vars{SYNC_ASSETS_HOOK} = "touch -t 201801010000 '$needles_dir/foo.png' '$needles_dir/foo.json'; exit 32";
+    my @new_needles = (
+        {
+            id => 1,
+            name => 'foo',
+            directory => 'fixtures',
+            tags => [qw(some tag)],
+            json_path => '/needles/1/json',
+            image_path => '/needles/1/image',
+            t_created => '2018-01-01T00:00:00Z',
+            t_updated => '2018-01-01T00:00:00Z',
+        },
+        {
+            id => 2,
+            name => 'bar',
+            directory => 'fixtures',
+            tags => [qw(yet another tag)],
+            json_path => '/needles/2/json',
+            image_path => '/needles/2/image',
+            t_created => '2018-01-01T00:00:00Z',
+            t_updated => '2018-01-01T00:00:00Z',
+        },
+    );
+
+    # define expected downloads: nothing as download is skipped
+    my @expected_downloads = ();
+
+    $downloader->download_missing_needles(\@new_needles);
+    is_deeply($downloader->files_to_download, \@expected_downloads, 'download skipped')
+      or always_explain $downloader->files_to_download;
+};
+
 remove_tree($needles_dir);
 
 done_testing;


### PR DESCRIPTION
This is useful to fetch new needles that might be created via developer
mode.
See SYNC_ASSETS_HOOK documentation in the OpenQA repo.

This PR extends https://github.com/os-autoinst/openQA/pull/6131