### PR TITLE
feat: Prefer `4m` version of OVMF firmware image

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -45,6 +45,7 @@ our $screenshotpath = 'qemuscreenshot';
 # the kraxel.org nightly packages, third is Fedora's edk2-ovmf package,
 # fourth is Debian's ovmf package.
 our @ovmf_locations = (
+    '/usr/share/qemu/ovmf-x86_64-ms-4m-code.bin',
     '/usr/share/qemu/ovmf-x86_64-ms-code.bin', '/usr/share/edk2.git/ovmf-x64/OVMF_CODE-pure-efi.fd',
     '/usr/share/edk2/ovmf/OVMF_CODE.fd', '/usr/share/OVMF/OVMF_CODE.fd'
 );


### PR DESCRIPTION
The version without `4m` has been removed in the latest version `202602` of the `qemu-ovmf-x86_64` package as provided by TW. So we should probably use the `4m` version instead.

For the best consistency, this change makes the `4m` version the most preferred version. Since the `4m` files are also present in `qemu-ovmf-x86_64` version `202502` as provided by Leap 16 this means we will use the `4m` version for most test runs with this commit.

Related ticket: https://progress.opensuse.org/issues/197930