### PR TITLE
Add a stash (key/value storage) to testapi

### DIFF
--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -1286,6 +1286,28 @@ subtest 'ensure_installed test' => sub {
     ensure_installed(['openQA', 'os-autoinst-devel']);
 };
 
+subtest stash => sub {
+    my @diag;
+    $mock_bmwqemu->redefine(diag => sub ($msg) { push @diag, $msg });
+    my $hash = bless {key => 23}, 'Some::Class';
+    stash somename => $hash;
+    my $stored = stash 'somename';
+    is $stored->{key}, 23, 'retrieving values via stash() works';
+
+    @diag = ();
+    debug_stash;
+    is $diag[0], <<~'EOM', 'debug_stash() works';
+    testapi stash:
+    ---
+    somename: !perl/hash:Some::Class
+      key: 23
+    EOM
+
+    delete_stash 'somename';
+    $stored = stash 'somename';
+    is $stored, undef, 'delete_stash() values works';
+};
+
 done_testing;
 
 END {


### PR DESCRIPTION
This came up in the company chat.

We don't want people to use global variables to save data between test modules, but people are using it.
So we should rather provide an API for it to avoid [action at a distance](https://en.wikipedia.org/wiki/Action_at_a_distance_(computer_programming)). That is at least traceable.

`get_var` / `set_var` is not the right choice for some data.
It is saved to `vars.json`, and JSON can't encode values like objects and regexes for example.
Also if you want to store big data, I think `vars.json` should not be cluttered with that.