### PR TITLE
Improve os-autoinst-setup-multi-machine

### DIFF
--- a/script/os-autoinst-setup-multi-machine
+++ b/script/os-autoinst-setup-multi-machine
@@ -40,7 +40,8 @@ ensure_ip_forwarding() {
 
 install_packages() {
     command -v retry > /dev/null || zypper -n in retry
-    retry -e -s 30 -r 7 -- sh -c "zypper ref && zypper -n in openvswitch os-autoinst-openvswitch firewalld libcap-progs"
+    pkgs=(openvswitch os-autoinst-openvswitch firewalld libcap-progs)
+    rpm -q ${pkgs[*]} > /dev/null || retry -e -s 30 -r 7 -- sh -c "zypper ref && zypper -n in ${pkgs[*]}"
 }
 
 configure_firewall() {


### PR DESCRIPTION
* os-autoinst-setup-multi-machine: Only call zypper when necessary
* os-autoinst-setup-multi-machine: Only check network interface if not supplied