### PR TITLE
fix: ensure serial buffer is cleared during backend_clear_serial_buffer

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -843,6 +843,9 @@ previous test's serial output. Call this before you start doing something new
 =cut
 
 sub clear_serial_buffer ($self, @) {
+    if (my $screen = $self->{current_screen}) {
+        $screen->clear_buffer() if $screen->can('clear_buffer');
+    }
     $self->{serial_offset} = -s $self->{serialfile};
     return $self->{serial_offset};
 }

--- a/consoles/serial_screen.pm
+++ b/consoles/serial_screen.pm
@@ -293,6 +293,20 @@ sub peak ($self, %nargs) {
     return $self->{carry_buffer};
 }
 
+=head2 clear_buffer
+
+Drain any pending data from the non-blocking socket and empty the internal carry buffer.
+
+=cut
+
+sub clear_buffer ($self) {
+    my $buf;
+    while (sysread $self->{fd_read}, $buf, SOCKET_READ_BUFFER_SIZE) {
+        # Drain the non-blocking socket
+    }
+    $self->{carry_buffer} = '';
+}
+
 sub current_screen ($self) { 0 }
 
 sub request_screen_update ($self, @) { }

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -616,7 +616,33 @@ subtest 'requesting full screen update' => sub {
 
 is($baseclass->get_wait_still_screen_on_here_doc_input({}), 0, 'wait_still_screen on here doc is off by default!');
 
+subtest 'clear_serial_buffer' => sub {
+    my $serialfile = tempfile;
+    $serialfile->spew('initial content');
+    local $baseclass->{serialfile} = $serialfile->to_string;
+
+    subtest 'with screen supporting clear_buffer' => sub {
+        my $mock_screen = Test::MockObject->new();
+        $mock_screen->mock('clear_buffer', sub { pass 'clear_buffer called on screen' });
+        local $baseclass->{current_screen} = $mock_screen;
+        $baseclass->clear_serial_buffer();
+        $mock_screen->called_ok('clear_buffer');
+    };
+
+    subtest 'without current_screen' => sub {
+        local $baseclass->{current_screen} = undef;
+        lives_ok { $baseclass->clear_serial_buffer() } 'works without current_screen';
+    };
+
+    subtest 'with screen without clear_buffer' => sub {
+        my $mock_screen = Test::MockObject->new();
+        local $baseclass->{current_screen} = $mock_screen;
+        lives_ok { $baseclass->clear_serial_buffer() } 'works with screen without clear_buffer';
+    };
+};
+
 subtest 'corner cases of do_capture/run_capture_loop' => sub {
+
     # note: This test covers a few corner cases of do_capture that are not otherwise covered anyways:
     #       using external video encoder, stall detection, screen update request, unresponsive console
 

--- a/t/26-serial_screen.t
+++ b/t/26-serial_screen.t
@@ -8,6 +8,7 @@ use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use consoles::serial_screen;
+use File::Temp ();
 
 my $screen = consoles::serial_screen->new('read', 'write');
 is($screen->{fd_write}, 'write', 'Check if channel was set for write fd');
@@ -23,5 +24,18 @@ dies_ok { $screen->release_key } 'release_key dies with error';
 dies_ok { $screen->send_key({key => 'space'}) } 'send_key dies for most keys';
 is $screen->current_screen, 0, 'no current screen';
 is $screen->request_screen_update, undef, 'can call request_screen_update';
+my ($fh_read, $filename) = File::Temp::tempfile();
+print $fh_read 'some data';
+seek $fh_read, 0, 0;
+$screen = consoles::serial_screen->new($fh_read);
+$screen->{carry_buffer} = 'stale data';
+$screen->clear_buffer();
+is $screen->{carry_buffer}, '', 'carry_buffer is cleared (with data)';
+my $res = sysread $fh_read, my $buf, 4096;
+is $res, 0, 'socket/fh is drained';
+seek $fh_read, 0, 2;
+$screen->{carry_buffer} = 'more stale data';
+$screen->clear_buffer();
+is $screen->{carry_buffer}, '', 'carry_buffer is cleared (without data)';
 
 done_testing;


### PR DESCRIPTION
Motivation:
When using PRETTY_SERIAL_MARKER=1, tests rely on the OA:DONE markers for
synchronization. However, after a VM resumes from a snapshot, unconsumed
serial data from the previous state might be flushed into the buffer.
The existing backend_clear_serial_buffer command only updated the file
offset but did not clear the live carry_buffer in the serial_screen
object. This might have led to false positive matches on stale markers,
especially causing first-after-snapshot tests like zypper_lr to fail.

Design Choices:
1. Add a clear_buffer method to consoles::serial_screen to drain the
   non-blocking socket and empty the internal carry_buffer.
2. Update backend::baseclass::clear_serial_buffer to invoke the new
   clear_buffer method on the active console. This ensures that the live
   interactive state is fully reset alongside the file offset.

Benefits:
Fixes a race condition during snapshot restores when using advanced
serial markers. Tests are now more robust against stale data lingering
in the serial communication pipe, ensuring reliable command-to-result
synchronization.

Manual verification:

```
openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org/t5916451 _GROUP=0 {TEST,BUILD}+=-okurz-pretty PRETTY_SERIAL_MARKER=1 WORKER_CLASS=openqaworker24
```

![[opensuse-Tumbleweed-DVD-x86_64-Build20260510-gnome@64bit](https://openqa.opensuse.org/tests/5917783)](https://openqa.opensuse.org/tests/5917783/badge)

Related issue: https://progress.opensuse.org/issues/183761