### PR TITLE
feat(edid): Add virtio-vga-gl support

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -659,7 +659,7 @@ sub _set_graphics_backend ($self) {
         $device = 'virtio-gpu';
     }
     $device //= 'VGA';
-    my @edids = ('VGA', 'virtio-vga', 'virtio-gpu-pci', 'bochs-display', 'virtio-gpu');
+    my @edids = ('VGA', 'virtio-vga', 'virtio-vga-gl', 'virtio-gpu-pci', 'bochs-display', 'virtio-gpu');
     if (grep { $device eq $_ } @edids) {
         # these devices support EDID
         $options = ",edid=on,xres=$self->{xres},yres=$self->{yres}";
@@ -668,6 +668,10 @@ sub _set_graphics_backend ($self) {
         $options .= ',' . $vars->{QEMU_VIDEO_DEVICE_OPTIONS};
     }
     sp('device', "${device}${options}");
+    # enable openGL support
+    if ($device eq 'virtio-vga-gl') {
+        sp('display', 'egl-headless,gl=on');
+    }
 }
 
 sub determine_qemu_version ($self, $qemubin) {
@@ -882,7 +886,7 @@ sub start_qemu ($self) {
     bmwqemu::diag('Initializing block device images');
     $self->{proc}->init_blockdev_images();
 
-    sp('only-migratable') if $self->can_handle({function => 'snapshots', no_warn => 1});
+    sp('only-migratable') if $self->can_handle({function => 'snapshots', no_warn => 1}) and (($vars->{QEMU_VIDEO_DEVICE} // '') ne 'virtio-vga-gl');
     sp('chardev', 'ringbuf,id=serial0,logfile=serial0,logappend=on');
     sp('serial', 'chardev:serial0');
 

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -326,6 +326,13 @@ subtest s390x_options => sub {
     like $cmdline, qr/-device virtio-tablet/, '-device virtio-tablet option added';
 };
 
+subtest x86_64_opengl_options => sub {
+    my $cmdline = qemu_cmdline(ARCH => 'x86_64', QEMU_VIDEO_DEVICE => 'virtio-vga-gl');
+    like $cmdline, qr/-device virtio-vga-gl,edid=on/, '-device virtio-vga-gl,edid=on option added';
+    like $cmdline, qr/-display egl-headless,gl=on/, '-device virtio-vga-gl,enabled openGL';
+    unlike $cmdline, qr/-only-migratable/, 'virgl is not yet migratable';
+};
+
 subtest 'capturing audio' => sub {
     $called{handle_qmp_command} = undef;
     $backend->start_audiocapture({filename => 'foo'});


### PR DESCRIPTION
This was discussed during the monthly openQA call.
When using 3D-accelerated video, `virtio-vga-gl`, the edid options (and resolutions in XRES and YRES) should be passed to qemu.

This is a minimal invasive patch. You might want to consider using a more complex pattern matching (for your backlog).
The qemu documentation (https://www.qemu.org/docs/master/system/devices/virtio/virtio-gpu.html) mentions more variants:
```
virtio-vga[-BACKEND]
virtio-gpu[-BACKEND][-INTERFACE]
vhost-user-vga
vhost-user-pci
```