### PR TITLE
fix: re-install serial marker hook after console reset

### DIFF
--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -9,7 +9,7 @@ use Mojo::Base -strict, -signatures;
 # -> increment on every change of such APIs
 # -> never move that variable to another place (when refactoring)
 #    because it may be accessed by the tests itself
-our $version = 54;
+our $version = 55;
 
 # major version of the (web socket) API relevant to the developer mode
 # -> increment when making non-backward compatible changes to that API

--- a/distribution.pm
+++ b/distribution.pm
@@ -15,6 +15,7 @@ sub new ($class, @) {
     $self->{serial_failures} = [];
     $self->{autoinst_failures} = [];
     $self->{_serial_marker_level} = {};
+    $self->{_serial_marker_hook_installed} = {};
 
 =head2 serial_term_prompt
 
@@ -450,6 +451,11 @@ sub install_serial_marker_hook ($self, $level) {
     testapi::type_string $hook_cmd;
     my $console = testapi::current_console() // 'sut';
     $self->{_serial_marker_hook_installed}->{$console} = 1;
+}
+
+sub reset_console_cache ($self, $console) {
+    delete $self->{_serial_marker_level}->{$console};
+    delete $self->{_serial_marker_hook_installed}->{$console};
 }
 
 =head2 _detect_serial_marker_capability

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -137,6 +137,21 @@ subtest 'pretty_serial_marker' => sub {
     throws_ok { $d->script_run('foo') } qr/typing command 'foo' timed out/, 'typing error handled in Level 1';
 };
 
+subtest 'serial_marker_reinstall_cached_level' => sub {
+    my $d = distribution->new;
+    my $mock_testapi = Test::MockModule->new('testapi');
+    $mock_testapi->redefine(current_console => sub { 'test-console' });
+    my $typed = '';
+    $mock_testapi->redefine(type_string => sub { $typed .= $_[0] });
+
+    $d->{_serial_marker_level}->{'test-console'} = 2;
+    delete $d->{_serial_marker_hook_installed}->{'test-console'};
+
+    is $d->_detect_serial_marker_capability(), 2, 'Returns cached level 2';
+    like $typed, qr/PROMPT_COMMAND=/, 'Calls install_serial_marker_hook (types PROMPT_COMMAND)';
+    ok $d->{_serial_marker_hook_installed}->{'test-console'}, 'Hook marked as installed';
+};
+
 subtest 'reboot_safety' => sub {
     my $d = distribution->new;
     my $mock_testapi = Test::MockModule->new('testapi');
@@ -174,11 +189,21 @@ subtest 'reboot_safety' => sub {
     like $typed_string, qr/bar\n/, 'Command typed';
 
     # Case 2: manual clear (e.g. if we know it was lost)
-    delete $d->{_serial_marker_hook_installed}->{'test-console'};
+    $d->reset_console_cache('test-console');
     $typed_string = '';
     $d->script_run('baz');
-    like $typed_string, qr/PROMPT_COMMAND=.*OA:DONE/, 'Re-install if missing';
-    like $typed_string, qr/baz\n/, 'Command typed after re-install';
+    like $typed_string, qr/PROMPT_COMMAND=.*OA:DONE/, 'Re-detect and re-install after resetting the console cache';
+    like $typed_string, qr/baz\n/, 'Command typed after re-installation';
+
+    # Case 3: select_console triggers reset
+    $d->{_serial_marker_hook_installed}->{'test-console'} = 1;
+    $typed_string = '';
+    $mock_testapi->redefine(query_isotovideo => sub { return {activated => 1} });
+    $testapi::distri = $d;
+
+    testapi::select_console('test-console');
+    $d->script_run('qux');
+    like $typed_string, qr/BASH:/, 'Re-detect after select_console re-activates the console';
 };
 
 subtest 'sut_marker' => sub {

--- a/testapi.pm
+++ b/testapi.pm
@@ -1706,6 +1706,7 @@ sub select_console ($testapi_console, @args) {
     $autotest::selected_console = $testapi_console;
     if ($ret->{activated}) {
         push @$autotest::activated_consoles, $testapi_console;
+        $testapi::distri->reset_console_cache($testapi_console);
         $testapi::distri->activate_console($testapi_console, @args);
     }
     $testapi::distri->console_selected($testapi_console, @args);


### PR DESCRIPTION
Motivation:
Pretty serial markers rely on shell hooks (PROMPT_COMMAND) installed in the
SUT. When the OS changes (e.g. after installation), these hooks are lost,
but os-autoinst kept using its cached knowledge of the hook being installed.

Design Choices:
Added reset_console_cache to distribution.pm and hooked it into
testapi::select_console. When a console is re-activated (e.g. after a
reboot or explicit reset), the cached serial marker state is cleared,
forcing re-detection and re-installation of the hook on the next command.

Benefits:
Ensures pretty serial markers work correctly across reboots and OS
transitions without manual intervention in test scripts.

Manual verification:
* https://openqa.suse.de/tests/22089177#step/system_prepare/7

Related issue: https://progress.opensuse.org/issues/183761