### PR TITLE
baseclass: Fix missing error details on failed SSH connection attempts

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -1241,8 +1241,7 @@ sub new_ssh_connection ($self, %args) {
         bmwqemu::diag "SSH connection to $con_pretty established" if $ssh->auth_ok;
         last;
     }
-    OpenQA::Exception::SSHConnectionError->throw(error => "Error connecting to <$con_pretty>: $@") unless $ssh->auth_ok;
-
+    OpenQA::Exception::SSHConnectionError->throw(error => "Error connecting to <$con_pretty>: " . ($ssh->error)[2]) unless $ssh->auth_ok;
     $self->{ssh_connections}->{$connection_key} = $ssh if ($args{keep_open});
     return $ssh;
 }

--- a/consoles/vnc_base.pm
+++ b/consoles/vnc_base.pm
@@ -63,16 +63,19 @@ sub current_screen ($self) {
 }
 
 sub send_key_event ($self, $key, $press_release_delay) {
+    die "No VNC console connection available" unless $self->{vnc};
     $self->{vnc}->map_and_send_key($key, undef, $press_release_delay);
 }
 
 sub hold_key ($self, $args) {
+    die "No VNC console connection available" unless $self->{vnc};
     $self->{vnc}->map_and_send_key($args->{key}, 1, 1 / VNC_TYPING_LIMIT_DEFAULT);
     $self->backend->run_capture_loop(.2);
     return {};
 }
 
 sub release_key ($self, $args) {
+    die "No VNC console connection available" unless $self->{vnc};
     $self->{vnc}->map_and_send_key($args->{key}, 0, 1 / VNC_TYPING_LIMIT_DEFAULT);
     $self->backend->run_capture_loop(.2);
     return {};
@@ -94,6 +97,7 @@ sub mouse_button ($self, $args) {
     my $bstate = $args->{bstate};
     my $mask = {left => $bstate, right => $bstate << 2, middle => $bstate << 1}->{$button} // 0;
     bmwqemu::diag "pointer_event $mask $self->{mouse}->{x}, $self->{mouse}->{y}";
+    die "No VNC console connection available" unless $self->{vnc};
     $self->{vnc}->send_pointer_event($mask, $self->{mouse}->{x}, $self->{mouse}->{y});
     return {};
 }

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -354,9 +354,9 @@ subtest 'SSH utilities' => sub {
         $mockbmw->redefine(diag => sub { $diag .= $_[0] });
         $bmwqemu::vars{SSH_CONNECT_RETRY} = 2;
         $ssh_connect_error = 1;
-        $exp_log_new = qr/Could not connect to serial\@foo. Retrying/;
+        $exp_log_new = qr/Could not connect to serial\@foo.*Retrying/;
         $baseclass->new_ssh_connection(keep_open => 0, hostname => 'foo', username => 'serial', password => 'XXX');
-        like $diag, qr/Could not connect to serial\@foo. Retrying/, 'connection error logged';
+        like $diag, qr/Could not connect to serial\@foo.*Retrying/, 'connection error logged';
     };
 };
 

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -245,8 +245,10 @@ subtest 'SSH utilities' => sub {
     isnt(refaddr($ssh4), refaddr($ssh8), "Got same connection with different ports");
 
     $ssh_auth_ok = 0;
+    @net_ssh2_error = (-1, 'MY_ERROR', 'Error connecting to');
     throws_ok { $baseclass->new_ssh_connection(%ssh_creds) } qr/Error connecting to/, 'Got exception on connection error';
 
+    @net_ssh2_error = ();
     $ssh_auth_ok = 1;
     $ssh_expect->{password} = '';
     @agent = ();


### PR DESCRIPTION
Already since in 631d0f7a the SSHConnectionError->throw was introduced
there was no useful content available for the error variable "$@" so
this variable can not have useful content causing error messages as
observed like

```
Error connecting to root@my.machine:  at …
```

mind the double space after ":". 

The message for the above example then will look like:

```
Error connecting to <root@my.machine>: All authentication methods failed
```