### PR TITLE
Update Perl::Tidy to 20250311

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -101,7 +101,7 @@ on 'develop' => sub {
     requires 'Code::TidyAll';
     requires 'Devel::Cover';
     requires 'Module::CPANfile';
-    requires 'Perl::Tidy', '== 20250214.0.0';
+    requires 'Perl::Tidy', '== 20250311.0.0';
     requires 'Template::Toolkit';
 
 };

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -52,7 +52,7 @@ devel_requires:
   perl(Devel::Cover):
   perl(Module::CPANfile):
   perl(Template::Toolkit):
-  perl(Perl::Tidy): == 20250214.0.0
+  perl(Perl::Tidy): == 20250311.0.0
   ShellCheck:
   shfmt:
 


### PR DESCRIPTION
Sync with Perl-Tidy version in factory 20250311.0.0-1.1

Corresponding change in test-distri: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21618