### PR TITLE
codecov: Mark consoles/ as completely covered

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -18,24 +18,7 @@ coverage:
         paths:
           - OpenQA/
           - backend/
-          - consoles/console.pm
-          - consoles/VMWare.pm
-          - consoles/VNC.pm
-          - consoles/video_base.pm
-          - consoles/localXvnc.pm
-          - consoles/network_console.pm
-          - consoles/serial_screen.pm
-          - consoles/sshSerial.pm
-          - consoles/sshVirtsh.pm
-          - consoles/sshVirtshSUT.pm
-          - consoles/sshIucvconn.pm
-          - consoles/sshXtermIPMI.pm
-          - consoles/sshXtermVt.pm
-          - consoles/ssh_screen.pm
-          - consoles/s3270.pm
-          - consoles/video_stream.pm
-          - consoles/virtio_terminal.pm
-          - consoles/vnc_base.pm
+          - consoles/
           - commands.pm
           - distribution.pm
           - autotest.pm


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/167920