### PR TITLE
fix: Avoid restarting openvswitch/NM after OVS bridge setup

### DIFF
--- a/script/os-autoinst-setup-multi-machine
+++ b/script/os-autoinst-setup-multi-machine
@@ -177,7 +177,6 @@ setup_multi_machine_with_networkmanager() {
         nmcli con add type tun mode tap owner "$(id -u _openqa-worker)" group "$(getent group nogroup | cut -f3 -d:)" con.int "tap$i" master "tap$i"
     done
     create_gre_preup_script /etc/NetworkManager/dispatcher.d/gre_tunnel_preup.sh
-    systemctl restart NetworkManager
 }
 
 setup_multi_machine_with_wicked() {
@@ -232,7 +231,7 @@ cleanup_openvswitch_db() {
 configure_openvswitch() {
     echo "OS_AUTOINST_USE_BRIDGE=$bridge" > /etc/sysconfig/os-autoinst-openvswitch
     systemctl enable os-autoinst-openvswitch
-    systemctl restart openvswitch os-autoinst-openvswitch
+    systemctl restart os-autoinst-openvswitch
 }
 
 determine_ethernet_interface() {


### PR DESCRIPTION
configure_openvswitch was restarting both openvswitch and
os-autoinst-openvswitch, which destroyed the bridges NM just created.
Commit https://github.com/d3flex/os-autoinst/commit/3232b807a6bf0eb0428ddf8592a0e6bcc5342ecb tried to fix this by adding a NM restart at the end of
setup_multi_machine_with_networkmanager, but that introduced a race
condition where br1 is torn down and tests fail before it comes back.

The root cause is that the openvswitch restart in configure_openvswitch
is redundant — cleanup_openvswitch_db already provides a clean, running
OVS instance. Remove both the unnecessary openvswitch restart and the
NM restart that was trying to compensate for it.