### PR TITLE
Enable validation of resumed asset downloads in svirt backend

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -384,7 +384,7 @@ sub _system (@cmd) { system @cmd }    # uncoverable statement
 sub _copy_image_else ($self, $file, $file_basename, $basedir) {
     my $download_timeout_s = ONE_MINUTE * ($bmwqemu::vars{SVIRT_ASSET_DOWNLOAD_TIMEOUT_M} // 15);
     my $inactivity_timeout_s = ONE_MINUTE * ($bmwqemu::vars{SVIRT_ASSET_DOWNLOAD_INACTIVITY_TIMEOUT_M} // 2.5);
-    my $rsync_args = "--timeout='$inactivity_timeout_s' --stats --partial -av";
+    my $rsync_args = "--timeout='$inactivity_timeout_s' --stats --partial --append-verify -av";
 
     # utilize asset possibly cached by openQA worker, otherwise sync locally on svirt host (usually relying on NFS mount)
     if (($bmwqemu::vars{SVIRT_WORKER_CACHE} // 0) && -e $file_basename && defined which 'rsync') {

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -952,7 +952,7 @@ subtest 'Method consoles::sshVirtsh::add_disk()' => sub {
             @last_ssh_commands = ();
             @ssh_cmd_return = (0, 0);
             $svirt->add_disk({cdrom => 1, dev_id => $dev_id, file => $file_path});
-            is $last_system_calls[0], "sshpass -p 'password_svirt' rsync -e 'ssh -o StrictHostKeyChecking=no' --timeout='150' --stats --partial -av '$dir/$file' 'root\@hostname_svirt:$basedir/$file'", 'file copied with rsync';
+            is $last_system_calls[0], "sshpass -p 'password_svirt' rsync -e 'ssh -o StrictHostKeyChecking=no' --timeout='150' --stats --partial --append-verify -av '$dir/$file' 'root\@hostname_svirt:$basedir/$file'", 'file copied with rsync';
             like $last_ssh_commands[0], qr%unxz%, 'file uncompressed with unxz';
 
             svirt_xml_validate($svirt,


### PR DESCRIPTION
* Use `--append-verify` to make sure resumed downloads are still fully validated
* See https://progress.opensuse.org/issues/178324