### PR TITLE
fix: Disable duplicate address detection in NetworkManager for br1

### DIFF
--- a/script/os-autoinst-setup-multi-machine
+++ b/script/os-autoinst-setup-multi-machine
@@ -162,7 +162,7 @@ setup_multi_machine_with_networkmanager() {
     # Create bridge, port and interface connection
     nmcli con add type ovs-bridge con.int "$bridge"
     nmcli con add type ovs-port con.int "$bridge" con.master "$bridge"
-    nmcli con add type ovs-interface con.int "$bridge" con.master "$bridge" ipv4.method manual ipv4.address 10.0.2.2/15 ipv6.method manual ipv6.address fec0::2/63 ethernet.mtu "$mtu" con.zone "$zone"
+    nmcli con add type ovs-interface con.int "$bridge" con.master "$bridge" ipv4.method manual ipv4.address 10.0.2.2/15 ipv4.dad-timeout 0 ipv6.method manual ipv6.dad-timeout 0 ipv6.address fec0::2/63 ethernet.mtu "$mtu" con.zone "$zone"
     # Create tap interfaces
     for i in 0 $(
         seq 1 "$instances"


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/199022

By default, NetworkManager is extremely strict and performs (DAD) Duplicate Address Detection via ARP before it actually binds an IPv4 address to an interface.
This commit sets dad-timeout in ipv4 and ipv6 configuration.