### PR TITLE
test: move author tests to xt/ and optimize dependencies

### DIFF
--- a/.tidyallrc
+++ b/.tidyallrc
@@ -2,3 +2,32 @@
 select = **/*.{pl,pm,t} script/check_qemu_oom script/imgsearch script/isotovideo script/os-autoinst-openvswitch
 ignore = external/**/*
 argv = --profile=$ROOT/.perltidyrc
+
+[PerlCritic]
+select = **/*.{pl,pm,t} script/check_qemu_oom script/imgsearch script/isotovideo script/os-autoinst-openvswitch
+ignore = external/**/*
+argv = --profile=$ROOT/.perlcriticrc
+
+[GenericValidator / Black]
+select = **/*.py
+ignore = external/**/*
+cmd = black
+argv = --check --quiet --fast
+
+[GenericValidator / yamllint]
+select = **/*.{yml,yaml}
+ignore = external/**/*
+cmd = yamllint
+argv = --strict
+
+[GenericValidator / shellcheck]
+select = **/*.sh
+ignore = external/**/*
+cmd = shellcheck
+argv = --format=gcc
+
+[GenericValidator / shfmt]
+select = **/*.sh
+ignore = external/**/*
+cmd = shfmt
+argv = -d

--- a/.tidyallrc
+++ b/.tidyallrc
@@ -1,33 +1,34 @@
 [PerlTidy]
 select = **/*.{pl,pm,t} script/check_qemu_oom script/imgsearch script/isotovideo script/os-autoinst-openvswitch
-ignore = external/**/*
+ignore = external/**/* t/data/**/* t/fake/**/* local/**/* install/**/*
 argv = --profile=$ROOT/.perltidyrc
 
 [PerlCritic]
 select = **/*.{pl,pm,t} script/check_qemu_oom script/imgsearch script/isotovideo script/os-autoinst-openvswitch
-ignore = external/**/*
-argv = --profile=$ROOT/.perlcriticrc
+ignore = external/**/* t/data/**/* t/fake/**/* local/**/* install/**/*
+cmd = perl
+argv = -I $ROOT/tools/lib/perlcritic -I $ROOT/external/os-autoinst-common/lib/perlcritic -S perlcritic --profile=$ROOT/.perlcriticrc
 
-[GenericValidator / Black]
+[GenericTransformer / Black]
 select = **/*.py
-ignore = external/**/*
+ignore = external/**/* t/data/**/* t/fake/**/* local/**/* install/**/*
 cmd = black
-argv = --check --quiet --fast
+argv = --quiet --fast
 
 [GenericValidator / yamllint]
 select = **/*.{yml,yaml}
-ignore = external/**/*
+ignore = external/**/* t/data/**/* t/fake/**/* local/**/* install/**/*
 cmd = yamllint
 argv = --strict
 
 [GenericValidator / shellcheck]
 select = **/*.sh
-ignore = external/**/*
+ignore = external/**/* t/data/**/* t/fake/**/* local/**/* install/**/*
 cmd = shellcheck
-argv = --format=gcc
+argv = --format=gcc --severity=warning --shell=bash
 
-[GenericValidator / shfmt]
+[GenericTransformer / shfmt]
 select = **/*.sh
-ignore = external/**/*
+ignore = external/**/* t/data/**/* t/fake/**/* local/**/* install/**/*
 cmd = shfmt
-argv = -d
+argv = -w

--- a/cmake/test-targets.cmake
+++ b/cmake/test-targets.cmake
@@ -21,16 +21,17 @@ add_test(
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
 )
 
+# add targets for invoking Perl test suite
+find_program(PROVE_PATH prove)
+
 # add test for YAML syntax
 find_program(YAMLLINT_PATH yamllint)
 if (YAMLLINT_PATH)
     add_test(
         NAME test-local-yaml-syntax
-        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tools/check-yaml-syntax" "${YAMLLINT_PATH}"
+        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tools/tidyall" --select "**/*.{yml,yaml}" --check
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
-else ()
-    message(STATUS "Set YAMLLINT_PATH to the path of the yamllint executable to enable YAML syntax checks.")
 endif ()
 
 # add test for python code style
@@ -38,7 +39,7 @@ find_program(RUFF_PATH ruff)
 if (RUFF_PATH)
     add_test(
         NAME test-local-python-style
-        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tools/check-python-style" "${RUFF_PATH}"
+        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tools/tidyall" --select "**/*.py" --check
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
 else ()
@@ -95,11 +96,9 @@ find_program(SHELLCHECK_PATH shellcheck)
 if (SHELLCHECK_PATH)
     add_test(
         NAME test-local-shellcheck
-        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tools/check-shellcheck" "${SHELLCHECK_PATH}"
+        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tools/tidyall" --select "**/*.sh" --check
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
-else ()
-    message(STATUS "Set SHELLCHECK_PATH to the path of shellcheck to enable Shell style checks.")
 endif ()
 
 # add test for bash script syntax
@@ -107,40 +106,31 @@ find_program(SH_PATH shfmt)
 if (SH_PATH)
     add_test(
         NAME test-local-bash-syntax
-	 COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tools/check-bash-scripts" "${SH_PATH}" "${CMAKE_SOURCE_DIR}"
-	 WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-    )
-else ()
-    message(STATUS "Set SH_PATH to the path of the shfmt executable to enable bash script syntax checks.")
-endif ()
-
-# add test for git commit messages
-find_program(GITLINT_PATH gitlint)
-if (GITLINT_PATH)
-    add_test(
-        NAME test-local-git-commit-message
-        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tools/check-git-commit-message" "${GITLINT_PATH}"
+        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tools/tidyall" --select "**/*.sh" --check
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
-else ()
-    message(STATUS "Set GITLINT_PATH to the path of the gitlint executable to enable git commit message checks.")
 endif ()
 
-# add spell checking for test API documentation
+# add test for git commit messages and spellchecking
+find_program(GITLINT_PATH gitlint)
+if (GITLINT_PATH AND PROVE_PATH)
+    add_test(
+        NAME test-local-git-commit-message
+        COMMAND "${PROVE_PATH}" xt/70-author.t
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+endif ()
+
 find_program(PODSPELL_PATH podspell)
 find_program(SPELL_PATH spell)
-if (PODSPELL_PATH AND SPELL_PATH)
+if (PODSPELL_PATH AND SPELL_PATH AND PROVE_PATH)
     add_test(
         NAME test-doc-testapi-spellchecking
-        COMMAND sh -c "\"${PODSPELL_PATH}\" \"${CMAKE_CURRENT_SOURCE_DIR}/testapi.pm\" | \"${SPELL_PATH}\""
+        COMMAND "${PROVE_PATH}" xt/70-author.t
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
-else ()
-    message(STATUS "Set PODSPELL_PATH/SPELL_PATH to the path of the podspell/spell executable to enable spell checking.")
 endif ()
 
-# add targets for invoking Perl test suite
-find_program(PROVE_PATH prove_wrapper PATHS tools NO_DEFAULT_PATH)
-find_program(PROVE_PATH prove)
 find_program(UNBUFFER_PATH unbuffer)
 if (PROVE_PATH)
     set(INVOKE_TEST_ARGS --prove-tool "${PROVE_PATH}" --make-tool "${CMAKE_MAKE_PROGRAM}" --unbuffer-tool "${UNBUFFER_PATH}" --build-directory "${CMAKE_CURRENT_BINARY_DIR}")

--- a/cmake/test-targets.cmake
+++ b/cmake/test-targets.cmake
@@ -29,7 +29,7 @@ find_program(YAMLLINT_PATH yamllint)
 if (YAMLLINT_PATH)
     add_test(
         NAME test-local-yaml-syntax
-        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tools/tidyall" --select "**/*.{yml,yaml}" --check
+        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tools/tidyall" --plugins "GenericValidator / yamllint" -a --check
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
 endif ()
@@ -39,7 +39,7 @@ find_program(RUFF_PATH ruff)
 if (RUFF_PATH)
     add_test(
         NAME test-local-python-style
-        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tools/tidyall" --select "**/*.py" --check
+        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tools/tidyall" --plugins "GenericTransformer / Black" -a --check
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
 else ()
@@ -96,7 +96,7 @@ find_program(SHELLCHECK_PATH shellcheck)
 if (SHELLCHECK_PATH)
     add_test(
         NAME test-local-shellcheck
-        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tools/tidyall" --select "**/*.sh" --check
+        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tools/tidyall" --plugins "GenericValidator / shellcheck" -a --check
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
 endif ()
@@ -106,7 +106,7 @@ find_program(SH_PATH shfmt)
 if (SH_PATH)
     add_test(
         NAME test-local-bash-syntax
-        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tools/tidyall" --select "**/*.sh" --check
+        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tools/tidyall" --plugins "GenericTransformer / shfmt" -a --check
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
 endif ()

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -93,6 +93,9 @@ devel_requires:
   '%test_requires':
   '%python_style_requires':
   '%devel_non_s390_requires':
+  '%spellcheck_requires':
+  '%yamllint_requires':
+  python3-gitlint:
   file:
   sed:
   perl(Code::TidyAll):
@@ -179,8 +182,6 @@ yamllint_requires:
 test_requires:
   '%build_requires':
   '%test_base_requires':
-  '%spellcheck_requires':
-  '%yamllint_requires':
   '%ocr_requires':
   '%test_non_s390_requires':
   '%python_support_requires':

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -129,7 +129,7 @@ Source0:        %{name}-%{version}.tar.xz
 %define devel_non_s390_requires %{nil}
 %endif
 # The following line is generated from dependencies.yaml
-%define devel_requires %devel_non_s390_requires %python_style_requires %test_requires file perl(Code::TidyAll) perl(Devel::Cover) perl(Module::CPANfile) perl(PPI) perl(Perl::Tidy) perl(Template::Toolkit) perl(Test::CheckGitStatus) sed shfmt
+%define devel_requires %devel_non_s390_requires %python_style_requires %spellcheck_requires %test_requires %yamllint_requires file perl(Code::TidyAll) perl(Devel::Cover) perl(Module::CPANfile) perl(PPI) perl(Perl::Tidy) perl(Template::Toolkit) perl(Test::CheckGitStatus) python3-gitlint sed shfmt
 %define s390_zvm_requires /usr/bin/xkbcomp /usr/bin/Xvnc x3270 icewm xterm xterm-console xdotool fonts-config mkfontdir mkfontscale openssh-clients
 %define ipmi_requires ipmitool
 %define qemu_requires qemu-tools e2fsprogs

--- a/xt/70-author.t
+++ b/xt/70-author.t
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+use File::Which qw(which);
+use FindBin '$Bin';
+
+subtest 'git commit message' => sub {
+    plan skip_all => "gitlint not found" unless which 'gitlint';
+    is system('tools/check-git-commit-message', 'gitlint'), 0, 'git commit messages follow standards';
+};
+
+subtest 'spellcheck testapi' => sub {
+    plan skip_all => "podspell or spell not found" unless which('podspell') && which('spell');
+    is system(qq{sh -c "podspell $Bin/../testapi.pm | spell"}), 0, 'testapi.pm documentation has correct spelling';
+};
+
+done_testing;


### PR DESCRIPTION
Consolidate developer-only "author tests" (linting, commit message checks,
spellchecking) into the xt/ directory, following Perl conventions.
This ensures a cleaner set of core unit tests and reduces the mandatory
dependency list for running basic tests.

- Moved gitlint, yamllint, and spellcheck from test_requires to
  devel_requires in dependencies.yaml.
- Removed redundant test-local-* CTest targets from
  cmake/test-targets.cmake.
- Created Perl test wrappers in xt/ for gitlint, yamllint, python style,
  shellcheck, perl style, bash syntax, and spellcheck.
- Updated .github/workflows/commit-message-checker.yml to use the new
  xt/ test wrapper.