### PR TITLE
Fix error handling when reading output of SSH commands after 0d09ec97e

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -1329,7 +1329,7 @@ sub run_ssh_cmd ($self, $cmd, %args) {
         # note: The example from the documentation suggests that a simple `else` is sufficient. However, this does
         #       not work when the command returns without producing any output and `die_with_error` dies with the
         #       error message `no libssh2 error registered` then.
-        elsif (defined $ssh->error) {
+        elsif ($ssh->error) {
             $log_output->();
             $ssh->die_with_error;
         }

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -148,7 +148,7 @@ subtest 'SSH utilities' => sub {
                     shift->{connected} = 0;
                     return 1;
             });
-            $self->mock(error => sub { return @net_ssh2_error ? @net_ssh2_error : undef; });
+            $self->mock(error => sub { wantarray ? @net_ssh2_error : ($net_ssh2_error[0] // 0) });
             $self->mock(sock => sub {
                     my $self = shift;
                     unless ($self->{sock}) {


### PR DESCRIPTION
This is the 2nd attempt after a54220b9. I must have forgotten to save my test script when experimenting with Net::SSH2 yesterday because I can now clearly reproduce that the error case is still wrongly reached. It works without the `define`. This is probably because Net::SSH2 checks explicitly whether an array is wanted (only the case without `define`) and only then returns an empty list if there is no error:

```
SSH2_ERROR
net_ss_error(SSH2* ss)
PREINIT:
    char* errstr;
    int errlen;
CODE:
    RETVAL = libssh2_session_last_error(ss->session, &errstr, &errlen, 0);
    if(GIMME_V == G_ARRAY) {
        SV *errcode_sv;
        if (RETVAL == LIBSSH2_ERROR_NONE)
            XSRETURN_EMPTY;
…
```

So I simply removed the `defined` and I changed the mocking in the unit tests to actually match the behavior of Net::SSH2. (So the changed test fails when `defined` is used.)

Related ticket: https://progress.opensuse.org/issues/176076