### PR TITLE
Enable is_shutdown to be used after "power('off')" on qemu

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -453,7 +453,7 @@ sub stop_vm ($self, @) {
     }
     $self->_stop_video_encoder();
     $self->close_ssh_connections();
-    $self->close_pipes();    # does not return
+    $self->close_pipes(1);    # does not return
     return;
 }
 
@@ -588,7 +588,7 @@ sub wait_still_screen ($self, $args) {
     return {postponed => 1};
 }
 
-sub close_pipes ($self) {
+sub close_pipes ($self, $closeall = 0) {
     if ($self->{cmdpipe}) {
         close($self->{cmdpipe}) || die "close $!\n";
         $self->{cmdpipe} = undef;

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -41,6 +41,7 @@ sub new ($class) {
     $self->{pidfilename} = 'qemu.pid';
     $self->{proc} = OpenQA::Qemu::Proc->new();
     $self->{proc}->_process->pidfile($self->{pidfilename});
+    $self->{expected_shutdown} = 0;
     return $self;
 }
 
@@ -74,6 +75,11 @@ sub power ($self, $args) {
         reset => 'system_reset',
         off => 'quit',
     );
+    if ($args->{action} eq 'off') {
+        $self->{expected_shutdown} = 1;
+        $self->disable_consoles();
+    }
+    bmwqemu::diag("POWER: action: $args->{action}, expected_shutdown: $self->{expected_shutdown}");
     $self->handle_qmp_command({execute => $action_to_cmd{$args->{action}}});
 }
 
@@ -1120,8 +1126,23 @@ sub handle_qmp_command ($self, $cmd, %optargs) {
         bmwqemu::fctinfo("Skipping the following qmp_command because QEMU_ONLY_EXEC is enabled:\n$line");
         return undef;
     }
-    my $wb = defined $optargs{send_fd} ? tinycv::send_with_fd($sk, $line, $optargs{send_fd}) : syswrite($sk, $line);
-    die "handle_qmp_command: syswrite failed $!" unless ($wb == length($line));
+    local $SIG{__DIE__} = undef;    # prevent custom die handler so that a broken pipe can be handled
+    my $wb;
+    try {
+        # die explicitly to workaround bug resulting in a warning when a function fails that got undef as an argument:
+        # "Use of uninitialized value $args[0] in join or string at /usr/lib/perl5/5.40.1/autodie/exception.pm line 507"
+        die "Can't syswrite(<UNDEF>, <BUFFER>): Bad file descriptor" unless $sk;
+        $wb = defined $optargs{send_fd} ? tinycv::send_with_fd($sk, $line, $optargs{send_fd}) : syswrite($sk, $line);
+    }
+    catch ($e) {
+        if ($line =~ qr/query-status/ && $self->{expected_shutdown} && $e =~ qr/(Broken pipe|Bad file descriptor)/) {
+            return {return => {status => 'shutdown'}};
+        }
+        # these two lines are actually covered via t/99-full-stack-stop.t but the coverage doesn't detect it
+        bmwqemu::fctwarn("The following qmp_command failed because qemu was explicitly stopped from test code via power('off'):\n$line") if $self->{expected_shutdown}; # uncoverable statement
+        die "handle_qmp_command: Unexpected error: $e";    # uncoverable statement
+    }
+    die "handle_qmp_command: syswrite failed $!" unless $wb && $wb == length($line);
 
     my $hash;
     do {
@@ -1157,7 +1178,8 @@ sub read_qemupipe ($self) {
     return $bytes;
 }
 
-sub close_pipes ($self) {
+sub close_pipes ($self, $closeall = 0) {
+    # if closeall is 1, close not only pipes to qemu but also jsonrpc connection to autotest
     $self->do_stop_vm() if $self->{started};
 
     if (my $qemu_pipe = $self->{qemupipe}) {
@@ -1175,7 +1197,7 @@ sub close_pipes ($self) {
         $self->{qmpsocket} = undef;
     }
 
-    $self->SUPER::close_pipes() unless exists $self->{stop_only_qemu} && $self->{stop_only_qemu};
+    $self->SUPER::close_pipes() if $closeall || !((exists $self->{stop_only_qemu} && $self->{stop_only_qemu}) || $self->{expected_shutdown});
 }
 
 sub is_shutdown ($self, @) {

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -792,4 +792,13 @@ subtest 'special cases when handling QMP command' => sub {
     qr/Skipping.*because QEMU_ONLY_EXEC/, 'skipping logged';
 };
 
+subtest 'die with error on QMP command after power("off")' => sub {
+    $bmwqemu::vars{QEMU_ONLY_EXEC} = 0;
+    $backend->{expected_shutdown} = 0;
+    $backend_mock->redefine(handle_qmp_command => undef);
+    $backend->power({action => 'off'});
+    $backend_mock->unmock('handle_qmp_command');
+    combined_like { throws_ok { $backend->power({action => 'reset'}) } qr/Bad file descriptor/, 'die as expected' } qr/qemu was explicitly stopped from test code.*system_reset/s, 'warning as expected';
+};
+
 done_testing();

--- a/t/data/tests/tests/shutdown.pm
+++ b/t/data/tests/tests/shutdown.pm
@@ -5,8 +5,9 @@ use Mojo::Base 'basetest', -signatures;
 use testapi;
 
 sub run ($) {
-    enter_cmd 'sudo poweroff';
+    power 'off';
     assert_shutdown(get_var('INTEGRATION_TESTS') ? 90 : undef);
+    power 'reset' if get_var('CMD_AFTER_STOP');
 }
 
 sub test_flags ($) { {fatal => 1} }


### PR DESCRIPTION
"power('off')" for the qemu backend sends the QMP command "quit" which
causes the whole qemu stack to shutdown closing the QMP pipe from the
remote end which previously triggered a "Broken pipe" exception whenever
"is_shutdown" is called after the power command. This commit explicitly
handles this situation by returning the "shutdown" status correctly.
Other combinations of testapi commands if used in undefined operations
might still fail

Tested using t/99-full-stack.t by using "power('off')" instead of "sudo
powerdown" in t/data/tests/tests/shutdown.pm

Related progress issue: https://progress.opensuse.org/issues/176319