### PR TITLE
fix: allow disabling disk space check by setting ratio to 0

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -170,6 +170,7 @@ sub default_numdisks ($v = \%vars) {
 
 sub _abort_if_storage_limit_exceeded () {
     my $keep_free = $vars{STORAGE_KEEP_FREE_RATIO} // STORAGE_KEEP_FREE_RATIO;
+    return undef if $keep_free <= 0;
     my $numdisks = $vars{NUMDISKS} // default_numdisks();
     my $total_hdd_size_gb = 0;
     for my $i (1 .. $numdisks) {

--- a/doc/backend_vars.md
+++ b/doc/backend_vars.md
@@ -60,7 +60,7 @@ Supported variables per backend
 | GIT_CACHE_DIR | string |  | If set enables locally caching Git repositories in the specified directory when handling Git URLs in variables like `CASEDIR` and wheels |
 | ENABLE_MODERN_PERL_FEATURES | boolean | 0 | Enables use of modern Perl features in test modules avoiding the need to use e.g. `use Mojo::Base 'basetest', -signatures;` in all test modules. This variable must be set before invoking `autotest::loadtest`. It only applies to the test modules themselves. It does *not* apply to e.g. `main.pm` and other Perl modules used via e.g. `use some::module`. |
 | _HIDE_SECRETS_REGEX | string |  | If set, any test variables whose **NAME** (key) matches the specified regular expression, in addition to the default '^_SECRET_' and '_PASSWORD', are excluded from being saved into vars.json or further processing. For example, to hide all variables starting with 'SCC_REGCODE', use '^SCC_REGCODE'. |
-| STORAGE_KEEP_FREE_RATIO | float | 0.2 | Ratio of total storage space to keep free (e.g. 0.2 for 20%). If the total requested HDD size exceeds the available space while keeping this ratio of total storage size free, the job is aborted early with "incomplete" status. |
+| STORAGE_KEEP_FREE_RATIO | float | 0.2 | Ratio of total storage space to keep free (e.g. 0.2 for 20%). If the total requested HDD size exceeds the available space while keeping this ratio of total storage size free, the job is aborted early with "incomplete" status. Set to 0 to disable this check. |
 |  |
 
 ## ZVM backend

--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -213,6 +213,42 @@ subtest 'abort on low disk space' => sub {
         bmwqemu::init;
         bmwqemu::ensure_valid_vars();
     } qr/keep-free 90%/, 'abort if requested HDDSIZEGB exceeds custom threshold';
+
+    unlink bmwqemu::STATE_FILE;
+    create_vars({CASEDIR => $dir, HDDSIZEGB => 1, STORAGE_KEEP_FREE_RATIO => 0});
+    $bmw_mock->mock(_get_storage_stats => sub { return (1024**3, 100 * 1024**2) });
+    lives_ok {
+        bmwqemu::init();
+        bmwqemu::ensure_valid_vars();
+    } 'succeed if requested HDDSIZEGB exceeds available space but ratio is 0';
+
+    unlink bmwqemu::STATE_FILE;
+    create_vars({CASEDIR => $dir});    # No HDDSIZEGB, uses default 10GB
+    $bmw_mock->mock(_get_storage_stats => sub { return (100 * 1024**3, 100 * 1024**3) });
+    lives_ok {
+        bmwqemu::init();
+        bmwqemu::ensure_valid_vars();
+    } 'succeed with default HDDSIZEGB';
+};
+
+subtest '_get_storage_stats' => sub {
+    my $tmp = tempdir(CLEANUP => 1);
+    my $dummy_df = "$tmp/df";
+    for my $case (
+        {output => ' 1000 500', total => 1000, avail => 500, msg => 'matches dummy df'},
+        {output => 'malformed', total => undef, avail => undef, msg => 'is undef on malformed df output'},
+    ) {
+        path($dummy_df)->spew("#!/bin/sh\necho '$case->{output}'");
+        chmod 0755, $dummy_df;
+        local $ENV{PATH} = "$tmp:$ENV{PATH}";
+        my ($total, $available) = bmwqemu::_get_storage_stats('.');
+        is $total, $case->{total}, "total $case->{msg}";
+        is $available, $case->{avail}, "available $case->{msg}";
+    }
+
+    my ($total, $available) = bmwqemu::_get_storage_stats('.');
+    like $total, qr/^\d+$/, 'returns numeric total storage';
+    like $available, qr/^\d+$/, 'returns numeric available storage';
 };
 
 done_testing;


### PR DESCRIPTION
Motivation:
The recently introduced disk space check (commit bb08a482) aborts jobs if the
requested HDD size exceeds the available space, even if the keep-free ratio is
set to 0. This prevents jobs using sparse disk images from running on workers
where the total requested size exceeds physical capacity, which is a valid use
case.

Design Choices:
- Modified bmwqemu::_abort_if_storage_limit_exceeded to return early if
  STORAGE_KEEP_FREE_RATIO is set to 0 or less.
- Updated documentation to reflect that 0 disables the check.
- Added a test case to t/12-bmwqemu.t to verify that setting the ratio to 0
  allows jobs to proceed regardless of available space.

Benefits:
- Restores the ability to run jobs with large (sparse) disk images when
  requested by the user.
- Provides a clear way to disable the safety check if needed.

Related issue: https://progress.opensuse.org/issues/199061