### PR TITLE
fix(consoles): support newer x3270 versions

### DIFF
--- a/consoles/s3270.pm
+++ b/consoles/s3270.pm
@@ -235,8 +235,7 @@ sub expect_3270 ($self, %arg) {
 sub wait_output ($self, $timeout = 0) {
     my $r = $self->send_3270("Wait($timeout,Output)", command_status => 'any');
     return 1 if $r->{command_status} eq 'ok';
-    return 0 if $r->{command_output}[0] eq 'Wait: Timed out';
-    return 0 if $r->{command_output}[0] eq 'Wait(): Timed out';
+    return 0 if $r->{command_output}[0] =~ /^Wait[^:]*: Timed out$/;
     confess "has the s3270 wait timeout failure response changed?\n" . Dumper $r;
 }
 

--- a/t/27-consoles-s3270.t
+++ b/t/27-consoles-s3270.t
@@ -148,6 +148,14 @@ subtest 'expect_3270 tests' => sub {
 
 subtest 'wait_output test' => sub {
     my $s3270_console_mock = Test::MockModule->new('consoles::s3270');
+    $s3270_console_mock->redefine(send_3270 => {'command_status' => 'ok'});
+    is $s3270_console->wait_output(), 1;
+
+    for my $errormsg (('Wait: Timed out', 'Wait(): Timed out', 'Wait(Output): Timed out')) {
+        $s3270_console_mock->redefine(send_3270 => {'command_output' => [$errormsg], 'command_status' => 'any'});
+        is $s3270_console->wait_output(), 0;
+    }
+
     $s3270_console_mock->redefine(send_3270 => {'command_output' => ['None'], 'command_status' => 'any'});
     warnings { throws_ok { $s3270_console->wait_output() } qr/has the s3270 wait timeout.*\n.*/, 'wait timeout failure expected' };
 };


### PR DESCRIPTION
The error message for wait timeouts changed yet again.

VR: https://openqa.opensuse.org/tests/5827376#live