### PR TITLE
Fix error handling when reading output of SSH commands after 0d09ec97e

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -1325,7 +1325,11 @@ sub run_ssh_cmd ($self, $cmd, %args) {
             $stdout .= $o;
             $stderr .= $e;
         }
-        else {
+        # check whether an error occurred
+        # note: The example from the documentation suggests that a simple `else` is sufficient. However, this does
+        #       not work when the command returns without producing any output and `die_with_error` dies with the
+        #       error message `no libssh2 error registered` then.
+        elsif (defined $ssh->error) {
             $log_output->();
             $ssh->die_with_error;
         }


### PR DESCRIPTION
Follow-up of https://github.com/os-autoinst/os-autoinst/pull/2629. I extended unit tests but also tested this with a small test script using `Net::SSH2` for real.

Related ticket: https://progress.opensuse.org/issues/176076#note-17