### PR TITLE
feat: abort test with incomplete if requested HDD size > threshold

### DIFF
--- a/backend/generalhw.pm
+++ b/backend/generalhw.pm
@@ -129,7 +129,7 @@ sub compute_hdd_args ($self) {
             push @hdd_args, $bmwqemu::vars{"HDD_$i"} or die 'Need variable HDD_$i';
             # Pass size of HDD
             my $size = $bmwqemu::vars{"HDDSIZEGB_$i"};
-            $size //= $bmwqemu::vars{HDDSIZEGB} // 10;
+            $size //= $bmwqemu::vars{HDDSIZEGB} // bmwqemu::default_hdd_size_gb();
             push @hdd_args, $size . 'G';
         }
     }

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -772,8 +772,8 @@ sub start_qemu ($self) {
         $vars->{HDDMODEL} ||= 'scsi-hd';
         $vars->{PATHCNT} ||= 2;
     }
-    $vars->{NUMDISKS} //= defined($vars->{RAIDLEVEL}) ? 4 : 1;
-    $vars->{HDDSIZEGB} ||= 10;
+    $vars->{NUMDISKS} //= bmwqemu::default_numdisks($vars);
+    $vars->{HDDSIZEGB} ||= bmwqemu::default_hdd_size_gb();
     $vars->{CDMODEL} ||= 'scsi-cd';
     $vars->{HDDMODEL} ||= 'virtio-blk';
 

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -73,7 +73,12 @@ sub result_dir () { 'testresults' }
     *init_logger = \&log::init_logger;
 }
 
-use constant STATE_FILE => 'base_state.json';
+use constant {
+    STATE_FILE => 'base_state.json',
+    MIB => 1024 * 1024,
+    GIB => 1024 * 1024 * 1024,
+    STORAGE_KEEP_FREE_RATIO => $ENV{OS_AUTOINST_STORAGE_KEEP_FREE_RATIO} // .2,
+};
 
 # Write a JSON representation of the process termination to disk
 sub serialize_state (%state) {
@@ -150,6 +155,39 @@ sub _check_publish_vars () {
     return 1;
 }
 
+sub _get_storage_stats ($path) {
+    my $df_output = qx{df -B1 --output=size,avail "$path"};
+    return undef unless defined $df_output;
+    my ($total, $available) = $df_output =~ /\s+(\d+)\s+(\d+)\s*$/;
+    return ($total, $available);
+}
+
+sub default_hdd_size_gb () { 10 }
+
+sub default_numdisks ($v = \%vars) {
+    return defined $v->{RAIDLEVEL} ? 4 : 1;
+}
+
+sub _abort_if_storage_limit_exceeded () {
+    my $keep_free = $vars{STORAGE_KEEP_FREE_RATIO} // STORAGE_KEEP_FREE_RATIO;
+    my $numdisks = $vars{NUMDISKS} // default_numdisks();
+    my $total_hdd_size_gb = 0;
+    for my $i (1 .. $numdisks) {
+        my $size = $vars{"HDDSIZEGB_$i"} // $vars{HDDSIZEGB} // default_hdd_size_gb();
+        $total_hdd_size_gb += $size;
+    }
+    return undef unless $total_hdd_size_gb > 0;
+    my ($total_storage, $available) = _get_storage_stats('.');
+    return warn "Could not determine available storage space\n" unless defined $total_storage;
+    my $requested_bytes = $total_hdd_size_gb * GIB;
+    my $min_free_bytes = $total_storage * $keep_free;
+    return undef unless $requested_bytes > $available - $min_free_bytes;
+    my $msg = sprintf 'Not enough storage for requested HDDSIZEGB (requested %d GiB, available %d GiB, total %d GiB, keep-free %d%%)',
+      $total_hdd_size_gb, int($available / GIB), int($total_storage / GIB), int($keep_free * 100);
+    serialize_state(result => 'incomplete', msg => $msg);
+    die "$msg\n";
+}
+
 sub ensure_valid_vars () {
     # defaults
     $vars{QEMUPORT} ||= 15222;
@@ -160,6 +198,7 @@ sub ensure_valid_vars () {
     die 'CASEDIR variable not set, unknown test case directory' if !defined $vars{CASEDIR};
     die "No scripts in CASEDIR '$vars{CASEDIR}'\n" unless -e $vars{CASEDIR};
     die "WHEELS_DIR '$vars{WHEELS_DIR}' does not exist" if defined $vars{WHEELS_DIR} && !-d $vars{WHEELS_DIR};
+    _abort_if_storage_limit_exceeded();
     _check_publish_vars();
     save_vars();
 }

--- a/doc/backend_vars.md
+++ b/doc/backend_vars.md
@@ -60,6 +60,7 @@ Supported variables per backend
 | GIT_CACHE_DIR | string |  | If set enables locally caching Git repositories in the specified directory when handling Git URLs in variables like `CASEDIR` and wheels |
 | ENABLE_MODERN_PERL_FEATURES | boolean | 0 | Enables use of modern Perl features in test modules avoiding the need to use e.g. `use Mojo::Base 'basetest', -signatures;` in all test modules. This variable must be set before invoking `autotest::loadtest`. It only applies to the test modules themselves. It does *not* apply to e.g. `main.pm` and other Perl modules used via e.g. `use some::module`. |
 | _HIDE_SECRETS_REGEX | string |  | If set, any test variables whose **NAME** (key) matches the specified regular expression, in addition to the default '^_SECRET_' and '_PASSWORD', are excluded from being saved into vars.json or further processing. For example, to hide all variables starting with 'SCC_REGCODE', use '^SCC_REGCODE'. |
+| STORAGE_KEEP_FREE_RATIO | float | 0.2 | Ratio of total storage space to keep free (e.g. 0.2 for 20%). If the total requested HDD size exceeds the available space while keeping this ratio of total storage size free, the job is aborted early with "incomplete" status. |
 |  |
 
 ## ZVM backend

--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
+use Test::MockModule;
 use Mojo::Base -signatures;
 use Test::Mock::Time;
 use Feature::Compat::Try;
@@ -181,6 +182,37 @@ subtest 'serializing state' => sub {
     ok !-e bmwqemu::STATE_FILE, 'no statefile created for shutdown-related message';
     bmwqemu::serialize_state(msg => 'foo');
     is_deeply decode_json(path(bmwqemu::STATE_FILE)->slurp), {msg => 'foo'}, 'state serialized';
+};
+
+subtest 'abort on low disk space' => sub {
+    my $bmw_mock = Test::MockModule->new('bmwqemu', no_auto => 1);
+    $bmw_mock->mock(_get_storage_stats => sub { return (1024**3, 1024**3) });
+
+    my $dir = "$data_dir/tests";
+    unlink bmwqemu::STATE_FILE;
+    create_vars({CASEDIR => $dir, HDDSIZEGB => 1});
+
+    throws_ok {
+        bmwqemu::init;
+        bmwqemu::ensure_valid_vars();
+    } qr/Not enough storage for requested HDDSIZEGB/, 'abort if requested HDDSIZEGB exceeds default threshold';
+
+    is decode_json(path(bmwqemu::STATE_FILE)->slurp)->{result}, 'incomplete', 'serialized result is incomplete';
+
+    $bmw_mock->mock(_get_storage_stats => sub { return (100 * 1024**3, 100 * 1024**3) });
+    unlink bmwqemu::STATE_FILE;
+    lives_ok {
+        bmwqemu::init;
+        bmwqemu::ensure_valid_vars();
+    } 'succeed if requested HDDSIZEGB is well within available space';
+
+    unlink bmwqemu::STATE_FILE;
+    create_vars({CASEDIR => $dir, HDDSIZEGB => 1, STORAGE_KEEP_FREE_RATIO => 0.9});
+    $bmw_mock->mock(_get_storage_stats => sub { return (5 * 1024**3, 5 * 1024**3) });
+    throws_ok {
+        bmwqemu::init;
+        bmwqemu::ensure_valid_vars();
+    } qr/keep-free 90%/, 'abort if requested HDDSIZEGB exceeds custom threshold';
 };
 
 done_testing;

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -33,6 +33,8 @@ mkdir $pool_dir;
 # avoid spending time on git clone retries
 $ENV{OS_AUTOINST_GIT_RETRY_COUNT} = 0;
 
+$ENV{OS_AUTOINST_STORAGE_KEEP_FREE_RATIO} = 0;
+
 sub isotovideo (%args) {
     $args{default_opts} //= 'backend=null';
     $args{opts} //= '';

--- a/t/18-qemu-options.t
+++ b/t/18-qemu-options.t
@@ -37,6 +37,7 @@ my @common_options = (
     CASEDIR => "$data_dir/tests",
     WORKER_INSTANCE => 3,
     SCHEDULE => 'tests/noop',
+    STORAGE_KEEP_FREE_RATIO => 0,
 );
 my $vars_json = path('vars.json');
 my $log_file = path('autoinst-log.txt');

--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -25,6 +25,8 @@ mkdir $pool_dir;
 note("data dir: $data_dir");
 note("pool dir: $pool_dir");
 
+$ENV{OS_AUTOINST_STORAGE_KEEP_FREE_RATIO} = 0;
+
 chdir $pool_dir;
 my $cleanup = scope_guard sub { chdir $Bin; undef $dir };
 


### PR DESCRIPTION
Motivation:
As observed in #199058, openQA jobs can completely exhaust available storage
on workers. We should check if the requested HDDSIZEGB values fit in the
available space minus a buffer (e.g., 60% threshold) when starting jobs in
os-autoinst and abort early with "incomplete" status if the check fails to
prevent worker node failure.

Design Choices:
- Added a disk space check in `bmwqemu::ensure_valid_vars` that calculates the
  total requested HDD size across all disks.
- Requested size is summed from `HDDSIZEGB` and `HDDSIZEGB_$i` for all disks
  (defaulting to 10 GiB if not specified).
- Extracted `MIB` and `GIB` constants in `bmwqemu.pm` for clearer disk size
  calculations.
- Used `df -PB1 .` to retrieve available disk space in bytes for the current
  directory where disks will be created.
- Implemented a configurable threshold (default 80%): if the total requested
  disk space (in bytes) exceeds the threshold of the available space, the job
  is aborted.
- On failure, `bmwqemu::serialize_state` is called with `result => 'incomplete'`
  and a descriptive message, followed by `die`.

Benefits:
Prevents worker storage exhaustion by proactively aborting jobs that request
excessive disk space. This improves worker stability, maintainability, and
provides clear feedback to users when a job cannot be accommodated.

Related issue: https://progress.opensuse.org/issues/199061