### PR TITLE
Allow redirects in needle NeedleDownloader

### DIFF
--- a/OpenQA/Isotovideo/NeedleDownloader.pm
+++ b/OpenQA/Isotovideo/NeedleDownloader.pm
@@ -52,7 +52,7 @@ has openqa_url => sub {
 
     return $url;
 };
-has ua => sub { Mojo::UserAgent->new };
+has ua => sub { Mojo::UserAgent->new->max_redirects(5) };
 has download_limit => 150;
 
 sub _add_download ($self, $needle, $extension, $path_param) {


### PR DESCRIPTION
This solves issues when openQA redirects to a separate asset domain.
Ticket: https://progress.opensuse.org/issues/189795