### PR TITLE
Make it obvious when autotest receives SIGTERM in any case

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -283,8 +283,9 @@ sub run_all () {
 }
 
 sub handle_sigterm ($sig) {    # uncoverable statement
+    my $info = $current_test ? ', saving results of current test before exiting' : '';    # uncoverable statement
+    bmwqemu::diag("autotest received signal $sig$info");    # uncoverable statement
     if ($current_test) {    # uncoverable statement
-        bmwqemu::diag("autotest received signal $sig, saving results of current test before exiting");    # uncoverable statement
         $current_test->result('canceled');    # uncoverable statement
         $current_test->save_test_result();    # uncoverable statement
     }


### PR DESCRIPTION
So far we silently exit when receiving SIGTERM when no test module is running (e.g. autotest is between modules). Then it is not obvious why the test terminated prematurely. With this change we always get the relevant log line.

Related ticket: https://progress.opensuse.org/issues/174259