### PR TITLE
Add variable to indicate IPv6 availability to tests

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -867,6 +867,10 @@ sub start_qemu ($self) {
         }
     }
 
+    my $v6checkhost = $vars->{IPV6_CHECKHOST} // 'opensuse.org';
+    my ($e, $out) = osutils::run('ping', '-6', '-c', 1, '-w', 1, '-W', 1, $v6checkhost);
+    $vars->{IPV6_AVAILABLE} = $e ? 0 : 1;
+
     bmwqemu::save_vars();    # update variables
 
     mkpath($basedir);

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -871,6 +871,10 @@ sub start_qemu ($self) {
         }
     }
 
+    my $v6checkhost = $vars->{IPV6_CHECKHOST} // 'opensuse.org';
+    my ($e, $out) = osutils::run('ping', '-6', '-c', 1, '-w', 1, '-W', 1, $v6checkhost);
+    $vars->{IPV6_AVAILABLE} = $e ? 0 : 1;
+
     bmwqemu::save_vars();    # update variables
 
     mkpath($basedir);

--- a/doc/backend_vars.md
+++ b/doc/backend_vars.md
@@ -216,6 +216,8 @@ Supported variables per backend
 | QEMU_VIDEO_DEVICE | string | virtio-gpu-pci on ARM, VGA otherwise | Video device to use with VM (using -device, not -vga). Can have options appended e.g. "virtio-gpu-gl,edid=on", but it is better to set QEMU_VIDEO_DEVICE_OPTIONS. See qemu docs and https://www.kraxel.org/blog/2019/09/display-devices-in-qemu/ for valid choices |
 | QEMU_VIDEO_DEVICE_OPTIONS | string | none | Additional options for QEMU_VIDEO_DEVICE (comma-separated). Will be appended after automatically-generated resolution setting options on devices that support EDID |
 | SAVE_STORAGE_TIMEOUT | integer | 900 | Timeout for saving one storage volume in `save_storage` test API function. |
+| IPV6_CHECKHOST | string | opensuse.org | Host to ping (ICMP) to determine if IPv6 is working on that worker |
+| IPV6_AVAILABLE | integer |  | Read-only variable which indicates if a ping via IPv6 to `IPV6_CHECKHOST` ran successfuly shortly before the test started running |
 
 ## SVIRT backend
 

--- a/doc/backend_vars.md
+++ b/doc/backend_vars.md
@@ -222,6 +222,8 @@ Supported variables per backend
 | QEMU_VIDEO_DEVICE | string | virtio-gpu-pci on ARM, VGA otherwise | Video device to use with VM (using -device, not -vga). Can have options appended e.g. "virtio-gpu-gl,edid=on", but it is better to set QEMU_VIDEO_DEVICE_OPTIONS. See qemu docs and https://www.kraxel.org/blog/2019/09/display-devices-in-qemu/ for valid choices |
 | QEMU_VIDEO_DEVICE_OPTIONS | string | none | Additional options for QEMU_VIDEO_DEVICE (comma-separated). Will be appended after automatically-generated resolution setting options on devices that support EDID |
 | SAVE_STORAGE_TIMEOUT | integer | 900 | Timeout for saving one storage volume in `save_storage` test API function. |
+| IPV6_CHECKHOST | string | opensuse.org | Host to ping (ICMP) to determine if IPv6 is working on that worker |
+| IPV6_AVAILABLE | integer |  | Read-only variable which indicates if a ping via IPv6 to `IPV6_CHECKHOST` ran successfuly shortly before the test started running |
 
 ## SVIRT backend
 


### PR DESCRIPTION
As we cannot ensure IPv6 availability on all hosts connected to o3 and other openQA instances, we can only signal it to the test. The test can then check for this variable and notify the user about a needed change (e.g. add a worker-class requirement to the test, skip the test with a warning, etc).