### PR TITLE
fix(t/08-autotest.t): Fix FTBFS for reproducible builds

### DIFF
--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -430,7 +430,9 @@ subtest python => sub {
     is $bmwqemu::vars{HELP}, 'I am a python script trapped in a perl script!', 'set_var() works';
 
     stderr_like {
-        throws_ok { autotest::loadtest 'tests/faulty.py' } qr/py_eval raised an exception/, 'dies on Python exception';
+        warning {
+            throws_ok { autotest::loadtest 'tests/faulty.py' } qr/py_eval raised an exception/, 'dies on Python exception';
+        }
     } qr/Traceback.*No module named.*thismoduleshouldnotexist.*/s, 'Python traceback logged';
 };
 


### PR DESCRIPTION
When $HOME is set to a non-existent directory, a spurious warning is shown. Suppress this warning if it occurs.

See the log at https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/os-autoinst.html
```
 #   Failed test 'no (unexpected) warnings (via done_testing)'
2: #   at t/08-autotest.t line 530.
2: # Got the following unexpected warnings:
2: #   1: Use of uninitialized value $home in string ne at /usr/share/perl5/Inline.pm line 1377.
```

To reproduce:
```
HOME=/nonexsistent/bla /home/roland/git.nobackup/os-autoinst/tools/invoke-tests "--prove-tool" "/usr/bin/prove" "--make-tool" "/usr/bin/ninja" "--unbuffer-tool" "/usr/bin/unbuffer" "--build-directory" "/home/roland/git.nobackup/os-autoinst/build"
 2072  HOME=/home/roland /home/roland/git.nobackup/os-autoinst/tools/invoke-tests "--prove-tool" "/usr/bin/prove" "--make-tool" "/usr/bin/ninja" "--unbuffer-tool" "/usr/bin/unbuffer" "--build-directory" "/home/roland/git.nobackup/os-autoinst/build"
```