### PR TITLE
chore(ci): bump checkout v4->v6

### DIFF
--- a/.github/workflows/author-tests.yaml
+++ b/.github/workflows/author-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     container:
       image: registry.opensuse.org/devel/openqa/containers/os-autoinst_dev
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: make test-local
         run: |
           git config --global --add safe.directory '*'

--- a/.github/workflows/checklist.yml
+++ b/.github/workflows/checklist.yml
@@ -10,7 +10,7 @@ jobs:
     name: Checklist job
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Checklist
         uses: wyozi/contextual-qa-checklist-action@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Static checks, unit tests and integration tests
         run: tools/container_run_ci
       - name: Upload coverage to Codecov
@@ -34,6 +34,6 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Test our container definitions
         run: tools/static_check_containers

--- a/.github/workflows/ci_extended.yml
+++ b/.github/workflows/ci_extended.yml
@@ -14,6 +14,6 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Test our container definitions
         run: tools/test_containers

--- a/.github/workflows/obs-helper.yaml
+++ b/.github/workflows/obs-helper.yaml
@@ -12,7 +12,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: debug
         run: |
           env | sort

--- a/.github/workflows/openqa_fullstack.yml
+++ b/.github/workflows/openqa_fullstack.yml
@@ -26,7 +26,7 @@ jobs:
       # See https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user
       options: --user root
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Make project folder user-writable
         run: chown -R $NORMAL_USER ../../os-autoinst
       - name: Clone openQA


### PR DESCRIPTION
This also fixes a warning about outdated nodejs