### PR TITLE
ci: Remove workaround for Devel::Cover

### DIFF
--- a/tools/invoke-tests
+++ b/tools/invoke-tests
@@ -64,10 +64,6 @@ db="$build_directory/cover_db"
 
 # set Perl module include path and coverage options
 export PERL5LIB="$source_directory:$source_directory/ppmclibs/blib/lib:$source_directory/ppmclibs/blib/arch/auto/tinycv:$PERL5LIB"
-if [[ "${GITHUB_ACTIONS}" == "true" ]]; then
-    # https://progress.opensuse.org/issues/182402
-    cpanm Devel::Cover
-fi
 if [[ $WITH_COVER_OPTIONS ]]; then
     ignore="external/|tools/|t/data/tests/tests/|t/data/wheels_dir|/tmp|$prove_path"
     # add ' -MOpenQA::Test::PatchDeparse' for older OS versions to avoid warnings


### PR DESCRIPTION
The new version 1.490 has reached Tumbleweed, which will be rebuilt for every perl version change.

Issue: https://progress.opensuse.org/issues/182402