### PR TITLE
chore(ci): bump upload-artifact v4->v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           verbose: true
       - run: |
           tar cvf coverage.tar build/cover_db
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: coverage.tar


### PR DESCRIPTION
This should fix a warning in GitHub action runs about "Node.js 20 actions
are deprecated".