### PR TITLE
Ensure a clean swtpm directory

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -590,19 +590,12 @@ sub setup_tpm ($self) {
     return unless ($vars->{QEMUTPM});
     my $tpmn = $vars->{QEMUTPM} eq 'instance' ? $vars->{WORKER_INSTANCE} : $vars->{QEMUTPM};
     my $vmpath = ($vars->{QEMUTPM_PATH_PREFIX} // '/tmp/mytpm') . $tpmn;
-    mkdir $vmpath unless -d $vmpath;
+    path($vmpath)->remove_tree->make_path;
     my $vmsock = "$vmpath/swtpm-sock";
-    unless (-e $vmsock) {
-        # Before create swtpm-sock, we should make sure there is no tpm*.permall file
-        # When tpm version is 2.0, the file is tpm2-00.permall.
-        # When tpm version is 1.x, the file is tpm-00.permall.
-        # See: https://progress.opensuse.org/issues/107155
-        unlink glob "$vmpath/tpm*.permall";
+    my @args = ('swtpm', 'socket', '--tpmstate', "dir=$vmpath", '--ctrl', "type=unixio,path=$vmsock", '--log', 'level=20', '-d');
+    push @args, '--tpm2' if (($vars->{QEMUTPM_VER} // '2.0') == '2.0');
+    runcmd(@args);
 
-        my @args = ('swtpm', 'socket', '--tpmstate', "dir=$vmpath", '--ctrl', "type=unixio,path=$vmsock", '--log', 'level=20', '-d');
-        push @args, '--tpm2' if (($vars->{QEMUTPM_VER} // '2.0') == '2.0');
-        runcmd(@args);
-    }
     sp('chardev', "socket,id=chrtpm,path=$vmsock");
     sp('tpmdev', 'emulator,id=tpm0,chardev=chrtpm');
     my $arch = $vars->{ARCH} // '';

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -62,7 +62,7 @@ ok(exists $called{add_console}, 'a console has been added');
 is($called{add_console}, 1, 'one console has been added');
 
 subtest 'using Open vSwitch D-Bus service' => sub {
-    my $expected = qr/Open vSwitch command.*show.*arguments 'foo bar'.*(The name.*not provided|Failed to connect)/;
+    my $expected = qr/Open vSwitch command.*show.*arguments 'foo bar'.*(The name.*not (provided|activatable)|Failed to connect)/;
     my $msg = 'error about missing service';
     throws_ok { $backend->_dbus_call('show', 'foo', 'bar') } $expected, $msg . ' in exception';
     $bmwqemu::vars{QEMU_NON_FATAL_DBUS_CALL} = 1;


### PR DESCRIPTION
- Increase reliability by always cleaning up existing temporary directory containing swtpm-sock
- Remove handling for dealing with existing socket
- Fix expected error message within t/18-backend-qemu.t

With this we do not have to rely on the cleanup process anymore, creating the socket files fresh everytime to increase reliability.