### PR TITLE
Add UEFI support for ipxe kernel boot

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -958,7 +958,9 @@ sub start_qemu ($self) {
         }
         if ($vars->{NBF}) {
             die "Need variable WORKER_HOSTNAME\n" unless $vars->{WORKER_HOSTNAME};
-            sp('kernel', -e '/usr/share/ipxe/ipxe.lkrn' ? '/usr/share/ipxe/ipxe.lkrn' : '/usr/share/qemu/ipxe.lkrn');
+            my $ipxe_binary = $vars->{UEFI} ? 'ipxe-x86_64.efi' : 'ipxe.lkrn';
+            my $ipxe_binary_path = "/usr/share/ipxe/$ipxe_binary";
+            sp('kernel', -e $ipxe_binary_path ? $ipxe_binary_path : "/usr/share/qemu/$ipxe_binary");
             my $worker_ip = inet_ntoa(inet_aton($vars->{WORKER_HOSTNAME}));
             die "Unable to determine worker IP from WORKER_HOSTNAME\n" unless $worker_ip;
             sp('append', "dhcp && sanhook iscsi:${worker_ip}::3260:1:$vars->{NBF}", no_quotes => 1);

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -700,7 +700,7 @@ subtest 'special cases when starting QEMU' => sub {
     is $load_state, 1, 'load_state called once due to KEEPHDDS=1';
     my $qemu_params = Mojo::Collection->new(\@qemu_params)->flatten->join(' ');
     like $qemu_params, qr{smbios file=.*dmidata/hp_elitebook_820g1/smbios_type_1.bin}, 'smbios params present';
-    like $qemu_params, qr{kernel /usr/share/.*/ipxe.lkrn}, 'ipxe kernel param for NBF=1 present';
+    like $qemu_params, qr{kernel /usr/share/.*/ipxe.*}, 'ipxe kernel param for NBF=1 present';
     like $qemu_params, qr{menu=on,splash-time=\d+}, 'menu parameter present for BOOT_MENU=1';
     unlike $qemu_params, qr{order=}, 'order parameter not present despite BOOT_HDD_IMAGE=1 because UEFI=1';
     unlike $qemu_params, qr{\sbios}, 'bios parameter not present despite BIOS=1 because UEFI=1';


### PR DESCRIPTION
iPXE kernel boot in UEFI mode uses another ipxe binary file `/usr/share/ipxe/ipxe-x86_64.efi`.

This binary file is from the same package `ipxe-bootimgs` as `/usr/share/ipxe/ipxe.lkrn` file which is used for Legacy BIOS mode