### PR TITLE
sshVirtsh provide_image_vmware_in_ds: fix file checks and add more info about images

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -350,20 +350,23 @@ sub provide_image_vmware_in_ds ($self, $input_file, $vmware_openqa_datastore, %a
     # Use the standard folder for an input file without full path
     my $file_origin = ($input_file eq $basefile) ? "$base_dir/$vmware_nfs_datastore/$nfs_dir/$basefile" : $input_file;
     # check image is present
+    # Note that on ESXi vmware hosts, /bin/sh points to 'busybox', based on underlying system.
     my $cmd = <<~"EOF";
     $debug
+    IN=$input_file
     if test -e "$dest_image"; then
         echo "Waiting while $input_file is loading:"
         while ps -v | grep -E "cp .*$baseimage|xz .*$basefile"|grep -v grep
             do sleep 5; done
         echo "VMware image $dest_image ready"
-    elif [[ "$input_file" == *.xz ]]; then 
+    elif [ \${IN##*.} = 'xz' ]; then 
         if [ -e "$dest_image.xz" ] || cp "$file_origin" "$vmware_openqa_datastore"; then
             xz --decompress --keep "$dest_image.xz"
         fi
     else
         cp "$file_origin" "$vmware_openqa_datastore"
     fi
+    echo "Done: origin:" $file_origin* " ; dest.:" $dest_image*
     EOF
 
     my $ret = $self->run_cmd($cmd, domain => 'sshVMwareServer');


### PR DESCRIPTION
In `provide_image_vmware_in_ds` image elaboration script
the syntax to check if a file ends by .xz, was ok in unit-tests 'bash', but not in vmware 'sh': apply common syntax valid in all cases.

Add in script: prints for steps identification and files names display; useful to trace the files flow and in debugging cases too. It helps to clarify doubtful cases where image should have been decompressed and detected, like in:
https://openqa.suse.de/tests/18692763/logfile?filename=autoinst-log.txt#line-334

That last case skipped the decompression due to the above glitch on check-syntax.
