### PR TITLE
feat: Prefer modules in CASEDIR/lib over test module paths

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -188,10 +188,10 @@ sub _make_test_code_to_eval ($script_path, $script, $name, $is_python) {
         $module_code = "# line 1 $script_path\n";
         $module_code .= path($script_path)->slurp;
     }
-    $code .= "use lib '.';" unless path($casedir)->is_abs;
-    $code .= "use lib '$casedir/lib';";
     my $basename = dirname($script_path);
-    $code .= "use lib '$basename';\n";
+    $code .= "use lib '$basename';";
+    $code .= "use lib '.';" unless path($casedir)->is_abs;
+    $code .= "use lib '$casedir/lib';\n";
     die "Unsupported file extension for '$script'" unless $script =~ /\.(p[my]|lua)/;
     if ($script =~ m/\.pm$/) {
         $code .= $module_code // "require '$script_path';";


### PR DESCRIPTION
The problem is that in os-autoinst-distri-opensuse:

    # tests/sles4sap/ipaddr2/registration.pm:
    use publiccloud::utils;

    # lib/publiccloud/utils.pm
    use registration \
      qw(get_addon_fullname add_suseconnect_product %ADDONS_REGCODE);

(Note: The code of course doesn't look like this, but we forbid long lines
in the commit message, so I added the backslash as a workaround)

This is meant to load `lib/registration.pm`.

But after loading `tests/sles4sap/ipaddr2/registration.pm via autotest`, we have `tests/sles4sap/ipaddr2` in `@INC` at the first entry, so now `tests/sles4sap/ipaddr2/registration.pm` is the first file matching `registration.pm`.
Under normal circumstances the `lib/registration.pm` module is probably already used earlier before loading this test module.

This is also happening because we have often just modules consisting of one word, and our test modules by design consist only of one word, while the rest of the path is stripped.

The other design flaw is that we allow to put the current test module path into `@INC`. Modules should be structured by purpose via path and filename. Putting a isotovideo test module in the same directory as a module that acts as a libary is bad design, and we should have never allowed that. That also makes it more difficult to add automatic checks for test modules, because the automatic check cannot know which module is a test module and which a library.

That said, this change will mitigate the issue here and do what is very likely the right thing in 99.9% of the cases.

Removing `$basedir` can happen as part of a followup ticket, as an opt out feature.

Issue: https://progress.opensuse.org/issues/194002

Followup ticket: https://progress.opensuse.org/issues/199796