### PR TITLE
perltidy: Use new --pack-operator-types option

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -12,6 +12,4 @@
 -bt=2    # no spaces around []
 -sbt=2   # no spaces around {}
 -sct     # stack closing tokens )}
-# Prevent excessive line-wrapping
-# See https://github.com/perltidy/perltidy/issues/171
---freeze-newlines
+--pack-operator-types='->' # allow chained method calls on one line

--- a/cpanfile
+++ b/cpanfile
@@ -101,7 +101,7 @@ on 'develop' => sub {
     requires 'Code::TidyAll';
     requires 'Devel::Cover';
     requires 'Module::CPANfile';
-    requires 'Perl::Tidy', '== 20250105.0.0';
+    requires 'Perl::Tidy', '== 20250214.0.0';
     requires 'Template::Toolkit';
 
 };

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -52,7 +52,7 @@ devel_requires:
   perl(Devel::Cover):
   perl(Module::CPANfile):
   perl(Template::Toolkit):
-  perl(Perl::Tidy): == 20250105.0.0
+  perl(Perl::Tidy): == 20250214.0.0
   ShellCheck:
   shfmt:
 


### PR DESCRIPTION
It was added in version 20250214.

See perltidy/perltidy#171

We temporarily used `---freeze-newlines` to disable wrapping chained
method calls.