### PR TITLE
Fix error from stricter Git permission checks when checking repo URL

### DIFF
--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -31,13 +31,17 @@ use constant GIT_CLONE_DEPTH => $ENV{OS_AUTOINST_GIT_CLONE_DEPTH} // 1;
 use constant GIT_RETRY_COUNT => $ENV{OS_AUTOINST_GIT_RETRY_COUNT} // 2;
 use constant GIT_RETRY_INTERVAL => $ENV{OS_AUTOINST_GIT_RETRY_INTERVAL} // 5;
 
+sub _configure_safe_dir_cmd ($output) {
+    return '' unless $output =~ /(git config.*safe.directory.*$)/;
+    return "TMPDIR=\$(mktemp -d --tmpdir os-autoinst-git.XXXXX) && HOME=\$TMPDIR && $1 &&";    # uncoverable statement
+}
+
 sub git_rev_parse ($dirname, $cmd_prefix = '') {
     $dirname = path($dirname)->realpath;
     chomp(my $version = qx{$cmd_prefix git -C "$dirname" rev-parse HEAD 2>&1});
     return $version if $? == 0;
-    return 'UNKNOWN' unless $version =~ /(git config.*safe.directory.*$)/;
-    my $addsafe = 'TMPDIR=$(mktemp -d --tmpdir os-autoinst-git.XXXXX) && HOME=$TMPDIR && ' . $1;    # uncoverable statement
-    $version = qx{$addsafe && git -C "$dirname" rev-parse HEAD && rm -r \$TMPDIR} || '(unreadable git hash)';    # uncoverable statement
+    return 'UNKNOWN' unless my $cmd = _configure_safe_dir_cmd($version);
+    $version = qx{$cmd git -C "$dirname" rev-parse HEAD && rm -r \$TMPDIR} || '(unreadable git hash)';    # uncoverable statement
     chomp($version);    # uncoverable statement
     return $version;    # uncoverable statement
 }
@@ -51,9 +55,11 @@ sub calculate_git_hash ($git_repo_dir) {
 sub git_remote_url ($git_repo_dir, $fallback = undef) {
     my $is_working_tree_or_bare_repo = -e "$git_repo_dir/.git" || -e "$git_repo_dir/FETCH_HEAD";
     return $fallback // 'UNKNOWN (no .git found)' unless $is_working_tree_or_bare_repo;
-    chomp(my @remotes = qx{git -C "$git_repo_dir" remote});
+    chomp(my $status = qx{git -C "$git_repo_dir" status 2>&1});
+    my $safe_dir_cmd = _configure_safe_dir_cmd($status);
+    chomp(my @remotes = qx{$safe_dir_cmd git -C "$git_repo_dir" remote});
     return $fallback // 'UNKNOWN (origin remote not found)' unless grep { $_ eq 'origin' } @remotes;
-    chomp(my $url = qx{git -C "$git_repo_dir" remote get-url origin 2>&1});
+    chomp(my $url = qx{$safe_dir_cmd git -C "$git_repo_dir" remote get-url origin 2>&1});
     return git_remote_url($url, $url) if $? == 0;    # recursive lookup to handle caching
     bmwqemu::diag("Could not retrieve remote url of $git_repo_dir: \"$url\"");    # uncoverable statement
     return $fallback // 'UNKNOWN (error on git remote call)';    # uncoverable statement


### PR DESCRIPTION
This is a follow-up of bafb9efe512c50022d536abb42a86d578f369ce9 which applies the same approach to the `git_remote_url` function as well.

This problem shows up in openQA-in-openQA tests where we see log messages like these:

```
[2025-05-11T20:05:00.450213-04:00] [debug] [pid:12631] git hash in 'opensuse': 26bd263220ee8c5c78dee6649dca3a00c1f633b5
fatal: detected dubious ownership in repository at '/var/lib/openqa/share/tests/opensuse'
To add an exception for this directory, call:
	git config --global --add safe.directory /var/lib/openqa/share/tests/opensuse
[2025-05-11T20:05:00.458613-04:00] [debug] [pid:12631] git url in 'opensuse': "UNKNOWN (origin remote not found)"
```

So determining the Git hash works due to
bafb9efe512c50022d536abb42a86d578f369ce9 but determining the Git URL still runs into the same problem.

I reproduced the problem and verified this fix locally by simply changing the ownership of my tests directory so that it no longer matches the user I run os-autoinst with.

Note that openQA-in-openQA tests are not the problem here. They execute `fetchneedles` as root but this script handles that and the checkout is nevertheless correctly owned by `geekotest`. The mismatch is only because isotovideo runs as `_openqa-worker` but this is expected.

Related ticket: https://progress.opensuse.org/issues/183086