### PR TITLE
style: unify copyright headers by dropping years

### DIFF
--- a/OpenQA/Commands.pm
+++ b/OpenQA/Commands.pm
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::Commands;

--- a/OpenQA/Exceptions.pm
+++ b/OpenQA/Exceptions.pm
@@ -1,4 +1,4 @@
-# Copyright 2016-2018 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::Exceptions;

--- a/OpenQA/Isotovideo/CommandHandler.pm
+++ b/OpenQA/Isotovideo/CommandHandler.pm
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::Isotovideo::CommandHandler;

--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::Isotovideo::Interface;

--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::Isotovideo::Utils;

--- a/OpenQA/NamedIOSelect.pm
+++ b/OpenQA/NamedIOSelect.pm
@@ -1,4 +1,4 @@
-# Copyright 2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Helper class to use descriptive names for file descriptors within IO::Select

--- a/OpenQA/Qemu/BlockDev.pm
+++ b/OpenQA/Qemu/BlockDev.pm
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 =head2 OpenQA::Qemu::BlockDev

--- a/OpenQA/Qemu/BlockDevConf.pm
+++ b/OpenQA/Qemu/BlockDevConf.pm
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 =head2 OpenQA::Qemu::BlockDevConf

--- a/OpenQA/Qemu/ControllerConf.pm
+++ b/OpenQA/Qemu/ControllerConf.pm
@@ -1,4 +1,4 @@
-# Copyright 2018 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::Qemu::ControllerConf;

--- a/OpenQA/Qemu/DriveController.pm
+++ b/OpenQA/Qemu/DriveController.pm
@@ -1,4 +1,4 @@
-# Copyright 2018 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 =head2 OpenQA::Qemu::DriveController

--- a/OpenQA/Qemu/DriveDevice.pm
+++ b/OpenQA/Qemu/DriveDevice.pm
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 =head2 OpenQA::Qemu::DriveDevice

--- a/OpenQA/Qemu/DrivePath.pm
+++ b/OpenQA/Qemu/DrivePath.pm
@@ -1,4 +1,4 @@
-# Copyright 2018 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 =head2 OpenQA::Qemu::DrivePath

--- a/OpenQA/Qemu/MutParams.pm
+++ b/OpenQA/Qemu/MutParams.pm
@@ -1,4 +1,4 @@
-# Copyright 2018 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 =head2 OpenQA::Qemu::MutParams

--- a/OpenQA/Qemu/PFlashDevice.pm
+++ b/OpenQA/Qemu/PFlashDevice.pm
@@ -1,4 +1,4 @@
-# Copyright 2018 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 =head3 OpenQA::Qemu::PFlashDevice

--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 =head2 OpenQA::Qemu::Proc

--- a/OpenQA/Qemu/Snapshot.pm
+++ b/OpenQA/Qemu/Snapshot.pm
@@ -1,4 +1,4 @@
-# Copyright 2018 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 =head2 OpenQA::Qemu::Snapshot

--- a/OpenQA/Qemu/SnapshotConf.pm
+++ b/OpenQA/Qemu/SnapshotConf.pm
@@ -1,4 +1,4 @@
-# Copyright 2018 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 =head3 OpenQA::Qemu::SnapshotConf

--- a/OpenQA/Test/RunArgs.pm
+++ b/OpenQA/Test/RunArgs.pm
@@ -1,4 +1,4 @@
-# Copyright 2017 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 =head2 OpenQA::Test::RunArgs

--- a/autotest.pm
+++ b/autotest.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package autotest;

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # this is an abstract class

--- a/backend/console_proxy.pm
+++ b/backend/console_proxy.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # This is the direct companion to backend::proxy_console_call()

--- a/backend/driver.pm
+++ b/backend/driver.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # this class is what presents $backend in isotovideo and its code runs

--- a/backend/generalhw.pm
+++ b/backend/generalhw.pm
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # this backend uses a KVM connector speaking VNC and external tools

--- a/backend/ipmi.pm
+++ b/backend/ipmi.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package backend::ipmi;

--- a/backend/null.pm
+++ b/backend/null.pm
@@ -1,4 +1,4 @@
-# Copyright 2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package backend::null;

--- a/backend/pvm_hmc.pm
+++ b/backend/pvm_hmc.pm
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package backend::pvm_hmc;

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package backend::qemu;

--- a/backend/s390x.pm
+++ b/backend/s390x.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package backend::s390x;

--- a/backend/spvm.pm
+++ b/backend/spvm.pm
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package backend::spvm;

--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2023 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package backend::svirt;

--- a/backend/vagrant.pm
+++ b/backend/vagrant.pm
@@ -1,4 +1,4 @@
-# Copyright 2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package backend::vagrant;

--- a/backend/virt.pm
+++ b/backend/virt.pm
@@ -1,4 +1,4 @@
-# Copyright 2016 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package backend::virt;

--- a/basetest.pm
+++ b/basetest.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package basetest;

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package bmwqemu;

--- a/commands.pm
+++ b/commands.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package commands;

--- a/consoles/VMWare.pm
+++ b/consoles/VMWare.pm
@@ -1,4 +1,4 @@
-# Copyright 2022 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package consoles::VMWare;

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -1172,6 +1172,6 @@ Copyright 2006, Leon Brocard
 Copyright 2014-2017 Stephan Kulow (coolo@suse.de)
 adapted to be purely useful for qemu/openqa
 
-Copyright 2017-2021 SUSE LLC
+Copyright SUSE LLC
 
 SPDX-License-Identifier: Artistic-1.0 OR GPL-1.0-or-later

--- a/consoles/console.pm
+++ b/consoles/console.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 =head2 consoles::console

--- a/consoles/ipmiSol.pm
+++ b/consoles/ipmiSol.pm
@@ -1,4 +1,4 @@
-# Copyright 2012-2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package consoles::ipmiSol;

--- a/consoles/localXvnc.pm
+++ b/consoles/localXvnc.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package consoles::localXvnc;

--- a/consoles/network_console.pm
+++ b/consoles/network_console.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2019-2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package consoles::network_console;

--- a/consoles/s3270.pm
+++ b/consoles/s3270.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package consoles::s3270;

--- a/consoles/serial_screen.pm
+++ b/consoles/serial_screen.pm
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 package consoles::serial_screen;
 

--- a/consoles/sshIucvconn.pm
+++ b/consoles/sshIucvconn.pm
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # this is just a stupid console to track if we're connected to the host

--- a/consoles/sshSerial.pm
+++ b/consoles/sshSerial.pm
@@ -1,4 +1,4 @@
-# Copyright 2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 #

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package consoles::sshVirtsh;

--- a/consoles/sshVirtshSUT.pm
+++ b/consoles/sshVirtshSUT.pm
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package consoles::sshVirtshSUT;

--- a/consoles/sshX3270.pm
+++ b/consoles/sshX3270.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2015 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package consoles::sshX3270;

--- a/consoles/sshXtermIPMI.pm
+++ b/consoles/sshXtermIPMI.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2015 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package consoles::sshXtermIPMI;

--- a/consoles/sshXtermVt.pm
+++ b/consoles/sshXtermVt.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2015 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package consoles::sshXtermVt;

--- a/consoles/ssh_screen.pm
+++ b/consoles/ssh_screen.pm
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package consoles::ssh_screen;

--- a/consoles/ttyConsole.pm
+++ b/consoles/ttyConsole.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package consoles::ttyConsole;

--- a/consoles/video_stream.pm
+++ b/consoles/video_stream.pm
@@ -1,5 +1,5 @@
 # Copyright 2021 Marek Marczykowski-Górecki
-# Copyright 2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package consoles::video_stream;

--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 package consoles::virtio_terminal;
 

--- a/consoles/vnc_base.pm
+++ b/consoles/vnc_base.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package consoles::vnc_base;

--- a/cv.pm
+++ b/cv.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # wrapper around tinycv

--- a/distribution.pm
+++ b/distribution.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2015 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package distribution;

--- a/lockapi.pm
+++ b/lockapi.pm
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 ## synchronization API

--- a/mmapi.pm
+++ b/mmapi.pm
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 ## Multi-Machine API

--- a/myjsonrpc.pm
+++ b/myjsonrpc.pm
@@ -1,4 +1,4 @@
-# Copyright 2012-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package myjsonrpc;

--- a/needle.pm
+++ b/needle.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package needle;

--- a/ocr.pm
+++ b/ocr.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package ocr;

--- a/osutils.pm
+++ b/osutils.pm
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package osutils;

--- a/ppmclibs/tinycv.h
+++ b/ppmclibs/tinycv.h
@@ -1,4 +1,4 @@
-// Copyright 2012-2020 SUSE LLC
+// Copyright SUSE LLC
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <string>

--- a/ppmclibs/tinycv.pm
+++ b/ppmclibs/tinycv.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package tinycv;

--- a/ppmclibs/tinycv_ast2100.cc
+++ b/ppmclibs/tinycv_ast2100.cc
@@ -1,4 +1,4 @@
-// Copyright 2012-2016 SUSE LLC
+// Copyright SUSE LLC
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <opencv2/core/core.hpp>

--- a/ppmclibs/tinycv_impl.cc
+++ b/ppmclibs/tinycv_impl.cc
@@ -1,4 +1,4 @@
-// Copyright 2012-2020 SUSE LLC
+// Copyright SUSE LLC
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <condition_variable>

--- a/script/check_qemu_oom
+++ b/script/check_qemu_oom
@@ -1,5 +1,5 @@
 #!/usr/bin/perl -w
-# Copyright 2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 

--- a/script/dewebsockify
+++ b/script/dewebsockify
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-# Copyright 2022 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Mojo::Base -strict, -signatures;

--- a/script/imgsearch
+++ b/script/imgsearch
@@ -1,5 +1,5 @@
 #!/usr/bin/perl -w
-# Copyright 2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 

--- a/script/isotovideo
+++ b/script/isotovideo
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 

--- a/script/vnctest
+++ b/script/vnctest
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-# Copyright 2022 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 

--- a/signalblocker.pm
+++ b/signalblocker.pm
@@ -1,4 +1,4 @@
-# Copyright 2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package signalblocker;

--- a/t/04-check_vars_docu.t
+++ b/t/04-check_vars_docu.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# Copyright 2015 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 
-# Copyright 2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;

--- a/t/07-commands.t
+++ b/t/07-commands.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# Copyright 2016-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 

--- a/t/10-terminal.t
+++ b/t/10-terminal.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 
-# Copyright 2016-2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 use Test::Most;
 use Mojo::Base -signatures;

--- a/t/10-virtio_terminal.t
+++ b/t/10-virtio_terminal.t
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-# Copyright 2020-2021 SUSE LLC
+# Copyright SUSE LLC
 
 use Test::Most;
 use Mojo::Base -signatures;

--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 
-# Copyright 2017-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;

--- a/t/13-osutils.t
+++ b/t/13-osutils.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 
-# Copyright 2017-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;

--- a/t/15-logging.t
+++ b/t/15-logging.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 
-# Copyright 2017-2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;

--- a/t/18-qemu-options.t
+++ b/t/18-qemu-options.t
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-# Copyright 2018-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;

--- a/t/24-myjsonrpc-debug.t
+++ b/t/24-myjsonrpc-debug.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# Copyright 2019-2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 

--- a/t/24-myjsonrpc.t
+++ b/t/24-myjsonrpc.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# Copyright 2019-2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;

--- a/t/26-serial_screen.t
+++ b/t/26-serial_screen.t
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-# Copyright 2019 SUSE LLC
+# Copyright SUSE LLC
 
 use Test::Most;
 use Mojo::Base -signatures;

--- a/t/26-ssh_screen.t
+++ b/t/26-ssh_screen.t
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-# Copyright 2019 SUSE LLC
+# Copyright SUSE LLC
 
 use Test::Most;
 use Mojo::Base -signatures;

--- a/t/26-video_stream.t
+++ b/t/26-video_stream.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 # Copyright 2021 Marek Marczykowski-Górecki
-# Copyright 2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Config;

--- a/t/28-signalblocker.t
+++ b/t/28-signalblocker.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# Copyright 2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # This test covers the signalblocker module and tinycv's helper to create

--- a/t/29-backend-generalhw.t
+++ b/t/29-backend-generalhw.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 
-# Copyright 2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;

--- a/t/30-mmapi.t
+++ b/t/30-mmapi.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# Copyright 2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # This test covers the signalblocker module and tinycv's helper to create

--- a/t/34-git.t
+++ b/t/34-git.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# Copyright 2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;

--- a/t/35-imgsearch.t
+++ b/t/35-imgsearch.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# Copyright 2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;

--- a/t/37-mutparams.t
+++ b/t/37-mutparams.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# Copyright 2022 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 

--- a/t/38-carp-trace.t
+++ b/t/38-carp-trace.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# Copyright 2022 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 

--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-# Copyright 2017-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 

--- a/t/data/tests/lib/testdistribution.pm
+++ b/t/data/tests/lib/testdistribution.pm
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package testdistribution;

--- a/t/data/tests/main.pm
+++ b/t/data/tests/main.pm
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Mojo::Base -strict, -signatures;

--- a/t/data/tests/pythontests/pre_boot.py
+++ b/t/data/tests/pythontests/pre_boot.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 import sys

--- a/testapi.pm
+++ b/testapi.pm
@@ -1,5 +1,5 @@
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package testapi;

--- a/xt/01-style.t
+++ b/xt/01-style.t
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-# Copyright 2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;
@@ -27,4 +27,6 @@ is qx{git grep -l '^use POSIX;'}, '', 'Use of bare POSIX import is discouraged, 
 is qx{git grep --all-match -P -e '^use Mojo::Base' -e '^use base (?!.*# no:style)'}, '', 'No redundant Mojo::Base+base';
 is qx{git grep -I -l -P '^use (warnings|strict)' ':!external/'}, '', 'No files using "warning|strict", should use Mojo::Base instead';
 is qx{git grep -I -l 'sub [a-z_A-Z0-9]\\+()'}, '', 'Consistent space before function signatures (this is not ensured by perltidy)';
+is qx{git grep -I -l -E 'Copyright [0-9]{4}(-?[0-9]{4})? SUSE LLC' ':!external/'}, '', "No files using 'Copyright <year> SUSE LLC'";
+
 done_testing;

--- a/xt/27-make-update-deps.t
+++ b/xt/27-make-update-deps.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright 2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use Test::Most;


### PR DESCRIPTION
Motivation:
Standardize copyright headers across the project and simplify style enforcement.
Explicit years in copyright headers are legally unnecessary under the Berne
Convention and create maintenance overhead.

Design Choices:
- Retroactively removed the year from all SUSE LLC copyright headers.
- Replaced the slow git-log-based style check in xt/01-style.t with a fast
  git grep check that forbids years in SUSE LLC copyright strings.

Benefits:
- Consistent header style across the entire codebase.
- Instantaneous style verification without external git calls.
- Compliance with modern open-source licensing best practices.

Reference:
* https://reuse.software/faq/#years-copyright