### PR TITLE
fix: restore serial marker hook after switching users

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -85,6 +85,7 @@ sub become_root ($self) {
     testapi::enter_cmd('test $(id -u) -eq 0 && echo "imroot" > /dev/' . $testapi::serialdev, 0);
     testapi::wait_serial('imroot') || die 'Root prompt not there';
     testapi::enter_cmd('cd /tmp');
+    $self->invalidate_serial_marker_hook();
 }
 
 =head 2 disable_key_repeat
@@ -449,12 +450,49 @@ sub install_serial_marker_hook ($self, $level) {
     my $marker_match = 'OA:START';
     my $hook_cmd = "for f in ~/.bashrc ~/.profile; do grep -q '$marker_match' \"\$f\" 2>/dev/null || cat <<'EOF' >> \"\$f\"\n$pc\nEOF\ndone\n";
     testapi::type_string $hook_cmd;
-    my $console = testapi::current_console() // 'sut';
+    my $console = testapi::current_console();
+    return undef unless defined $console;
     $self->{_serial_marker_hook_installed}->{$console} = 1;
 }
 
-sub reset_console_cache ($self, $console) {
+=head2 reset_serial_marker
+
+  reset_serial_marker([$console])
+
+Perform a full reset of the serial marker state for the given C<$console> (or
+the current console if omitted). This clears both the detected shell capability
+level and the hook installation status, forcing a complete re-detection and
+re-installation on the next command.
+
+Useful when the console environment has fundamentally changed, such as after
+a reboot or when switching to a different OS/shell.
+
+=cut
+
+sub reset_serial_marker ($self, $console = undef) {
+    $console //= testapi::current_console();
+    return undef unless defined $console;
     delete $self->{_serial_marker_level}->{$console};
+    $self->invalidate_serial_marker_hook($console);
+}
+
+=head2 invalidate_serial_marker_hook
+
+  invalidate_serial_marker_hook([$console])
+
+Invalidate the synchronization hook (e.g. C<PROMPT_COMMAND>) for the given
+C<$console> (or the current console if omitted). Unlike L</reset_serial_marker>,
+this preserves the detected shell capability level.
+
+Useful when switching users within the same shell (e.g. via C<sudo> or C<su>),
+where we know the shell still supports the same level of markers, but the
+environment-specific hook needs to be re-installed for the new user.
+
+=cut
+
+sub invalidate_serial_marker_hook ($self, $console = undef) {
+    $console //= testapi::current_console();
+    return undef unless defined $console;
     delete $self->{_serial_marker_hook_installed}->{$console};
 }
 
@@ -471,7 +509,8 @@ Returns:
 =cut
 
 sub _detect_serial_marker_capability ($self) {
-    my $console = testapi::current_console() // 'sut';
+    my $console = testapi::current_console();
+    return 1 unless defined $console;
     if (my $level = $self->{_serial_marker_level}->{$console}) {
         return $level if $level < 2 || $self->{_serial_marker_hook_installed}->{$console};
 

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -145,7 +145,7 @@ subtest 'serial_marker_reinstall_cached_level' => sub {
     $mock_testapi->redefine(type_string => sub { $typed .= $_[0] });
 
     $d->{_serial_marker_level}->{'test-console'} = 2;
-    delete $d->{_serial_marker_hook_installed}->{'test-console'};
+    $d->invalidate_serial_marker_hook('test-console');
 
     is $d->_detect_serial_marker_capability(), 2, 'Returns cached level 2';
     like $typed, qr/PROMPT_COMMAND=/, 'Calls install_serial_marker_hook (types PROMPT_COMMAND)';
@@ -189,10 +189,10 @@ subtest 'reboot_safety' => sub {
     like $typed_string, qr/bar\n/, 'Command typed';
 
     # Case 2: manual clear (e.g. if we know it was lost)
-    $d->reset_console_cache('test-console');
+    $d->reset_serial_marker('test-console');
     $typed_string = '';
     $d->script_run('baz');
-    like $typed_string, qr/PROMPT_COMMAND=.*OA:DONE/, 'Re-detect and re-install after resetting the console cache';
+    like $typed_string, qr/PROMPT_COMMAND=.*OA:DONE/, 'Re-detect and re-install after resetting the serial marker';
     like $typed_string, qr/baz\n/, 'Command typed after re-installation';
 
     # Case 3: select_console triggers reset

--- a/testapi.pm
+++ b/testapi.pm
@@ -1706,7 +1706,7 @@ sub select_console ($testapi_console, @args) {
     $autotest::selected_console = $testapi_console;
     if ($ret->{activated}) {
         push @$autotest::activated_consoles, $testapi_console;
-        $testapi::distri->reset_console_cache($testapi_console);
+        $testapi::distri->reset_serial_marker($testapi_console);
         $testapi::distri->activate_console($testapi_console, @args);
     }
     $testapi::distri->console_selected($testapi_console, @args);


### PR DESCRIPTION
Motivation
When a test switches users on the same GUI console (e.g., using `su -`
via `become_root`), the new shell environment no longer has the serial
marker hook (PROMPT_COMMAND) installed if it was only installed for the
previous user. This causes subsequent `script_run` calls to time out
waiting for the `OA:DONE` marker.

Design Choices
We add an `invalidate_serial_marker_hook` method to `distribution.pm`
and call it at the end of `become_root` within `distribution.pm`. This
forces the backend to reinstall the hook on the next `script_run` for the
new user, ensuring the synchronization markers are properly emitted.

As part of this change, we also refactored the marker reset API for
clarity:
- Renamed `reset_console_cache` to `reset_serial_marker` (full reset of
  capabilities and hook).
- Introduced `invalidate_serial_marker_hook` (invalidation of the hook
  while preserving detected capabilities).

Benefits
Ensures reliable command synchronization after user switching while
avoiding redundant re-detection overhead in `script_sudo`. The codebase
maintainability is improved through clearer naming and detailed POD
documentation of the marker state management.

Manual verification:
https://openqa.opensuse.org/tests/5890577

Related issue: https://progress.opensuse.org/issues/183761