### PR TITLE
Avoid running `$basetest->parse_serial_output_qemu` without checks

### DIFF
--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -141,7 +141,6 @@ subtest parse_serial_output => sub {
             $message = $output;
     });
 
-    $basetest->parse_serial_output_qemu();
     $basetest->{serial_failures} = [
         {type => 'soft', message => 'DoNotMatch', pattern => qr/DoNotMatch/},
     ];


### PR DESCRIPTION
This invocation of `$basetest->parse_serial_output_qemu` in our unit tests is probably not very useful as it isn't followed by any checks (and instead just another `$basetest->parse_serial_output_qemu` invocation follows).

https://progress.opensuse.org/issues/185065