### PR TITLE
Retry asset sync in svirt backend after timeouts

### DIFF
--- a/doc/backend_vars.asciidoc
+++ b/doc/backend_vars.asciidoc
@@ -251,6 +251,7 @@ SVIRT_KEEP_VM_RUNNING;boolean;undef;Keep VM running after execution, disabled by
 SVIRT_WORKER_CACHE;boolean;0;Use the openQA worker cache if possible to copy images to the svirt host - this means the path specified when invoking `add_disk` is **not** fully regarded, e.g. if the specified path points into the `fixed`-subdirectory but the openQA worker cached the same asset under the regular directory (which it prefers over the `fixed`-subdirectory) then the asset from the regular directory will be used
 SVIRT_ASSET_DOWNLOAD_TIMEOUT_M;number;15;Timeout for asset downloads within svirt backend in minutes.
 SVIRT_ASSET_DOWNLOAD_INACTIVITY_TIMEOUT_M;number;2.5;Inactvity timeout for asset downloads within svirt backend in minutes.
+SVIRT_ASSET_DOWNLOAD_ATTEMPTS;integer;3;The number of attempts when syncing assets (without worker cache) runs into SVIRT_ASSET_DOWNLOAD_TIMEOUT_M.
 WORKER_HOSTNAME;string;undef;Worker hostname
 |====================
 


### PR DESCRIPTION
* Add test variable `SVIRT_ASSET_DOWNLOAD_ATTEMPTS` specify the number of sync attempts after timeouts
* Use the rsync option `--partial` so the download can continue where it was interrupted
* Do not simply increase the timeout because before introducing the timeout jobs ran into the overall timeout (so just waiting longer probably does not help)
* See https://progress.opensuse.org/issues/178324