### PR TITLE
feat(llm): integrate LLM analysis into isotovideo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ set(PERL_FILES
     OpenQA/Isotovideo/CommandHandler.pm
     OpenQA/Isotovideo/Dewebsockify.pm
     OpenQA/Isotovideo/Interface.pm
+    OpenQA/Isotovideo/LLMAnalysis.pm
     OpenQA/Isotovideo/NeedleDownloader.pm
     OpenQA/Isotovideo/Runner.pm
     OpenQA/Isotovideo/Utils.pm

--- a/OpenQA/Isotovideo/LLMAnalysis.pm
+++ b/OpenQA/Isotovideo/LLMAnalysis.pm
@@ -1,0 +1,130 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package OpenQA::Isotovideo::LLMAnalysis;
+use Mojo::Base -signatures;
+use bmwqemu;
+use Feature::Compat::Try;
+use IPC::Run ();
+use Mojo::UserAgent;
+use Mojo::JSON qw(decode_json);
+use Mojo::File qw(path);
+use Text::ParseWords;
+
+use constant MAX_PAYLOAD_SIZE => 8000;
+
+sub _get_file_tail ($filename, $result_dir, $max_lines) {
+    my $file = $filename;
+    $file = "$result_dir/$filename" unless -e $file;
+    return '' unless -e $file;
+    my $tail = qx(tail -n $max_lines \Q$file\E 2>/dev/null) || '';
+    chomp $tail;
+    return $tail;
+}
+
+sub gather_context ($result_dir) {
+    my @failed_tests;
+    for my $res_file (glob "$result_dir/result-*.json") {
+        my $json = eval { decode_json(path($res_file)->slurp) };
+        next unless $json && ($json->{result} // '') eq 'fail';
+        my $name = $json->{name};
+        ($name) = $res_file =~ /result-(.*)\.json$/ unless $name;
+        push @failed_tests, $name if $name;
+    }
+    return undef unless @failed_tests;
+    my $failed_str = join ', ', @failed_tests;
+    my $log_tail = _get_file_tail('autoinst-log.txt', $result_dir, 200);
+    my $serial_tail = _get_file_tail('serial0', $result_dir, 100);
+    my $context = {
+        failed_tests => $failed_str,
+        log_tail => $log_tail,
+        serial_tail => $serial_tail,
+        distri => $bmwqemu::vars{DISTRI} || 'unknown',
+        version => $bmwqemu::vars{VERSION} || 'unknown',
+        arch => $bmwqemu::vars{ARCH} || 'unknown',
+    };
+    return $context;
+}
+
+sub build_prompt ($context) {
+    my $distri = $context->{distri};
+    my $version = $context->{version};
+    my $arch = $context->{arch};
+    my $failed_tests = $context->{failed_tests};
+    my $log_tail = $context->{log_tail};
+    my $serial_tail = $context->{serial_tail};
+
+    # Truncate inputs to preserve instructions at the end of the prompt
+    $log_tail = substr $log_tail, -MAX_PAYLOAD_SIZE if length($log_tail) > MAX_PAYLOAD_SIZE;
+    $serial_tail = substr $serial_tail, -MAX_PAYLOAD_SIZE if length($serial_tail) > MAX_PAYLOAD_SIZE;
+
+    my $prompt = <<"EOF";
+You are analyzing an automated test run of $distri $version $arch.
+The following tests failed: $failed_tests.
+
+Relevant log tail:
+$log_tail
+
+Serial output tail:
+$serial_tail
+
+Provide exactly 2-3 sentences answering:
+1. Why did the tests fail?
+2. What should be done to prevent these failures?
+3. Is this likely a product regression or a test infrastructure problem
+   (false positive)?
+EOF
+
+    return $prompt;
+}
+
+sub query_llm_api ($prompt, $url, $model) {
+    my $ua = Mojo::UserAgent->new;
+    $ua->connect_timeout(300);
+    $ua->inactivity_timeout(300);
+    my $req = {
+        model => $model,
+        messages => [{role => 'user', content => $prompt}],
+        temperature => 0.3
+    };
+    my $tx = $ua->post($url => json => $req);
+    if (my $err = $tx->error) {
+        return 'Error: HTTP API failed with status ' . $err->{code} if $err->{code};
+        return 'Error: ' . ($err->{message} || 'Connection failed');
+    }
+    my $res = $tx->result;
+    my $json = eval { decode_json($res->body) };
+    return $json->{choices}[0]{message}{content} if $json && $json->{choices} && $json->{choices}[0]{message}{content};
+    return 'Error: Unexpected response format from LLM API.';
+}
+
+sub query_llm_cmd ($prompt, $cmd) {
+    my @cmd_array = Text::ParseWords::shellwords($cmd);
+    my $out;
+    my $err;
+    try {
+        IPC::Run::run(\@cmd_array, \$prompt, \$out, \$err, IPC::Run::timeout(300));
+    } catch ($e) { return "Error: Command failed - $e" }
+    return "Error: Command exited with $? - " . ($err || $out || '') if $?;
+    return $out || $err || 'Error: Command produced no output.';
+}
+
+sub run ($result_dir) {
+    my $context = gather_context($result_dir);
+    return unless $context;
+    bmwqemu::diag('Starting LLM Analysis…');
+    my $prompt = build_prompt($context);
+    my $output;
+    if (my $cmd = $bmwqemu::vars{LLM_FAILURE_ANALYSIS_CMD}) {
+        $output = query_llm_cmd($prompt, $cmd);
+    }
+    else {
+        my $url = $bmwqemu::vars{LLM_FAILURE_ANALYSIS_URL} || 'http://localhost:8080/v1/chat/completions';
+        my $model = $bmwqemu::vars{LLM_FAILURE_ANALYSIS_MODEL} || 'gemma-4-26B-A4B-it';
+        $output = query_llm_api($prompt, $url, $model);
+    }
+    path("$result_dir/llm-failure-analysis.txt")->spurt($output);
+    bmwqemu::diag("LLM Analysis complete. Saved to $result_dir/llm-failure-analysis.txt");
+}
+
+1;

--- a/OpenQA/Isotovideo/LLMAnalysis.pm
+++ b/OpenQA/Isotovideo/LLMAnalysis.pm
@@ -103,9 +103,9 @@ sub query_llm_cmd ($prompt, $cmd) {
     my $out;
     my $err;
     try {
-        IPC::Run::run(\@cmd_array, \$prompt, \$out, \$err, IPC::Run::timeout(300));
+        my $success = IPC::Run::run(\@cmd_array, \$prompt, \$out, \$err, IPC::Run::timeout(300));
+        return "Error: Command exited with $? - " . ($err || $out || '') unless $success;
     } catch ($e) { return "Error: Command failed - $e" }
-    return "Error: Command exited with $? - " . ($err || $out || '') if $?;
     return $out || $err || 'Error: Command produced no output.';
 }
 

--- a/doc/backend_vars.md
+++ b/doc/backend_vars.md
@@ -48,6 +48,10 @@ Supported variables per backend
 | UPLOAD_MAX_MESSAGE_SIZE_GB | integer | 0 | Specifies the max. upload size in GiB for the test API functions `upload_logs()` and `upload_assets()` and the underlying command server API. Zero denotes infinity. |
 | UPLOAD_INACTIVITY_TIMEOUT | integer | 300 | Specifies the inactivity timeout in seconds for the test API functions `upload_logs()` and `upload_assets()` and underlying the command server API. |
 | NO_DEPRECATE_BACKEND_$backend | boolean | 0 | Only warn about deprecated backends instead of aborting |
+| LLM_FAILURE_ANALYSIS | boolean | 0 | Enable LLM failure analysis |
+| LLM_FAILURE_ANALYSIS_URL | string | http://localhost:8080/v1/chat/completions | OpenAI-compatible API endpoint |
+| LLM_FAILURE_ANALYSIS_MODEL | string | gemma-4-26B-A4B-it | Model name sent in the API request |
+| LLM_FAILURE_ANALYSIS_CMD | string |  | If set, run this CLI command instead of the HTTP API (prompt piped via stdin). For demo/one-off use. |
 | XRES | integer | 1024 | Resolution of display on x axis. Sets the resolution of the video encoder, and in qemu, the initial console resolution when OFW is set (Power and SPARC), and the EDID resolution for devices that support EDID |
 | YRES | integer | 768 | Resolution of display on y axis. Sets the resolution of the video encoder, and in qemu, the initial console resolution when OFW is set (Power and SPARC), and the EDID resolution for devices that support EDID |
 | VIDEO_ENCODER_BLOCKING_PIPE | boolean | 0 | Whether the pipe for writing data to the video encoder should be blocking or not. Making it blocking might allow following the live view in realtime despite large screenshot file sizes but it is not a well tested configuration |

--- a/script/isotovideo
+++ b/script/isotovideo
@@ -113,6 +113,7 @@ Getopt::Long::Configure('no_ignore_case');
 use OpenQA::Isotovideo::Interface;
 use OpenQA::Isotovideo::Runner;
 use OpenQA::Isotovideo::Utils qw(git_rev_parse spawn_debuggers handle_generated_assets);
+use OpenQA::Isotovideo::LLMAnalysis;
 
 my %options;
 
@@ -152,10 +153,7 @@ sub handle_shutdown () {
     my $clean_shutdown = $runner->handle_shutdown(\$RETURN_CODE);
     bmwqemu::load_vars();    # read calculated variables from backend and tests
     $RETURN_CODE = handle_generated_assets($runner->command_handler, $clean_shutdown) unless $RETURN_CODE;
-    if ($bmwqemu::vars{LLM_FAILURE_ANALYSIS}) {
-        require OpenQA::Isotovideo::LLMAnalysis;
-        OpenQA::Isotovideo::LLMAnalysis::run(bmwqemu::result_dir());
-    }
+    OpenQA::Isotovideo::LLMAnalysis::run(bmwqemu::result_dir()) if $bmwqemu::vars{LLM_FAILURE_ANALYSIS};
     diag 'isotovideo completed handle_shutdown: ' . ($RETURN_CODE ? 'failed' : 'done');
 }
 

--- a/script/isotovideo
+++ b/script/isotovideo
@@ -152,6 +152,10 @@ sub handle_shutdown () {
     my $clean_shutdown = $runner->handle_shutdown(\$RETURN_CODE);
     bmwqemu::load_vars();    # read calculated variables from backend and tests
     $RETURN_CODE = handle_generated_assets($runner->command_handler, $clean_shutdown) unless $RETURN_CODE;
+    if ($bmwqemu::vars{LLM_FAILURE_ANALYSIS}) {
+        require OpenQA::Isotovideo::LLMAnalysis;
+        OpenQA::Isotovideo::LLMAnalysis::run(bmwqemu::result_dir());
+    }
     diag 'isotovideo completed handle_shutdown: ' . ($RETURN_CODE ? 'failed' : 'done');
 }
 

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -336,6 +336,27 @@ subtest 'publish assets' => sub {
         delete $bmwqemu::vars{FORCE_PUBLISH_HDD_1};
     };
 
+    subtest 'LLM failure analysis' => sub {
+        chdir $pool_dir;
+        path('vars.json')->remove if -e 'vars.json';
+        path('testresults/')->remove_tree;
+        path('testresults/')->make_path;
+        # Create a dummy failed test result to trigger gathering context
+        path('testresults/result-failing_module.json')->spurt('{"result": "fail", "name": "failing_module"}');
+        path('autoinst-log.txt')->spurt("Something went wrong in the log\n");
+        path('serial0')->spurt("Kernel panic in serial output\n");
+        my $log = combined_from {
+            isotovideo(
+                opts => "casedir=$data_dir/tests schedule=module1 LLM_FAILURE_ANALYSIS=1 LLM_FAILURE_ANALYSIS_CMD=cat",
+                exit_code => 0)
+        };
+        like $log, qr/Starting LLM Analysis/, 'LLM analysis started';
+        like $log, qr/LLM Analysis complete/, 'LLM analysis finished';
+        my $analysis_file = path($pool_dir, 'testresults', 'llm-failure-analysis.txt');
+        ok -e $analysis_file, 'LLM analysis output file exists';
+        like $analysis_file->slurp, qr/analyzing an automated test run/, 'LLM analysis output contains expected content';
+    };
+
     subtest 'unclean shutdown' => sub {
         $bmwqemu::vars{PUBLISH_HDD_1} = 'publish_test.qcow2';
         $command_handler->test_completed(1);

--- a/t/44-llm-failure-analysis.t
+++ b/t/44-llm-failure-analysis.t
@@ -1,0 +1,140 @@
+#!/usr/bin/env perl
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+use Test::Warnings ':report_warnings';
+use Test::MockModule;
+use Mojo::Base -signatures;
+use Mojo::File qw(path tempdir);
+use FindBin '$Bin';
+use lib "$FindBin::Bin/lib", "$Bin/..", "$Bin/../external/os-autoinst-common/lib";
+use OpenQA::Test::TimeLimit '10';
+use bmwqemu;
+use OpenQA::Isotovideo::LLMAnalysis;
+
+my $tmpdir = tempdir;
+chdir $tmpdir or die "Cannot chdir to $tmpdir: $!";
+$bmwqemu::result_dir = 'testresults';
+
+sub setup_results (@results) {
+    my $testresults = path($bmwqemu::result_dir);
+    $testresults->make_path;
+    $testresults->list->each(sub ($f, $) { $f->remove });
+
+    my $i = 1;
+    for my $res (@results) {
+        $testresults->child("result-$i.json")->spurt(qq({"name":"test$i", "result":"$res"}));
+        $i++;
+    }
+}
+
+subtest 'Context gathering and truncation' => sub {
+    setup_results('ok', 'fail');
+    ok OpenQA::Isotovideo::LLMAnalysis::gather_context($bmwqemu::result_dir), 'Returns context when failures exist';
+
+    setup_results('ok');
+    ok !OpenQA::Isotovideo::LLMAnalysis::gather_context($bmwqemu::result_dir), 'Skips when no failures';
+
+    # Missing names
+    setup_results('fail');
+    path($bmwqemu::result_dir)->child('result-1.json')->spurt('{"result":"fail"}');
+    my $ctx = OpenQA::Isotovideo::LLMAnalysis::gather_context($bmwqemu::result_dir);
+    is $ctx->{failed_tests}, '1', 'Fallback to filename for test name';
+
+    # Truncation logic
+    path($bmwqemu::result_dir)->child('autoinst-log.txt')->spurt(join "\n", map { "L$_" } 1 .. 300);
+    path($bmwqemu::result_dir)->child('serial0')->spurt(join "\n", map { "S$_" } 1 .. 150);
+    $ctx = OpenQA::Isotovideo::LLMAnalysis::gather_context($bmwqemu::result_dir);
+    is scalar(split "\n", $ctx->{log_tail}), 200, 'Log tail truncated';
+    is scalar(split "\n", $ctx->{serial_tail}), 100, 'Serial tail truncated';
+
+    # Empty files
+    path($bmwqemu::result_dir)->child('autoinst-log.txt')->spurt('');
+    path($bmwqemu::result_dir)->child('serial0')->spurt('');
+    $ctx = OpenQA::Isotovideo::LLMAnalysis::gather_context($bmwqemu::result_dir);
+    is $ctx->{log_tail}, '', 'Handles empty log';
+};
+
+subtest 'Prompt generation' => sub {
+    my $ctx = {distri => 'D', version => 'V', arch => 'A', failed_tests => 'F', log_tail => 'L', serial_tail => 'S'};
+    my $prompt = OpenQA::Isotovideo::LLMAnalysis::build_prompt($ctx);
+    like $prompt, qr/D V A.*F.*L.*S/s, 'Prompt contains all context';
+
+    my $long = 'A' x 10000;
+    $ctx->{log_tail} = $long;
+    $ctx->{serial_tail} = $long;
+    $prompt = OpenQA::Isotovideo::LLMAnalysis::build_prompt($ctx);
+    ok length($prompt) < 17000, 'Prompt truncated';
+    like $prompt, qr/sentences answering/s, 'Instructions preserved at end';
+};
+
+subtest 'HTTP API mode' => sub {
+    my $mock_ua = Test::MockModule->new('Mojo::UserAgent');
+    require Mojo::Transaction::HTTP;
+    require Mojo::Message::Response;
+
+    my $test_api = sub ($res_body, $res_error = undef) {
+        $mock_ua->redefine(post => sub {
+                my $tx = Mojo::Transaction::HTTP->new;
+                $tx->res->code(200);
+                $tx->res->body($res_body) if defined $res_body;
+                $tx->res->error($res_error) if $res_error;
+                return $tx;
+        });
+        return OpenQA::Isotovideo::LLMAnalysis::query_llm_api('p', 'u', 'm');
+    };
+
+    is $test_api->('{"choices":[{"message":{"content":"OK"}}]}'), 'OK', 'Success path';
+    like $test_api->(undef, {message => 'Fail', code => 500}), qr/status 500/, 'HTTP error';
+    is $test_api->(undef, {message => 'Timeout'}), 'Error: Timeout', 'Connection error';
+    is $test_api->('{"malformed":1}'), 'Error: Unexpected response format from LLM API.', 'Malformed JSON';
+    is $test_api->('Not JSON'), 'Error: Unexpected response format from LLM API.', 'Non-JSON response';
+    is $test_api->('{"choices":[]}'), 'Error: Unexpected response format from LLM API.', 'Empty choices';
+};
+
+subtest 'CLI command mode' => sub {
+    my $mock_ipc = Test::MockModule->new('IPC::Run');
+    my $test_cmd = sub ($out, $err, $exit_code, $die_msg = undef) {
+        $mock_ipc->redefine(run => sub ($cmd, $in, $out_ref, $err_ref, @rest) {
+                die $die_msg if $die_msg;
+                $$out_ref = $out;
+                $$err_ref = $err;
+                $? = $exit_code << 8;
+                return $exit_code == 0;
+        });
+        return OpenQA::Isotovideo::LLMAnalysis::query_llm_cmd('p', 'c');
+    };
+
+    is $test_cmd->('Out', '', 0), 'Out', 'Success path';
+    like $test_cmd->('', '', 0, 'dead'), qr/Command failed - dead/, 'Command death';
+    like $test_cmd->('Out', 'Err', 1), qr/exited with 256 - Err/, 'Non-zero exit with stderr';
+    like $test_cmd->('Out', '', 1), qr/exited with 256 - Out/, 'Non-zero exit with stdout only';
+    is $test_cmd->('', '', 0), 'Error: Command produced no output.', 'No output';
+};
+
+subtest 'Execution routing' => sub {
+    my $mock_llm = Test::MockModule->new('OpenQA::Isotovideo::LLMAnalysis');
+    my $mock_bmwqemu = Test::MockModule->new('bmwqemu');
+    $mock_bmwqemu->noop('diag');
+
+    $mock_llm->redefine(gather_context => sub { return {distri => 'D'} });
+    $mock_llm->redefine(build_prompt => sub { return 'P' });
+    $mock_llm->redefine(query_llm_api => sub { return 'api' });
+    $mock_llm->redefine(query_llm_cmd => sub { return 'cmd' });
+
+    delete $bmwqemu::vars{LLM_FAILURE_ANALYSIS_CMD};
+    OpenQA::Isotovideo::LLMAnalysis::run($bmwqemu::result_dir);
+    is path($bmwqemu::result_dir)->child('llm-failure-analysis.txt')->slurp, 'api', 'Default to API';
+
+    $bmwqemu::vars{LLM_FAILURE_ANALYSIS_CMD} = 'c';
+    OpenQA::Isotovideo::LLMAnalysis::run($bmwqemu::result_dir);
+    is path($bmwqemu::result_dir)->child('llm-failure-analysis.txt')->slurp, 'cmd', 'Route to CMD';
+
+    $mock_llm->redefine(gather_context => sub { return undef });
+    $mock_bmwqemu->redefine(diag => sub { die 'No context should return' });
+    ok !OpenQA::Isotovideo::LLMAnalysis::run($bmwqemu::result_dir), 'Early return if no context';
+};
+
+done_testing;
+chdir '/';


### PR DESCRIPTION
Motivation:
We can enable a LLM failure analysis to run automatically at the end of
a test run after all assets are generated and results are finalized.

Design Choices:
- Inject the analysis call inside `handle_shutdown()` right after
  `handle_generated_assets`.
- Use `require` instead of `use` to avoid unnecessary loading when the
  feature is disabled.

Verified manually with an isotovideo run, e.g.

```
isotovideo -d schedule=tests/boot,tests/assert_screen llm_failure_analysis=1
```

using the existing os-autoinst test modules with local adaptions. For
invalid code like an additional test module line
`invalid_function_called();` the LLM investigation using a local
llama.cpp server running the model
"unsloth/gemma-4-E4B-it-GGUF:UD-IQ2_M" the analysis needs 40s and
concludes with

```
The tests failed because the `assert_screen` test encountered an
internal error (`Undefined subroutine`) during execution, indicating a
bug within the test code itself.
To prevent these failures, the test suite needs to be corrected or
updated.
This is likely a test infrastructure problem (false positive) rather
than a product regression.
```

For a non-existant needle tag the analysis revealed

```
1. The tests failed because the test backend was unable to find a
     matching screen state (`on_prompt_does_not_exist`) within the
     allotted timeout, causing the assertion to time out.
2. To prevent these failures, the test environment needs to be robustly
     configured to handle the absence of expected screen states, or the
     test case needs to be modified to handle the timeout scenario
     gracefully.
3. This is likely a test infrastructure problem (false positive) because
     the failure is related to the test runner's inability to confirm the
     expected state, rather than a functional bug in the software being
     tested.
```

Benefits:
- When enabled captures the complete execution context for analysis.

Related issues:
* https://progress.opensuse.org/issues/198056