### PR TITLE
Use Test::Exception functions consistently

### DIFF
--- a/t/01-test_needle.t
+++ b/t/01-test_needle.t
@@ -7,7 +7,6 @@ use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use Cwd 'abs_path';
-use Test::Exception;
 use Test::Output qw(combined_like stderr_like);
 use Test::Warnings qw(warning :report_warnings);
 use File::Basename;

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -413,12 +413,12 @@ subtest 'check_assert_screen' => sub {
     my $mock_tinycv = Test::MockModule->new('tinycv');
     $mock_tinycv->redefine(from_ppm => sub : prototype($) { return bless({} => __PACKAGE__); });
 
-    throws_ok(sub { assert_screen(''); }, qr/no tags specified/, 'error if tag(s) is falsy scalar');
-    throws_ok(sub { assert_screen([]); }, qr/no tags specified/, 'error if tag(s) is empty array');
+    throws_ok { assert_screen('') } qr/no tags specified/, 'error if tag(s) is falsy scalar';
+    throws_ok { assert_screen([]) } qr/no tags specified/, 'error if tag(s) is empty array';
 
     my $current_test = $autotest::current_test;
     $autotest::current_test = undef;
-    throws_ok(sub { assert_screen('foo', 1); }, qr/current_test undefined/, 'error if current test undefined');
+    throws_ok { assert_screen('foo', 1) } qr/current_test undefined/, 'error if current test undefined';
     $autotest::current_test = $current_test;
 
     $mock_bmwqemu->unmock('log_call');
@@ -477,10 +477,9 @@ subtest 'check_assert_screen' => sub {
         $cmds = [];
 
         # simulate that we don't want to pause at all and just let it fail
-        throws_ok(sub { assert_screen('foo', 3, timeout => 2) },
-            qr/no candidate needle with tag\(s\) \'foo\' matched/,
-            'no candidate needle matched tags'
-        );
+        throws_ok { assert_screen('foo', 3, timeout => 2) }
+        qr/no candidate needle with tag\(s\) \'foo\' matched/,
+          'no candidate needle matched tags';
         is($report_timeout_called, 1, 'report_timeout called on timeout');
         is_deeply($cmds, [{
                     timeout => 2,
@@ -503,10 +502,9 @@ subtest 'check_assert_screen' => sub {
         # simulate that we want to pause after timeout in the first place but fail as usual on 2nd attempt
         $report_timeout_called = 0;
         $fake_pause_on_timeout = 1;
-        throws_ok(sub { assert_screen('foo', 3, timeout => 2) },
-            qr/no candidate needle with tag\(s\) \'foo\' matched/,
-            'no candidate needle matched tags'
-        );
+        throws_ok { assert_screen('foo', 3, timeout => 2) }
+        qr/no candidate needle with tag\(s\) \'foo\' matched/,
+          'no candidate needle matched tags';
         is($report_timeout_called, 2, 'report_timeout called once, and then again after pause');
 
         # simulate a match after pausing due to timeout
@@ -1209,10 +1207,7 @@ subtest 'send_key_until_needlematch' => sub {
     $mock_testapi->unmock('send_key');
     $fake_needle_found = $fake_needle_found_after_pause = 0;
     $cmds = [];
-    throws_ok(sub { send_key_until_needlematch('tag', 'esc', 3); },
-        qr/assert_screen reached/,
-        'no candidate needle matched tags'
-    );
+    throws_ok { send_key_until_needlematch('tag', 'esc', 3) } qr/assert_screen reached/, 'no candidate needle matched tags';
 
     my $count_send_key = 0;
     # Skip the first check_screen

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -14,7 +14,6 @@ use Mojo::Util qw(b64_encode);
 use Test::Output qw(combined_like stderr_like stderr_unlike);
 use Test::Fatal;
 use Test::Warnings qw(:all :report_warnings);
-use Test::Exception;
 use Scalar::Util 'looks_like_number';
 
 use OpenQA::Isotovideo::Interface;

--- a/t/04-testapi-python.t
+++ b/t/04-testapi-python.t
@@ -1,7 +1,6 @@
 #!/usr/bin/perl
 
 use Test::Most;
-use Test::Exception;
 use Test::Warnings;
 use Mojo::Base -strict, -signatures;
 

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -31,9 +31,9 @@ subtest 'script_run' => sub {
     like $typed_string, qr/foo; echo .* > .*serial/, 'command is typed plus marker and redirection';
     $typed_string = '';
     throws_ok { $d->script_run('foo &') } qr/Terminator.*found.*background_script_run/, 'script_run with terminator is caught';
-    lives_ok sub { $d->script_run('foo\&') }, 'escaped terminator is accepted';
-    lives_ok sub { $d->script_run('foo && bar') }, 'AND operator is accepted';
-    lives_ok sub { $d->script_run('foo "x&"') }, 'quoted & is accepted';
+    lives_ok { $d->script_run('foo\&') } 'escaped terminator is accepted';
+    lives_ok { $d->script_run('foo && bar') } 'AND operator is accepted';
+    lives_ok { $d->script_run('foo "x&"') } 'quoted & is accepted';
     $mock_testapi->redefine(wait_serial => sub {
             my $regexp = shift;
             push @wait_serial_calls, {

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -6,7 +6,6 @@
 use Test::Most;
 use Mojo::Base -strict, -signatures;
 use Test::Warnings qw(:all :report_warnings);
-use Test::Fatal;
 use Test::MockModule;
 use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";
@@ -20,7 +19,7 @@ subtest 'script_run' => sub {
     my $mock_testapi = Test::MockModule->new('testapi');
     $mock_testapi->redefine(type_string => undef);
     $mock_testapi->redefine(wait_serial => undef);
-    like(exception { $d->script_run }, qr/^Too few arguments/, 'Error on incorrect usage');
+    throws_ok { $d->script_run() } qr/^Too few arguments/, 'Error on incorrect usage';
     like(warning { $d->script_run('foo') }, qr/^Use of uninitialized.*serialdev/, 'Warning on undefined serialdev');
     {
         no warnings 'once';
@@ -31,7 +30,7 @@ subtest 'script_run' => sub {
     lives_ok { $d->script_run('foo') } 'script_run succeeds with trivial command';
     like $typed_string, qr/foo; echo .* > .*serial/, 'command is typed plus marker and redirection';
     $typed_string = '';
-    like(exception { $d->script_run('foo &') }, qr/Terminator.*found.*background_script_run/, 'script_run with terminator is caught');
+    throws_ok { $d->script_run('foo &') } qr/Terminator.*found.*background_script_run/, 'script_run with terminator is caught';
     lives_ok sub { $d->script_run('foo\&') }, 'escaped terminator is accepted';
     lives_ok sub { $d->script_run('foo && bar') }, 'AND operator is accepted';
     lives_ok sub { $d->script_run('foo "x&"') }, 'quoted & is accepted';

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -390,7 +390,7 @@ subtest 'python with bad run method' => sub {
     my $p1 = $autotest::tests{'tests-pythontest_with_bad_run_fn'};
 
     stderr_like {
-        throws_ok(sub { $p1->runtest }, qr{test pythontest_with_bad_run_fn died}, "expected failure on python side");
+        throws_ok { $p1->runtest } qr{test pythontest_with_bad_run_fn died}, "expected failure on python side";
     } qr{TypeError: run\(\) takes 0 positional arguments but 1 was given}, 'Expected output from pythontest_with_bad_runargs.py';
     is $bmwqemu::vars{PY_SUPPORT_FN_NOT_CALLED}, undef, 'set_var() was never called';
 };

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -7,7 +7,6 @@ use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use Test::Output qw(stderr_like combined_from output_like combined_like);
-use Test::Exception;
 use Test::Fatal;
 use Test::Warnings qw(:report_warnings warning);
 use Test::MockModule;

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -7,7 +7,6 @@ use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use Test::Output qw(stderr_like combined_from output_like combined_like);
-use Test::Fatal;
 use Test::Warnings qw(:report_warnings warning);
 use Test::MockModule;
 use Test::MockObject;
@@ -20,11 +19,11 @@ use OpenQA::Test::RunArgs;
 
 $bmwqemu::vars{CASEDIR} = File::Basename::dirname($0) . '/fake';
 
-like(exception { autotest::runalltests }, qr/ERROR: no tests loaded/, 'runalltests needs tests loaded first');
+throws_ok { autotest::runalltests } qr/ERROR: no tests loaded/, 'runalltests needs tests loaded first';
 like warning {
-    like(exception { autotest::loadtest 'does/not/match' }, qr/loadtest.*does not match required pattern/,
-        'loadtest catches incorrect test script paths')
-},
+    throws_ok { autotest::loadtest 'does/not/match' } qr/loadtest.*does not match required pattern/,
+    'loadtest catches incorrect test script paths'
+  },
   qr/loadtest needs a script below.*is not/,
   'loadtest outputs on stderr';
 

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -7,7 +7,6 @@ use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use Test::MockModule;
-use Test::Fatal;
 use Test::Output qw(combined_like combined_from);
 use File::Basename;
 use Mojo::File qw(path tempdir);

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -11,7 +11,6 @@ use Test::MockObject;
 use Test::Mock::Time;
 use Test::Output qw(combined_like stderr_like);
 use Test::Warnings qw(:all :report_warnings);
-use Test::Fatal;
 use Carp;
 use Mojo::Collection;
 use Mojo::File qw(tempdir path);
@@ -65,12 +64,12 @@ is($called{add_console}, 1, 'one console has been added');
 subtest 'using Open vSwitch D-Bus service' => sub {
     my $expected = qr/Open vSwitch command.*show.*arguments 'foo bar'.*(The name.*not provided|Failed to connect)/;
     my $msg = 'error about missing service';
-    like exception { $backend->_dbus_call('show', 'foo', 'bar') }, $expected, $msg . ' in exception';
+    throws_ok { $backend->_dbus_call('show', 'foo', 'bar') } $expected, $msg . ' in exception';
     $bmwqemu::vars{QEMU_NON_FATAL_DBUS_CALL} = 1;
     combined_like { ok($backend->_dbus_call('show', 'foo', 'bar'), 'failed dbus call ignored gracefully') } $expected, $msg;
     $bmwqemu::vars{QEMU_NON_FATAL_DBUS_CALL} = 0;
     $backend_mock->redefine(_dbus_do_call => sub { (1, 'failed') });
-    like exception { $backend->_dbus_call('show') }, qr/failed/, 'failed dbus call throws exception';
+    throws_ok { $backend->_dbus_call('show') } qr/failed/, 'failed dbus call throws exception';
 
     # test one unmocked _dbus_do_call againsted mocked Net::DBus
     $backend_mock->unmock('_dbus_do_call');

--- a/t/19-isotovideo-command-processing.t
+++ b/t/19-isotovideo-command-processing.t
@@ -9,7 +9,6 @@ use OpenQA::Test::TimeLimit '5';
 use Test::MockModule;
 use Test::Output qw(stderr_like stderr_unlike combined_like);
 use Test::Warnings ':report_warnings';
-use Test::Fatal;
 use Mojo::JSON 'encode_json';
 use Mojo::File qw(tempdir path);
 use Mojo::Util qw(scope_guard);
@@ -363,12 +362,12 @@ subtest 'send_clients' => sub {
 };
 
 subtest 'invalid command' => sub {
-    like exception {
+    throws_ok {
         $command_handler->process_command($answer_fd, {
                 cmd => 'foobar',
                 lala => 23,
         });
-    }, qr{isotovideo: unknown command foobar}, 'Correct error message for unknown command';
+    } qr{isotovideo: unknown command foobar}, 'Correct error message for unknown command';
 };
 
 subtest '_is_configured_to_pause_on_timeout' => sub {

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -535,12 +535,12 @@ subtest 'Method backend::svirt::open_serial_console_via_ssh()' => sub {
     $bmwqemu::vars{JOBTOKEN} = 'CHECK_DELETE_TOKEN';
     my $expected_serial_file = '/tmp/' . $svirt->SERIAL_TERMINAL_LOG_PATH . '.CHECK_DELETE_TOKEN';
     $test_log_cnt = 11;
-    dies_ok(sub { $svirt->open_serial_console_via_ssh('NAME') }, "die() when log file wasn't created");
+    dies_ok { $svirt->open_serial_console_via_ssh('NAME') } "die() when log file wasn't created";
     is(shift @deleted_logs, $expected_serial_file, "Check if $expected_serial_file was deleted on die()");
 
     $test_log_cnt = 0;
     $grep_return = 0;
-    dies_ok(sub { $svirt->open_serial_console_via_ssh('NAME') }, 'die() when emulate CONSOLE_EXIT token in log file');
+    dies_ok { $svirt->open_serial_console_via_ssh('NAME') } 'die() when emulate CONSOLE_EXIT token in log file';
     is(shift @deleted_logs, $expected_serial_file, "Check if $expected_serial_file was deleted on die()");
 };
 

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -5,7 +5,6 @@ use Mojo::Base -strict, -signatures;
 use FindBin qw($Bin $Script);
 use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
-use Test::Exception;
 use Test::Mock::Time;
 use Test::MockModule;
 use Test::MockObject;

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -247,7 +247,7 @@ subtest 'SSH utilities' => sub {
     isnt(refaddr($ssh4), refaddr($ssh8), "Got same connection with different ports");
 
     $ssh_auth_ok = 0;
-    throws_ok(sub { $baseclass->new_ssh_connection(%ssh_creds) }, qr/Error connecting to/, 'Got exception on connection error');
+    throws_ok { $baseclass->new_ssh_connection(%ssh_creds) } qr/Error connecting to/, 'Got exception on connection error';
 
     $ssh_auth_ok = 1;
     $ssh_expect->{password} = '';

--- a/t/24-myjsonrpc.t
+++ b/t/24-myjsonrpc.t
@@ -5,7 +5,6 @@
 
 use Test::Most;
 use Mojo::Base -strict, -signatures;
-use Test::Exception;
 use Test::MockModule 'strict';
 use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";

--- a/t/26-serial_screen.t
+++ b/t/26-serial_screen.t
@@ -4,7 +4,6 @@
 use Test::Most;
 use Mojo::Base -strict, -signatures;
 use Test::Warnings ':report_warnings';
-use Test::Fatal;
 use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';

--- a/t/26-ssh_screen.t
+++ b/t/26-ssh_screen.t
@@ -10,7 +10,6 @@ use OpenQA::Test::TimeLimit '5';
 use consoles::ssh_screen;
 use consoles::serial_screen;
 use bmwqemu;
-use Test::Exception;
 use Test::MockObject;
 use Test::MockModule;
 use Test::Output qw(combined_like);

--- a/t/26-video_stream.t
+++ b/t/26-video_stream.t
@@ -16,7 +16,6 @@ use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use Test::MockModule;
 use Test::MockObject;
-use Test::Fatal;
 
 use consoles::video_stream;
 use tinycv;

--- a/t/27-consoles-vmware.t
+++ b/t/27-consoles-vmware.t
@@ -17,7 +17,6 @@ use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '10';
 
-use Test::Exception;
 use Test::MockObject;
 use Test::MockModule;
 use Test::Mojo;

--- a/t/27-consoles-vnc.t
+++ b/t/27-consoles-vnc.t
@@ -9,7 +9,6 @@ use utf8;
 
 use Mojo::File qw(path);
 use Test::Warnings qw(:all :report_warnings);
-use Test::Exception;
 use Test::Output qw(combined_like);
 use Test::MockModule;
 use Test::MockObject;

--- a/t/27-consoles-vnc_base.t
+++ b/t/27-consoles-vnc_base.t
@@ -6,7 +6,6 @@
 use Test::Most;
 use Mojo::Base -strict, -signatures;
 use Test::Warnings qw(:all :report_warnings);
-use Test::Fatal;
 use Test::MockModule;
 use Test::MockObject;
 use Test::Output qw(stderr_like);

--- a/t/29-backend-generalhw.t
+++ b/t/29-backend-generalhw.t
@@ -15,7 +15,6 @@ use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use Test::MockModule;
 use Test::Warnings qw(:all :report_warnings);
-use Test::Fatal;
 use Mojo::File qw(tempdir tempfile);
 use Scalar::Util qw(blessed openhandle);
 use POSIX qw(waitpid WNOHANG);

--- a/t/29-backend-svirt.t
+++ b/t/29-backend-svirt.t
@@ -6,7 +6,6 @@
 use Test::Most;
 use Mojo::Base -strict, -signatures;
 use Test::Warnings qw(:all :report_warnings);
-use Test::Fatal;
 use Test::MockModule;
 use Test::MockObject;
 use Test::Mock::Time;

--- a/t/30-mmapi.t
+++ b/t/30-mmapi.t
@@ -22,7 +22,6 @@ BEGIN {
 use FindBin;
 use lib "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
-use Test::Fatal;
 use Test::Output;
 use Test::MockModule;
 use Test::Warnings qw(:report_warnings);
@@ -229,7 +228,7 @@ subtest 'mmapi: wait functions' => sub {
     combined_like { mmapi::wait_for_children_to_start } qr/Waiting for 1 jobs to start/, 'wait for children to be runnning';
     my $mmapi_mock = Test::MockModule->new('mmapi');
     $mmapi_mock->redefine(get_children => undef);
-    like exception { mmapi::wait_for_children }, qr/Failed to wait/, 'wait for children dies on error';
+    throws_ok { mmapi::wait_for_children } qr/Failed to wait/, 'wait for children dies on error';
 };
 
 subtest 'mmapi: get_current_job_id function' => sub {

--- a/t/37-mutparams.t
+++ b/t/37-mutparams.t
@@ -6,7 +6,6 @@
 
 use Test::Most;
 use Mojo::Base -strict, -signatures;
-use Test::Fatal;
 use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
@@ -17,7 +16,7 @@ my $mutparams = OpenQA::Qemu::MutParams->new;
 
 my @methods = qw(gen_cmdline to_map from_map has_state);
 for my $method (@methods) {
-    like(exception { $mutparams->$method }, qr{has not implemented $method}, "Exception for not implemented $method");
+    throws_ok { $mutparams->$method } qr{has not implemented $method}, "Exception for not implemented $method";
 }
 
 done_testing;

--- a/xt/01-style.t
+++ b/xt/01-style.t
@@ -12,6 +12,7 @@ ok system(qq{git grep -I -l 'This program is free software.*if not, see <http://
 ok system(qq{git grep -I -l '[#/ ]*SPDX-License-Identifier ' ':!COPYING' ':!external/' ':!xt/01-style.t'}) != 0, 'SPDX-License-Identifier correctly terminated';
 is qx{git grep -I -L '^use Test::Most' t/**.t}, '', 'All tests use Test::Most';
 is qx{git grep -I -L '^use Test::Warnings' t/**.t}, '', 'All tests use Test::Warnings';
+is qx{git grep -I -l '^use Test::Exception' t/**.t}, '', 'Test::Most already includes Test::Exception, no need to use Test::Exception';
 is qx{git grep -I -l '^use testapi' backend/ consoles/}, '', 'No backend or console files use external facing testapi';
 is qx{git grep -l -e '^sub \\S\\+ [^(]\\+' --and --not -e 'sub [(\{]' --and --not -e 'sub \\S\\+(' --and --not -e 'sub \\S\\+;' --and --not -e '# no:style:signatures' ':!external/'}, '', 'All files use sub signatures everywhere (nameless and in-place definitions still allowed)';
 is qx{git grep -L '^#!.*perl' t/**.t}, '', 'All test files have shebang';

--- a/xt/01-style.t
+++ b/xt/01-style.t
@@ -12,7 +12,7 @@ ok system(qq{git grep -I -l 'This program is free software.*if not, see <http://
 ok system(qq{git grep -I -l '[#/ ]*SPDX-License-Identifier ' ':!COPYING' ':!external/' ':!xt/01-style.t'}) != 0, 'SPDX-License-Identifier correctly terminated';
 is qx{git grep -I -L '^use Test::Most' t/**.t}, '', 'All tests use Test::Most';
 is qx{git grep -I -L '^use Test::Warnings' t/**.t}, '', 'All tests use Test::Warnings';
-is qx{git grep -I -l '^use Test::Exception' t/**.t}, '', 'Test::Most already includes Test::Exception, no need to use Test::Exception';
+is qx{git grep -I -l '^use Test::\\(Exception\\|Fatal\\)' t/**.t}, '', 'Test::Most already includes Test::Exception, no need to use Test::Exception or Test::Fatal';
 is qx{git grep -I -l '^use testapi' backend/ consoles/}, '', 'No backend or console files use external facing testapi';
 is qx{git grep -l -e '^sub \\S\\+ [^(]\\+' --and --not -e 'sub [(\{]' --and --not -e 'sub \\S\\+(' --and --not -e 'sub \\S\\+;' --and --not -e '# no:style:signatures' ':!external/'}, '', 'All files use sub signatures everywhere (nameless and in-place definitions still allowed)';
 is qx{git grep -L '^#!.*perl' t/**.t}, '', 'All test files have shebang';

--- a/xt/01-style.t
+++ b/xt/01-style.t
@@ -13,6 +13,7 @@ ok system(qq{git grep -I -l '[#/ ]*SPDX-License-Identifier ' ':!COPYING' ':!exte
 is qx{git grep -I -L '^use Test::Most' t/**.t}, '', 'All tests use Test::Most';
 is qx{git grep -I -L '^use Test::Warnings' t/**.t}, '', 'All tests use Test::Warnings';
 is qx{git grep -I -l '^use Test::\\(Exception\\|Fatal\\)' t/**.t}, '', 'Test::Most already includes Test::Exception, no need to use Test::Exception or Test::Fatal';
+is qx{git grep -I -l '^\\(throws\\|dies\\|lives\\)_ok.*sub' t/**.t}, '', 'Only use simplified prototyped Test::Exception functions';
 is qx{git grep -I -l '^use testapi' backend/ consoles/}, '', 'No backend or console files use external facing testapi';
 is qx{git grep -l -e '^sub \\S\\+ [^(]\\+' --and --not -e 'sub [(\{]' --and --not -e 'sub \\S\\+(' --and --not -e 'sub \\S\\+;' --and --not -e '# no:style:signatures' ':!external/'}, '', 'All files use sub signatures everywhere (nameless and in-place definitions still allowed)';
 is qx{git grep -L '^#!.*perl' t/**.t}, '', 'All test files have shebang';


### PR DESCRIPTION
* t: Use more simple prototyped Test::Exceptions functions
* t: Focus on using Test::Exception only instead of Test::Fatal
* t: Ensure we use implicit Test::Exception in all places


Related to
* #2636
where we met some confusion about which approach to follow