### PR TITLE
Extend timeout for rsync commands done by the svirt backend to 15 min

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -15,6 +15,7 @@ use Mojo::DOM;
 use Mojo::File qw(path);
 use Mojo::JSON qw(decode_json);
 use Mojo::Util;
+use Time::Seconds;
 use Carp 'croak';
 use backend::svirt;
 
@@ -380,15 +381,17 @@ sub _copy_nvram_vmware ($self, $name, $vmware_openqa_datastore, $vmware_disk_pat
 sub _system (@cmd) { system @cmd }    # uncoverable statement
 
 sub _copy_image_else ($self, $file, $file_basename, $basedir) {
+    my $timeout_s = ONE_MINUTE * ($bmwqemu::vars{SVIRT_ASSET_DOWNLOAD_TIMEOUT_M} // 15);
+
     # utilize asset possibly cached by openQA worker, otherwise sync locally on svirt host (usually relying on NFS mount)
     if (($bmwqemu::vars{SVIRT_WORKER_CACHE} // 0) && -e $file_basename && defined which 'rsync') {
         my %c = $self->get_ssh_credentials;
         my $abs = path($file_basename)->to_abs;    # pass abs path so it can contain a colon
         bmwqemu::diag "Syncing '$file_basename' directly from worker host to $c{hostname}";
-        _system("sshpass -p '$c{password}' rsync -e 'ssh -o StrictHostKeyChecking=no' -av '$abs' '$c{username}\@$c{hostname}:$basedir/$file_basename'");
+        _system("sshpass -p '$c{password}' rsync -e 'ssh -o StrictHostKeyChecking=no' --timeout='$timeout_s' -av '$abs' '$c{username}\@$c{hostname}:$basedir/$file_basename'");
     }
     else {
-        $self->run_cmd("rsync -av '$file' '$basedir/$file_basename'") && die 'rsync failed';
+        $self->run_cmd("rsync --timeout='$timeout_s' -av '$file' '$basedir/$file_basename'", timeout => $timeout_s + ONE_MINUTE) && die 'rsync failed';
     }
     if ($file_basename =~ /(.*)\.xz$/) {
         $self->run_cmd("nice ionice unxz -f -k '$basedir/$file_basename'");

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -389,10 +389,10 @@ sub _copy_image_else ($self, $file, $file_basename, $basedir) {
         my %c = $self->get_ssh_credentials;
         my $abs = path($file_basename)->to_abs;    # pass abs path so it can contain a colon
         bmwqemu::diag "Syncing '$file_basename' directly from worker host to $c{hostname}";
-        _system("sshpass -p '$c{password}' rsync -e 'ssh -o StrictHostKeyChecking=no' --timeout='$inactivity_timeout_s' -av '$abs' '$c{username}\@$c{hostname}:$basedir/$file_basename'");
+        _system("sshpass -p '$c{password}' rsync -e 'ssh -o StrictHostKeyChecking=no' --timeout='$inactivity_timeout_s' --stats -av '$abs' '$c{username}\@$c{hostname}:$basedir/$file_basename'");
     }
     else {
-        $self->run_cmd("rsync --timeout='$inactivity_timeout_s' -av '$file' '$basedir/$file_basename'", timeout => $download_timeout_s) && die 'rsync failed';
+        $self->run_cmd("rsync --timeout='$inactivity_timeout_s' --stats -av '$file' '$basedir/$file_basename'", timeout => $download_timeout_s) && die 'rsync failed';
     }
     if ($file_basename =~ /(.*)\.xz$/) {
         $self->run_cmd("nice ionice unxz -f -k '$basedir/$file_basename'");

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -383,16 +383,17 @@ sub _system (@cmd) { system @cmd }    # uncoverable statement
 sub _copy_image_else ($self, $file, $file_basename, $basedir) {
     my $download_timeout_s = ONE_MINUTE * ($bmwqemu::vars{SVIRT_ASSET_DOWNLOAD_TIMEOUT_M} // 15);
     my $inactivity_timeout_s = ONE_MINUTE * ($bmwqemu::vars{SVIRT_ASSET_DOWNLOAD_INACTIVITY_TIMEOUT_M} // 2.5);
+    my $rsync_args = "--timeout='$inactivity_timeout_s' --stats -av";
 
     # utilize asset possibly cached by openQA worker, otherwise sync locally on svirt host (usually relying on NFS mount)
     if (($bmwqemu::vars{SVIRT_WORKER_CACHE} // 0) && -e $file_basename && defined which 'rsync') {
         my %c = $self->get_ssh_credentials;
         my $abs = path($file_basename)->to_abs;    # pass abs path so it can contain a colon
         bmwqemu::diag "Syncing '$file_basename' directly from worker host to $c{hostname}";
-        _system("sshpass -p '$c{password}' rsync -e 'ssh -o StrictHostKeyChecking=no' --timeout='$inactivity_timeout_s' --stats -av '$abs' '$c{username}\@$c{hostname}:$basedir/$file_basename'");
+        _system("sshpass -p '$c{password}' rsync -e 'ssh -o StrictHostKeyChecking=no' $rsync_args '$abs' '$c{username}\@$c{hostname}:$basedir/$file_basename'");
     }
     else {
-        $self->run_cmd("rsync --timeout='$inactivity_timeout_s' --stats -av '$file' '$basedir/$file_basename'", timeout => $download_timeout_s) && die 'rsync failed';
+        $self->run_cmd("rsync $rsync_args '$file' '$basedir/$file_basename'", timeout => $download_timeout_s) && die 'rsync failed';
     }
     if ($file_basename =~ /(.*)\.xz$/) {
         $self->run_cmd("nice ionice unxz -f -k '$basedir/$file_basename'");

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -249,6 +249,7 @@ NUMDISKS;integer;1;Number of disks to be created and attached to VM, can be 0 to
 RAIDLEVEL;integer;undef;Sets the raid level, affects NUMDISKS.
 SVIRT_KEEP_VM_RUNNING;boolean;undef;Keep VM running after execution, disabled by default
 SVIRT_WORKER_CACHE;boolean;0;Use the openQA worker cache if possible to copy images to the svirt host - this means the path specified when invoking `add_disk` is **not** fully regarded, e.g. if the specified path points into the `fixed`-subdirectory but the openQA worker cached the same asset under the regular directory (which it prefers over the `fixed`-subdirectory) then the asset from the regular directory will be used
+SVIRT_ASSET_DOWNLOAD_TIMEOUT_M;integer;15;Timeout for asset downloads within svirt backend in minutes.
 WORKER_HOSTNAME;string;undef;Worker hostname
 |====================
 

--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -249,7 +249,8 @@ NUMDISKS;integer;1;Number of disks to be created and attached to VM, can be 0 to
 RAIDLEVEL;integer;undef;Sets the raid level, affects NUMDISKS.
 SVIRT_KEEP_VM_RUNNING;boolean;undef;Keep VM running after execution, disabled by default
 SVIRT_WORKER_CACHE;boolean;0;Use the openQA worker cache if possible to copy images to the svirt host - this means the path specified when invoking `add_disk` is **not** fully regarded, e.g. if the specified path points into the `fixed`-subdirectory but the openQA worker cached the same asset under the regular directory (which it prefers over the `fixed`-subdirectory) then the asset from the regular directory will be used
-SVIRT_ASSET_DOWNLOAD_TIMEOUT_M;integer;15;Timeout for asset downloads within svirt backend in minutes.
+SVIRT_ASSET_DOWNLOAD_TIMEOUT_M;number;15;Timeout for asset downloads within svirt backend in minutes.
+SVIRT_ASSET_DOWNLOAD_INACTIVITY_TIMEOUT_M;number;2.5;Inactvity timeout for asset downloads within svirt backend in minutes.
 WORKER_HOSTNAME;string;undef;Worker hostname
 |====================
 

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -919,7 +919,7 @@ subtest 'Method consoles::sshVirtsh::add_disk()' => sub {
                     dev_id => $dev_id,
                     file => '/my/path/to/this/file/' . $file,
             });
-            like($last_ssh_commands[0], qr%^rsync.*--timeout='150'.*/my/path/to/this/file/$file.*$basedir/$file%, 'Use rsync to copy cdrom iso');
+            like($last_ssh_commands[0], qr%^rsync.*--timeout='150' --stats .*/my/path/to/this/file/$file.*$basedir/$file%, 'Use rsync to copy cdrom iso');
             my %ssh_args = @{$last_ssh_args[0]};
             is $ssh_args{timeout}, 900, 'timeout for ssh command specified';
 
@@ -941,7 +941,7 @@ subtest 'Method consoles::sshVirtsh::add_disk()' => sub {
             @last_ssh_commands = ();
             @ssh_cmd_return = (0, 0);
             $svirt->add_disk({cdrom => 1, dev_id => $dev_id, file => $file_path});
-            is $last_system_calls[0], "sshpass -p 'password_svirt' rsync -e 'ssh -o StrictHostKeyChecking=no' --timeout='150' -av '$dir/$file' 'root\@hostname_svirt:$basedir/$file'", 'file copied with rsync';
+            is $last_system_calls[0], "sshpass -p 'password_svirt' rsync -e 'ssh -o StrictHostKeyChecking=no' --timeout='150' --stats -av '$dir/$file' 'root\@hostname_svirt:$basedir/$file'", 'file copied with rsync';
             like $last_ssh_commands[0], qr%unxz%, 'file uncompressed with unxz';
 
             svirt_xml_validate($svirt,

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -919,9 +919,9 @@ subtest 'Method consoles::sshVirtsh::add_disk()' => sub {
                     dev_id => $dev_id,
                     file => '/my/path/to/this/file/' . $file,
             });
-            like($last_ssh_commands[0], qr%^rsync.*--timeout='900'.*/my/path/to/this/file/$file.*$basedir/$file%, 'Use rsync to copy cdrom iso');
+            like($last_ssh_commands[0], qr%^rsync.*--timeout='150'.*/my/path/to/this/file/$file.*$basedir/$file%, 'Use rsync to copy cdrom iso');
             my %ssh_args = @{$last_ssh_args[0]};
-            is $ssh_args{timeout}, 960, 'timeout for ssh command specified';
+            is $ssh_args{timeout}, 900, 'timeout for ssh command specified';
 
             svirt_xml_validate($svirt,
                 disk_device => 'cdrom',
@@ -941,7 +941,7 @@ subtest 'Method consoles::sshVirtsh::add_disk()' => sub {
             @last_ssh_commands = ();
             @ssh_cmd_return = (0, 0);
             $svirt->add_disk({cdrom => 1, dev_id => $dev_id, file => $file_path});
-            is $last_system_calls[0], "sshpass -p 'password_svirt' rsync -e 'ssh -o StrictHostKeyChecking=no' --timeout='900' -av '$dir/$file' 'root\@hostname_svirt:$basedir/$file'", 'file copied with rsync';
+            is $last_system_calls[0], "sshpass -p 'password_svirt' rsync -e 'ssh -o StrictHostKeyChecking=no' --timeout='150' -av '$dir/$file' 'root\@hostname_svirt:$basedir/$file'", 'file copied with rsync';
             like $last_ssh_commands[0], qr%unxz%, 'file uncompressed with unxz';
 
             svirt_xml_validate($svirt,


### PR DESCRIPTION
After 0d09ec97e6c84068e2f9911c1d0229f991484a15 the timeout of 5 minutes is actually effective. We now see that some jobs are running into that timeout, see https://progress.opensuse.org/issues/176868.

It makes sense to set a higher timeout for these asset downloads because rsync would not produce any output during the possibly long-running download. We could use `--progress` but it would probably be too much having all these status updates in our log files. So this change uses `--timeout` instead so rsync will itself time out. It also sets the timeout of `run_cmd` accordingly (with one minute headroom).

This change also sets the timeout in case `SVIRT_WORKER_CACHE` is used to enforce it consistently regardless of that setting.

The timeout itself is configurable via `SVIRT_ASSET_DOWNLOAD_TIMEOUT_M`.

---

I haven't done a full test run yet but the change is hopefully simple enough so unit tests are enough.