### PR TITLE
Revert "Remove unused variables and exports from testapi"

### DIFF
--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -9,7 +9,7 @@ use Mojo::Base -strict, -signatures;
 # -> increment on every change of such APIs
 # -> never move that variable to another place (when refactoring)
 #    because it may be accessed by the tests itself
-our $version = 43;
+our $version = 44;
 
 # major version of the (web socket) API relevant to the developer mode
 # -> increment when making non-backward compatible changes to that API

--- a/testapi.pm
+++ b/testapi.pm
@@ -29,7 +29,7 @@ use Time::Seconds;
 require bmwqemu;
 use constant OPENQA_LIBPATH => '/usr/share/openqa/lib';
 
-our @EXPORT = qw($realname $username $password $serialdev
+our @EXPORT = qw($realname $username $password $serialdev %cmd
 
   get_var get_required_var check_var set_var get_var_array check_var_array autoinst_url
 
@@ -62,6 +62,8 @@ our @EXPORT = qw($realname $username $password $serialdev
   save_tmp_file get_test_data
 );
 our @EXPORT_OK = qw(is_serial_terminal);
+
+our %cmd;
 
 our $distri;
 


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst#2695 due to failures showing up on openqa.opensuse.org, see https://github.com/os-autoinst/os-autoinst/pull/2695#issuecomment-2791751789