### PR TITLE
feat: Improve message when aborting if there is not enough storage

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -185,11 +185,12 @@ sub _abort_if_storage_limit_exceeded () {
     my $requested_bytes = $total_hdd_size_gb * GIB;
     my $min_free_bytes = $total_storage * $keep_free;
     my $keep_free_gb = $vars{STORAGE_KEEP_FREE_GB} // STORAGE_KEEP_FREE_GB;
-    my $relative_exceeded = $requested_bytes > $available - $min_free_bytes;
+    my $relative_available = $available - $min_free_bytes;
+    my $relative_exceeded = $requested_bytes > $relative_available;
     my $absolute_exceeded = $keep_free_gb > 0 && $requested_bytes > $available - ($keep_free_gb * GIB);
     return undef unless $relative_exceeded && $absolute_exceeded;
-    my $msg = sprintf 'Not enough storage for requested HDDSIZEGB (requested %d GiB, available %d GiB, total %d GiB, keep-free %d%%)',
-      $total_hdd_size_gb, int($available / GIB), int($total_storage / GIB), int($keep_free * 100);
+    my $msg = sprintf 'Not enough storage for requested HDDSIZEGB (requested %d GiB, available keeping %d%% free: %d GiB, generally available %d GiB, total %d GiB)',
+      $total_hdd_size_gb, int($keep_free * 100), $relative_available > 0 ? int($relative_available / GIB) : 0, int($available / GIB), int($total_storage / GIB);
     serialize_state(result => 'incomplete', msg => $msg);
     die "$msg\n";
 }

--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -191,7 +191,11 @@ subtest 'abort on low disk space' => sub {
         {hdd_size_gb => 10, total_storage => 100, avail_storage => 100, expect => 'pass',
             desc => 'succeed if requested HDDSIZEGB is well within available space'},
         {hdd_size_gb => 60, total_storage => 5, avail_storage => 5, expect => 'fail', extra_vars => {STORAGE_KEEP_FREE_RATIO => 0.9},
-            desc => 'abort if requested HDDSIZEGB exceeds custom threshold'},
+            desc => 'abort if requested HDDSIZEGB exceeds available storage (keeping certain ratio free) which is already negative anyway',
+            expected_stats => 'requested 60 GiB, available keeping 90% free: 0 GiB, generally available 5 GiB, total 5 GiB'},
+        {hdd_size_gb => 30, total_storage => 36, avail_storage => 30, expect => 'fail', extra_vars => {STORAGE_KEEP_FREE_RATIO => 0.2},
+            desc => 'abort if requested HDDSIZEGB exceeds available storage (keeping certain ratio free)',
+            expected_stats => 'requested 30 GiB, available keeping 20% free: 22 GiB, generally available 30 GiB, total 36 GiB'},
         {hdd_size_gb => 1, total_storage => 1, avail_storage => 0.1, expect => 'pass', extra_vars => {STORAGE_KEEP_FREE_RATIO => 0},
             desc => 'succeed if requested HDDSIZEGB exceeds available space but ratio is 0'},
         {total_storage => 100, avail_storage => 100, expect => 'pass',
@@ -223,7 +227,8 @@ subtest 'abort on low disk space' => sub {
             lives_ok { bmwqemu::init(); bmwqemu::ensure_valid_vars(); } $case->{desc};
         }
         else {
-            throws_ok { bmwqemu::init(); bmwqemu::ensure_valid_vars(); } qr/Not enough storage for requested HDDSIZEGB/, $case->{desc};
+            my $stats = $case->{expected_stats} // '';
+            throws_ok { bmwqemu::init(); bmwqemu::ensure_valid_vars(); } qr/Not enough storage for requested HDDSIZEGB.*$stats/, $case->{desc};
             is decode_json(path(bmwqemu::STATE_FILE)->slurp)->{result}, 'incomplete', "serialized result is incomplete for: $case->{desc}";
         }
     }


### PR DESCRIPTION
With the current message one gets e.g. `requested 25 GiB, available 30 GiB, …` which is confusing because `25 < 30`. This commit changes the message to e.g. `requested 25 GiB, available keeping 20 % free: 22 GiB, generally available 30 GiB, …` where `22 < 25` which makes more sense.

Related ticket: https://progress.opensuse.org/issues/199790