### PR TITLE
feat: set job to incomplete when perl package is not in @INC

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -301,7 +301,11 @@ sub loadtest ($script, %args) {
         }
         my $msg = "error on $script: $err";
         bmwqemu::fctwarn($msg);
-        bmwqemu::serialize_state(component => 'tests', msg => "unable to load $script, check the log for the cause (e.g. syntax error)");
+        my ($is_missing_module) = $err =~ /(Can't locate .+ in \@INC)/;
+        my ($state_msg) = $is_missing_module
+          ? "Missing Perl module while loading $script: $is_missing_module"
+          : "unable to load $script, check the log for the cause (e.g. syntax error)";
+        bmwqemu::serialize_state(component => 'tests', msg => $state_msg, result => 'incomplete');
         die $msg;
     }
     $test = $name->new($category);

--- a/basetest.pm
+++ b/basetest.pm
@@ -334,6 +334,14 @@ sub runtest ($self) {
         if (!@{$self->{details}} || ($self->{details}->[-1]->{result} || '') ne 'fail') {
             $self->take_screenshot();
         }
+        if (!$internal && $e =~ /Can't locate .+ in \@INC/) {
+            my $msg = "# Test died with missing dependency: $e";
+            bmwqemu::fctinfo($msg);
+            $self->record_resultfile('Failed', $msg, result => 'fail');
+            $self->{fatal_failure} = 1;
+            bmwqemu::serialize_state(component => 'tests', msg => "Missing Perl module: $e", result => 'incomplete');
+            $died = 1;
+        }
         # show a text result with the die message unless the die was internally generated
         if (!$internal) {
             my $msg = "# Test died: $e";

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -282,6 +282,28 @@ subtest 'number of test results is limited' => sub {
     ok $basetest->{fatal_failure}, 'failure considered fatal';
     $basetest->remove_last_result;
     is_deeply $basetest->record_testresult('ok'), {result => 'ok'}, 'can add one test result again';
+    path(bmwqemu::STATE_FILE)->remove;
+};
+
+subtest 'missing Perl module triggers incomplete' => sub {
+    Test::MockModule->new('autotest')->noop('set_current_test');
+    my $mock = Test::MockModule->new('basetest');
+    $mock->noop('take_screenshot');
+    $mock->mock(run => sub {
+            die "Can't locate HTTP/Request/Common.pm in \@INC (you may need to install the HTTP::Request::Common module)\n";
+    });
+    local $bmwqemu::vars{MAX_TEST_STEPS} = 100;
+    my $basetest = bless {details => [], name => 'foo', fullname => 'foo', category => 'category1'}, 'basetest';
+    my $logs = combined_from { dies_ok { $basetest->runtest } 'runtest dies due to missing module' };
+    like $logs, qr/Can't locate.*\@INC/, 'catch expected error message';
+
+    # Verify state file has incomplete result
+    ok -e bmwqemu::STATE_FILE, 'state file was written';
+    my $state = decode_json(path(bmwqemu::STATE_FILE)->slurp);
+    is $state->{result}, 'incomplete', 'result is incomplete for missing Perl module';
+    # like $state->{msg}, qr/Can't locate/, 'message mentions the missing module';
+    ok $basetest->{fatal_failure}, 'failure is fatal';
+    path(bmwqemu::STATE_FILE)->remove if -e bmwqemu::STATE_FILE;
 };
 
 delete $bmwqemu::vars{MAX_TEST_STEPS};

--- a/t/20-openqa-isotovideo-utils.t
+++ b/t/20-openqa-isotovideo-utils.t
@@ -59,7 +59,7 @@ subtest 'error handling when loading test schedule' => sub {
         my $state = decode_json($base_state->slurp);
         if (is(ref $state, 'HASH', 'state file contains object')) {
             is($state->{component}, 'tests', 'state file contains component');
-            like($state->{msg}, qr/unable to load foo\/bar\.pm/, 'state file contains error message');
+            like($state->{msg}, qr/Missing Perl module while loading foo\/bar\.pm/, 'state file contains error message');
         }
     };
     subtest 'invalid productdir' => sub {


### PR DESCRIPTION
Use the error in the try/catch to trace which reports the `Can't locate.. in \@INC` and update the JSON representation of the process to disk via `serialize_state`. Note that the function makes use of STATE_FILE. As a result the WebUI will render the msg as reason and it will mark the corresponding tests as incomplete.

At that point, as corresponding failures are considered issues originated by both worker and test distris. A follow up task could separate the origin in order to tackle each of the categories differently.

Issue: https://progress.opensuse.org/issues/197183