### PR TITLE
refactor: import IO::Socket::UNIX explicitly wherever is used

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -27,6 +27,7 @@ use File::Basename;
 use File::Which;
 use Mojo::JSON qw(encode_json decode_json);
 use Mojo::File 'path';
+use IO::Socket::UNIX;
 use OpenQA::Qemu::BlockDevConf;
 use OpenQA::Qemu::ControllerConf;
 use OpenQA::Qemu::DriveDevice 'QEMU_IMAGE_FORMAT';

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -11,7 +11,6 @@ use File::Path 'mkpath';
 use File::Which;
 use Time::HiRes qw(sleep gettimeofday);
 use Time::Seconds;
-use IO::Socket::UNIX 'SOCK_STREAM';
 use IO::Handle;
 use POSIX qw(strftime :sys_wait_h mkfifo);
 use Mojo::File 'path';


### PR DESCRIPTION
Qemu.pm doesn't really need IO::Socket::UNIX and the only place which is used actually is in OpenQA/Qemu/Proc.pm. The import can be ommitted as it is already loaded with some transient way from another module apparently. This commit just make this explicit wherever is needed.