### PR TITLE
git subrepo pull (merge) --force external/os-autoinst-common

### DIFF
--- a/external/os-autoinst-common/.gitrepo
+++ b/external/os-autoinst-common/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = git@github.com:os-autoinst/os-autoinst-common.git
 	branch = master
-	commit = 4e71e20292cd76298e53e9726e4d2b49be0eb7e0
-	parent = 6913c369c5314bdc441fe373a954d42f3b15aebb
+	commit = 0e48179240f9383db02b76a265e15f865e632ff3
+	parent = bd0b68ebfb3129b3a34d3c908b5644f630050ba6
 	method = merge
 	cmdver = 0.4.6

--- a/external/os-autoinst-common/tools/prove_wrapper
+++ b/external/os-autoinst-common/tools/prove_wrapper
@@ -26,6 +26,8 @@ if [ "$STATUS" -ne 0 ]; then
 fi
 
 UNHANDLED=$(sed --regexp-extended \
+    -e 's/\x1b\[[0-9;]*[mK]//g' \
+    -e 's/\r//g' \
     -e 's/^\[[0-9]{2}:[0-9]{2}:[0-9]{2}\][[:space:]]*//' \
     -e '/x?t\/.*\.t\s*\.+/d' \
     -e '/\s*[0-9]+\.\.[0-9]+.*/d' \


### PR DESCRIPTION
subrepo:
  subdir:   "external/os-autoinst-common"
  merged:   "0e481792"
upstream:
  origin:   "git@github.com:os-autoinst/os-autoinst-common.git"
  branch:   "master"
  commit:   "0e481792"
git-subrepo:
  version:  "0.4.6"
  origin:   "???"
  commit:   "???"

This fixes the check for unhandled test output when running tests in parallel, e.g. with `make -j test`