### PR TITLE
Adapt check for git error message to new version

### DIFF
--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -173,7 +173,7 @@ sub clone_git ($local_path, $clone_url, $clone_depth, $branch, $dir, $dir_variab
     my $depth_args = $cache_dir ? '' : "--depth='$clone_depth'";    # cannot use `--depth` with $cache_dir
     if (!$cache_dir) {    # cannot use `--branch` with $cache_dir so just move to fallback directly
         my @out = qx{$clone_cmd $depth_args $branch_args $source_url 2>&1};
-        return $handle_output->($?, @out) unless ($branch && grep /warning: Could not find remote branch/, @out);
+        return $handle_output->($?, @out) unless ($branch && grep /fatal: Remote branch .* not found in upstream origin/, @out);
     }
 
     # if cloning with `--branch=…` does not work, just clone the default branch instead and fetch and checkout the missing

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -111,7 +111,7 @@ subtest 'isotovideo with custom git repo parameters specified' => sub {
     like $log, qr/Cloning into 'repo'/, 'repo picked up';
     like $log, qr{git URL.*/repo}, 'git repository attempted to be cloned';
     like $log, qr/branch.*foo/, 'branch in git repository attempted to be checked out';
-    like $log, qr/fatal:.*/, 'fatal Git error logged';
+    like $log, qr/warning:.*empty repository/, 'Git warning logged';
     unlike $log, qr/No scripts/, 'execution of isotovideo aborted; no follow-up error about empty CASEDIR produced';
 
     subtest 'fatal error recorded for passing as reason' => sub {


### PR DESCRIPTION
Until git 2.48 we get:

    % git clone repo --depth=1 --branch abcdef
    warning: Could not find remote branch abcdef to clone.
    fatal: Remote branch abcdef not found in upstream origin

Since 2.49 only the fatal error is printed.

Issue: https://progress.opensuse.org/issues/179017