### PR TITLE
feat: Add --force param to os-autoinst-testmodules-strict

### DIFF
--- a/script/os-autoinst-testmodules-strict
+++ b/script/os-autoinst-testmodules-strict
@@ -36,6 +36,10 @@ Be verbose
 Always add signatures.
 By default it does not add C<-signatures> if it was not alraedy used.
 
+=item B<-v, --force>
+
+Ignore C<## no os-autoinst style> comments.
+
 =item B<-h, -?, --help>
 
 Show this help.
@@ -56,7 +60,7 @@ sub usage ($r) { require Pod::Usage; Pod::Usage::pod2usage($r) }
 my $rc = 0;
 unless (caller) {
     $|++;
-    GetOptions(\my %options, 'help|h|?', 'verbose|v', 'write', 'signatures') or usage(1);
+    GetOptions(\my %options, 'help|h|?', 'verbose|v', 'force', 'write', 'signatures') or usage(1);
     usage(0) if $options{help};
     usage(1) unless @ARGV;
     $rc = main(\%options, @ARGV);
@@ -77,7 +81,7 @@ sub main ($options, @files) {
         $options->{verbose} and printf $format, $progress, 'Analyzing', $length, $file;
         my $module;
         try {
-            $module = analyze($doc);
+            $module = analyze($doc, {force => $options->{force}});
         }
         catch ($e) {    # uncoverable statement
             say "\nError in '$file': $e";
@@ -160,15 +164,17 @@ sub add_include ($module, $stmt) {
     return \%include;
 }
 
-sub analyze ($doc) {
+sub analyze ($doc, $args) {
     my %module = (doc => $doc);
     $module{objects} = \my @objects;
     $module{base_classes} = \my @classes;
     my $comments = $doc->find('PPI::Token::Comment') || [];
     for my $comment (@$comments) {
         if ($comment->content =~ m/^## no os-autoinst style/) {
-            $module{nofix} = 1;
-            return \%module;
+            unless ($args->{force}) {
+                $module{nofix} = 1;
+                return \%module;
+            }
         }
     }
 

--- a/t/48-testmodules-style.t
+++ b/t/48-testmodules-style.t
@@ -23,7 +23,7 @@ subtest 'various inputs' => sub {
         my $module;
         my $err;
         try {
-            $module = main::analyze($doc);
+            $module = main::analyze($doc, {});
         }
         catch ($e) {
             $err = $e;
@@ -46,7 +46,7 @@ subtest 'various inputs' => sub {
     }
 };
 
-subtest 'main' => sub {
+subtest main => sub {
     my @args = qw(t/data/tests/bar/module2.pm);
     combined_like { main::main({}, @args) } qr/Would change @args/, 'checking file';
 
@@ -61,12 +61,24 @@ subtest 'main' => sub {
     is $code, q{use Mojo::Base 'x';}, 'changed string like expected';
 };
 
-subtest 'script' => sub {
+subtest script => sub {
     my $out = qx{$^X $script};
     is $? >> 8, 1, 'script exits with 1 in case of usage errors';
 
     $out = qx{$^X $script t/data/tests/bar/module2.pm};
     is $? >> 8, 2, 'script exits with 2 in case of changes';
+};
+
+subtest force => sub {
+    my $code = <<~'EOM';
+    ## no os-autoinst style
+    use base 'foo';
+    EOM
+    my $doc = PPI::Document->new(\$code) or die 'Could not parse code';
+    my $module = main::analyze($doc, {});
+    is $module->{nofix}, 1, 'requested to skip by comment';
+    $module = main::analyze($doc, {force => 1});
+    !exists $module->{nofix}, 'requested to skip by comment';
 };
 
 done_testing;


### PR DESCRIPTION
Ignore any `## no os-autoinst style` comment so we can easily test where the comment is not necessary anymore.

Issue: https://progress.opensuse.org/issues/194002