### PR TITLE
setup-multi-machine: extend network service detection

### DIFF
--- a/script/os-autoinst-setup-multi-machine
+++ b/script/os-autoinst-setup-multi-machine
@@ -147,6 +147,10 @@ configure_openvswitch() {
 
 main() {
     network=$(basename -s.service "$(readlink /etc/systemd/system/network.service)")
+    if [[ -z "${network}" ]]; then
+        systemctl is-enabled NetworkManager.service && network=NetworkManager
+        systemctl is-enabled wicked.service && network=wicked
+    fi
     test "$network" = wicked -o "$network" = NetworkManager || {
         echo "This script only works with wicked network daemon or NetworkManager"
         exit 1


### PR DESCRIPTION
network.service being a symlink to the configured networking service is a SUSE-ism; on Fedora, for e.g., network.service was for the old network-scripts and is now mostly no longer used. Extend the detection so that if network.service-based detection doesn't work, we make a guess based on enabled services under common names.