### PR TITLE
feat(qemu): improve port conflict detection and VNC error diagnostics                                                                

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -11,6 +11,7 @@ use File::Path 'mkpath';
 use File::Which;
 use Time::HiRes qw(sleep gettimeofday);
 use Time::Seconds;
+use IO::Socket::UNIX 'SOCK_STREAM';
 use IO::Handle;
 use POSIX qw(strftime :sys_wait_h mkfifo);
 use Mojo::File 'path';
@@ -922,6 +923,7 @@ sub start_qemu ($self) {
 
         for (my $i = 0; $i < $num_networks; $i++) {
             if ($vars->{NICTYPE} eq 'user') {
+                _assert_port_availability($_, 'hostfwd') for _extract_hostfwd_ports($vars->{NICTYPE_USER_OPTIONS} // '');
                 my $nictype_user_options = $vars->{NICTYPE_USER_OPTIONS} ? ',' . $vars->{NICTYPE_USER_OPTIONS} : '';
                 $nictype_user_options .= ",smb=${\(dirname($basedir))}" if ($vars->{QEMU_ENABLE_SMBD});
                 sp('netdev', [qv "user id=qanet$i$nictype_user_options"]);
@@ -1058,20 +1060,23 @@ sub start_qemu ($self) {
     $self->{qmpsocket} = $self->{proc}->connect_qmp();
     my $init = myjsonrpc::read_json($self->{qmpsocket});
     my $hash = $self->handle_qmp_command({execute => 'qmp_capabilities'});
-
+    my $vncport = 5900 + $bmwqemu::vars{VNC};
     my $vnc = $testapi::distri->add_console(
         'sut',
         'vnc-base',
         {
             hostname => 'localhost',
             connect_timeout => 3,
-            port => 5900 + $bmwqemu::vars{VNC},
+            port => $vncport,
             description => q{QEMU's VNC}});
 
     $vnc->backend($self);
     my $ret = $self->select_console({testapi_console => 'sut'});
-    die $ret->{error} if $ret->{error};
 
+    if ($ret->{error}) {
+        bmwqemu::fctinfo("VNC port details:\n" . _port_details($vncport));
+        die $ret->{error};
+    }
     if ($vars->{NICTYPE} eq 'tap') {
         $self->{allocated_networks} = $num_networks;
         $self->{allocated_tap_devices} = \@tapdev;
@@ -1221,6 +1226,29 @@ sub check_socket ($self, $fh, $write = undef) {
         return 1;
     }
     return $self->SUPER::check_socket($fh);
+}
+
+sub _extract_hostfwd_ports ($args) { return $args =~ /hostfwd=(?:tcp|udp)::(\d+)-/g; }
+
+sub _port_details ($port) {
+    my @ss_output = qx{ss -tlnp 2>/dev/null};
+    my @port_info = grep { /\b$port\b/ } @ss_output;
+    return @port_info ? join('', @port_info) : 'no details found';
+}
+
+sub _assert_port_availability ($port, $service) {
+    bmwqemu::fctinfo("checking $port port availability");
+    my $sock = IO::Socket::IP->new(
+        PeerAddr => 'localhost',
+        PeerPort => $port,
+        Type => SOCK_STREAM,
+        Timeout => 1,
+    );
+    if ($sock) {
+        $sock->close;
+        die "Port $port ($service) is already in use\n" . _port_details($port);
+    }
+    return 0;
 }
 
 sub freeze_vm ($self, @) {

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -814,6 +814,39 @@ subtest 'special cases when starting QEMU' => sub {
     };
 };
 
+subtest 'extract hostfwd ports from NICTYPE_USER_OPTIONS' => sub {
+    is_deeply [backend::qemu::_extract_hostfwd_ports('hostfwd=tcp::39100-:39100')], [39100], 'single tcp hostfwd';
+    is_deeply [backend::qemu::_extract_hostfwd_ports('hostfwd=tcp::39100-:39100,hostfwd=tcp::5555-:22')],
+      [39100, 5555], 'multiple tcp hostfwd';
+    is_deeply [backend::qemu::_extract_hostfwd_ports('hostfwd=udp::1234-:1234')], [1234], 'udp hostfwd';
+    is_deeply [backend::qemu::_extract_hostfwd_ports('restrict=on')], [], 'no hostfwd options';
+    is_deeply [backend::qemu::_extract_hostfwd_ports('')], [], 'empty string';
+};
+
+subtest 'port availability checks' => sub {
+    my %initial_vars = %bmwqemu::vars;
+    my $sock_mock = Test::MockModule->new('IO::Socket::IP');
+    subtest VNC => sub {
+        combined_like { lives_ok { backend::qemu::_assert_port_availability(5991, 'test') } 'free port passes' }
+        qr/checking 5991 port availability/, 'logs port post-qemu check for VNC';
+        $backend_mock->redefine(select_console => sub { {error => 'VNC connection failed'} });
+        combined_like {
+            throws_ok { $backend->start_qemu } qr/VNC connection failed/, 'dies on VNC error'
+        } qr/VNC port details/, 'logs port details on VNC failure';
+        $backend_mock->redefine(select_console => undef);
+    };
+    subtest hostfwd => sub {
+        $bmwqemu::vars{NICTYPE} = 'user';
+        $bmwqemu::vars{NICTYPE_USER_OPTIONS} = 'hostfwd=tcp::39100-:39100';
+        combined_like { lives_ok { backend::qemu::_assert_port_availability(39100, 'test') } 'free port passes' }
+        qr/checking 39100 port availability/, 'logs port pre-qemu check with hostfwd';
+        $sock_mock->redefine(new => sub { Test::MockObject->new->set_true('close') });
+        combined_like { throws_ok { $backend->start_qemu } qr/Port 39100 \(hostfwd\) is already in use/, 'dies on hostfwd port conflict' }
+          qr/qemu version/si, 'expected logs before hostfwd port check';
+    };
+    %bmwqemu::vars = %initial_vars;
+};
+
 subtest 'special cases when handling QMP command' => sub {
     my $create_virtio_console_fifo_called;
     # uncoverable statement count:2


### PR DESCRIPTION
To handle better the situations where the some network ports are already in use                                                      
and provide clearier feedback on conflict, the commit introduces two-fold checks                                                     
in start_qemu(). For the input from user (hostfwd) is checked before QEMU starts                                                     
and abort immediately. Where for VNC the check takes place after QEMU, in order                                                      
to get the error which it returns. So instead of errors like                                                                         
"QEMU terminated before QMP connection could be established" or                                                                      
"unexpected end of data", users now get the ss output:                                                                               
Port 39100 (hostfwd port) is already in use:                                                                                         
LISTEN 0 128 0.0.0.0:39100 0.0.0.0:* users:(("nc",pid=12345,fd=3))                                                                   
                                                                                                                                     
The port check uses connect instead of bind to work around localhost resolving                                                       
differently for IPv4/IPv6.                                                                                                           
Finally, at least for hostfwd the reason in openQA reflects the cause in an                                                          
incomplete job result. What is not address is the assignment to an open port for                                                     
any of the cases above. That has to be a different story as there should be                                                          
alignments between the test distributions and openQA side.

Issue: https://progress.opensuse.org/issues/198428