### PR TITLE
Fix signature of test module

### DIFF
--- a/t/data/tests/tests/select_ssh_console_fail_test.pm
+++ b/t/data/tests/tests/select_ssh_console_fail_test.pm
@@ -4,7 +4,7 @@
 use Mojo::Base 'basetest', -signatures;
 use testapi;
 
-sub run () {
+sub run ($) {
     select_console 'brokeniucv';
 }
 


### PR DESCRIPTION
The fullstack test never failed because apparently this test module is supposed to fail anyway, and we never check why it's failing.

Found during debugging of #2734