### PR TITLE
feat: fail explicitly if always_rollback is not supported

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -536,6 +536,9 @@ sub runalltests () {
     for (my $testindex = 0; $testindex <= $#testorder; $testindex++) {
         my $t = $testorder[$testindex];
         my $flags = $t->test_flags();
+        if ($flags->{always_rollback} && !$snapshots_supported && $bmwqemu::vars{FAIL_ON_ALWAYS_ROLLBACK_NOT_SUPPORTED}) {
+            die "always_rollback requested but snapshots are not supported by the backend\n";
+        }
         my $fullname = $t->{fullname};
 
         if (!$vmloaded && $fullname eq $firsttest) {

--- a/doc/backend_vars.md
+++ b/doc/backend_vars.md
@@ -61,6 +61,7 @@ Supported variables per backend
 | ENABLE_MODERN_PERL_FEATURES | boolean | 0 | Enables use of modern Perl features in test modules avoiding the need to use e.g. `use Mojo::Base 'basetest', -signatures;` in all test modules. This variable must be set before invoking `autotest::loadtest`. It only applies to the test modules themselves. It does *not* apply to e.g. `main.pm` and other Perl modules used via e.g. `use some::module`. |
 | _HIDE_SECRETS_REGEX | string |  | If set, any test variables whose **NAME** (key) matches the specified regular expression, in addition to the default '^_SECRET_' and '_PASSWORD', are excluded from being saved into vars.json or further processing. For example, to hide all variables starting with 'SCC_REGCODE', use '^SCC_REGCODE'. |
 | STORAGE_KEEP_FREE_RATIO | float | 0.2 | Ratio of total storage space to keep free (e.g. 0.2 for 20%). If the total requested HDD size exceeds the available space while keeping this ratio of total storage size free, the job is aborted early with "incomplete" status. Set to 0 to disable this check. |
+| FAIL_ON_ALWAYS_ROLLBACK_NOT_SUPPORTED | boolean | 0 | Fail explicitly if a test module is scheduled with the `always_rollback` flag but snapshots are not supported by the backend. |
 |  |
 
 ## ZVM backend

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -232,6 +232,15 @@ subtest 'test always_rollback flag' => sub {
         is $reverts_done, 0, 'no snapshots loaded after fatal failure';
         is $snapshots_made, 0, 'no snapshots made after fatal failure';
     };
+    snapshot_subtest 'fails if snapshots are not supported and FAIL_ON_ALWAYS_ROLLBACK_NOT_SUPPORTED is set' => sub {
+        $mock_basetest->redefine(test_flags => {always_rollback => 1});
+        $mock_autotest->redefine(query_isotovideo => sub { 0 });
+        $bmwqemu::vars{FAIL_ON_ALWAYS_ROLLBACK_NOT_SUPPORTED} = 1;
+        my $w;
+        stderr_like { $w = warning { autotest::run_all } } qr/Snapshots are not supported/, 'run_all outputs on stderr';
+        like $w, qr/always_rollback requested but snapshots are not supported by the backend/, 'fails with explicit error message';
+        delete $bmwqemu::vars{FAIL_ON_ALWAYS_ROLLBACK_NOT_SUPPORTED};
+    };
     $mock_basetest->unmock($_) for qw(runtest test_flags);
     $mock_autotest->unmock($_) for qw(load_snapshot make_snapshot query_isotovideo);
 };


### PR DESCRIPTION
Motivation:
Always rollback is silently ignored on backends that do not support
snapshots. This can lead to unexpected test results when the test author
expects a clean state.

Design Choices:
Introduce a new feature switch FAIL_ON_ALWAYS_ROLLBACK_NOT_SUPPORTED to
optionally enforce snapshot support when always_rollback is used.

Benefits:
Provides better feedback to test authors and ensures that test
requirements are met by the backend.