### PR TITLE
backend: Turn off direct-io for multi-fd migration

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -271,7 +271,10 @@ sub _migrate_to_file ($self, %args) {
                 execute => 'migrate-set-parameters',
                 arguments => {
                     'multifd-channels' => $multifd_channels + 0,
-                    'direct-io' => Mojo::JSON->true,
+                    # With direct-io, migration on qa-power8-3 achieves 3.6 MB/s
+                    # and runs into a timeout, but with it turned off it's 4GB/s
+                    # (not a typo, 1000x faster!)
+                    'direct-io' => Mojo::JSON->false,
                     # Ensure slow dump times are not due to a transfer rate cap
                     'max-bandwidth' => $max_bandwidth + 0,
                 }

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -389,7 +389,7 @@ subtest 'migration to file_qemu9' => sub {
         {execute => 'migrate-set-capabilities', arguments => {capabilities => [{capability => 'events', state => Mojo::JSON->true}]}},
         {execute => 'migrate-set-capabilities', arguments => {capabilities => [{capability => 'multifd', state => Mojo::JSON->true}]}},
         {execute => 'migrate-set-capabilities', arguments => {capabilities => [{capability => 'mapped-ram', state => Mojo::JSON->true}]}},
-        {execute => 'migrate-set-parameters', arguments => {'multifd-channels' => 2, 'direct-io' => Mojo::JSON->true, 'max-bandwidth' => '9223372036854775807'}},
+        {execute => 'migrate-set-parameters', arguments => {'multifd-channels' => 2, 'direct-io' => Mojo::JSON->false, 'max-bandwidth' => '9223372036854775807'}},
         {execute => 'getfd', arguments => {fdname => 'dumpfd'}},
         {execute => 'stop'},
         {execute => 'migrate', arguments => {uri => 'file:dumpfd'}}
@@ -486,7 +486,7 @@ subtest 'saving memory dump qemu9' => sub {
         },
         {
             execute => 'migrate-set-parameters',
-            arguments => {'multifd-channels' => 2, 'direct-io' => Mojo::JSON->true, 'max-bandwidth' => '9223372036854775807'},
+            arguments => {'multifd-channels' => 2, 'direct-io' => Mojo::JSON->false, 'max-bandwidth' => '9223372036854775807'},
         },
         {execute => 'getfd', arguments => {fdname => 'dumpfd'}},
         {execute => 'stop'},


### PR DESCRIPTION
direct-io bypasses caches and is extremely slow. Turn it off.

Failure: https://openqa.opensuse.org/tests/5219914
VR: https://openqa.opensuse.org/tests/5219939

The VR did not fully survive snapshot loading though. No idea if that's related to this change :shrug:

Marked as draft as the worker has various other issues ATM