### PR TITLE
Support Wait() timeout message from newer versions of x3270

### DIFF
--- a/consoles/s3270.pm
+++ b/consoles/s3270.pm
@@ -236,6 +236,7 @@ sub wait_output ($self, $timeout = 0) {
     my $r = $self->send_3270("Wait($timeout,Output)", command_status => 'any');
     return 1 if $r->{command_status} eq 'ok';
     return 0 if $r->{command_output}[0] eq 'Wait: Timed out';
+    return 0 if $r->{command_output}[0] eq 'Wait(): Timed out';
     confess "has the s3270 wait timeout failure response changed?\n" . Dumper $r;
 }
 


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/183110

Verification run: https://openqa.opensuse.org/tests/5102454