### PR TITLE
Document max_interval (and quiet) in (assert_)script_run

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -86,7 +86,7 @@ sub become_root ($self) {
 
 =head2 script_run
 
-  script_run($cmd [, timeout => $timeout] [, output => $output] [,quiet => $quiet])
+  script_run($cmd [, timeout => $timeout] [, output => $output] [,quiet => $quiet] [,max_interval => $max_interval])
 
 Deprecated mode
 
@@ -101,6 +101,9 @@ thrown.
 Use C<output> to add a description or a comment of the $cmd.
 
 Use C<quiet> to avoid recording serial_results.
+
+Use C<max_interval> (1-250) to control the typing speed. Lower values mean slower
+typing.
 
 <Returns> exit code received from I<$cmd>, or C<undef> in case of C<not> waiting for I<$cmd>
 to return.

--- a/testapi.pm
+++ b/testapi.pm
@@ -909,7 +909,7 @@ sub _handle_script_run_ret {    # no:style:signatures
 
 =head2 assert_script_run
 
-  assert_script_run($cmd [, timeout => $timeout] [, fail_message => $fail_message] [,quiet => $quiet]);
+  assert_script_run($cmd [, timeout => $timeout] [, fail_message => $fail_message] [,quiet => $quiet] [,max_interval => $max_interval]);
 
 Positional mode (not suggested)
 
@@ -920,6 +920,10 @@ Run C<$cmd> via C<< $distri->script_run >> and C<die> unless it returns zero
 Use C<script_run> instead if C<$cmd> may fail.
 
 C<$fail_message> is returned in the die message if specified.
+
+C<$quiet> and C<$max_interval> are passed through to C<< $distri->script_run >>. In
+the default implementation, C<$quiet> is used to avoid recording serial_results.
+C<$max_interval> (1-250) controls typing speed (lower values mean slower typing).
 
 I<The C<script_run> implementation is distribution specific and not always available.
 For this to work correctly, it must return 0 if and only if C<$command> completes
@@ -949,7 +953,7 @@ sub assert_script_run {    # no:style:signatures
 
 =head2 script_run
 
-  script_run($cmd [, timeout => $timeout] [, output => ''] [, quiet => $quiet]);
+  script_run($cmd [, timeout => $timeout] [, output => ''] [, quiet => $quiet] [,max_interval => $max_interval]);
 
 Positional mode (not suggested)
 
@@ -961,6 +965,10 @@ execution to complete.
 
 C<$output> can be used as an explanatory text that will be displayed with the execution of
 the command.
+
+C<$quiet> and C<$max_interval> are passed through to C<< $distri->script_run >>. In
+the default implementation, C<$quiet> is used to avoid recording serial_results.
+C<$max_interval> (1-250) controls typing speed (lower values mean slower typing).
 
 C<script_run> will throw an exception if the timeout has expired.
 


### PR DESCRIPTION
As requested by @kalikiana , this documents max_interval in assert_script_run and script_run (both testapi and distribution). We also document quiet in the testapi subs, as that wasn't documented there either.