### PR TITLE
Fix timeout of SSH commands after fc8ab5395 and ca4f085c

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -1314,7 +1314,7 @@ sub run_ssh_cmd ($self, $cmd, %args) {
     if (defined(my $new_timeout = $args{timeout})) {
         my $initial_timeout = $ssh->timeout;
         $timeout_guard = scope_guard sub { $ssh->timeout($initial_timeout) };
-        $ssh->timeout($new_timeout);
+        $ssh->timeout($new_timeout * 1000);
     }
     until ($chan->eof) {
         if (my ($o, $e) = $chan->read2) {

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -265,7 +265,7 @@ subtest 'SSH utilities' => sub {
     # test handling read errors and timeout parameter of run_ssh_cmd()
     ($fail_on_read2, @net_ssh2_error) = (1, -9, 'LIBSSH2_ERROR_TIMEOUT', 'Time out waiting for data');
     throws_ok { $baseclass->run_ssh_cmd('sleep infinity', %ssh_creds, timeout => 100) } qr/waiting for data.*timeout/i, 'read timeout is fatal error';
-    is_deeply \@timeouts, [100, 42], 'timeout increased to specified value, then set back to mocked default again';
+    is_deeply \@timeouts, [100000, 42], 'timeout increased to specified value, then set back to mocked default again';
     ($fail_on_read2, @net_ssh2_error) = ();
     @output = $baseclass->run_ssh_cmd('test foo', %ssh_creds, timeout => 100, wantarray => 1);
     is_deeply \@output, [0, '', ''], 'command successful exit without output';


### PR DESCRIPTION
The timeout was documented to be in seconds in ca4f085c but was actually in milliseconds. With this change it is now in seconds so fc8ab5395 works as intended.

Related ticket: https://progress.opensuse.org/issues/176868