### PR TITLE
fix: handle pre-marker pending text in script_output

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -353,7 +353,7 @@ sub script_output ($self, $script, @args) {
     }
 
     # and the markers including internal exit catcher
-    my $out = $output =~ /(?:^|\r?\n)$marker\r?\n(?<expected_output>.*?)SCRIPT_FINISHED$marker-\d+-/s ? $+ : '';
+    my $out = $output =~ /$marker\r?\n(?<expected_output>.*?)SCRIPT_FINISHED$marker-\d+-/s ? $+ : '';
     # trim whitespaces
     $out =~ s/^\s+|\s+$//g;
     return $out;

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -805,6 +805,9 @@ sub script_output_test ($is_serial_terminal) {
     $mock_testapi->redefine(wait_serial => "XXX\nfoo\nSCRIPT_FINISHEDXXX-1-");
     is(script_output('echo foo', undef, proceed_on_failure => 1), 'foo', 'proceed_on_failure=1 retrieves retrieves output of script and do not die');
 
+    $mock_testapi->redefine(wait_serial => "login: XXX\nfoo\nSCRIPT_FINISHEDXXX-0-");
+    is(script_output('echo foo'), 'foo', 'script_output handles pre-marker pending text correctly');
+
     $mock_testapi->redefine(wait_serial => sub { return 'none' unless $_[0] =~ /SCRIPT_FINISHEDXXX/; return; });
     throws_ok { script_output('timeout'); } qr/timeout/, 'die expected with timeout';
 


### PR DESCRIPTION
Motivation:
The recent commit to fix `pretty_serial_markers` introduced a strict
start-of-line anchor `(?:^|\r?\n)` to the regex matching the serial marker.
However, this causes failures when the marker is preceded by terminal output
that lacks a newline (e.g., `susetest login: dKaeI`), leading to
`Argument "" isn't numeric in int` errors when reading empty strings.

Design Choices:
The regex in `distribution.pm` was updated to remove the strict prefix
anchoring, keeping only the `\r?\n` suffix constraint to ensure the output
doesn't capture any trace prefixes. This safely handles scenarios where the
start marker follows pending, un-newline-terminated text on the serial console,
while still preventing unintended capturing of bash traces like `.sh` or `;`.
A corresponding test case was added to `t/03-testapi.t`.

Benefits:
Fixes test regressions (like `reboot_plasma5`) where pending terminal text
prevented matching the `script_output` markers, ensuring `script_output` works
robustly across all scenarios without false positives.

Manual verification:
https://openqa.opensuse.org/tests/5890304 (passed)

Related issue: https://progress.opensuse.org/issues/183761