### PR TITLE
Avoid potential endless loop in case of SSH read timeouts in `check_ssh_serial`

### DIFF
--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -9,7 +9,7 @@ use Mojo::Base -strict, -signatures;
 # -> increment on every change of such APIs
 # -> never move that variable to another place (when refactoring)
 #    because it may be accessed by the tests itself
-our $version = 42;
+our $version = 43;
 
 # major version of the (web socket) API relevant to the developer mode
 # -> increment when making non-backward compatible changes to that API

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -1292,8 +1292,13 @@ sub check_ssh_serial ($self, $fh = undef, $write = undef) {
 
 =head2 run_ssh_cmd
 
-   $ret = run_ssh_cmd($cmd [, username => ?][, password => ?][,host => ?]);
-   ($ret, $stdout, $stderr) = run_ssh_cmd($cmd [, username => ?][, password => ?][,host => ?], wantarray => 1);
+   $ret = run_ssh_cmd($cmd [, username => ?][, password => ?][,host => ?][,timeout => undef]);
+   ($ret, $stdout, $stderr) = run_ssh_cmd($cmd [, username => ?][, password => ?][,host => ?][,timeout => undef], wantarray => 1);
+
+   The timeout is in seconds and defaults to SSH_COMMAND_TIMEOUT_S. The timeout is enforced for each individual
+   operation, e.g. sending the command and reading its output as it is produced. That means the total runtime
+   of the command is allowed to be higher as long as the command can be sent in time and produces new output
+   frequently enough.
 
 =cut
 sub run_ssh_cmd ($self, $cmd, %args) {

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -671,10 +671,10 @@ sub run_cmd ($self, $cmd, %args) {
 
 =head2 get_cmd_output
 
-    $stdout = $svirt->get_cmd_output($cmd , $args = {domain => 'default', wantarray => 0});
+    $stdout = $svirt->get_cmd_output($cmd , $args = {domain => 'default', timeout => undef, wantarray => 0});
 
-With C<<wantarray => 1>> the function will return a reference to a list which
-contains I<stdout> and I<stderr>.
+With C<<wantarray => 1>> the function returns an array reference containing I<stdout> and
+I<stderr>.
 This function is B<deprecated>, you should use C<<$svirt->run_cmd()>> instead.
 =cut
 sub get_cmd_output ($self, $cmd, $args = {}) {

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -678,7 +678,7 @@ contains I<stdout> and I<stderr>.
 This function is B<deprecated>, you should use C<<$svirt->run_cmd()>> instead.
 =cut
 sub get_cmd_output ($self, $cmd, $args = {}) {
-    my (undef, $stdout, $stderr) = $self->backend->run_ssh_cmd($cmd, $self->get_ssh_credentials($args->{domain}), wantarray => 1);
+    my (undef, $stdout, $stderr) = $self->backend->run_ssh_cmd($cmd, $self->get_ssh_credentials($args->{domain}), timeout => $args->{timeout}, wantarray => 1);
     return $args->{wantarray} ? [$stdout, $stderr] : $stdout;
 }
 

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -24,7 +24,7 @@ NOVIDEO;boolean;0;Whether the creation of the video should be disabled and also 
 NO_DEBUG_IO;boolean;0;Disable the I/O debug output in case of needle comparison times longer than expected
 OSUTILS_WAIT_ATTEMPT_INTERVAL;float;1;The interval in seconds between "attempts" in osutils, e.g. used for connections to qemu qmp backend
 SCREENSHOTINTERVAL;float;0.5;The interval in seconds at which screenshots are taken internally
-SSH_COMMAND_TIMEOUT_S;integer;300;Timeout for any SSH based command in SSH based consoles, disabled for a value of 0. Time in seconds.
+SSH_COMMAND_TIMEOUT_S;integer;300;Timeout in seconds for any SSH based command in SSH based consoles, disabled for a value of 0. It can be overriden by particular run_ssh_cmd() calls. Checkout the documentation of this function for details.
 SSH_CONNECT_RETRY;integer;5;Maximum retries to connect to SSH based console targets
 SSH_CONNECT_RETRY_INTERVAL;float;10;Interval in seconds between retries to connect to SSH based console targets. Related to SSH_CONNECT_RETRY
 VNC_STALL_THRESHOLD;integer;4;Time after which is VNC considered stalled

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -100,7 +100,7 @@ throws_ok { $baseclass->handle_command({cmd => 'power'}) } qr/not implemented/, 
 
 subtest 'SSH utilities' => sub {
     my $ssh_expect = {username => 'root', password => 'password', hostname => 'foo.bar', port => undef};
-    my $fail_on_channel_call = undef;
+    my ($fail_on_channel_call, $fail_on_read2);
     my $ssh_auth_ok = 1;
     my $ssh_obj_data = {};    # used to store Net::SSH2 fake data per object
     my $ssh_connect_error;
@@ -174,8 +174,8 @@ subtest 'SSH utilities' => sub {
                             }
                             return 1;
                     });
-                    $mock_channel->mock(read2 => sub {
-                            my ($self) = @_;
+                    $mock_channel->mock(read2 => sub ($self) {
+                            return () if $fail_on_read2;
                             $self->{eof} = 1;
                             return ($self->{stdout}, $self->{stderr});
                     });
@@ -188,7 +188,7 @@ subtest 'SSH utilities' => sub {
                     $mock_channel->mock(close => sub { return 1; });
                     return $mock_channel;
             });
-
+            $self->mock(die_with_error => \&Net::SSH2::die_with_error);
             return $self;
     });
     sub refaddr ($host) { $host->{my_custom_id} }
@@ -261,6 +261,11 @@ subtest 'SSH utilities' => sub {
     isnt($baseclass->run_ssh_cmd('test 23 -eq 42', %ssh_creds), 0, 'Command failed exit');
     my @output = $baseclass->run_ssh_cmd('echo -n "foo"', wantarray => 1, %ssh_creds);
     is_deeply(\@output, [0, 'foo', ''], 'Command successful exit with output');
+
+    # test handling read errors in run_ssh_cmd()
+    ($fail_on_read2, @net_ssh2_error) = (1, -9, 'LIBSSH2_ERROR_TIMEOUT', 'Time out waiting for data');
+    throws_ok { $baseclass->run_ssh_cmd('sleep infinity', %ssh_creds) } qr/waiting for data.*timeout/i, 'read timeout is fatal error';
+    ($fail_on_read2, @net_ssh2_error) = ();
 
     # Create a SSH session implecit with `run_ssh_cmd()`
     $ssh_expect->{password} = '2+3=5';


### PR DESCRIPTION
The `read2` call might time out (the default timeout is 5 minutes) or otherwise fail. So far this leads to an endless loop until `eof` is reached which might not happen in a timely manner, e.g. because the command being executed is stuck. Then the whole backend would get stuck and the test might run into `MAX_JOB_TIME`, see
https://progress.opensuse.org/issues/176076.

With this change the timeout on SSH operations is effective in case the invoked command does not produce any output as tests would now die with `Time out waiting for data (-9 LIBSSH2_ERROR_TIMEOUT)` when a command does not return any new output for the timeout.

Since the default timeout is only 5 minutes this might disrupt long operations such as copying big files over network if those operations don't produce any output while running. ~~So maybe it should be possible to set the timeout on command-level (not included by this change).~~ So this PR adds an option to specify the timeout (see 2nd commit for details).

This change also provokes more immediate errors in other cases where `read2` fails.

---

I tested this with by cloning https://openqa.suse.de/tests/16551116 locally and just put an unconditional `die` where this change might cause a `die`. The result looks like this:

![grafik](https://github.com/user-attachments/assets/3d3b79fa-0fed-4709-9a10-53a68a43c908)
