### PR TITLE
feat: include executed command in step details and serial markers

### DIFF
--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -9,7 +9,7 @@ use Mojo::Base -strict, -signatures;
 # -> increment on every change of such APIs
 # -> never move that variable to another place (when refactoring)
 #    because it may be accessed by the tests itself
-our $version = 51;
+our $version = 52;
 
 # major version of the (web socket) API relevant to the developer mode
 # -> increment when making non-backward compatible changes to that API

--- a/basetest.pm
+++ b/basetest.pm
@@ -429,12 +429,14 @@ sub record_resultfile ($self, $title, $output, %nargs) {
     $self->write_resultfile($filename, $output);
 }
 
-sub record_serialresult ($self, $ref, $res, $string = undef) {
+sub record_serialresult ($self, $ref, $res, $string = undef, %args) {
     $string //= '';
     # take screenshot for documentation (screenshot does not represent fail itself)
     $self->take_screenshot() unless (testapi::is_serial_terminal);
 
-    my $output = "# wait_serial expected: $ref\n";
+    my $output = '';
+    $output .= "# Command: $args{command}\n" if defined $args{command};
+    $output .= "# wait_serial expected: $ref\n";
     $output .= "# Result:\n";
     $output .= "$string\n";
     $self->record_resultfile('wait_serial', $output, result => $res);

--- a/distribution.pm
+++ b/distribution.pm
@@ -155,7 +155,7 @@ sub script_run ($self, $cmd, @args) {
         if ($level == 3) {
             testapi::query_isotovideo('backend_clear_serial_buffer', {});
             testapi::type_string "$cmd\n", max_interval => $args{max_interval};
-            my $res = testapi::wait_serial(qr/OA:DONE-(\d+)-/, timeout => $args{timeout}, quiet => $args{quiet});
+            my $res = testapi::wait_serial(qr/OA:DONE-(\d+)-/, timeout => $args{timeout}, quiet => $args{quiet}, record_command => $cmd);
             return unless $res;
             return ($res =~ /OA:DONE-(\d+)-/)[0];
         }
@@ -178,7 +178,7 @@ sub script_run ($self, $cmd, @args) {
                 testapi::type_string "$marker > /dev/$testapi::serialdev\n", max_interval => $args{max_interval};
             }
         }
-        my $res = testapi::wait_serial($wait_pattern, timeout => $args{timeout}, quiet => $args{quiet});
+        my $res = testapi::wait_serial($wait_pattern, timeout => $args{timeout}, quiet => $args{quiet}, record_command => $cmd);
         return unless $res;
         return ($res =~ $wait_pattern)[0];
     }
@@ -439,13 +439,13 @@ sub install_serial_marker_hook ($self, $level) {
     my $pc;
     my $dev = "/dev/$testapi::serialdev";
     if ($level == 3) {
-        $pc = "PROMPT_COMMAND='printf \"OA:DONE-%d-\\n\" \$? > $dev'";
+        $pc = "PROMPT_COMMAND='ret=\$?; cmd=\$(fc -ln -1 2>/dev/null); printf \"OA:DONE-%d-%s\\nOA:START\\n\" \$ret \"\${cmd#\${cmd%%[![:space:]]*}}\" > $dev'";
     }
     else {
-        $pc = "PROMPT_COMMAND='if [ -n \"\$__OA_MARK\" ]; then echo \"\${__OA_MARK}-\$?-\" > $dev; unset __OA_MARK; fi'";
+        $pc = "PROMPT_COMMAND='if [ -n \"\$__OA_MARK\" ]; then echo \"\${__OA_MARK}-\$?-\" > $dev; unset __OA_MARK; fi; echo \"OA:START\" > $dev'";
     }
     testapi::type_string "$pc\n";
-    my $marker_match = $level == 3 ? 'OA:DONE' : '__OA_MARK';
+    my $marker_match = 'OA:START';
     my $hook_cmd = "for f in ~/.bashrc ~/.profile; do grep -q '$marker_match' \"\$f\" 2>/dev/null || cat <<'EOF' >> \"\$f\"\n$pc\nEOF\ndone\n";
     testapi::type_string $hook_cmd;
     my $console = testapi::current_console() // 'sut';

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -1334,6 +1334,16 @@ subtest 'retrieve and change various global variables' => sub {
     }
 };
 
+subtest 'wait_serial record_command' => sub {
+    my $mock_test = Test::MockModule->new('basetest');
+    my $recorded_cmd;
+    $mock_test->redefine(record_serialresult => sub ($self, $ref, $res, $string, %args) {
+            $recorded_cmd = $args{command};
+    });
+    wait_serial('regex', record_command => 'my_command');
+    is($recorded_cmd, 'my_command', 'command passed to record_serialresult');
+};
+
 done_testing;
 
 END {

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -518,4 +518,15 @@ subtest search_for_expected_serial_failures => sub {
     is($basetest->{result}, 'successfully called function', 'search for expected serial failures is working');
 };
 
+subtest record_serialresult_with_command => sub {
+    my $basetest = basetest->new();
+    $basetest->{name} = 'test';
+    my $recorded_output;
+    my $mock_basetest_local = Test::MockModule->new('basetest');
+    $mock_basetest_local->redefine(record_resultfile => sub ($self, $title, $output, %nargs) { $recorded_output = $output });
+    $basetest->record_serialresult('regex', 'ok', 'output', command => 'my_command');
+    like($recorded_output, qr/# Command: my_command/, 'command is in output');
+    like($recorded_output, qr/# wait_serial expected: regex/, 'expected regex is in output');
+};
+
 done_testing;

--- a/testapi.pm
+++ b/testapi.pm
@@ -869,6 +869,7 @@ sub wait_serial {    # no:style:signatures
             no_regex => 0,
             buffer_size => undef,
             record_output => undef,
+            record_command => undef,
         }, ['timeout', 'expect_not_found'], @_);
 
     bmwqemu::log_call(%args);
@@ -885,7 +886,7 @@ sub wait_serial {    # no:style:signatures
     # hyperv and vmware (backend/svirt.pm) connect serial line over TCP/IP (socat)
     # convert CRLF to LF only
     $ret->{string} =~ s,\r\n,\n,g;
-    $autotest::current_test->record_serialresult(bmwqemu::pp($regexp), $matched, $ret->{string}) unless ($args{quiet});
+    $autotest::current_test->record_serialresult(bmwqemu::pp($regexp), $matched, $ret->{string}, command => $args{record_command}) unless ($args{quiet});
     bmwqemu::fctres("$regexp: $matched");
     return $ret->{string} if ($matched eq 'ok');
     return;    # false


### PR DESCRIPTION
Motivation:
Command outputs in the serial log (autoinst-log.txt) and step details are
currently difficult to link back to the originating test API command.
Including the command string in both places improves visibility and
traceability for both human reviewers and automated analysis tools.

Design Choices:
1. Modified distribution.pm to inject an OA:START marker before command
   execution and include the command in the OA:DONE marker using bash's
   fc -ln -1.
2. Extended wait_serial and record_serialresult to propagate the
   executed command.
3. Injected the command string into the generated .txt detail files in
   basetest.pm, ensuring visibility in the openQA Web UI without
   requiring frontend changes.

Example content of test result step text output:

```
Command: ip a del 10.0.2.2/15 dev br1
wait_serial expected: qr/OA:DONE-(\d+)-/u
Result:
OA:DONE-0-
```

Benefits:
- Clear command boundaries in the serial log.
- Executed commands are immediately visible in the openQA step details.
- No changes required to the openQA web frontend.

Related issue: https://progress.opensuse.org/issues/198872