### PR TITLE
Avoid leftover rsync processes on svirt host

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -676,7 +676,7 @@ sub run_cmd ($self, $cmd, %args) {
 }
 
 sub run_cmd_retrying_on_timeouts ($self, $command, @args) {
-    my $attempts = $bmwqemu::vars{SVIRT_ASSET_DOWNLOAD_ATTEMPTS} // 3;
+    my $attempts = $bmwqemu::vars{SVIRT_ASSET_DOWNLOAD_ATTEMPTS} // 1;
     for (my $attempt = 1;;) {
         try {
             return $self->run_cmd($command, @args);

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -451,6 +451,7 @@ subtest 'SSH usage in console::sshVirtsh' => sub {
     };
 
     subtest 'running command with retry on ssh timeout' => sub {
+        local $bmwqemu::vars{SVIRT_ASSET_DOWNLOAD_ATTEMPTS} = 3;
         %ssh_expect = ();
         $run_ssh_cmd_return = 42;
         $fake_timeouts = 2;


### PR DESCRIPTION
Alternative to https://github.com/os-autoinst/os-autoinst/pull/2682.

---

* Disable retries introduced by c30cd0ec again as this potentially leaves leftover rsync processes slowing everything down
* See https://progress.opensuse.org/issues/178324 and https://progress.opensuse.org/issues/179077