### PR TITLE
consoles/s3270: Keep track of which lines are new

### DIFF
--- a/consoles/s3270.pm
+++ b/consoles/s3270.pm
@@ -19,6 +19,8 @@ has [qw(zVM_host guest_user guest_login)];
 sub start ($self) {
     # prepare the communication queue
     $self->{raw_expect_queue} = Thread::Queue->new;
+    # Keep track up to which line the screen was already read
+    $self->{new_content_start_line} = 0;
 
     # start the local terminal emulator
     $self->{in} = "";
@@ -82,11 +84,10 @@ sub ensure_screen_update ($self) {
     usleep(5_000);
     $self->{backend}->capture_screenshot();
     $self->send_3270("Clear");
+    $self->{new_content_start_line} = 0;
 }
 
 sub _handle_expect_3270_cycle ($self, $result, $start_time, %arg) {
-    my $we_had_new_output = 0;
-
     # grab any pending output
     if ($self->wait_output()) {
         $self->send_3270("Snap");
@@ -98,12 +99,22 @@ sub _handle_expect_3270_cycle ($self, $result, $start_time, %arg) {
         my $input_line = pop @$co;
         my @output_area = @$co;
 
-        @output_area = grep !/$arg{delete_lines}/, @output_area if defined $arg{delete_lines};
+        # Discard already seen lines
+        # (TODO: What about new content on seen lines? Hard to implement as long as
+        # raw_expect_queue is line based.)
+        @output_area = @output_area[$self->{new_content_start_line} .. $#output_area];
 
-        if (@output_area > 0) {
-            $self->{raw_expect_queue}->enqueue(@output_area);
-            $we_had_new_output = 1;
+        # Find the last nonempty line
+        my $last_nonempty_line;
+        for ($last_nonempty_line = $#output_area; $last_nonempty_line >= 0; $last_nonempty_line--) {
+            last if $output_area[$last_nonempty_line] !~ /$arg{delete_lines}/;
         }
+
+        if ($last_nonempty_line >= 0) {
+            $self->{raw_expect_queue}->enqueue(@output_area[0 .. $last_nonempty_line]);
+            $self->{new_content_start_line} += $last_nonempty_line + 1;
+        }
+
         say "expect_3270 queue content:\n\t" . join("\n\t", @{$self->{raw_expect_queue}->{queue}});
 
         # if there is MORE..., go and grab it.
@@ -151,17 +162,6 @@ sub _handle_expect_3270_cycle ($self, $result, $start_time, %arg) {
 
     # If we matched the 'output_delim', we are done.
     return 0 if defined $line;
-
-    # The queue is empty. If we got so far and we had some output on the
-    # screen the last time, clear the screen so we don't grab the same
-    # stuff again.
-
-    # TODO The better alternative solution to the same problem
-    # would be to remember lines that were not updated since the
-    # last Snap(Ascii) and to thus avoid duplicate lines.
-
-    # For now we have to live with having a clear screen.
-    $self->ensure_screen_update() if $we_had_new_output;
 
     # wait for new output from the host.
     my $elapsed_time = time() - $start_time;


### PR DESCRIPTION
Sending clear before the buffer is full may discard new content that wasn't consumed yet. Avoid that by manually keeping track of which lines are new compared to the last screen snapshot.

Should fix the race leading to boot failures: https://progress.opensuse.org/issues/194390

Draft because not tested yet.