### PR TITLE
Fix log colors

### DIFF
--- a/log.pm
+++ b/log.pm
@@ -32,36 +32,31 @@ sub log_format_callback ($time, $level, @items) {
 
 sub diag (@args) {
     confess "missing input" unless @args;
-    logger->append(color('white'));
-    $args[-1] .= color('reset');
+    $args[-1] = color('white') . ($args[-1] // '') . color('reset');
     logger->debug(@args);
     return;
 }
 
 sub fctres ($text, $fname = undef) {
     $fname //= (caller(1))[3];
-    logger->append(color('green'));
-    logger->debug(">>> $fname: $text" . color('reset'));
+    logger->debug(color('green') . ">>> $fname: $text" . color('reset'));
     return;
 }
 
 sub fctinfo ($text, $fname = undef) {
     $fname //= (caller(1))[3];
-    logger->append(color('yellow'));
-    logger->info("::: $fname: $text" . color('reset'));
+    logger->info(color('yellow') . "::: $fname: $text" . color('reset'));
     return;
 }
 
 sub fctwarn ($text, $fname = undef) {
     $fname //= (caller(1))[3];
-    logger->append(color('red'));
-    logger->warn("!!! $fname: $text" . color('reset'));
+    logger->warn(color('red') . "!!! $fname: $text" . color('reset'));
     return;
 }
 
 sub modstate (@text) {
-    logger->append(color('bold blue'));
-    logger->debug("||| @{[join(' ', @text)]}" . color('reset'));
+    logger->debug(color('bold blue') . "||| @{[join(' ', @text)]}" . color('reset'));
     return;
 }
 

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -226,17 +226,17 @@ subtest 'productdir variable relative/absolute' => sub {
     chdir($pool_dir);
     unlink('vars.json') if -e 'vars.json';
     combined_like { isotovideo(
-            opts => "casedir=$data_dir/tests _exit_after_schedule=1 productdir=$data_dir/tests") } qr/\d* scheduling.*shutdown/, 'schedule has been evaluated';
+            opts => "casedir=$data_dir/tests _exit_after_schedule=1 productdir=$data_dir/tests") } qr/scheduling.*shutdown/, 'schedule has been evaluated';
     mkdir('product') unless -e 'product';
     mkdir('product/foo') unless -e 'product/foo';
     symlink("$data_dir/tests/main.pm", "$pool_dir/product/foo/main.pm") unless -e "$pool_dir/product/foo/main.pm";
-    combined_like { isotovideo(opts => "casedir=$data_dir/tests _exit_after_schedule=1 productdir=product/foo") } qr/\d* scheduling.*shutdown/, 'schedule can still be found';
+    combined_like { isotovideo(opts => "casedir=$data_dir/tests _exit_after_schedule=1 productdir=product/foo") } qr/scheduling.*shutdown/, 'schedule can still be found';
     unlink("$pool_dir/product/foo/main.pm");
     mkdir("$data_dir/tests/product") unless -e "$data_dir/tests/product";
     symlink("$data_dir/tests/main.pm", "$data_dir/tests/product/main.pm") unless -e "$data_dir/tests/product/main.pm";
     # additionally testing correct schedule for our "integration tests" mode
     my $log = combined_from { isotovideo(opts => "casedir=$data_dir/tests _exit_after_schedule=1 productdir=product integration_tests=1") };
-    like $log, qr/\d* scheduling.*shutdown/, 'schedule can still be found for productdir relative to casedir';
+    like $log, qr/scheduling.*shutdown/, 'schedule can still be found for productdir relative to casedir';
     unlike $log, qr/assert_screen_fail_test/, 'assert screen test not scheduled';
 };
 
@@ -289,7 +289,7 @@ subtest 'load test success when casedir and productdir are relative path' => sub
     my $log = combined_from { isotovideo(opts => "casedir=my_cases productdir=my_cases/products/foo schedule=$module", exit_code => 0) };
     unlike $log, qr/\[warn\]/, 'no warnings';
     like $log, qr/scheduling failing_module/, 'schedule can still be found';
-    like $log, qr/\d* loaded 4 needles/, 'loaded needles successfully';
+    like $log, qr/loaded 4 needles/, 'loaded needles successfully';
 };
 
 

--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -53,7 +53,7 @@ my $log = path('autoinst-log.txt')->slurp;
 my $version = -e "$toplevel_dir/.git" ? qr/[a-f0-9]+/ : 'UNKNOWN';
 like $log, qr/Current version is $version [interface v[0-9]+]/, 'version read from git';
 like $log, qr/\d*: EXIT 0/, 'test executed fine';
-like $log, qr/\d* Snapshots are supported/, 'Snapshots are enabled';
+like $log, qr/Snapshots are supported/, 'Snapshots are enabled';
 unlike $log, qr/Tests died:/, 'Tests did not fail within modules' or diag "autoinst-log.txt: $log";
 unlike $log, qr/script_run: DEPRECATED call of script_run.+die_on_timeout/, 'no deprecation warning for script_run';
 like $log, qr/do not wait_still_screen/, 'test type string and do not wait';


### PR DESCRIPTION
The problem was that when calling `fctinfo` for example, but the log level would not include info, it would print the `color('yellow')`, but not the `color('reset')`.

The result is that the prefix

    2025-02-13T15:50:34.660152Z] [debug] [pid:2866]

itself is not colored anymore, so I had to adapt the tests.

Issue: https://progress.opensuse.org/issues/177024