### PR TITLE
test(t/27-consoles-vmware): fix logic error in WebSocket server code

### DIFF
--- a/t/27-consoles-vmware.t
+++ b/t/27-consoles-vmware.t
@@ -148,7 +148,7 @@ subtest 'turning WebSocket into normal socket via dewebsockify' => sub {
             $self->send({binary => 'binary sent from WebSocket'}, sub {
                     $self->send({text => 'text message sent from WebSocket'}, sub {
                             $sent_everything = 1;
-                            $self->finish if length $self->app->received_everything;
+                            $self->finish if $self->app->received_everything;
                     });
             });
             $self->on(


### PR DESCRIPTION
Motivation:
The test was using length() on the result of a method returning a boolean
value, which could lead to incorrect behavior if the boolean false value
was not empty.

Design Choices:
Use the boolean result directly.