### PR TITLE
testapi: allow keeping mouse in place after clicking

### DIFF
--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -723,6 +723,9 @@ subtest 'assert_and_click' => sub {
     ok(assert_and_click('foo', button => 'right'));
     is_deeply($cmds->[-2], {bstate => 0, button => 'right', cmd => 'backend_mouse_button'}, 'assert_and_click succeeds with right click');
     is_deeply($cmds->[-1], {cmd => 'backend_mouse_set', x => 100, y => 100}, 'assert_and_click succeeds and move to old mouse set');
+
+    ok(assert_and_click('foo', mousehide => -1));
+    is_deeply($cmds->[-1], {cmd => 'backend_mouse_button', button => 'left', bstate => 0}, 'assert_and_click succeeds and keep mouse with mousehide => -1');
 };
 
 subtest 'assert_and_dclick' => sub {

--- a/testapi.pm
+++ b/testapi.pm
@@ -486,8 +486,9 @@ instead. Supported values for C<$button> are C<'left'> and C<'right'>, C<'left'>
 is the default. If C<$mousehide> is true then always move mouse to the 'hidden'
 position after clicking to prevent to disturb the area where the user wants to
 assert/click in the second step, otherwise move the mouse back to its previous
-position. If C<$point_id> is specified, the clickpoint used will be the one
-with a matching ID.
+position. If C<$mousehide> is -1 then keep mouse in the place where it clicked.
+If C<$point_id> is specified, the clickpoint used will be the one with a
+matching ID.
 
 =cut
 
@@ -529,8 +530,10 @@ sub click_lastmatch (%args) {
     if ($old_mouse_coords->{x} > -1 && $old_mouse_coords->{y} > -1 && !$args{mousehide}) {
         return mouse_set($old_mouse_coords->{x}, $old_mouse_coords->{y});
     }
-    else {
+    elsif ($args{mousehide} != -1) {
         return mouse_hide();
+    } else {
+        return 1;
     }
 }
 


### PR DESCRIPTION
Sometimes it's useful to keep the mouse cursor in place after clicking,
to avoid spurious hover events between actions. This is especially
useful when emulated mouse is really a mouse (with relative movement)
instead of a tablet device (with instant teleport).
On the API side, there is already mousehide arg, accepting 0 and 1
values (or true/false). Logically, it should be mousehide=>0, but that
has other meaning already. Implement this as mousehide=>-1 instead.