### PR TITLE
Fix return value of _dbus_call

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -119,7 +119,7 @@ sub _dbus_do_call ($self, $fn, @args) {
 }
 
 sub _dbus_call ($self, $fn, @args) {
-    my ($rt, $message, $error);
+    my ($rt, $message);
     try {
         # do not die on unconfigured service
         local $SIG{__DIE__};
@@ -131,9 +131,8 @@ sub _dbus_call ($self, $fn, @args) {
         my $msg = "Open vSwitch command '$fn' with arguments '@args' failed: $e";
         die "$msg\n" unless $bmwqemu::vars{QEMU_NON_FATAL_DBUS_CALL};
         bmwqemu::diag $msg;
-        $error = $e;
     }
-    return ($rt, $message, ($error) x !!($error));
+    return ($rt, $message);
 }
 
 sub do_stop_vm ($self, @) {

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -66,7 +66,7 @@ subtest 'using Open vSwitch D-Bus service' => sub {
     my $msg = 'error about missing service';
     throws_ok { $backend->_dbus_call('show', 'foo', 'bar') } $expected, $msg . ' in exception';
     $bmwqemu::vars{QEMU_NON_FATAL_DBUS_CALL} = 1;
-    combined_like { ok($backend->_dbus_call('show', 'foo', 'bar'), 'failed dbus call ignored gracefully') } $expected, $msg;
+    combined_like { is_deeply([$backend->_dbus_call('show', 'foo', 'bar')], [undef, undef], 'failed dbus call ignored gracefully') } $expected, $msg;
     $bmwqemu::vars{QEMU_NON_FATAL_DBUS_CALL} = 0;
     $backend_mock->redefine(_dbus_do_call => sub { (1, 'failed') });
     throws_ok { $backend->_dbus_call('show') } qr/failed/, 'failed dbus call throws exception';


### PR DESCRIPTION
The third return value is and was never used anyway.

It was producing a warning now because $error could be undef: 8ee2c5d2d37516fdcb3844f7478e7aedec34e00e
Where before `$@` contained the empty string.

Issue: https://progress.opensuse.org/issues/177384