### PR TITLE
[HELP NEEDED] feat: improve LLM failure analysis visibility

### DIFF
--- a/OpenQA/Isotovideo/LLMAnalysis.pm
+++ b/OpenQA/Isotovideo/LLMAnalysis.pm
@@ -125,6 +125,16 @@ sub run ($result_dir) {
     }
     path("$result_dir/llm-failure-analysis.txt")->spew($output);
     bmwqemu::diag("LLM Analysis:\n$output\nSaved to $result_dir/llm-failure-analysis.txt");
+    my $analysis_result = {
+        name => 'llm_failure_analysis',
+        result => 'ok',
+        details => [{
+                title => 'LLM Failure Analysis',
+                result => 'none',
+                text => 'llm-failure-analysis.txt',
+        }],
+    };
+    bmwqemu::save_json_file($analysis_result, "$result_dir/result-llm_failure_analysis.json");
 }
 
 1;

--- a/script/isotovideo
+++ b/script/isotovideo
@@ -155,9 +155,7 @@ sub handle_shutdown () {
         $runner->stop_autotest();    # uncoverable statement
     }
     my $clean_shutdown = $runner->handle_shutdown(\$RETURN_CODE);
-    bmwqemu::load_vars();    # read calculated variables from backend and tests
     $RETURN_CODE = handle_generated_assets($runner->command_handler, $clean_shutdown) unless $RETURN_CODE;
-    OpenQA::Isotovideo::LLMAnalysis::run(bmwqemu::result_dir()) if $bmwqemu::vars{LLM_FAILURE_ANALYSIS};
     diag 'isotovideo completed handle_shutdown: ' . ($RETURN_CODE ? 'failed' : 'done');
 }
 
@@ -193,6 +191,8 @@ try {
     $RETURN_CODE = EXIT_STATUS_OK;
     $runner->run;    # enter the main loop: process messages from autotest, command server and backend
     $RETURN_CODE = $runner->exit_code_from_test_results if $options{'exit-status-from-test-results'};
+    bmwqemu::load_vars();    # read calculated variables from backend and tests
+    OpenQA::Isotovideo::LLMAnalysis::run(bmwqemu::result_dir()) if $bmwqemu::vars{LLM_FAILURE_ANALYSIS};
     handle_shutdown;
 }
 catch ($e) {

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -343,13 +343,11 @@ subtest 'publish assets' => sub {
         path('vars.json')->remove if -e 'vars.json';
         path('testresults/')->remove_tree;
         path('testresults/')->make_path;
-        # Create a dummy failed test result to trigger gathering context
-        path('testresults/result-failing_module.json')->spew('{"result": "fail", "name": "failing_module"}');
         path('autoinst-log.txt')->spew("Something went wrong in the log\n");
         path('serial0')->spew("Kernel panic in serial output\n");
         my $log = combined_from {
             isotovideo(
-                opts => "casedir=$data_dir/tests schedule=module1 LLM_FAILURE_ANALYSIS=1 LLM_FAILURE_ANALYSIS_CMD=cat",
+                opts => "casedir=$data_dir/tests schedule=tests/fail_fast.pm LLM_FAILURE_ANALYSIS=1 LLM_FAILURE_ANALYSIS_CMD=cat",
                 exit_code => 0)
         };
         like $log, qr/Starting LLM Analysis/, 'LLM analysis started';
@@ -358,6 +356,7 @@ subtest 'publish assets' => sub {
         ok -e $analysis_file, 'LLM analysis output file exists';
         ok -e path($pool_dir, 'testresults', 'result-llm_failure_analysis.json'), 'LLM analysis result JSON exists';
         like $analysis_file->slurp, qr/analyzing an automated test run/, 'LLM analysis output contains expected content';
+        like $analysis_file->slurp, qr/fail_fast/, 'LLM analysis output contains failing test name';
     };
 
     subtest 'unclean shutdown' => sub {

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -356,6 +356,7 @@ subtest 'publish assets' => sub {
         like $log, qr/LLM Analysis:/, 'LLM analysis finished';
         my $analysis_file = path($pool_dir, 'testresults', 'llm-failure-analysis.txt');
         ok -e $analysis_file, 'LLM analysis output file exists';
+        ok -e path($pool_dir, 'testresults', 'result-llm_failure_analysis.json'), 'LLM analysis result JSON exists';
         like $analysis_file->slurp, qr/analyzing an automated test run/, 'LLM analysis output contains expected content';
     };
 

--- a/t/44-llm-failure-analysis.t
+++ b/t/44-llm-failure-analysis.t
@@ -116,7 +116,8 @@ subtest 'CLI command mode' => sub {
 subtest 'Execution routing' => sub {
     my $mock_llm = Test::MockModule->new('OpenQA::Isotovideo::LLMAnalysis');
     my $mock_bmwqemu = Test::MockModule->new('bmwqemu');
-    $mock_bmwqemu->noop('diag');
+    my @diags;
+    $mock_bmwqemu->redefine(diag => sub { push @diags, $_[0] });
 
     $mock_llm->redefine(gather_context => sub { return {distri => 'D'} });
     $mock_llm->redefine(build_prompt => sub { return 'P' });
@@ -126,10 +127,16 @@ subtest 'Execution routing' => sub {
     delete $bmwqemu::vars{LLM_FAILURE_ANALYSIS_CMD};
     OpenQA::Isotovideo::LLMAnalysis::run($bmwqemu::result_dir);
     is path($bmwqemu::result_dir)->child('llm-failure-analysis.txt')->slurp, 'api', 'Default to API';
+    like $diags[1], qr/LLM Analysis:\napi/, 'Includes LLM output in diag';
+    my $json = Mojo::JSON::decode_json(path($bmwqemu::result_dir)->child('result-llm_failure_analysis.json')->slurp);
+    is $json->{name}, 'llm_failure_analysis', 'Standalone module name correct';
+    is $json->{details}[0]{text}, 'llm-failure-analysis.txt', 'Refers to correct text file';
 
+    @diags = ();
     $bmwqemu::vars{LLM_FAILURE_ANALYSIS_CMD} = 'c';
     OpenQA::Isotovideo::LLMAnalysis::run($bmwqemu::result_dir);
     is path($bmwqemu::result_dir)->child('llm-failure-analysis.txt')->slurp, 'cmd', 'Route to CMD';
+    like $diags[1], qr/LLM Analysis:\ncmd/, 'Includes LLM output in diag';
 
     $mock_llm->redefine(gather_context => sub { return undef });
     $mock_bmwqemu->redefine(diag => sub { die 'No context should return' });

--- a/t/data/tests/tests/fail_fast.pm
+++ b/t/data/tests/tests/fail_fast.pm
@@ -1,0 +1,5 @@
+use base 'basetest';
+sub run ($) {
+    die "fail fast";
+}
+1;


### PR DESCRIPTION
Motivation:
LLM-based failure analysis was only saved to a file that was often
inaccessible in openQA. It should be directly visible in the logs
and as a test step.

Design Choices:
- Modified LLMAnalysis.pm to output the analysis via bmwqemu::diag.
- Created a standalone test module result (result-llm_failure_analysis.json)
  to ensure the analysis is uploaded and displayed in the OpenQA UI.
- Updated tests to verify diagnostic output and JSON file creation.
- Replaced wide ellipsis character with three dots to avoid TAP encoding
  issues in some environments.

Benefits:
- Immediate feedback in the test log.
- Native integration with the OpenQA web interface as a result step.