### PR TITLE
Fix test API function `force_soft_failure`

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -275,7 +275,7 @@ sub done ($self) {
 }
 
 sub fail_if_running ($self) {
-    $self->{result} = 'fail' if $self->{result};
+    $self->{result} = 'fail' if $self->{result} && !$self->{_result_forced};
     autotest::set_current_test(undef);
 }
 
@@ -494,6 +494,7 @@ sub record_testresult ($self, $result = undef, %args) {
     elsif ($result eq 'softfail') {
         if (!$$current_result || $$current_result ne 'fail' || $args{force_status}) {
             $$current_result = 'softfail';
+            $self->{_result_forced} = 1 if $args{force_status};
         }
     }
     elsif ($result && $result eq 'ok') {


### PR DESCRIPTION
This function can be invoked from the post fail hook to override the test according to the documentation. That didn't work because the override is overridden itself. This change prevents that so the test actually ends up softfailed.

Related ticket: https://progress.opensuse.org/issues/176820

---

I also tested this locally cloning the reproducer mentioned in the ticket (`openqa-clone-job https://openqa.opensuse.org/tests/4867539 CASEDIR=https://github.com/os-autoinst/os-autoinst-distri-openQA.git#reproducer`).