### PR TITLE
t/consoles-s3270.t: fix with IPC::Run 20250809.0

### DIFF
--- a/t/27-consoles-s3270.t
+++ b/t/27-consoles-s3270.t
@@ -33,7 +33,7 @@ ok my $s3270_console = consoles::s3270->new('consoles::s3270', undef), 's3270_co
 $s3270_console->{backend} = backend::baseclass->new();
 
 subtest 's3270_console start' => sub {
-    my $bless_obj = bless({KIDS => [{VAL => '', PID => '0', NUM => 1, TYPE => 'cmd', RESULT => 1, OPS => []}]}, 'IPC::Run');
+    my $bless_obj = bless({KIDS => [{VAL => '', PID => '0', NUM => 1, TYPE => 'cmd', RESULT => 1, OPS => []}], PTYS => {}, PIPES => [], TIMERS => []}, 'IPC::Run');
     $ipc_run_mock->redefine(start => sub ($self, $in, $out, $err) {
             $$out = "success\nconnet($bmwqemu::vars{ZVM_HOST})\nstart to execute process\nok";
             return $bless_obj;


### PR DESCRIPTION
A change in IPC::Run 20250809.0 assumes several things are defined in `finish()`. This is a safe assumption in normal usage because they're defined by `harness()`, which is called by `start()`. But in our tests, we mock out Run's `start()`, so they're not defined, and our test that calls `finish()` blows up with undefined ref errors. To fix this, let's have our mocked `start()` define the necessary things.