### PR TITLE
feat: add unique hash to pretty serial markers

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -155,9 +155,9 @@ sub script_run ($self, $cmd, @args) {
         if ($level == 3) {
             testapi::query_isotovideo('backend_clear_serial_buffer', {});
             testapi::type_string "$cmd\n", max_interval => $args{max_interval};
-            my $res = testapi::wait_serial(qr/OA:DONE-(\d+)-/, timeout => $args{timeout}, quiet => $args{quiet}, record_command => $cmd);
+            my $res = testapi::wait_serial(qr/OA:DONE-[0-9a-f]{4}-(\d+)-/, timeout => $args{timeout}, quiet => $args{quiet}, record_command => $cmd);
             return unless $res;
-            return ($res =~ /OA:DONE-(\d+)-/)[0];
+            return ($res =~ /OA:DONE-[0-9a-f]{4}-(\d+)-/)[0];
         }
         $str = testapi::hashed_string('SR' . $cmd . $args{timeout});
         $wait_pattern = qr/$str-(\d+)-/;
@@ -439,7 +439,7 @@ sub install_serial_marker_hook ($self, $level) {
     my $pc;
     my $dev = "/dev/$testapi::serialdev";
     if ($level == 3) {
-        $pc = "PROMPT_COMMAND='ret=\$?; cmd=\$(fc -ln -1 2>/dev/null); printf \"OA:DONE-%d-%s\\nOA:START\\n\" \$ret \"\${cmd#\${cmd%%[![:space:]]*}}\" > $dev'";
+        $pc = "PROMPT_COMMAND='ret=\$?; cmd=\$(fc -ln -1 2>/dev/null); printf \"OA:DONE-%04x-%d-%s\\nOA:START\\n\" \$RANDOM \$ret \"\${cmd#\${cmd%%[![:space:]]*}}\" > $dev'";
     }
     else {
         $pc = "PROMPT_COMMAND='if [ -n \"\$__OA_MARK\" ]; then echo \"\${__OA_MARK}-\$?-\" > $dev; unset __OA_MARK; fi; echo \"OA:START\" > $dev'";

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -99,12 +99,12 @@ subtest 'pretty_serial_marker' => sub {
             my ($regexp) = @_;
             return 'BASH:4.4:' if ref($regexp) eq 'Regexp' && 'BASH:4.4:' =~ $regexp;
             return 'FC:OK:' if ref($regexp) eq 'Regexp' && 'FC:OK:' =~ $regexp;
-            return 'OA:foo3foo-0-';
+            return 'OA:DONE-abcd-0-foo';
     });
 
     $d->{_serial_marker_level} = {};
     $typed_string = '';
-    $d->script_run('foo');
+    is $d->script_run('foo'), 0, 'Level 3 returns exit code';
     like $typed_string, qr/foo\n$/, 'Level 3 ends with command + newline';
     is substr($typed_string, -4), "foo\n", 'Level 3 uses clean command line';
 
@@ -156,7 +156,7 @@ subtest 'reboot_safety' => sub {
             my ($regexp) = @_;
             return 'BASH:4.4:' if ref($regexp) eq 'Regexp' && 'BASH:4.4:' =~ $regexp;
             return 'FC:OK:' if ref($regexp) eq 'Regexp' && 'FC:OK:' =~ $regexp;
-            return 'OA:DONE-0-';
+            return 'OA:DONE-abcd-0-';
     });
 
     $d->script_run('foo');


### PR DESCRIPTION
Motivation:
Pretty serial markers (OA:DONE) were identical for every command, making it
difficult to distinguish between different command executions in serial logs.

Design Choices:
- Used Bash's built-in $RANDOM to generate a 4-digit hex token.
- This provides ~65,000 unique markers without spawning external processes.
- Updated host-side regex to capture the exit code from the new format.

Benefits:
- Commands are now uniquely identifiable in serial0.txt.
- No performance overhead as it uses shell built-ins.
- Improved test debuggability.

Verification runs:
- Previous behaviour, pretty serial markers:
```
openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org/tests/5865461 {TEST,BUILD}+=-okurz-poo178885 _GROUP=0 PRETTY_SERIAL_MARKER=1
```
-> https://openqa.opensuse.org/tests/5865608
- New behaviour, pretty serial markers and unique hash:
```
openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org/tests/5865461 {TEST,BUILD}+=-okurz-poo178885 _GROUP=0 PRETTY_SERIAL_MARKER=1 WORKER_CLASS=openqaworker20
```
-> https://openqa.opensuse.org/tests/5865609

The difference can be seen for example in
https://openqa.opensuse.org/tests/5865608#step/prepare/11 showing

```
# Command: systemctl mask --now packagekit
# wait_serial expected: qr/OA:DONE-(\d+)-/u
# Result:
OA:DONE-0-
```

vs. the new behaviour https://openqa.opensuse.org/tests/5865609#step/prepare/11

```
# Command: systemctl mask --now packagekit
# wait_serial expected: qr/OA:DONE-[0-9a-f]{4}-(\d+)-/u
# Result:
OA:DONE-72c9-0-
```

Related issue: https://progress.opensuse.org/issues/178885