### PR TITLE
Avoid sporadic test failures of fullstack test

### DIFF
--- a/t/data/tests/needles/boot-on_prompt.json
+++ b/t/data/tests/needles/boot-on_prompt.json
@@ -4,7 +4,7 @@
       "xpos": 2,
       "ypos": 64,
       "width": 84,
-      "height": 18,
+      "height": 12,
       "type": "match"
     }
   ],


### PR DESCRIPTION
The Tiny Core system might log additional lines before printing the prompt, see https://progress.opensuse.org/issues/182279#note-3. This is probably not a problem per-se, especially after ea08193. So this change allow the test to continue by making the match area smaller and thus the needle less restrictive.