### PR TITLE
feat: implement retry test flag

### DIFF
--- a/OpenQA/Isotovideo/CommandHandler.pm
+++ b/OpenQA/Isotovideo/CommandHandler.pm
@@ -266,7 +266,7 @@ sub _handle_command_set_current_test ($self, $response, @) {
     # Note: It is unclear why we call set_serial_offset here
     $bmwqemu::backend->_send_json({cmd => 'clear_serial_buffer'});
 
-    my ($test_name, $full_test_name) = ($response->{name}, $response->{full_name});
+    my ($test_name, $full_test_name, $attempt) = ($response->{name}, $response->{full_name}, $response->{attempt} // 0);
     my $pause_test_name = $self->pause_test_name;
     $self->current_test_name($test_name);
     $self->status('running');
@@ -274,6 +274,7 @@ sub _handle_command_set_current_test ($self, $response, @) {
     $self->_send_to_cmd_srv({
             set_current_test => $test_name,
             current_test_full_name => $full_test_name,
+            attempt => $attempt,
     });
 
     if ($pause_test_name

--- a/OpenQA/Isotovideo/CommandHandler.pm
+++ b/OpenQA/Isotovideo/CommandHandler.pm
@@ -288,7 +288,7 @@ sub _handle_command_set_current_test ($self, $response, @) {
     # Note: It is unclear why we call set_serial_offset here
     $bmwqemu::backend->_send_json({cmd => 'clear_serial_buffer'});
 
-    my ($test_name, $full_test_name) = ($response->{name}, $response->{full_name});
+    my ($test_name, $full_test_name, $attempt) = ($response->{name}, $response->{full_name}, $response->{attempt} // 0);
     my $pause_test_name = $self->pause_test_name;
     $self->current_test_name($test_name);
     $self->status('running');
@@ -296,6 +296,7 @@ sub _handle_command_set_current_test ($self, $response, @) {
     $self->_send_to_cmd_srv({
             set_current_test => $test_name,
             current_test_full_name => $full_test_name,
+            attempt => $attempt,
     });
 
     if ($pause_test_name

--- a/autotest.pm
+++ b/autotest.pm
@@ -373,6 +373,7 @@ sub set_current_test ($test) {
           {
             name => $current_test->{name},
             full_name => $current_test->{fullname},
+            attempt => $current_test->{attempt} // 0,
           }
         : {});
 }
@@ -562,6 +563,7 @@ sub runalltests () {
         my $error;
 
         while (1) {
+            $t->{attempt} = $attempt;
             bmwqemu::modstate "starting $name $t->{script}" . ($attempt ? " (retry $attempt/$retry_count)" : '');
             $t->start();
 

--- a/autotest.pm
+++ b/autotest.pm
@@ -557,17 +557,38 @@ sub runalltests () {
         }
 
         my $name = $t->{name};
-        bmwqemu::modstate "starting $name $t->{script}";
-        $t->start();
-
-        # avoid erasing the good vm snapshot
-        if ($snapshots_supported && (($bmwqemu::vars{SKIPTO} || '') ne $fullname) && $bmwqemu::vars{MAKETESTSNAPSHOTS}) {
-            make_snapshot($t->{fullname});
-        }
-
+        my $retry_count = $flags->{retry} // 0;
+        my $attempt = 0;
         my $error;
-        try { $t->runtest }
-        catch ($e) { $error = $e }
+
+        while (1) {
+            bmwqemu::modstate "starting $name $t->{script}" . ($attempt ? " (retry $attempt/$retry_count)" : '');
+            $t->start();
+
+            # avoid erasing the good vm snapshot
+            if ($snapshots_supported && (($bmwqemu::vars{SKIPTO} || '') ne $fullname) && $bmwqemu::vars{MAKETESTSNAPSHOTS}) {
+                make_snapshot($t->{fullname});
+            }
+
+            $error = undef;
+            try { $t->runtest }
+            catch ($e) { $error = $e }
+
+            last unless $error;
+            last if $attempt >= $retry_count;
+            last if !$snapshots_supported || !$last_milestone || $flags->{no_rollback};
+            last if $bmwqemu::vars{TESTDEBUG};
+
+            $attempt++;
+            bmwqemu::diag "Retrying $name after failure (attempt $attempt/$retry_count)";
+            load_snapshot('lastgood');
+            rollback_activated_consoles();
+
+            # Reset test object state for retry
+            $t->{result} = undef;
+            $t->{fatal_failure} = 0;
+            delete $t->{_result_forced};
+        }
         $t->save_test_result();
         my $next_test = $testorder[$testindex + 1];
 

--- a/autotest.pm
+++ b/autotest.pm
@@ -386,6 +386,7 @@ sub set_current_test ($test) {
           {
             name => $current_test->{name},
             full_name => $current_test->{fullname},
+            attempt => $current_test->{attempt} // 0,
           }
         : {});
 }
@@ -575,6 +576,7 @@ sub runalltests () {
         my $error;
 
         while (1) {
+            $t->{attempt} = $attempt;
             bmwqemu::modstate "starting $name $t->{script}" . ($attempt ? " (retry $attempt/$retry_count)" : '');
             $t->start();
 

--- a/autotest.pm
+++ b/autotest.pm
@@ -570,17 +570,38 @@ sub runalltests () {
         }
 
         my $name = $t->{name};
-        bmwqemu::modstate "starting $name $t->{script}";
-        $t->start();
-
-        # avoid erasing the good vm snapshot
-        if ($snapshots_supported && (($bmwqemu::vars{SKIPTO} || '') ne $fullname) && $bmwqemu::vars{MAKETESTSNAPSHOTS}) {
-            make_snapshot($t->{fullname});
-        }
-
+        my $retry_count = $flags->{retry} // 0;
+        my $attempt = 0;
         my $error;
-        try { $t->runtest }
-        catch ($e) { $error = $e }
+
+        while (1) {
+            bmwqemu::modstate "starting $name $t->{script}" . ($attempt ? " (retry $attempt/$retry_count)" : '');
+            $t->start();
+
+            # avoid erasing the good vm snapshot
+            if ($snapshots_supported && (($bmwqemu::vars{SKIPTO} || '') ne $fullname) && $bmwqemu::vars{MAKETESTSNAPSHOTS}) {
+                make_snapshot($t->{fullname});
+            }
+
+            $error = undef;
+            try { $t->runtest }
+            catch ($e) { $error = $e }
+
+            last unless $error;
+            last if $attempt >= $retry_count;
+            last if !$snapshots_supported || !$last_milestone || $flags->{no_rollback};
+            last if $bmwqemu::vars{TESTDEBUG};
+
+            $attempt++;
+            bmwqemu::diag "Retrying $name after failure (attempt $attempt/$retry_count)";
+            load_snapshot('lastgood');
+            rollback_activated_consoles();
+
+            # Reset test object state for retry
+            $t->{result} = undef;
+            $t->{fatal_failure} = 0;
+            delete $t->{_result_forced};
+        }
         $t->save_test_result();
         my $next_test = $testorder[$testindex + 1];
 

--- a/basetest.pm
+++ b/basetest.pm
@@ -47,6 +47,7 @@ sub new ($class, $category = undef) {
     $self->{running} = 0;
     $self->{category} = $category;
     $self->{test_count} = 0;
+    $self->{attempt} = 0;
     $self->{screen_count} = 0;
     $self->{wav_fn} = undef;
     $self->{recording_number} = 0;
@@ -286,7 +287,7 @@ sub post_run_hook ($self) {
 
 sub run_post_fail ($self, $msg) {
     my $name = $self->{name};
-    autotest::query_isotovideo(set_current_test => {name => $name, full_name => ($self->{fullname} // $name) . ' (post fail hook)'});
+    autotest::query_isotovideo(set_current_test => {name => $name, full_name => ($self->{fullname} // $name) . ' (post fail hook)', attempt => $self->{attempt} // 0});
     my $post_fail_hook_start_time = time;
     unless ($bmwqemu::vars{_SKIP_POST_FAIL_HOOKS}) {
         $self->{post_fail_hook_running} = 1;

--- a/basetest.pm
+++ b/basetest.pm
@@ -91,6 +91,7 @@ Return a hash of flags that are either there or not
   'milestone'      - after this test succeeds, update 'lastgood'
   'no_rollback'     - don't roll back to 'lastgood' snapshot if this fails
   'always_rollback' - roll back to 'lastgood' snapshot even if this does not fail
+  'retry'           - number of times to retry a test module on failure if a milestone is available
 
 =cut
 

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -125,6 +125,27 @@ $mock_basetest->redefine(test_flags => {milestone => 1});
 $mock_basetest->noop('record_resultfile');
 sub snapshot_subtest ($name, $sub) { subtest $name, $sub; $reverts_done = $snapshots_made = 0; @sent = () }
 
+sub retry_subtest ($name, $tests, $sub) {
+    snapshot_subtest $name, sub {
+        local %autotest::tests = ();
+        local @autotest::testorder = ();
+        local $autotest::last_milestone = undef;
+        local $autotest::last_milestone_active_consoles = [];
+        local $autotest::activated_consoles = [];
+        local $autotest::last_milestone_console = undef;
+
+        loadtest $_ for @$tests;
+
+        $mock_autotest->redefine(query_isotovideo => sub ($command, $arguments) {
+                return 1 if $command eq 'backend_can_handle' && $arguments->{function} eq 'snapshots';
+                return {snapshot_done => 1} if $command eq 'backend_make_snapshot';
+                return {};
+        });
+
+        $sub->(@autotest::testorder);
+    };
+}
+
 subtest 'test always_rollback flag' => sub {
     snapshot_subtest 'no rollback is triggered when flag is not explicitly set to true' => sub {
         stderr_like { autotest::run_all } qr/finished/, 'run_all outputs status on stderr';
@@ -195,22 +216,7 @@ subtest 'test always_rollback flag' => sub {
         stderr_like { autotest::run_all } qr/.*stopping overall test execution because TESTDEBUG has been set.*/, 'reason logged (TESTDEBUG)';
         delete $bmwqemu::vars{TESTDEBUG};
     };
-    snapshot_subtest 'always_run flag ensures execution after fatal failure' => sub {
-        local %autotest::tests = ();
-        local @autotest::testorder = ();
-        local $autotest::last_milestone = undef;
-        local $autotest::last_milestone_active_consoles = [];
-        local $autotest::activated_consoles = [];
-        local $autotest::last_milestone_console = undef;
-
-        loadtest $_ for qw(fatal start next);
-        my ($fatal_test, $normal_test, $cleanup_test) = @autotest::testorder;
-        $mock_autotest->redefine(query_isotovideo => sub ($command, $arguments) {
-                return 1 if $command eq 'backend_can_handle' && $arguments->{function} eq 'snapshots';
-                return {snapshot_done => 1} if $command eq 'backend_make_snapshot';
-                return {};
-        });
-
+    retry_subtest 'always_run flag ensures execution after fatal failure', [qw(fatal start next)], sub ($fatal_test, $normal_test, $cleanup_test) {
         $mock_basetest->redefine(test_flags => sub ($self) {
                 return {fatal => 1} if $self == $fatal_test;
                 return {always_run => 1} if $self == $cleanup_test;
@@ -240,6 +246,56 @@ subtest 'test always_rollback flag' => sub {
         stderr_like { $w = warning { autotest::run_all } } qr/Snapshots are not supported/, 'run_all outputs on stderr';
         like $w, qr/always_rollback requested but snapshots are not supported by the backend/, 'fails with explicit error message';
         delete $bmwqemu::vars{FAIL_ON_ALWAYS_ROLLBACK_NOT_SUPPORTED};
+    };
+    retry_subtest 'test retry flag', [qw(start next)], sub ($milestone_test, $retry_test) {
+        $mock_basetest->redefine(test_flags => sub ($self) {
+                return {milestone => 1} if $self == $milestone_test;
+                return {retry => 2} if $self == $retry_test;
+                return {};
+        });
+
+        my $retry_runs = 0;
+        $mock_basetest->redefine(runtest => sub ($self) {
+                if ($self == $retry_test) {
+                    $retry_runs++;
+                    die "retryable failure\n" if $retry_runs < 3;
+                }
+                return 1;
+        });
+
+        my $rollbacks = 0;
+        $mock_autotest->redefine(load_snapshot => sub { $rollbacks++ });
+
+        stderr_like { autotest::run_all } qr/Retrying next after failure \(attempt 1\/2\)/, 'logged first retry';
+        is $retry_runs, 3, 'test run total of 3 times (initial + 2 retries)';
+        is $rollbacks, 2, 'two rollbacks triggered';
+        ($died, $completed) = get_tests_done;
+        is $died, 0, 'tests not considered died';
+        is $completed, 1, 'tests completed after successful retry';
+    };
+    retry_subtest 'test retry flag with all attempts failing', [qw(start next)], sub ($milestone_test, $retry_test) {
+        $mock_basetest->redefine(test_flags => sub ($self) {
+                return {milestone => 1} if $self == $milestone_test;
+                return {retry => 1} if $self == $retry_test;
+        });
+
+        my $retry_runs = 0;
+        $mock_basetest->redefine(runtest => sub ($self) {
+                if ($self == $retry_test) {
+                    $retry_runs++;
+                    die "permanent failure\n";
+                }
+                return 1;
+        });
+
+        my $rollbacks = 0;
+        $mock_autotest->redefine(load_snapshot => sub { $rollbacks++ });
+
+        stderr_like { autotest::run_all } qr/Retrying next after failure \(attempt 1\/1\)/, 'logged retry';
+        is $retry_runs, 2, 'test run total of 2 times (initial + 1 retry)';
+        is $rollbacks, 1, 'one rollback triggered';
+        ($died, $completed) = get_tests_done;
+        is $completed, 1, 'tests completed (even if one module failed, as it was not fatal)';
     };
     $mock_basetest->unmock($_) for qw(runtest test_flags);
     $mock_autotest->unmock($_) for qw(load_snapshot make_snapshot query_isotovideo);

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -125,6 +125,27 @@ $mock_basetest->redefine(test_flags => {milestone => 1});
 $mock_basetest->noop('record_resultfile');
 sub snapshot_subtest ($name, $sub) { subtest $name, $sub; $reverts_done = $snapshots_made = 0; @sent = () }
 
+sub retry_subtest ($name, $tests, $sub) {
+    snapshot_subtest $name, sub {
+        local %autotest::tests = ();
+        local @autotest::testorder = ();
+        local $autotest::last_milestone = undef;
+        local $autotest::last_milestone_active_consoles = [];
+        local $autotest::activated_consoles = [];
+        local $autotest::last_milestone_console = undef;
+
+        loadtest $_ for @$tests;
+
+        $mock_autotest->redefine(query_isotovideo => sub ($command, $arguments) {
+                return 1 if $command eq 'backend_can_handle' && $arguments->{function} eq 'snapshots';
+                return {snapshot_done => 1} if $command eq 'backend_make_snapshot';
+                return {};
+        });
+
+        $sub->(@autotest::testorder);
+    };
+}
+
 subtest 'test always_rollback flag' => sub {
     snapshot_subtest 'no rollback is triggered when flag is not explicitly set to true' => sub {
         stderr_like { autotest::run_all } qr/finished/, 'run_all outputs status on stderr';
@@ -213,6 +234,7 @@ subtest 'test always_rollback flag' => sub {
                 return {};
         });
 
+    retry_subtest 'always_run flag ensures execution after fatal failure', [qw(fatal start next)], sub ($fatal_test, $normal_test, $cleanup_test) {
         $mock_basetest->redefine(test_flags => sub ($self) {
                 return {fatal => 1} if $self == $fatal_test;
                 return {always_run => 1} if $self == $cleanup_test;
@@ -240,6 +262,56 @@ subtest 'test always_rollback flag' => sub {
         my $w;
         stderr_like { $w = warning { autotest::run_all } } qr/Snapshots are not supported/, 'run_all outputs on stderr';
         like $w, qr/always_rollback requested but snapshots are not supported by the backend/, 'fails with explicit error message';
+    };
+    retry_subtest 'test retry flag', [qw(start next)], sub ($milestone_test, $retry_test) {
+        $mock_basetest->redefine(test_flags => sub ($self) {
+                return {milestone => 1} if $self == $milestone_test;
+                return {retry => 2} if $self == $retry_test;
+                return {};
+        });
+
+        my $retry_runs = 0;
+        $mock_basetest->redefine(runtest => sub ($self) {
+                if ($self == $retry_test) {
+                    $retry_runs++;
+                    die "retryable failure\n" if $retry_runs < 3;
+                }
+                return 1;
+        });
+
+        my $rollbacks = 0;
+        $mock_autotest->redefine(load_snapshot => sub { $rollbacks++ });
+
+        stderr_like { autotest::run_all } qr/Retrying next after failure \(attempt 1\/2\)/, 'logged first retry';
+        is $retry_runs, 3, 'test run total of 3 times (initial + 2 retries)';
+        is $rollbacks, 2, 'two rollbacks triggered';
+        ($died, $completed) = get_tests_done;
+        is $died, 0, 'tests not considered died';
+        is $completed, 1, 'tests completed after successful retry';
+    };
+    retry_subtest 'test retry flag with all attempts failing', [qw(start next)], sub ($milestone_test, $retry_test) {
+        $mock_basetest->redefine(test_flags => sub ($self) {
+                return {milestone => 1} if $self == $milestone_test;
+                return {retry => 1} if $self == $retry_test;
+        });
+
+        my $retry_runs = 0;
+        $mock_basetest->redefine(runtest => sub ($self) {
+                if ($self == $retry_test) {
+                    $retry_runs++;
+                    die "permanent failure\n";
+                }
+                return 1;
+        });
+
+        my $rollbacks = 0;
+        $mock_autotest->redefine(load_snapshot => sub { $rollbacks++ });
+
+        stderr_like { autotest::run_all } qr/Retrying next after failure \(attempt 1\/1\)/, 'logged retry';
+        is $retry_runs, 2, 'test run total of 2 times (initial + 1 retry)';
+        is $rollbacks, 1, 'one rollback triggered';
+        ($died, $completed) = get_tests_done;
+        is $completed, 1, 'tests completed (even if one module failed, as it was not fatal)';
     };
     $mock_basetest->unmock($_) for qw(runtest test_flags);
     $mock_autotest->unmock($_) for qw(load_snapshot make_snapshot query_isotovideo);

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -88,7 +88,7 @@ subtest run_post_fail_test => sub {
         my %pause_on_failure = (cmd => 'pause_test_execution', due_to_failure => 1);
         like delete $cmds->[0]->{reason}, qr/test died: Died at .*17-basetest\.t/, 'reason for pause passed';
         is_deeply $cmds->[0], \%pause_on_failure, 'failure reported to pause if pausing on failures enabled';
-        my %test_name_update = (cmd => 'set_current_test', name => 'foo', full_name => 'foo (post fail hook)');
+        my %test_name_update = (cmd => 'set_current_test', name => 'foo', full_name => 'foo (post fail hook)', attempt => 0);
         is_deeply $cmds->[1], \%test_name_update, 'test name updated (to show post fail hook in developer mode)';
     } or always_explain $cmds;
 

--- a/t/19-isotovideo-command-processing.t
+++ b/t/19-isotovideo-command-processing.t
@@ -110,9 +110,14 @@ subtest 'set pause at test' => sub {
     is($command_handler->pause_test_name, 'some test', 'test to pause at set');
 
     stderr_unlike {
-        $command_handler->process_command($answer_fd, {cmd => 'set_current_test', name => 'foo', full_name => 'foo'})
+        $command_handler->process_command($answer_fd, {cmd => 'set_current_test', name => 'foo', full_name => 'foo', attempt => 1})
     } qr/pausing/, 'pausing not logged';
     is_deeply $last_received_msg_by_fd[$answer_fd], {ret => 1}, 'not paused on different test module';
+    is_deeply $last_received_msg_by_fd[$cmd_srv_fd], {
+        set_current_test => 'foo',
+        current_test_full_name => 'foo',
+        attempt => 1,
+    }, 'broadcasted via command server';
     ok !$command_handler->reason_for_pause, 'reason for pause set not set';
     is $command_handler->postponed_answer_fd, undef, 'answer not postponed';
 


### PR DESCRIPTION
Motivation:
Allow test modules to be retried automatically upon failure when milestones
are available. This is useful for dealing with flaky tests or environmental
issues.

Design Choices:
- Added a new `retry` test flag that specifies the number of additional
  attempts.
- Modified `runalltests` in `autotest.pm` to include a retry loop.
- Retries are only attempted if snapshots are supported and a milestone
  exists.
- The test object is reset for each retry attempt while preserving `details`
  for debugging.
- Rollback to the last milestone and console reset are performed before each
  retry.

Benefits:
Increased test suite robustness by handling transient failures automatically.
Provides better integration with existing snapshot/rollback features.