### PR TITLE
fix(spec): prevent unstable OBS check failures on 28-signalblocker.t

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -264,8 +264,9 @@ rm t/02-test_ocr.t
 # qemu emulation always starts a separate thread
 rm t/28-signalblocker.t
 %endif
-%ifarch aarch64
+%ifarch aarch64 s390x
 # https://progress.opensuse.org/issues/194359
+# https://progress.opensuse.org/issues/199940
 rm -f t/28-signalblocker.t
 %endif
 


### PR DESCRIPTION
Related issue: https://progress.opensuse.org/issues/199940