### PR TITLE
feat: hide internal markers + display exit code

### DIFF
--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -9,7 +9,7 @@ use Mojo::Base -strict, -signatures;
 # -> increment on every change of such APIs
 # -> never move that variable to another place (when refactoring)
 #    because it may be accessed by the tests itself
-our $version = 52;
+our $version = 53;
 
 # major version of the (web socket) API relevant to the developer mode
 # -> increment when making non-backward compatible changes to that API

--- a/basetest.pm
+++ b/basetest.pm
@@ -437,11 +437,29 @@ sub record_serialresult ($self, $ref, $res, $string = undef, %args) {
     # take screenshot for documentation (screenshot does not represent fail itself)
     $self->take_screenshot() unless (testapi::is_serial_terminal);
 
+    my $pretty = testapi::get_var('PRETTY_SERIAL_MARKER') || testapi::get_var('HIDE_MARKER_EVALUATION');
+    my $internal = $args{internal_marker};
+    my $output_string = $string;
+
+    if ($internal && $pretty) {
+        my $pattern = $args{marker_pattern};
+        if ($pattern) {
+            # Strip the marker from the end of the string
+            if (ref $pattern eq 'Regexp') {
+                $output_string =~ s/$pattern\s*\z//m;
+            }
+            else {
+                # literal match
+                $output_string =~ s/\Q$pattern\E\s*\z//m;
+            }
+        }
+    }
+
     my $output = '';
     $output .= "# Command: $args{command}\n" if defined $args{command};
-    $output .= "# wait_serial expected: $ref\n";
+    $output .= "# wait_serial expected: $ref\n" unless $internal && $pretty;
     $output .= "# Result:\n";
-    $output .= "$string\n";
+    $output .= "$output_string\n";
     $self->record_resultfile('wait_serial', $output, result => $res);
     return undef;
 }

--- a/basetest.pm
+++ b/basetest.pm
@@ -440,18 +440,16 @@ sub record_serialresult ($self, $ref, $res, $string = undef, %args) {
     my $pretty = testapi::get_var('PRETTY_SERIAL_MARKER') || testapi::get_var('HIDE_MARKER_EVALUATION');
     my $internal = $args{internal_marker};
     my $output_string = $string;
+    my $captured_val;
 
-    if ($internal && $pretty) {
+    if ($internal && $args{marker_pattern}) {
         my $pattern = $args{marker_pattern};
-        if ($pattern) {
-            # Strip the marker from the end of the string
-            if (ref $pattern eq 'Regexp') {
-                $output_string =~ s/$pattern\s*\z//m;
-            }
-            else {
-                # literal match
-                $output_string =~ s/\Q$pattern\E\s*\z//m;
-            }
+        my $is_regex = ref $pattern eq 'Regexp';
+        $captured_val = $1 if $is_regex && $string =~ /$pattern/;
+
+        if ($pretty) {
+            my $search = $is_regex ? $pattern : qr/\Q$pattern\E/;
+            $output_string =~ s/$search\s*\z//m;
         }
     }
 
@@ -460,6 +458,9 @@ sub record_serialresult ($self, $ref, $res, $string = undef, %args) {
     $output .= "# wait_serial expected: $ref\n" unless $internal && $pretty;
     $output .= "# Result:\n";
     $output .= "$output_string\n";
+    if (defined $captured_val && $args{capture_name}) {
+        $output .= "# $args{capture_name}: $captured_val\n";
+    }
     $self->record_resultfile('wait_serial', $output, result => $res);
     return undef;
 }

--- a/distribution.pm
+++ b/distribution.pm
@@ -155,7 +155,7 @@ sub script_run ($self, $cmd, @args) {
         if ($level == 3) {
             testapi::query_isotovideo('backend_clear_serial_buffer', {});
             testapi::type_string "$cmd\n", max_interval => $args{max_interval};
-            my $res = testapi::wait_serial(qr/OA:DONE-[0-9a-f]{4}-(\d+)-/, timeout => $args{timeout}, quiet => $args{quiet}, record_command => $cmd);
+            my $res = testapi::wait_serial(qr/OA:DONE-[0-9a-f]{4}-(\d+)-/, timeout => $args{timeout}, quiet => $args{quiet}, record_command => $cmd, internal_marker => 1);
             return unless $res;
             return ($res =~ /OA:DONE-[0-9a-f]{4}-(\d+)-/)[0];
         }
@@ -169,7 +169,7 @@ sub script_run ($self, $cmd, @args) {
             if (testapi::is_serial_terminal) {
                 testapi::type_string "$cmd", max_interval => $args{max_interval};
                 testapi::type_string $marker, max_interval => $args{max_interval};
-                testapi::wait_serial($cmd . $marker, no_regex => 1, quiet => $args{quiet}, buffer_size => (length $cmd) + 128)
+                testapi::wait_serial($cmd . $marker, no_regex => 1, quiet => $args{quiet}, buffer_size => (length $cmd) + 128, internal_marker => 1)
                   or _handle_cmd_typing_error($cmd, \%args);
                 testapi::type_string "\n", max_interval => $args{max_interval};
             }
@@ -178,7 +178,7 @@ sub script_run ($self, $cmd, @args) {
                 testapi::type_string "$marker > /dev/$testapi::serialdev\n", max_interval => $args{max_interval};
             }
         }
-        my $res = testapi::wait_serial($wait_pattern, timeout => $args{timeout}, quiet => $args{quiet}, record_command => $cmd);
+        my $res = testapi::wait_serial($wait_pattern, timeout => $args{timeout}, quiet => $args{quiet}, record_command => $cmd, internal_marker => 1);
         return unless $res;
         return ($res =~ $wait_pattern)[0];
     }
@@ -215,13 +215,13 @@ sub background_script_run ($self, $cmd, %args) {
     my $marker = "& echo $str-\$!-" . ($args{output} ? "Comment: $args{output}" : '');
     if (testapi::is_serial_terminal) {
         testapi::type_string $marker;
-        testapi::wait_serial($cmd . $marker, no_regex => 1, quiet => $args{quiet}) or _handle_cmd_typing_error($cmd, \%args);
+        testapi::wait_serial($cmd . $marker, no_regex => 1, quiet => $args{quiet}, internal_marker => 1) or _handle_cmd_typing_error($cmd, \%args);
         testapi::type_string "\n";
     }
     else {
         testapi::type_string "$marker > /dev/$testapi::serialdev\n";
     }
-    my $res = testapi::wait_serial(qr/$str-\d+-/, quiet => $args{quiet});
+    my $res = testapi::wait_serial(qr/$str-\d+-/, quiet => $args{quiet}, internal_marker => 1);
     die 'PID marker not found' unless ($res =~ m/$str-(\d+)-/);
     return $1;
 }
@@ -248,7 +248,7 @@ sub script_sudo ($self, $prog, $wait = 10) {
         testapi::send_key 'ret';
     }
     if ($str) {
-        return testapi::wait_serial($str, $wait);
+        return testapi::wait_serial($str, $wait, internal_marker => 1);
     }
     return;
 }
@@ -307,7 +307,7 @@ sub script_output ($self, $script, @args) {
         testapi::wait_serial('> ', no_regex => 1, quiet => $args{quiet});
         testapi::type_string "$script\n$heretag\n";
         testapi::wait_serial("> $heretag", no_regex => 1, quiet => $args{quiet});
-        testapi::wait_serial("$marker-0-", quiet => $args{quiet});
+        testapi::wait_serial("$marker-0-", quiet => $args{quiet}, internal_marker => 1);
     }
     elsif ($args{type_command}) {
         my $cat = "cat - > $script_path;";
@@ -339,7 +339,7 @@ sub script_output ($self, $script, @args) {
     else {
         testapi::type_string "($run_script) | tee /dev/$testapi::serialdev\n";
     }
-    my $output = testapi::wait_serial("SCRIPT_FINISHED$marker-\\d+-", timeout => $args{timeout}, record_output => 1, quiet => $args{quiet})
+    my $output = testapi::wait_serial(qr/SCRIPT_FINISHED$marker-(\d+)-/, capture_name => 'Exit code', timeout => $args{timeout}, record_output => 1, quiet => $args{quiet}, internal_marker => 1)
       || croak "script timeout: $script";
 
     if ($output !~ "SCRIPT_FINISHED$marker-0-") {

--- a/distribution.pm
+++ b/distribution.pm
@@ -155,7 +155,7 @@ sub script_run ($self, $cmd, @args) {
         if ($level == 3) {
             testapi::query_isotovideo('backend_clear_serial_buffer', {});
             testapi::type_string "$cmd\n", max_interval => $args{max_interval};
-            my $res = testapi::wait_serial(qr/OA:DONE-[0-9a-f]{4}-(\d+)-/, timeout => $args{timeout}, quiet => $args{quiet}, record_command => $cmd, internal_marker => 1);
+            my $res = testapi::wait_serial(qr/OA:DONE-[0-9a-f]{4}-(\d+)-/, timeout => $args{timeout}, quiet => $args{quiet}, record_command => $cmd, internal_marker => 1, capture_name => 'Exit code');
             return unless $res;
             return ($res =~ /OA:DONE-[0-9a-f]{4}-(\d+)-/)[0];
         }
@@ -178,7 +178,7 @@ sub script_run ($self, $cmd, @args) {
                 testapi::type_string "$marker > /dev/$testapi::serialdev\n", max_interval => $args{max_interval};
             }
         }
-        my $res = testapi::wait_serial($wait_pattern, timeout => $args{timeout}, quiet => $args{quiet}, record_command => $cmd, internal_marker => 1);
+        my $res = testapi::wait_serial($wait_pattern, timeout => $args{timeout}, quiet => $args{quiet}, record_command => $cmd, internal_marker => 1, capture_name => 'Exit code');
         return unless $res;
         return ($res =~ $wait_pattern)[0];
     }
@@ -307,7 +307,7 @@ sub script_output ($self, $script, @args) {
         testapi::wait_serial('> ', no_regex => 1, quiet => $args{quiet});
         testapi::type_string "$script\n$heretag\n";
         testapi::wait_serial("> $heretag", no_regex => 1, quiet => $args{quiet});
-        testapi::wait_serial("$marker-0-", quiet => $args{quiet}, internal_marker => 1);
+        testapi::wait_serial(qr/$marker-(0)-/, capture_name => 'Exit code', quiet => $args{quiet}, internal_marker => 1);
     }
     elsif ($args{type_command}) {
         my $cat = "cat - > $script_path;";

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -827,8 +827,8 @@ sub script_output_test ($is_serial_terminal) {
         @wait_serial_args = ();
         is script_output('echo foo', $t->{args}->@*), 'foo', "$t->{msg}: returns expected output";
         is $wait_serial_args[-1]->{timeout}, $t->{timeout}, "$t->{msg}: correct timeout passed to final wait_serial call";
-        my $inconsistent_quiet = grep { ($_->{quiet} // 0) != ($t->{quiet} // 0) } @wait_serial_args;
-        ok !$inconsistent_quiet, "$t->{msg}: quiet argument is consistent across all calls";
+        my @inconsistent_quiet = grep { ($_->{quiet} // 0) != ($t->{quiet} // 0) } @wait_serial_args;
+        is_deeply \@inconsistent_quiet, [], "$t->{msg}: quiet argument is consistent across all calls";
     }
     $mock_testapi->redefine(wait_serial => "This is a simulated output on the serial dev\nXXXfoo\nSCRIPT_FINISHEDXXX-0-\nand more here");
     is script_output('echo foo', type_command => 0), 'foo', 'script_output with type_command => 0 output in a file';

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -815,21 +815,21 @@ sub script_output_test ($is_serial_terminal) {
         }
     };
 
+    my @wait_serial_args;
     $mock_testapi->redefine(wait_serial => sub ($regex, %args) {
-            is($args{quiet}, undef, 'Check default quiet argument');
-            if ($regex =~ m/SCRIPT_FINISHEDXXX-\\d\+-/) {
-                is($args{timeout}, 30, 'pass $wait value to wait_serial');
-            }
+            push @wait_serial_args, \%args;
             return "XXXfoo\nSCRIPT_FINISHEDXXX-0-";
     });
-    is(script_output('echo foo', 30), 'foo', '');
-    is(script_output('echo foo', timeout => 30), 'foo', '');
-
-    $mock_testapi->redefine(wait_serial => sub ($regex, %args) {
-            is($args{quiet}, 1, 'Check quiet argument');
-            return "XXXfoo\nSCRIPT_FINISHEDXXX-0-";
-    });
-    is(script_output('echo foo', quiet => 1), 'foo', '');
+    for my $t (
+        {args => [30], timeout => 30, quiet => undef, msg => 'positional wait'},
+        {args => [timeout => 30], timeout => 30, quiet => undef, msg => 'keyword timeout'},
+        {args => [quiet => 1], timeout => undef, quiet => 1, msg => 'keyword quiet'}) {
+        @wait_serial_args = ();
+        is script_output('echo foo', $t->{args}->@*), 'foo', "$t->{msg}: returns expected output";
+        is $wait_serial_args[-1]->{timeout}, $t->{timeout}, "$t->{msg}: correct timeout passed to final wait_serial call";
+        my $inconsistent_quiet = grep { ($_->{quiet} // 0) != ($t->{quiet} // 0) } @wait_serial_args;
+        ok !$inconsistent_quiet, "$t->{msg}: quiet argument is consistent across all calls";
+    }
     $mock_testapi->redefine(wait_serial => "This is a simulated output on the serial dev\nXXXfoo\nSCRIPT_FINISHEDXXX-0-\nand more here");
     is script_output('echo foo', type_command => 0), 'foo', 'script_output with type_command => 0 output in a file';
 }

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -805,7 +805,7 @@ sub script_output_test ($is_serial_terminal) {
     $mock_testapi->redefine(wait_serial => "XXXfoo\nSCRIPT_FINISHEDXXX-1-");
     is(script_output('echo foo', undef, proceed_on_failure => 1), 'foo', 'proceed_on_failure=1 retrieves retrieves output of script and do not die');
 
-    $mock_testapi->redefine(wait_serial => sub { return 'none' if (shift !~ m/SCRIPT_FINISHEDXXX-\\d\+-/) });
+    $mock_testapi->redefine(wait_serial => sub { return 'none' unless $_[0] =~ /SCRIPT_FINISHEDXXX/; return; });
     throws_ok { script_output('timeout'); } qr/timeout/, 'die expected with timeout';
 
     subtest 'script_output check error codes' => sub {

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -551,4 +551,51 @@ subtest record_serialresult_with_command => sub {
     like($recorded_output, qr/# wait_serial expected: regex/, 'expected regex is in output');
 };
 
+
+subtest record_serialresult_hiding => sub {
+    my $basetest = basetest->new();
+    $basetest->{name} = 'test_hiding';
+    my $recorded_output;
+    my $mock_basetest_local = Test::MockModule->new('basetest');
+    my $mock_testapi = Test::MockModule->new('testapi');
+    $mock_basetest_local->redefine(record_resultfile => sub ($self, $title, $output, %nargs) { $recorded_output = $output });
+
+    my @test_cases = (
+        {
+            name => 'expected regex is visible by default (no pretty vars set)',
+            vars => {},
+            params => ['regex', 'ok', 'some output marker', internal_marker => 1, marker_pattern => 'marker'],
+            expected => [qr/# wait_serial expected: regex/],
+            not_expected => [],
+        },
+        {
+            name => 'expected regex is hidden and literal marker is stripped when PRETTY_SERIAL_MARKER is set',
+            vars => {PRETTY_SERIAL_MARKER => 1},
+            params => ['regex', 'ok', "some output\nmarker\n", internal_marker => 1, marker_pattern => 'marker'],
+            expected => [qr/some output\n\s*\n/],
+            not_expected => [qr/# wait_serial expected: regex/],
+        },
+        {
+            name => 'expected regex is hidden and regex marker is stripped when HIDE_MARKER_EVALUATION is set',
+            vars => {HIDE_MARKER_EVALUATION => 1},
+            params => ['regex', 'ok', "command output\nOA:DONE-1234-0-\n", internal_marker => 1, marker_pattern => qr/OA:DONE-[0-9a-f]{4}-(\d+)-/],
+            expected => [qr/command output\n\s*\n/],
+            not_expected => [qr/# wait_serial expected: regex/, qr/OA:DONE-1234-0-/],
+        },
+        {
+            name => 'no hiding occurs if it is not an internal marker even if pretty vars are set',
+            vars => {PRETTY_SERIAL_MARKER => 1, HIDE_MARKER_EVALUATION => 1},
+            params => ['regex', 'ok', 'some output marker', internal_marker => 0, marker_pattern => 'marker'],
+            expected => [qr/# wait_serial expected: regex/],
+            not_expected => [],
+        },
+    );
+
+    foreach my $case (@test_cases) {
+        $mock_testapi->mock(get_var => sub ($var) { return $case->{vars}->{$var} });
+        $basetest->record_serialresult(@{$case->{params}});
+        like($recorded_output, $_, "$case->{name} (contains expected)") for @{$case->{expected}};
+        unlike($recorded_output, $_, "$case->{name} (does not contain unexpected)") for @{$case->{not_expected}};
+    }
+};
 done_testing;

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -551,7 +551,6 @@ subtest record_serialresult_with_command => sub {
     like($recorded_output, qr/# wait_serial expected: regex/, 'expected regex is in output');
 };
 
-
 subtest record_serialresult_hiding => sub {
     my $basetest = basetest->new();
     $basetest->{name} = 'test_hiding';
@@ -583,11 +582,32 @@ subtest record_serialresult_hiding => sub {
             not_expected => [qr/# wait_serial expected: regex/, qr/OA:DONE-1234-0-/],
         },
         {
+            name => 'Exit code is displayed when capture_name is provided',
+            vars => {PRETTY_SERIAL_MARKER => 1},
+            params => ['regex', 'ok', "command output\nOA:DONE-1234-0-\n", internal_marker => 1, marker_pattern => qr/OA:DONE-[0-9a-f]{4}-(\d+)-/, capture_name => 'Exit code'],
+            expected => [qr/# Exit code: 0/, qr/command output\n\s*\n/],
+            not_expected => [qr/# wait_serial expected: regex/],
+        },
+        {
+            name => 'PID is displayed for background commands',
+            vars => {HIDE_MARKER_EVALUATION => 1},
+            params => ['regex', 'ok', "background output\nMARKER-1234-\n", internal_marker => 1, marker_pattern => qr/MARKER-(\d+)-/, capture_name => 'PID'],
+            expected => [qr/# PID: 1234/, qr/background output\n\s*\n/],
+            not_expected => [qr/MARKER-1234-/],
+        },
+        {
             name => 'no hiding occurs if it is not an internal marker even if pretty vars are set',
             vars => {PRETTY_SERIAL_MARKER => 1, HIDE_MARKER_EVALUATION => 1},
             params => ['regex', 'ok', 'some output marker', internal_marker => 0, marker_pattern => 'marker'],
             expected => [qr/# wait_serial expected: regex/],
             not_expected => [],
+        },
+        {
+            name => 'regex marker is provided but string does not match (e.g. on timeout)',
+            vars => {PRETTY_SERIAL_MARKER => 1},
+            params => ['regex', 'fail', "some output that did not hit the marker\n", internal_marker => 1, marker_pattern => qr/OA:DONE-[0-9a-f]{4}-(\d+)-/, capture_name => 'Exit code'],
+            expected => [qr/some output that did not hit the marker\n/],
+            not_expected => [qr/# Exit code:/],
         },
     );
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -870,6 +870,7 @@ sub wait_serial {    # no:style:signatures
             buffer_size => undef,
             record_output => undef,
             record_command => undef,
+            internal_marker => 0,
         }, ['timeout', 'expect_not_found'], @_);
 
     bmwqemu::log_call(%args);
@@ -886,7 +887,7 @@ sub wait_serial {    # no:style:signatures
     # hyperv and vmware (backend/svirt.pm) connect serial line over TCP/IP (socat)
     # convert CRLF to LF only
     $ret->{string} =~ s,\r\n,\n,g;
-    $autotest::current_test->record_serialresult(bmwqemu::pp($regexp), $matched, $ret->{string}, command => $args{record_command}) unless ($args{quiet});
+    $autotest::current_test->record_serialresult(bmwqemu::pp($regexp), $matched, $ret->{string}, command => $args{record_command}, internal_marker => $args{internal_marker}, marker_pattern => $regexp) unless ($args{quiet});
     bmwqemu::fctres("$regexp: $matched");
     return $ret->{string} if ($matched eq 'ok');
     return;    # false

--- a/testapi.pm
+++ b/testapi.pm
@@ -871,6 +871,7 @@ sub wait_serial {    # no:style:signatures
             record_output => undef,
             record_command => undef,
             internal_marker => 0,
+            capture_name => undef,
         }, ['timeout', 'expect_not_found'], @_);
 
     bmwqemu::log_call(%args);
@@ -887,7 +888,7 @@ sub wait_serial {    # no:style:signatures
     # hyperv and vmware (backend/svirt.pm) connect serial line over TCP/IP (socat)
     # convert CRLF to LF only
     $ret->{string} =~ s,\r\n,\n,g;
-    $autotest::current_test->record_serialresult(bmwqemu::pp($regexp), $matched, $ret->{string}, command => $args{record_command}, internal_marker => $args{internal_marker}, marker_pattern => $regexp) unless ($args{quiet});
+    $autotest::current_test->record_serialresult(bmwqemu::pp($regexp), $matched, $ret->{string}, command => $args{record_command}, internal_marker => $args{internal_marker}, marker_pattern => $regexp, capture_name => $args{capture_name}) unless ($args{quiet});
     bmwqemu::fctres("$regexp: $matched");
     return $ret->{string} if ($matched eq 'ok');
     return;    # false


### PR DESCRIPTION
* feat: display exit code in openQA step details
* feat: hide internal synchronization markers for PRETTY_SERIAL_MARKER

Example output:
Instead of a step output with

```
wait_serial expected: qr/OA:DONE-(\d+)-/u
Result:
OA:DONE-0-
```

this now contains:
```
Command: systemctl mask --now packagekit
Result:

Exit code: 0
```

Related issue: https://progress.opensuse.org/issues/183761