### PR TITLE
VMware fix for provide_image_vmware_in_ds

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -354,7 +354,7 @@ sub provide_image_vmware_in_ds ($self, $input_file, $vmware_openqa_datastore, %a
     $debug
     if test -e "$dest_image"; then
         echo "Waiting while $input_file is loading:"
-        while ps -x | grep -E "cp .*$baseimage|xz .*$basefile"|grep -v grep
+        while ps -v | grep -E "cp .*$baseimage|xz .*$basefile"|grep -v grep
             do sleep 5; done
         echo "VMware image $dest_image ready"
     elif [[ "$input_file" == *.xz ]]; then 


### PR DESCRIPTION
In production tests on Vmware host `ps -x` resulted [_invalid option_](https://openqa.suse.de/tests/18028518/logfile?filename=autoinst-log.txt#line-303) (related to [prev.line](https://openqa.suse.de/tests/18028518/logfile?filename=autoinst-log.txt#line-292)) (non-standard GNU).
But in previous [CI unit test](https://github.com/os-autoinst/os-autoinst/actions/runs/15449730705/job/43488588711) it worked fine.

Then we'll use `ps -v`, valid and useful in any case.
