### PR TITLE
fix(container): add missing diffutils package to dev Dockerfile

### DIFF
--- a/container/os-autoinst_dev/Dockerfile
+++ b/container/os-autoinst_dev/Dockerfile
@@ -29,6 +29,7 @@ RUN zypper in -y -C \
        aspell-spell \
        cmake \
        cpio \
+       diffutils \
        ffmpeg \
        file \
        gcc-c++ \

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -109,6 +109,7 @@ docker_requires:
   shadow:
   sudo:
   which:
+  diffutils:
 
 spellcheck_requires:
   aspell-spell:


### PR DESCRIPTION
install-new-deps.sh was failing with "diff: command not found" at line 28 because the diffutils package was not installed in the container image.