### PR TITLE
tidy: Enforce blank lines before subs

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -3,7 +3,7 @@
 --character-encoding=none
 --no-valign
 -l=160
--fbl     # don't change blank lines
+--noblanks-before-comments
 -fnl     # don't remove new lines
 -nsfs    # no spaces before semicolons
 -baao    # space after operators
@@ -13,3 +13,6 @@
 -sbt=2   # no spaces around {}
 -sct     # stack closing tokens )}
 --pack-operator-types='->' # allow chained method calls on one line
+--blanks-before-subs
+--keep-old-blank-lines=2 # keep all blank lines
+--noblanks-before-blocks

--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -217,6 +217,7 @@ If C<repo> is specified it is used as the actual URL of the repo.
 Cloning may fail up to C<retry_count> times with a delay of C<retry_interval> seconds.
 
 =cut
+
 sub checkout_git_repo_and_branch ($dir_variable, %args) {
     my $dir = $bmwqemu::vars{$dir_variable} // $args{repo};
     return undef unless defined $dir;
@@ -259,6 +260,7 @@ optional git refspec to checkout.
 If no wheels are configured the function returns early.
 
 =cut
+
 sub checkout_wheels ($case_dir, $wheels_dir = undef) {
     my $specfile = path($case_dir, 'wheels.yaml');
     return 1 unless -e $specfile;
@@ -299,6 +301,7 @@ Example:
     checkout_git_refspec('/path/to/casedir', 'TEST_GIT_REFSPEC');
 
 =cut
+
 sub checkout_git_refspec ($dir, $refspec_variable) {
     return undef unless defined $dir;
     if (my $refspec = $bmwqemu::vars{$refspec_variable}) {

--- a/OpenQA/Qemu/BlockDev.pm
+++ b/OpenQA/Qemu/BlockDev.pm
@@ -74,6 +74,7 @@ still be taken from the backing files in the chain).
 To avoid memory leaks we weaken this reference.
 
 =cut
+
 sub overlay ($self, $ol) {
     return $self->{overlay} unless defined $ol;
     $self->{overlay} = $ol;
@@ -143,6 +144,7 @@ for the entire blockdevice chain or an empty array if it does not need
 creating.
 
 =cut
+
 sub gen_qemu_img_cmdlines ($self) {
     my $backing_file = $self->backing_file;
     my @cmdlns = defined $backing_file ? $backing_file->gen_qemu_img_cmdlines : ();
@@ -163,6 +165,7 @@ If any image file in the chain is marked as needs_creating, but already exists
 this will return it in an array so that the caller can unlink it.
 
 =cut
+
 sub gen_unlink_list ($self) {
     return () unless $self->needs_creating;
     return ($self->file, $self->backing_file->gen_unlink_list())

--- a/OpenQA/Qemu/BlockDevConf.pm
+++ b/OpenQA/Qemu/BlockDevConf.pm
@@ -26,6 +26,7 @@ has _drives => sub ($self) { [] };
 Add an existing image file at the bottom/start of a block device chain.
 
 =cut
+
 sub add_existing_base ($self, $id, $file_name, $size) {
     $file_name //= $id;
 
@@ -41,6 +42,7 @@ Add a new image file at the bottom of a block device chain. The file is not
 created by this function, this just updates the object model.
 
 =cut
+
 sub add_new_base ($self, $id, $file_name, $size) {
     $file_name //= $id;
 
@@ -53,6 +55,7 @@ sub add_new_base ($self, $id, $file_name, $size) {
 Add an existing image file as the overlay of $backing_file.
 
 =cut
+
 sub add_existing_overlay ($self, $id, $backing_file) {
     my $ol = OpenQA::Qemu::BlockDev->new()
       ->node_name($id)
@@ -93,6 +96,7 @@ sub _push_new_drive_dev ($self, $id, $drive, $model, $num_queues = undef, $secto
 Create a new drive device and qcow2 image.
 
 =cut
+
 sub add_new_drive ($self, $id, $model, $size, $num_queues = undef, $sector_size = undef) {
     my $base_drive = $self->add_new_base($id, $id, $size);
     return $self->_push_new_drive_dev($id, $base_drive, $model, $num_queues, $sector_size);
@@ -104,6 +108,7 @@ Create a new drive device with an existing qcow2 image as the backing store. A
 new overlay is created so that the existing qcow2 image is not modified.
 
 =cut
+
 sub add_existing_drive ($self, $id, $file_name, $model, $size, $num_queues = undef, $sector_size = undef) {
     my $base_drive = $self->add_existing_base($id, $file_name, $size)->implicit(1)->deduce_driver;
     my $overlay = $self->add_new_overlay($id . OVERLAY_POSTFIX . '0', $base_drive);
@@ -119,6 +124,7 @@ is created, so the test can write to this drive and it won't modify the
 underlying image.
 
 =cut
+
 sub add_iso_drive ($self, $id, $file_name, $model, $size) {
     my $base_drive = $self->add_existing_base($id, $file_name, $size)
       ->implicit(1)
@@ -134,6 +140,7 @@ Add a pflash drive which is generally used for UEFI firmware code and
 variables. See the OpenQA::Qemu::PFlashDevice class.
 
 =cut
+
 sub add_pflash_drive ($self, $id, $file_name, $size) {
     my $base_drive = $self->add_existing_base($id, $file_name, $size)->implicit(1)->deduce_driver;
     my $overlay = $self->add_new_overlay($id . OVERLAY_POSTFIX . '0', $base_drive);
@@ -151,6 +158,7 @@ Add a connection between a drive device and a controller device. You can add
 multiple connections to simulate multipath.
 
 =cut
+
 sub add_path_to_drive ($self, $id, $drive, $controller) {
     my $dp = OpenQA::Qemu::DrivePath->new()
       ->controller($controller)
@@ -167,6 +175,7 @@ added at runtime by a QEMU QMP command which creates the overlay, so this
 function will not mark the overlay for creation by qemu-img.
 
 =cut
+
 sub add_snapshot_to_drive ($self, $drive, $snapshot) {
     my $id = $drive->id . OVERLAY_POSTFIX . $drive->new_overlay_id;
 
@@ -185,6 +194,7 @@ after the snapshot. These should be deleted to prevent QEMU from doing
 something unexpected. Also init_blockdev_images needs to be run after this.
 
 =cut
+
 sub revert_to_snapshot ($self, $drive, $snapshot) {
     my @del_files = ();
 

--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -70,6 +70,7 @@ Add a plain QEMU parameter, represented as an array of strings. The first item
 in the array will have '-' prepended to it.
 
 =cut
+
 sub static_param ($self, @args) {
     if (@args < 2) {
         push(@{$self->_static_params}, '-' . $args[0]);
@@ -85,6 +86,7 @@ Add SCSI, PCI and USB controllers if necessary. QEMU will automatically create
 controllers for simple configurations.
 
 =cut
+
 sub configure_controllers ($self, $vars) {
     # Setting the HD or CD model to a type of SCSI controller has been
     # deprecated for a long time.
@@ -146,6 +148,7 @@ sub get_img_format ($self, $path) { $self->get_img_json_field($path, 'format') }
 Configure disk drives and their block device backing chains. See BlockDevConf.pm.
 
 =cut
+
 sub configure_blockdevs ($self, $bootfrom, $basedir, $vars) {
     my $bdc = $self->blockdev_conf;
     my @scsi_ctrs = $self->controller_conf->get_controllers(qr/scsi/);
@@ -238,6 +241,7 @@ variables. Unfortunately pflash drives are handled differently by QEMU than
 other block devices which slightly complicates things. See BlockDevConf.pm.
 
 =cut
+
 sub configure_pflash ($self, $vars) {
     my $bdc = $self->blockdev_conf;
 
@@ -275,6 +279,7 @@ sub configure_pflash ($self, $vars) {
 Generate the QEMU command line arguments from our object model.
 
 =cut
+
 sub gen_cmdline ($self) {
     return ($self->qemu_bin,
         @{$self->_static_params},
@@ -306,6 +311,7 @@ create them.
 This should only be called when QEMU is not running.
 
 =cut
+
 sub init_blockdev_images ($self) {
     for my $file ($self->blockdev_conf->gen_unlink_list()) {
         no autodie 'unlink';
@@ -329,6 +335,7 @@ need to export the VM state (migration) file, which is effectively the same
 thing as performing an offline migration.
 
 =cut
+
 sub export_blockdev_images ($self, $filter, $img_dir, $name, $qemu_compress_qcow) {
     my $count = 0;
 
@@ -391,6 +398,7 @@ Connect to QEMU's QMP command socket so that we can control QEMU's execution
 using the JSON QAPI. QMP and QAPI are documented in the QEMU source tree.
 
 =cut
+
 sub connect_qmp ($self) {
     my $sk;
     osutils::attempt {
@@ -420,6 +428,7 @@ Roll back the SUT to a previous state, including its temporary and permanent
 storage as well as its CPU.
 
 =cut
+
 sub revert_to_snapshot ($self, $name) {
     my $bdc = $self->blockdev_conf;
 
@@ -445,6 +454,7 @@ sub revert_to_snapshot ($self, $name) {
 Serialise our object model of QEMU to JSON and return the JSON text.
 
 =cut
+
 sub serialise_state ($self) {
     return encode_json({
             blockdev_conf => $self->blockdev_conf->to_map(),
@@ -458,6 +468,7 @@ sub serialise_state ($self) {
 Save our object model of QEMU to a file.
 
 =cut
+
 sub save_state ($self) {
     if ($self->has_state) {
         bmwqemu::fctinfo('Saving QEMU state to ' . STATE_FILE);
@@ -474,6 +485,7 @@ sub save_state ($self) {
 Deserialise our object model from a string of JSON text.
 
 =cut
+
 sub deserialise_state ($self, $json) {
     my $state_map = decode_json($json);
 
@@ -491,6 +503,7 @@ sub deserialise_state ($self, $json) {
 Load our object model of QEMU from a file.
 
 =cut
+
 sub load_state ($self) {
     # In order to remove this, you need to merge the new state with the
     # existing state from disk without breaking existing snapshots (block

--- a/autotest.pm
+++ b/autotest.pm
@@ -29,6 +29,7 @@ our @testorder;    # for keeping them in order
 our $isotovideo;
 our $process;
 our $tests_running = 0;
+
 =head1 Introduction
 
 OS Autoinst decides which test modules to run based on a distribution specific
@@ -362,6 +363,7 @@ sub croak ($command, $error) {
 }
 
 my $failed_command;
+
 sub pause_on_failure ($reason, $command = undef) {
     # avoid handling a failing command again (via the die handler) after the test execution has been resumed
     if (!defined $command && $failed_command) {

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -712,6 +712,7 @@ unprocessed output from the SUT in their buffers which is needed by test
 module after the snapshot.
 
 =cut
+
 sub save_console_snapshots ($self, $name) {
     for my $console (keys %{$testapi::distri->{consoles}}) {
         my $console_info = $self->console($console);
@@ -725,6 +726,7 @@ Should be called when a snapshot of the SUT is loaded to ensure consoles are
 in the same state as when the snapshot was taken.
 
 =cut
+
 sub load_console_snapshots ($self, $name) {
     for my $console (keys %{$testapi::distri->{consoles}}) {
         my $console_info = $self->console($console);
@@ -1295,6 +1297,7 @@ sub check_ssh_serial ($self, $fh = undef, $write = undef) {
    frequently enough.
 
 =cut
+
 sub run_ssh_cmd ($self, $cmd, %args) {
     $args{wantarray} //= 0;
     $args{keep_open} //= 1;

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -1117,6 +1117,7 @@ Pass send_fd => $fd to send $fd to QEMU using SCM rights. Probably only useful
 with the getfd command.
 
 =cut
+
 sub handle_qmp_command ($self, $cmd, %optargs) {
     $optargs{fatal} ||= 0;
     my $sk = $self->{qmpsocket};

--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -234,6 +234,7 @@ into file.
 C<$args{port}> used non-default port
 C<$args{devname}> used device name
 =cut
+
 sub open_serial_console_via_ssh ($self, $name, %args) {
     bmwqemu::log_call(name => $name, %args);
     my ($chan, $cmd, $cmd_full, $ret, $ssh, $stderr, $stdout);

--- a/basetest.pm
+++ b/basetest.pm
@@ -434,6 +434,7 @@ sub write_resultfile ($self, $filename, $output) {
 Record result file to be parsed when evaluating test results, for example
 within the openQA web interface.
 =cut
+
 sub record_resultfile ($self, $title, $output, %nargs) {
     my $filename = $self->next_resultname('txt', $nargs{resultname});
     my $detail = {

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -291,6 +291,7 @@ sub scale_timeout ($timeout) {
 
 Just a random string useful for pseudo security or temporary files.
 =cut
+
 sub random_string ($count) {
     $count //= 4;
     my $string;

--- a/consoles/serial_screen.pm
+++ b/consoles/serial_screen.pm
@@ -47,6 +47,7 @@ been implemented. In the future this could be extended to provide more key
 name to terminal code mappings.
 
 =cut
+
 sub send_key ($self, $nargs) {
     croak $trying_to_use_keys unless $nargs->{key} eq 'ret';
     $nargs->{text} = "\n";
@@ -77,6 +78,7 @@ and ETX is the same as pressing Ctrl-C on a terminal.
 consoles.
 
 =cut
+
 sub type_string ($self, $nargs) {
     my $fd = $self->{fd_write};
 
@@ -133,6 +135,7 @@ An undefined timeout will cause to wait indefinitely. A timeout of 0 means to
 just read once.
 
 =cut
+
 sub do_read {    # no:style:signatures
     my ($self, undef, %args) = @_;
     my $buffer = '';
@@ -192,6 +195,7 @@ C<{ matched => 0, string => 'text from the terminal' }>
 on failure.
 
 =cut
+
 sub read_until ($self, $pattern, $timeout, %nargs) {
     my $fd = $self->{fd_read};
     my $buflen = $nargs{buffer_size} || SOCKET_READ_BUFFER_SIZE;
@@ -267,6 +271,7 @@ the backend and data transport. Therefore it should only be used when there is
 no information available about what data is expected to be available.
 
 =cut
+
 sub peak ($self, %nargs) {
     my $buflen = $nargs{buffer_size} || SOCKET_READ_BUFFER_SIZE;
     my $total_read = 0;

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -669,6 +669,7 @@ B<vmware> and defined via C<VMWARE_HOST>, C<VMWARE_PASSWORD> and 'root' as
 username.
 For further arguments see C<baseclass:run_ssh_cmd()>.
 =cut
+
 sub run_cmd ($self, $cmd, %args) {
     my %credentials = $self->get_ssh_credentials($args{domain});
     delete $args{domain};
@@ -698,6 +699,7 @@ With C<<wantarray => 1>> the function returns an array reference containing I<st
 I<stderr>.
 This function is B<deprecated>, you should use C<<$svirt->run_cmd()>> instead.
 =cut
+
 sub get_cmd_output ($self, $cmd, $args = {}) {
     my (undef, $stdout, $stderr) = $self->backend->run_ssh_cmd($cmd, $self->get_ssh_credentials($args->{domain}), timeout => $args->{timeout}, wantarray => 1);
     return $args->{wantarray} ? [$stdout, $stderr] : $stdout;

--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -121,6 +121,7 @@ Returns the read and write file descriptors for the open sockets,
 otherwise it dies.
 
 =cut
+
 sub open_pipe ($self) {
     bmwqemu::log_call(pipe_prefix => $self->{pipe_prefix});
 

--- a/distribution.pm
+++ b/distribution.pm
@@ -226,6 +226,7 @@ You may be able to avoid overriding this function by setting
 $serial_term_prompt.
 
 =cut
+
 sub script_output ($self, $script, @args) {
     my %args = testapi::compat_args(
         {
@@ -327,6 +328,7 @@ Example:
     );
 
 =cut
+
 sub set_expected_serial_failures ($self, $failures) {
     $self->{serial_failures} = $failures;
 }
@@ -347,6 +349,7 @@ Example:
     );
 
 =cut
+
 sub set_expected_autoinst_failures ($self, $failures) {
     $self->{autoinst_failures} = $failures;
 }

--- a/mmapi.pm
+++ b/mmapi.pm
@@ -249,6 +249,7 @@ sub wait_for_children () {
 Wait while any scheduled children exist.
 
 =cut
+
 sub wait_for_children_to_start () {
     while (1) {
         my $children = get_children() // die 'Failed to wait for children to start';
@@ -270,6 +271,7 @@ sub wait_for_children_to_start () {
 
 Query openQA's API to retrieve the current job ID
 =cut
+
 sub get_current_job_id () {
     my $tx = api_call_2(get => 'whoami', undef, $CODES_EXPECTED_BY_MMAPI);
     return undef if handle_api_error($tx, 'whoami', $CODES_EXPECTED_BY_MMAPI);

--- a/script/imgsearch
+++ b/script/imgsearch
@@ -14,8 +14,8 @@ use cv;
 use needle;
 
 # define a basic needle package; normally `needle` should inherit from this package
-{
-    package basic_needle;    # uncoverable statement
+
+package basic_needle {    # uncoverable statement
     use base 'needle';
     use Mojo::File qw(path);
 

--- a/script/os-autoinst-openvswitch
+++ b/script/os-autoinst-openvswitch
@@ -183,6 +183,7 @@ sub check_min_ovs_version ($min_ver) {
 sub _set_ip ($tap) { system('ip', 'link', 'set', $tap, 'up') }
 
 dbus_method("set_vlan", ["string", "uint32"], ["int32", "string"]);
+
 sub set_vlan ($self, $tap, $vlan) {
     my $return_output;
     my $return_code = 1;
@@ -214,6 +215,7 @@ sub set_vlan ($self, $tap, $vlan) {
 }
 
 dbus_method("unset_vlan", ["string", "uint32"], ["int32", "string"]);
+
 sub unset_vlan ($self, $tap, $vlan) {
     my $return_output;
     my $return_code = 1;
@@ -239,6 +241,7 @@ sub unset_vlan ($self, $tap, $vlan) {
 sub _ovs_show () { _cmd('ovs-vsctl', 'show') }
 
 dbus_method("show", [], ["int32", "string"]);
+
 sub show ($self) {
     my ($return_code, undef, $ovs_vsctl_output) = _ovs_show;
     return $return_code, $ovs_vsctl_output;

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -37,6 +37,7 @@ my @sent;    # array of messages sent with the fake json_send
 my @reset_consoles;
 my @selected_consoles;
 sub fake_send ($target, $msg) { push @sent, $msg }
+
 sub fake_read ($fd, $cmd_token = undef) {
     my $lcmd = $sent[-1];
     my $cmd = $lcmd->{cmd};

--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -42,6 +42,7 @@ sub read_vars () {
 
 subtest 'log_call' => sub {
     require bmwqemu;
+
     sub log_call_test {
         bmwqemu::log_call(foo => "bar\tbaz\rboo\n");
     }

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -294,8 +294,8 @@ subtest 'load test success when casedir and productdir are relative path' => sub
 
 
 # mock backend/driver
-{
-    package FakeBackendDriver;    # uncoverable statement
+package FakeBackendDriver {    # uncoverable statement
+
     sub new ($class, $name) {
         my $self = bless({class => $class}, $class);
         require "backend/$name.pm";

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -43,6 +43,7 @@ my $fake_ignore_failure;
 my $suppress_match;
 my @selected_consoles;
 sub fake_send_json ($to_fd, $cmd) { push(@$cmds, $cmd) }
+
 sub fake_read_json ($fd) {
     my $lcmd = $cmds->[-1];
     my $cmd = $lcmd->{cmd};

--- a/t/18-qemu-options.t
+++ b/t/18-qemu-options.t
@@ -41,6 +41,7 @@ my @common_options = (
 my $vars_json = path('vars.json');
 my $log_file = path('autoinst-log.txt');
 my $log = '';
+
 sub run_isotovideo (@args) {
     $vars_json->spew(encode_json({@common_options, @args}));
     ok system("cd $toplevel_dir && perl $toplevel_dir/isotovideo --workdir $pool_dir -d qemu_disable_snapshots=1 2>&1 | tee $pool_dir/autoinst-log.txt") == 0, 'zero exit status';

--- a/t/19-isotovideo-command-processing.t
+++ b/t/19-isotovideo-command-processing.t
@@ -41,17 +41,17 @@ $rpc_mock->redefine(read_json => sub {
 });
 
 # mock bmwqemu/backend
-{
-    package FakeBackend;    # uncoverable statement
+package FakeBackend {    # uncoverable statement
     sub new ($class) { bless({messages => []}, $class) }
+
     sub _send_json ($self, $cmd) {
         push(@{$self->{messages}}, $cmd);
         return $cmd->{cmd} eq 'is_shutdown' ? 'down' : {tags => [qw(some fake tags)]};
     }
     sub stop { die "faking stop\n" }
 }
-{
-    package bmwqemu;
+
+package bmwqemu {
     our $backend = FakeBackend->new();
 }
 

--- a/t/24-myjsonrpc-debug.t
+++ b/t/24-myjsonrpc-debug.t
@@ -10,6 +10,7 @@ use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use Socket;
+
 BEGIN {
     $ENV{PERL_MYJSONRPC_DEBUG} = 1;
 }

--- a/t/27-consoles-vmware.t
+++ b/t/27-consoles-vmware.t
@@ -129,20 +129,20 @@ subtest 'deducing VNC over WebSockets URL from vars' => sub {
 
 subtest 'turning WebSocket into normal socket via dewebsockify' => sub {
     # define simple WebSocket server for testing
-    {
-        package TestWebSocketApp;    # uncoverable statement
+    package TestWebSocketApp {    # uncoverable statement
         use Mojo::Base 'Mojolicious', -signatures;
         has received_data => '';
+
         sub startup ($self) {
             $self->routes->websocket('/test')->to('test#start_ws');
             $self->routes->any('*')->to('test#fallback');
         }
         sub received_everything ($self) { length $self->received_data >= length 'message sent from raw socket' }
     }
-    {
-        # uncoverable statement count:2
-        package TestWebSocketApp::Controller::Test;
+    # uncoverable statement count:2
+    package TestWebSocketApp::Controller::Test {
         use Mojo::Base 'Mojolicious::Controller', -signatures;
+
         sub start_ws ($self) {
             my $sent_everything;
             $self->send({binary => 'binary sent from WebSocket'}, sub {
@@ -158,6 +158,7 @@ subtest 'turning WebSocket into normal socket via dewebsockify' => sub {
                 });
             $self->on(finish => sub ($ws, $code, $reason) { $self->ua->ioloop->stop });
         }
+
         sub fallback ($self) {
             Test::Most::note 'start replying HTTP response';
             $self->render(text => 'fallback', status => 404);

--- a/t/39-dewebsockify.t
+++ b/t/39-dewebsockify.t
@@ -54,6 +54,7 @@ $mock_ua->mock(start => sub ($ua, $tx, $cb) {
 });
 
 {
+
     package MockTxGeneric;    # uncoverable statement
     use Test::Most;
     use Mojo::Base -strict, -signatures;
@@ -62,6 +63,7 @@ $mock_ua->mock(start => sub ($ua, $tx, $cb) {
     sub max_websocket_size { }
     sub error { }
     sub req { bless {}, 'MockTxGenericReq' }
+
     sub on ($self, $event, $cb) {
         if ($event eq 'text') { $main::ws_on_text = $cb }
         elsif ($event eq 'binary') { $main::ws_on_binary = $cb }
@@ -95,6 +97,7 @@ $mock_ua->mock(start => sub ($ua, $tx, $cb) {
 
     package MockTxFailWithCode;
     sub is_websocket { 0 }
+
     sub error {
         return {code => 403, message => 'Forbidden'};
     }


### PR DESCRIPTION
For that I had to remove --fbl, but added --keep-old-blank-lines and --noblanks-before-blocks

I used the modern `package ... {` syntax because it also adds blank lines before packages.

Also it adds blank lines before pod


Motivation: mostly because I was annoyed by missing blank lines between pod and subs