### PR TITLE
fix(distribution): make PRETTY_SERIAL_MARKER reboot-safe

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -466,8 +466,7 @@ Returns:
 
 sub _detect_serial_marker_capability ($self) {
     my $console = testapi::current_console() // 'sut';
-    if ($self->{_serial_marker_level}->{$console}) {
-        my $level = $self->{_serial_marker_level}->{$console};
+    if (my $level = $self->{_serial_marker_level}->{$console}) {
         return $level if $level < 2 || $self->{_serial_marker_hook_installed}->{$console};
 
         $self->install_serial_marker_hook($level);
@@ -477,10 +476,7 @@ sub _detect_serial_marker_capability ($self) {
     my $level = 1;
     my $pretty = testapi::get_var('PRETTY_SERIAL_MARKER');
     my $serial_term = testapi::is_serial_terminal();
-    if (!$pretty || $serial_term) {
-        $self->{_serial_marker_level}->{$console} = $level;
-        return $level;
-    }
+    return $self->{_serial_marker_level}->{$console} = $level if !$pretty || $serial_term;
 
     testapi::type_string "echo \"BASH:\$BASH_VERSION:\" > /dev/$testapi::serialdev\n";
     my $out = testapi::wait_serial(qr/BASH:([^:]*):/, 10);
@@ -498,8 +494,7 @@ sub _detect_serial_marker_capability ($self) {
         bmwqemu::log_call("serial_marker: console '$console' Level 1 detected (fallback)");
         return 1;
     }
-    $self->{_serial_marker_level}->{$console} = $level;
-    return $level;
+    return $self->{_serial_marker_level}->{$console} = $level;
 }
 
 1;

--- a/distribution.pm
+++ b/distribution.pm
@@ -466,23 +466,26 @@ sub _detect_serial_marker_capability ($self) {
     my $level = 1;
     my $pretty = testapi::get_var('PRETTY_SERIAL_MARKER');
     my $serial_term = testapi::is_serial_terminal();
-    if ($pretty && !$serial_term) {
-        testapi::type_string "echo \"BASH:\$BASH_VERSION:\" > /dev/$testapi::serialdev\n";
-        my $out = testapi::wait_serial(qr/BASH:([^:]*):/, 10);
-        if ($out && $out =~ /BASH:([3-9]|\d{2,})/) {
-            $level = 2;
-            # Check if bash and history features are available to use pretty serial markers
-            testapi::type_string "type fc && set -o | grep -q 'history.*on' && echo \"FC:OK:\" > /dev/$testapi::serialdev\n";
-            if (testapi::wait_serial(qr/FC:OK:/, 10)) {
-                $level = 3;
-            }
-            $self->install_serial_marker_hook($level);
-            bmwqemu::log_call("serial_marker: console '$console' Level $level detected");
+    if (!$pretty || $serial_term) {
+        $self->{_serial_marker_level}->{$console} = $level;
+        return $level;
+    }
+
+    testapi::type_string "echo \"BASH:\$BASH_VERSION:\" > /dev/$testapi::serialdev\n";
+    my $out = testapi::wait_serial(qr/BASH:([^:]*):/, 10);
+    if ($out && $out =~ /BASH:([3-9]|\d{2,})/) {
+        $level = 2;
+        # Check if bash and history features are available to use pretty serial markers
+        testapi::type_string "type fc && set -o | grep -q 'history.*on' && echo \"FC:OK:\" > /dev/$testapi::serialdev\n";
+        if (testapi::wait_serial(qr/FC:OK:/, 10)) {
+            $level = 3;
         }
-        else {
-            bmwqemu::log_call("serial_marker: console '$console' Level 1 detected (fallback)");
-            return 1;
-        }
+        $self->install_serial_marker_hook($level);
+        bmwqemu::log_call("serial_marker: console '$console' Level $level detected");
+    }
+    else {
+        bmwqemu::log_call("serial_marker: console '$console' Level 1 detected (fallback)");
+        return 1;
     }
     $self->{_serial_marker_level}->{$console} = $level;
     return $level;

--- a/distribution.pm
+++ b/distribution.pm
@@ -445,6 +445,11 @@ sub install_serial_marker_hook ($self, $level) {
         $pc = "PROMPT_COMMAND='if [ -n \"\$__OA_MARK\" ]; then echo \"\${__OA_MARK}-\$?-\" > $dev; unset __OA_MARK; fi'";
     }
     testapi::type_string "$pc\n";
+    my $marker_match = $level == 3 ? 'OA:DONE' : '__OA_MARK';
+    my $hook_cmd = "for f in ~/.bashrc ~/.profile; do grep -q '$marker_match' \"\$f\" 2>/dev/null || cat <<'EOF' >> \"\$f\"\n$pc\nEOF\ndone\n";
+    testapi::type_string $hook_cmd;
+    my $console = testapi::current_console() // 'sut';
+    $self->{_serial_marker_hook_installed}->{$console} = 1;
 }
 
 =head2 _detect_serial_marker_capability
@@ -461,7 +466,13 @@ Returns:
 
 sub _detect_serial_marker_capability ($self) {
     my $console = testapi::current_console() // 'sut';
-    return $self->{_serial_marker_level}->{$console} if $self->{_serial_marker_level}->{$console};
+    if ($self->{_serial_marker_level}->{$console}) {
+        my $level = $self->{_serial_marker_level}->{$console};
+        return $level if $level < 2 || $self->{_serial_marker_hook_installed}->{$console};
+
+        $self->install_serial_marker_hook($level);
+        return $level;
+    }
 
     my $level = 1;
     my $pretty = testapi::get_var('PRETTY_SERIAL_MARKER');

--- a/distribution.pm
+++ b/distribution.pm
@@ -484,7 +484,7 @@ sub _detect_serial_marker_capability ($self) {
 
     testapi::type_string "echo \"BASH:\$BASH_VERSION:\" > /dev/$testapi::serialdev\n";
     my $out = testapi::wait_serial(qr/BASH:([^:]*):/, 10);
-    if ($out && $out =~ /BASH:([3-9]|\d{2,})/) {
+    if ($out && $out =~ /BASH:(?:[3-9]|\d{2,})/) {
         $level = 2;
         # Check if bash and history features are available to use pretty serial markers
         testapi::type_string "type fc && set -o | grep -q 'history.*on' && echo \"FC:OK:\" > /dev/$testapi::serialdev\n";

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -137,6 +137,50 @@ subtest 'pretty_serial_marker' => sub {
     throws_ok { $d->script_run('foo') } qr/typing command 'foo' timed out/, 'typing error handled in Level 1';
 };
 
+subtest 'reboot_safety' => sub {
+    my $d = distribution->new;
+    my $mock_testapi = Test::MockModule->new('testapi');
+    my $mock_bmwqemu = Test::MockModule->new('bmwqemu');
+    $mock_bmwqemu->noop('log_call');
+    my $typed_string = '';
+    $mock_testapi->redefine(query_isotovideo => sub { });
+    $mock_testapi->redefine(type_string => sub { $typed_string .= $_[0] });
+    $mock_testapi->redefine(hashed_string => sub { return 'SR' . substr $_[0], 0, 8 });
+    $mock_testapi->redefine(is_serial_terminal => sub { 0 });
+    $mock_testapi->redefine(current_console => sub { 'test-console' });
+    $mock_testapi->redefine(get_var => sub { $_[0] eq 'PRETTY_SERIAL_MARKER' ? 1 : undef });
+    $testapi::serialdev = 'ttyS0';
+
+    # Initial detection (Level 3)
+    $mock_testapi->redefine(wait_serial => sub {
+            my ($regexp) = @_;
+            return 'BASH:4.4:' if ref($regexp) eq 'Regexp' && 'BASH:4.4:' =~ $regexp;
+            return 'FC:OK:' if ref($regexp) eq 'Regexp' && 'FC:OK:' =~ $regexp;
+            return 'OA:DONE-0-';
+    });
+
+    $d->script_run('foo');
+    like $typed_string, qr/PROMPT_COMMAND=.*OA:DONE/, 'Initial install';
+    like $typed_string, qr/\.bashrc/, 'Persistence added';
+    $typed_string = '';
+
+    # Simulate console selection (e.g. after reboot/login)
+    $d->console_selected('test-console');
+
+    # Case 1: still there (e.g. persistent)
+    $typed_string = '';
+    $d->script_run('bar');
+    unlike $typed_string, qr/PROMPT_COMMAND=.*OA:DONE/, 'No re-install if still there';
+    like $typed_string, qr/bar\n/, 'Command typed';
+
+    # Case 2: manual clear (e.g. if we know it was lost)
+    delete $d->{_serial_marker_hook_installed}->{'test-console'};
+    $typed_string = '';
+    $d->script_run('baz');
+    like $typed_string, qr/PROMPT_COMMAND=.*OA:DONE/, 'Re-install if missing';
+    like $typed_string, qr/baz\n/, 'Command typed after re-install';
+};
+
 subtest 'sut_marker' => sub {
     my $d = distribution->new;
     is $d->sut_marker('ls -la /tmp'), 'OA:ls -11/tmp', 'sut_marker for normal command';


### PR DESCRIPTION
Motivation:
When PRETTY_SERIAL_MARKER=1 is used, os-autoinst relies on PROMPT_COMMAND being
set in the SUT shell. After a reboot or a new console login, this environment
variable is lost, but os-autoinst assumes it is still there due to internal
caching of the detection result. This leads to command timeouts as the expected
serial markers are never printed.

Design Choices:
- Implemented console_selected hook in Distribution to reset the hook status
  whenever a console is selected (e.g. after a login).
- Added a crosscheck in _detect_serial_marker_capability that verifies if the
  hook is still active (using a quick newline check for Level 3) before
  re-installing it.
- Modified install_serial_marker_hook to add the PROMPT_COMMAND to
  ~/.bashrc and ~/.profile, ensuring it persists across reboots and new
  login shells for the same user.

Verified with an adapted "openQA-in-openQA" test scenario that reboots
in the middle of the execution with console commands evaluated before
and after reboot.

Screenshot of two purposely failing commands without visible serial
markers that trigger the post_fail_hook:
![mpv-shot0001](https://github.com/user-attachments/assets/f9c6a1a9-49a2-4500-9eaa-a3576331c9b4)

Complete video:
[video.webm](https://github.com/user-attachments/assets/6d99c3d8-4f60-435d-a8b3-a6d5a65fd461)

Benefits:
- Pretty serial markers remain functional after reboot

Related issue: https://progress.opensuse.org/issues/183761