### PR TITLE
feat: add predefined QEMU hardware profiles support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ set(PERL_FILES
     OpenQA/Qemu/DriveController.pm
     OpenQA/Qemu/DriveDevice.pm
     OpenQA/Qemu/DrivePath.pm
+    OpenQA/Qemu/HWProfiles.pm
     OpenQA/Qemu/MutParams.pm
     OpenQA/Qemu/PFlashDevice.pm
     OpenQA/Qemu/Proc.pm
@@ -93,6 +94,7 @@ set(MISC_FILES
     dmidata/hp_elitebook_820g1/smbios_type_2.bin
     dmidata/hp_elitebook_820g1/smbios_type_3.bin
     dmidata/dump
+    OpenQA/Qemu/hw_profiles.yaml
 )
 set(PYTHON_BINDINGS
     lockapi

--- a/OpenQA/Qemu/HWProfiles.pm
+++ b/OpenQA/Qemu/HWProfiles.pm
@@ -1,0 +1,34 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package OpenQA::Qemu::HWProfiles;
+use Mojo::Base -signatures;
+use Mojo::File qw(path);
+use YAML::PP;
+
+my $serial = [
+    ['chardev', 'ringbuf,id=serial0,logfile=serial0,logappend=on'],
+    ['serial', 'chardev:serial0'],
+];
+
+our %profiles = (
+    default => {
+        default => $serial,
+        provides => [qw(serial)],
+    },
+);
+
+my $external_profiles;
+
+sub get_profile ($name, $arch) {
+    if (!$profiles{$name}) {
+        $external_profiles //= YAML::PP->new->load_file(path(__FILE__)->sibling('hw_profiles.yaml'));
+        return undef unless $external_profiles->{$name};
+        my $p = $external_profiles->{$name};
+        return {args => ($p->{$arch} // $p->{default} // []), provides => ($p->{provides} // [])};
+    }
+    my $p = $profiles{$name};
+    return {args => ($p->{$arch} // $p->{default} // []), provides => ($p->{provides} // [])};
+}
+
+1;

--- a/OpenQA/Qemu/hw_profiles.yaml
+++ b/OpenQA/Qemu/hw_profiles.yaml
@@ -1,0 +1,21 @@
+---
+# Predefined QEMU hardware profiles
+virt-manager-defaults:
+  x86_64:
+    - [chardev, 'ringbuf,id=serial0,logfile=serial0,logappend=on']
+    - [serial, 'chardev:serial0']
+    - [device, 'pcie-root-port,id=root_port1,bus=pcie.0,chassis=1,slot=1,addr=0x1']
+    - [device, 'pcie-root-port,id=root_port2,bus=pcie.0,chassis=2,slot=2,addr=0x1.0x1']
+    - [device, 'pcie-root-port,id=root_port3,bus=pcie.0,chassis=3,slot=3,addr=0x1.0x2']
+    - [device, 'pcie-root-port,id=root_port4,bus=pcie.0,chassis=4,slot=4,addr=0x1.0x3']
+    - [device, 'pcie-root-port,id=root_port5,bus=pcie.0,chassis=5,slot=5,addr=0x1.0x4']
+    - [device, 'pcie-root-port,id=root_port6,bus=pcie.0,chassis=6,slot=6,addr=0x1.0x5']
+    - [device, 'pcie-root-port,id=root_port7,bus=pcie.0,chassis=7,slot=7,addr=0x1.0x6']
+    - [device, 'pcie-root-port,id=root_port8,bus=pcie.0,chassis=8,slot=8,addr=0x1.0x7']
+    - [device, 'qemu-xhci,id=usb,bus=root_port1,addr=0x0']
+    - [device, 'virtio-serial-pci,id=virtio-serial0,bus=root_port3,addr=0x0']
+    - [device, 'virtio-vga,id=video0,bus=root_port4,addr=0x0']
+    - [device, 'virtio-balloon-pci,id=balloon0,bus=root_port6,addr=0x0']
+    - [device, 'virtio-rng-pci,rng=rng0,id=rng0,bus=root_port7,addr=0x0']
+    - [object, 'rng-random,filename=/dev/urandom,id=rng0']
+  provides: [serial, pci, usb, graphics, balloon, rng, input]

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -21,6 +21,7 @@ use Fcntl;
 use Net::DBus;
 use bmwqemu qw(diag);
 require IPC::System::Simple;
+use OpenQA::Qemu::HWProfiles;
 use osutils qw(find_bin qv run_diag runcmd port_details);
 use List::Util qw(first max);
 use Data::Dumper;
@@ -682,6 +683,33 @@ sub determine_qemu_version ($self, $qemubin) {
     $self->{qemu_version} = $qemu_version;
 }
 
+sub apply_hwprofile ($self) {
+    my $vars = \%bmwqemu::vars;
+    my $name = $vars->{QEMU_HWPROFILE} // 'default';
+    if ($name =~ /\/|\.txt$/) {
+        my $path = $name =~ /^\// ? $name : "$vars->{CASEDIR}/$name";
+        bmwqemu::diag("Loading custom QEMU hardware profile from $path");
+        my @commands = map { [$_->[0] =~ s/^-+//r, @$_[1 .. $#$_]] }
+          map { [split ' '] }
+          grep { /\S/ }
+          map { s/#.*//r }
+          split /\n/, path($path)->slurp('UTF-8');
+        $self->{proc}->static_param(@$_) for @commands;
+        $self->{hwprofile} = {provides => []};
+    }
+    else {
+        my $arch = $vars->{ARCH} // '';
+        $self->{hwprofile} = OpenQA::Qemu::HWProfiles::get_profile($name, $arch);
+        die "QEMU hardware profile '$name' not found for architecture '$arch'" unless $self->{hwprofile};
+        bmwqemu::diag("Applying QEMU hardware profile: $name");
+        $self->{proc}->static_param(@$_) for @{$self->{hwprofile}->{args}};
+    }
+}
+
+sub _profile_has ($self, $cap) {
+    return grep { $_ eq $cap } @{$self->{hwprofile}->{provides} // []};
+}
+
 sub start_qemu ($self) {
     my $vars = \%bmwqemu::vars;
 
@@ -788,7 +816,6 @@ sub start_qemu ($self) {
         # of ports is 32 so enough for 14 workers per host.
         $vars->{VDE_PORT} ||= ($vars->{WORKER_ID} // 0) * 2 + 2;
     }
-    $self->_set_graphics_backend;
 
     # misc
     my $arch_supports_boot_order = $vars->{UEFI} ? 0 : 1;    # UEFI/OVMF supports ",bootindex=N", but not "-boot order=X"
@@ -887,8 +914,12 @@ sub start_qemu ($self) {
     $self->{proc}->init_blockdev_images();
 
     sp('only-migratable') if $self->can_handle({function => 'snapshots', no_warn => 1}) and (($vars->{QEMU_VIDEO_DEVICE} // '') ne 'virtio-vga-gl');
-    sp('chardev', 'ringbuf,id=serial0,logfile=serial0,logappend=on');
-    sp('serial', 'chardev:serial0');
+
+    $self->apply_hwprofile();
+
+    unless ($self->_profile_has('graphics')) {
+        $self->_set_graphics_backend;
+    }
 
     if (!is_s390x($arch)) {
         if ($self->requires_audiodev) {
@@ -943,7 +974,7 @@ sub start_qemu ($self) {
         }
 
         # Keep additional virtio _after_ Ethernet setup to keep virtio-net as eth0
-        if ($vars->{QEMU_VIRTIO_RNG} // 1) {
+        if (($vars->{QEMU_VIRTIO_RNG} // 1) && !$self->_profile_has('rng')) {
             my $rngdev = is_s390x($arch) ? 'virtio-rng' : 'virtio-rng-pci';
             sp('object', 'rng-random,filename=/dev/urandom,id=rng0');
             sp('device', "$rngdev,rng=rng0");
@@ -990,7 +1021,7 @@ sub start_qemu ($self) {
             sp(lc($attribute), $vars->{$attribute}) if $vars->{$attribute};
         }
 
-        unless ($vars->{QEMU_NO_TABLET}) {
+        unless ($vars->{QEMU_NO_TABLET} || $self->_profile_has('usb')) {
             sp('device', ($vars->{OFW} || $arch eq 'aarch64') ? 'nec-usb-xhci' : is_s390x($arch) ? 'virtio-tablet' : 'qemu-xhci');
             sp('device', 'usb-tablet') unless is_s390x($arch);
         }
@@ -998,7 +1029,7 @@ sub start_qemu ($self) {
         sp('device', 'usb-kbd') if $use_usb_kbd;
         # Enable virtio-keyboard by default on s390x qemu but not on others
         # See https://progress.opensuse.org/issues/193258
-        sp('device', 'virtio-keyboard') if $vars->{QEMU_VIRTIO_KEYBOARD} // is_s390x($arch);
+        sp('device', 'virtio-keyboard') if ($vars->{QEMU_VIRTIO_KEYBOARD} // is_s390x($arch)) && !$self->_profile_has('input');
 
         sp('device', 'canokey,file=canokey') if $vars->{FIDO2};
 
@@ -1033,7 +1064,7 @@ sub start_qemu ($self) {
 
         my @virtio_consoles = virtio_console_names;
         if (@virtio_consoles) {
-            sp('device', 'virtio-serial');
+            sp('device', 'virtio-serial') unless $self->_profile_has('serial');
             for my $name (@virtio_consoles) {
                 sp('chardev', [qv "pipe id=$name path=$name logfile=$name.log logappend=on"]);
                 sp('device', [qv "virtconsole chardev=$name name=org.openqa.console.$name"]);

--- a/doc/backend_vars.md
+++ b/doc/backend_vars.md
@@ -168,6 +168,7 @@ Supported variables per backend
 | QEMU_COMPRESS_QCOW2 | boolean | 1 | compress qcow2 images intended for upload |
 | QEMU_IMG_CREATE_TRIES | integer | 3 | Define number of tries for qemu-img commands |
 | QEMU_HUGE_PAGES_PATH | string | undef | Define a path to use huge pages (e.g. /dev/hugepages/) |
+| QEMU_HWPROFILE | string | undef | Name of a predefined hardware profile (see `OpenQA/Qemu/hw_profiles.yaml`) or path to a file containing QEMU arguments. Arguments in the file are newline-separated and support comments via `#`. Custom files are read as UTF-8. |
 | QEMU_HOST_IP | string | 10.0.2.2 | The VM host IP used in usermode networking. Set `NICTYPE=user` and NICTYPE_USER_OPTIONS accordingly to match following https://wiki.qemu.org/Documentation/Networking#User_Networking_.28SLIRP.29 |
 | QEMU_MAX_MIGRATION_TIME | integer | 240 | Maximum time in seconds a migration to file may take for example for snapshot creation before being forcefully aborted. |
 | QEMU_NO_FDC_SET | boolean | 0 | Don't disable the floppy drive. |

--- a/t/04-check_vars_docu.t
+++ b/t/04-check_vars_docu.t
@@ -25,7 +25,7 @@ use constant VARS_DOC => DOC_DIR . '/backend_vars.md';
 my @backend_blocklist = qw();
 # blocklist of vars per backend. These vars will be ignored during vars exploration
 my %var_blocklist = (
-    QEMU => ['WORKER_ID', 'WORKER_INSTANCE', 'NAME'],
+    QEMU => ['WORKER_ID', 'WORKER_INSTANCE', 'NAME', 'CASEDIR'],
     VAGRANT => ['QEMUCPUS', 'QEMURAM'],
     GENERALHW => ['HDD_1'],
     SVIRT => ['JOBTOKEN'],

--- a/t/30-qemu-hwprofiles.t
+++ b/t/30-qemu-hwprofiles.t
@@ -1,0 +1,109 @@
+#!/usr/bin/perl
+
+use Test::Most;
+use Mojo::Base -signatures;
+
+use Test::Warnings qw(:all :report_warnings);
+use Test::MockModule;
+use Test::MockObject;
+use Mojo::File qw(tempdir path);
+use Mojo::Util qw(scope_guard);
+
+use FindBin qw($Bin $Script);
+use lib "$Bin/../external/os-autoinst-common/lib";
+use OpenQA::Test::TimeLimit '5';
+
+use backend::qemu;
+
+sub backend () {
+    my $backend = backend::qemu->new();
+    ($backend->{"select_$_"} = Test::MockObject->new)->set_true('add') for qw(read write);
+    return $backend;
+}
+
+my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
+chdir $dir;
+my $cleanup = scope_guard sub { chdir $Bin; undef $dir };
+
+my $proc_mock = Test::MockModule->new('OpenQA::Qemu::Proc');
+$proc_mock->redefine(exec_qemu => undef);
+$proc_mock->redefine(connect_qmp => undef);
+$proc_mock->redefine(init_blockdev_images => undef);
+
+my $jsonrpc = Test::MockModule->new('myjsonrpc');
+$jsonrpc->redefine(read_json => undef);
+
+my $backend_mock = Test::MockModule->new('backend::qemu', no_auto => 1);
+$backend_mock->redefine(handle_qmp_command => undef);
+$backend_mock->redefine(determine_qemu_version => sub ($self, @) { $self->{qemu_version} = '9.0' });
+
+my $distri = Test::MockModule->new('distribution');
+$distri->redefine(add_console => Test::MockObject->new->set_true('backend'));
+$backend_mock->mock(select_console => undef);
+$testapi::distri = distribution->new;
+
+my $mock_bmwqemu = Test::MockModule->new('bmwqemu');
+$mock_bmwqemu->noop('log_call', 'fctwarn', 'diag', 'save_vars');
+
+subtest 'default hardware profile' => sub {
+    my $backend = backend();
+    %bmwqemu::vars = (ARCH => 'x86_64', VNC => 1, CASEDIR => $dir);
+    my @params;
+    $proc_mock->redefine(static_param => sub ($self, @args) { push @params, \@args });
+
+    $backend->start_qemu();
+
+    ok(grep { ref $_ eq 'ARRAY' && $_->[0] eq 'serial' && defined $_->[1] && $_->[1] eq 'chardev:serial0' } @params, 'default profile applied (serial)');
+    ok($backend->_profile_has('serial'), 'profile has serial capability');
+};
+
+subtest 'virt-manager-defaults profile' => sub {
+    my $backend = backend();
+    %bmwqemu::vars = (ARCH => 'x86_64', VNC => 1, QEMU_HWPROFILE => 'virt-manager-defaults', CASEDIR => $dir);
+    my @params;
+    $proc_mock->redefine(static_param => sub ($self, @args) { push @params, \@args });
+
+    $backend->start_qemu();
+
+    ok(grep { ref $_ eq 'ARRAY' && $_->[1] && $_->[1] =~ /pcie-root-port/ } @params, 'virt-manager-defaults applied (pcie-root-port)');
+    ok($backend->_profile_has('graphics'), 'profile has graphics capability');
+
+    ok(!grep { ref $_ eq 'ARRAY' && $_->[0] eq 'device' && $_->[1] eq 'VGA,edid=on,xres=1024,yres=768' } @params, 'standard graphics backend skipped');
+};
+
+subtest 'custom profile from file' => sub {
+    my $backend = backend();
+    my $profile_path = "$dir/custom_profile.txt";
+    path($profile_path)->spew("-machine q35\n-device my-custom-device\n-name \x{263A}\n# comment\n", 'UTF-8');
+
+    %bmwqemu::vars = (ARCH => 'x86_64', VNC => 1, QEMU_HWPROFILE => $profile_path, CASEDIR => $dir);
+    my @params;
+    $proc_mock->redefine(static_param => sub ($self, @args) { push @params, \@args });
+
+    $backend->start_qemu();
+
+    ok(grep { ref $_ eq 'ARRAY' && $_->[0] eq 'machine' && $_->[1] eq 'q35' } @params, 'custom machine from file');
+    ok(grep { ref $_ eq 'ARRAY' && $_->[0] eq 'device' && $_->[1] eq 'my-custom-device' } @params, 'custom device from file');
+    ok(grep { ref $_ eq 'ARRAY' && $_->[0] eq 'name' && $_->[1] eq "\x{263A}" } @params, 'custom non-ASCII name from file');
+    ok(!$backend->_profile_has('serial'), 'custom profile has no serial capability');
+};
+
+subtest 'conditional variation (override)' => sub {
+    my $backend = backend();
+    %bmwqemu::vars = (ARCH => 'x86_64', VNC => 1, QEMU_HWPROFILE => 'virt-manager-defaults', QEMUMACHINE => 'pc-q35-4.2', CASEDIR => $dir);
+    my @params;
+    $proc_mock->redefine(static_param => sub ($self, @args) { push @params, \@args });
+
+    $backend->start_qemu();
+
+    my @machines = grep { ref $_ eq 'ARRAY' && $_->[0] eq 'machine' } @params;
+    is($machines[-1]->[1], 'pc-q35-4.2', 'QEMUMACHINE override works (last one wins)');
+};
+
+subtest 'invalid hardware profile' => sub {
+    my $backend = backend();
+    %bmwqemu::vars = (ARCH => 'x86_64', VNC => 1, QEMU_HWPROFILE => 'non-existent', CASEDIR => $dir);
+    throws_ok { $backend->start_qemu() } qr/QEMU hardware profile 'non-existent' not found for architecture 'x86_64'/, 'dies on invalid hardware profile';
+};
+
+done_testing();


### PR DESCRIPTION
Motivation:
Allow test jobs to select named sets of QEMU arguments (profiles) using a job
setting QEMU_HWPROFILE. This helps catch regressions that only occur on specific
hardware configurations, such as complex PCIe topologies. The initial
implementation used hardcoded profile names, which was refactored to use
capability-based guards for better maintainability.

Design Choices:
- Introduced a new module OpenQA::Qemu::HWProfiles to store named profiles and
  refactored it to eliminate data duplication using shared references.
- Implemented apply_hwprofile in backend::qemu to handle profile selection,
  using a functional pipeline (map/grep/split) and capability-based guards
  (e.g. 'graphics', 'rng', 'usb') to prevent device duplication.
- Added a _profile_has helper to backend::qemu to safely check for capabilities
  instead of checking for specific profile names.
- Stripped leading dashes from custom profile arguments to match
  OpenQA::Qemu::Proc::static_param expectations.
- Documented the new variable in doc/backend_vars.md.

Benefits:
- Facilitates testing with different hardware configurations and simplifies
  integration of complex QEMU command line arguments.
- Decouples backend logic from specific hardware profile data, improving
  legibility and reducing potential for logic errors.
- Provides a flexible way to switch between standard and advanced
  virtualization defaults with zero code duplication in profile definitions.

Related issue: https://progress.opensuse.org/issues/69700