### PR TITLE
feat: add absolute storage threshold to prevent over-conservative aborts

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -78,6 +78,7 @@ use constant {
     MIB => 1024 * 1024,
     GIB => 1024 * 1024 * 1024,
     STORAGE_KEEP_FREE_RATIO => $ENV{OS_AUTOINST_STORAGE_KEEP_FREE_RATIO} // .2,
+    STORAGE_KEEP_FREE_GB => $ENV{OS_AUTOINST_STORAGE_KEEP_FREE_GB} // 50,
 };
 
 # Write a JSON representation of the process termination to disk
@@ -182,7 +183,10 @@ sub _abort_if_storage_limit_exceeded () {
     return warn "Could not determine available storage space\n" unless defined $total_storage;
     my $requested_bytes = $total_hdd_size_gb * GIB;
     my $min_free_bytes = $total_storage * $keep_free;
-    return undef if $requested_bytes <= $available - $min_free_bytes;
+    my $keep_free_gb = $vars{STORAGE_KEEP_FREE_GB} // STORAGE_KEEP_FREE_GB;
+    my $relative_exceeded = $requested_bytes > $available - $min_free_bytes;
+    my $absolute_exceeded = $keep_free_gb > 0 && $requested_bytes > $available - ($keep_free_gb * GIB);
+    return undef unless $relative_exceeded && $absolute_exceeded;
     my $msg = sprintf 'Not enough storage for requested HDDSIZEGB (requested %d GiB, available %d GiB, total %d GiB, keep-free %d%%)',
       $total_hdd_size_gb, int($available / GIB), int($total_storage / GIB), int($keep_free * 100);
     serialize_state(result => 'incomplete', msg => $msg);

--- a/doc/backend_vars.md
+++ b/doc/backend_vars.md
@@ -61,6 +61,7 @@ Supported variables per backend
 | ENABLE_MODERN_PERL_FEATURES | boolean | 0 | Enables use of modern Perl features in test modules avoiding the need to use e.g. `use Mojo::Base 'basetest', -signatures;` in all test modules. This variable must be set before invoking `autotest::loadtest`. It only applies to the test modules themselves. It does *not* apply to e.g. `main.pm` and other Perl modules used via e.g. `use some::module`. |
 | _HIDE_SECRETS_REGEX | string |  | If set, any test variables whose **NAME** (key) matches the specified regular expression, in addition to the default '^_SECRET_' and '_PASSWORD', are excluded from being saved into vars.json or further processing. For example, to hide all variables starting with 'SCC_REGCODE', use '^SCC_REGCODE'. |
 | STORAGE_KEEP_FREE_RATIO | float | 0.2 | Ratio of total storage space to keep free (e.g. 0.2 for 20%). If the total requested HDD size exceeds the available space while keeping this ratio of total storage size free, the job is aborted early with "incomplete" status. Set to 0 to disable this check. |
+| STORAGE_KEEP_FREE_GB | integer | 50 | Absolute free space threshold in GiB. If the total requested HDD size leaves less than this amount of free space, the job can only run if the relative check (`STORAGE_KEEP_FREE_RATIO`) is also satisfied. Set to 0 to disable the absolute threshold. |
 | FAIL_ON_ALWAYS_ROLLBACK_NOT_SUPPORTED | boolean | 0 | Fail explicitly if a test module is scheduled with the `always_rollback` flag but snapshots are not supported by the backend. |
 |  |
 

--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -186,49 +186,42 @@ subtest 'serializing state' => sub {
 
 subtest 'abort on low disk space' => sub {
     my $bmw_mock = Test::MockModule->new('bmwqemu', no_auto => 1);
-    $bmw_mock->mock(_get_storage_stats => sub { return (1024**3, 1024**3) });
-
-    my $dir = "$data_dir/tests";
-    unlink bmwqemu::STATE_FILE;
-    create_vars({CASEDIR => $dir, HDDSIZEGB => 1});
-
-    throws_ok {
-        bmwqemu::init;
-        bmwqemu::ensure_valid_vars();
-    } qr/Not enough storage for requested HDDSIZEGB/, 'abort if requested HDDSIZEGB exceeds default threshold';
-
-    is decode_json(path(bmwqemu::STATE_FILE)->slurp)->{result}, 'incomplete', 'serialized result is incomplete';
-
-    $bmw_mock->mock(_get_storage_stats => sub { return (100 * 1024**3, 100 * 1024**3) });
-    unlink bmwqemu::STATE_FILE;
-    lives_ok {
-        bmwqemu::init;
-        bmwqemu::ensure_valid_vars();
-    } 'succeed if requested HDDSIZEGB is well within available space';
-
-    unlink bmwqemu::STATE_FILE;
-    create_vars({CASEDIR => $dir, HDDSIZEGB => 1, STORAGE_KEEP_FREE_RATIO => 0.9});
-    $bmw_mock->mock(_get_storage_stats => sub { return (5 * 1024**3, 5 * 1024**3) });
-    throws_ok {
-        bmwqemu::init;
-        bmwqemu::ensure_valid_vars();
-    } qr/keep-free 90%/, 'abort if requested HDDSIZEGB exceeds custom threshold';
-
-    unlink bmwqemu::STATE_FILE;
-    create_vars({CASEDIR => $dir, HDDSIZEGB => 1, STORAGE_KEEP_FREE_RATIO => 0});
-    $bmw_mock->mock(_get_storage_stats => sub { return (1024**3, 100 * 1024**2) });
-    lives_ok {
-        bmwqemu::init();
-        bmwqemu::ensure_valid_vars();
-    } 'succeed if requested HDDSIZEGB exceeds available space but ratio is 0';
-
-    unlink bmwqemu::STATE_FILE;
-    create_vars({CASEDIR => $dir});    # No HDDSIZEGB, uses default 10GB
-    $bmw_mock->mock(_get_storage_stats => sub { return (100 * 1024**3, 100 * 1024**3) });
-    lives_ok {
-        bmwqemu::init();
-        bmwqemu::ensure_valid_vars();
-    } 'succeed with default HDDSIZEGB';
+    my @cases = (
+        {hdd_size_gb => 1, total_storage => 100, avail_storage => 10, expect => 'fail',
+            desc => 'abort if requested HDDSIZEGB exceeds default threshold (1GB requested with 10GB avail on 100GB disk)'},
+        {hdd_size_gb => 10, total_storage => 100, avail_storage => 100, expect => 'pass',
+            desc => 'succeed if requested HDDSIZEGB is well within available space'},
+        {hdd_size_gb => 60, total_storage => 5, avail_storage => 5, expect => 'fail', extra_vars => {STORAGE_KEEP_FREE_RATIO => 0.9},
+            desc => 'abort if requested HDDSIZEGB exceeds custom threshold'},
+        {hdd_size_gb => 1, total_storage => 1, avail_storage => 0.1, expect => 'pass', extra_vars => {STORAGE_KEEP_FREE_RATIO => 0},
+            desc => 'succeed if requested HDDSIZEGB exceeds available space but ratio is 0'},
+        {total_storage => 100, avail_storage => 100, expect => 'pass',
+            desc => 'succeed with default HDDSIZEGB'},
+        {hdd_size_gb => 20, total_storage => 1000, avail_storage => 200, expect => 'pass',
+            desc => 'passes if only relative threshold exceeded but leaves > 50GB free (e.g. 20GB requested on 1000GB disk with 200GB avail)'},
+        {hdd_size_gb => 160, total_storage => 1000, avail_storage => 200, expect => 'fail',
+            desc => 'large job fails when both relative and default 50GB absolute thresholds exceeded'},
+        {hdd_size_gb => 160, total_storage => 1000, avail_storage => 500, expect => 'pass',
+            desc => 'large job passes when sufficient absolute storage available'},
+        {hdd_size_gb => 50, total_storage => 100, avail_storage => 60, expect => 'fail',
+            desc => 'fails if both relative and absolute thresholds exceeded (e.g. 50GB requested on 100GB disk with 60GB avail leaves 10GB free)'},
+        {hdd_size_gb => 50, total_storage => 100, avail_storage => 60, expect => 'pass', extra_vars => {STORAGE_KEEP_FREE_GB => 0},
+            desc => 'passes if both thresholds would be exceeded but absolute threshold is disabled via 0'},
+    );
+    for my $case (@cases) {
+        unlink bmwqemu::STATE_FILE;
+        my %vars = (CASEDIR => "$data_dir/tests", %{$case->{extra_vars} // {}});
+        $vars{HDDSIZEGB} = $case->{hdd_size_gb} if defined $case->{hdd_size_gb};
+        create_vars(\%vars);
+        $bmw_mock->mock(_get_storage_stats => sub (@) { ($case->{total_storage} * 1024**3, $case->{avail_storage} * 1024**3) });
+        if ($case->{expect} eq 'pass') {
+            lives_ok { bmwqemu::init(); bmwqemu::ensure_valid_vars(); } $case->{desc};
+        }
+        else {
+            throws_ok { bmwqemu::init(); bmwqemu::ensure_valid_vars(); } qr/Not enough storage for requested HDDSIZEGB/, $case->{desc};
+            is decode_json(path(bmwqemu::STATE_FILE)->slurp)->{result}, 'incomplete', "serialized result is incomplete for: $case->{desc}";
+        }
+    }
 };
 
 subtest '_get_storage_stats' => sub {


### PR DESCRIPTION
Motivation:
Jobs requesting a small amount of storage (e.g., 20 GiB) were being aborted on
workers with large disks (e.g., 938 GiB) because they failed the 20% relative
free space check, even though 189 GiB was available. This was overly
conservative for workers with large storage.

Design Choices:
1. Introduced STORAGE_KEEP_FREE_GB (defaulting to 50 GiB) as an absolute minimum
   free space threshold.
2. Updated the storage check logic to only abort if BOTH the relative
   (STORAGE_KEEP_FREE_RATIO) and absolute (STORAGE_KEEP_FREE_GB) thresholds
   would be violated by the job.

Benefits:
- Small jobs can run on workers with large disks as long as enough absolute
  space remains.
- Maintains safety for workers with limited storage.
- Improved test maintainability and readability.

Related issue: https://progress.opensuse.org/issues/200006