### PR TITLE
Fix race condition when autotest terminates

### DIFF
--- a/OpenQA/Isotovideo/CommandHandler.pm
+++ b/OpenQA/Isotovideo/CommandHandler.pm
@@ -291,6 +291,7 @@ sub _handle_command_set_current_test ($self, $response, @) {
 sub _handle_command_tests_done ($self, $response, @) {
     $self->test_died($response->{died});
     $self->test_completed($response->{completed});
+    $self->_respond_ok;
     $self->emit(tests_done => $response);
     $self->current_test_name('');
     $self->status('finished');

--- a/OpenQA/Isotovideo/Runner.pm
+++ b/OpenQA/Isotovideo/Runner.pm
@@ -127,8 +127,8 @@ sub handle_commands ($self) {
     $command_handler->on(tests_done => sub (@) {
             CORE::close($self->testfd);
             $self->testfd(undef);
-            $self->stop_autotest();
             $self->loop(0);
+            $self->stop_autotest();
     });
     # uncoverable statement count:1
     # uncoverable statement count:2

--- a/autotest.pm
+++ b/autotest.pm
@@ -276,7 +276,8 @@ sub run_all () {
     eval {
         bmwqemu::save_vars(no_secret => 1);
         bmwqemu::diag("Sending tests_done");
-        myjsonrpc::send_json($isotovideo, {cmd => 'tests_done', died => $died, completed => $completed});
+        my $token = myjsonrpc::send_json($isotovideo, {cmd => 'tests_done', died => $died, completed => $completed});
+        myjsonrpc::read_json($isotovideo, $token);    # wait for response from isotovideo before exiting
     };
     warn "Error at the end of run_all: $@" if $@;
     _terminate;

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -39,7 +39,7 @@ my @sent;    # array of messages sent with the fake json_send
 my @reset_consoles;
 my @selected_consoles;
 sub fake_send ($target, $msg) { push @sent, $msg }
-sub fake_read ($fd) {
+sub fake_read ($fd, $cmd_token = undef) {
     my $lcmd = $sent[-1];
     my $cmd = $lcmd->{cmd};
 


### PR DESCRIPTION
When autotest terminates because all tests are done it sends the message `tests_done` to isotovideo to indicate a normal exit. If isotovideo does not get this message it concludes autotest has exited prematurely and considers the test incomplete.

This makes generally sense. However, autotest exists immediately after sending the `tests_done` message. Then isotovideo handles that exit by setting its loop condition to false (like the it does when any of its persistent child processes exists). This means it is not guaranteed that the I/O loop of isotovideo still reads the `tests_done`. In case it does not the test would be wrongfully considered incomplete.

This is happening from time to time in production openQA-in-openQA tests, see https://progress.opensuse.org/issues/174259#note-24.

This change should fix the issue by letting autotest wait until isotovideo responds to the `tests_done` message. It is actually normal for autotest to wait for isotovideo to respond as this happens on every query_isotovideo invocation. So it shouldn't cause any problems to use the same approach also to communicate termination.