### PR TITLE
Remove unused variables and exports from testapi

### DIFF
--- a/testapi.pm
+++ b/testapi.pm
@@ -29,7 +29,7 @@ use Time::Seconds;
 require bmwqemu;
 use constant OPENQA_LIBPATH => '/usr/share/openqa/lib';
 
-our @EXPORT = qw($realname $username $password $serialdev %cmd %vars
+our @EXPORT = qw($realname $username $password $serialdev
 
   get_var get_required_var check_var set_var get_var_array check_var_array autoinst_url
 
@@ -62,8 +62,6 @@ our @EXPORT = qw($realname $username $password $serialdev %cmd %vars
   save_tmp_file get_test_data
 );
 our @EXPORT_OK = qw(is_serial_terminal);
-
-our %cmd;
 
 our $distri;
 


### PR DESCRIPTION
It seems the code using `%cmd` was already removed in 75678433628cbb876ba8efcd22021c50c093b0ef
and `%vars`in
33f52cd18cbd6db7b89a176a99b6d4118abb83f2