### PR TITLE
fix(manpages): Fix the output of pod2man

### DIFF
--- a/script/isotovideo
+++ b/script/isotovideo
@@ -4,9 +4,13 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 
+=head1 NAME
+
+isotovideo - test the given assets/ISOs
+
 =head1 SYNOPSIS
 
-isotovideo [OPTIONS] [TEST PARAMETER]
+isotovideo [OPTIONS] [TEST PARAMETERS]
 
 Parses command line parameters, vars.json and tests the given assets/ISOs.
 

--- a/script/os-autoinst-generate-needle-preview
+++ b/script/os-autoinst-generate-needle-preview
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 
-=head1 os-autoinst-generate-needle-preview
+
+=head1 NAME
 
 os-autoinst-generate-needle-preview - generate an .svg file with the needle information as an overlay
 


### PR DESCRIPTION
The output of pod2man can be used by lexgrog, which is used by e.g. apropos.

And this will remove 2 lintian warning for Debian :-)