### PR TITLE
fix(test): handle D-Bus AccessDenied in Open vSwitch test

### DIFF
--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -62,7 +62,7 @@ ok(exists $called{add_console}, 'a console has been added');
 is($called{add_console}, 1, 'one console has been added');
 
 subtest 'using Open vSwitch D-Bus service' => sub {
-    my $expected = qr/Open vSwitch command.*show.*arguments 'foo bar'.*(The name.*not (provided|activatable)|Failed to connect)/;
+    my $expected = qr/Open vSwitch command.*show.*arguments 'foo bar'.*(The name.*not (provided|activatable)|Failed to connect|AccessDenied)/;
     my $msg = 'error about missing service';
     throws_ok { $backend->_dbus_call('show', 'foo', 'bar') } $expected, $msg . ' in exception';
     $bmwqemu::vars{QEMU_NON_FATAL_DBUS_CALL} = 1;


### PR DESCRIPTION
On machines where the Open vSwitch D-Bus service is running but the user lacks permission, the error is "AccessDenied" rather than "name not provided/activatable" or "Failed to connect". This caused the Open vSwitch D-Bus subtest in t/18-backend-qemu.t to fail locally while still passing in CI