### PR TITLE
Potential fix for code scanning alert no. 8: Multiplication result converted to larger type

### DIFF
--- a/ppmclibs/tinycv_ast2100.cc
+++ b/ppmclibs/tinycv_ast2100.cc
@@ -300,7 +300,7 @@ static void idctqtab(unsigned char* qin, PREC* qout, double scale)
 
     for (i = 0; i < 8; i++)
         for (j = 0; j < 8; j++)
-            qout[zig[i * 8 + j]] = qin[i * 8 + j] * aaidct[i] * aaidct[j] * scale;
+            qout[zig[i * 8 + j]] = static_cast<double>(qin[i * 8 + j]) * aaidct[i] * aaidct[j] * scale;
 }
 
 static void setpalette(int* co, int cy, int cb, int cr)


### PR DESCRIPTION
Potential fix for [https://github.com/os-autoinst/os-autoinst/security/code-scanning/8](https://github.com/os-autoinst/os-autoinst/security/code-scanning/8)

To fix this safely without changing intended functionality, cast one multiplicand to `double` at the beginning of the product so all subsequent multiplications are performed in `double`. This avoids intermediate `float` overflow/precision loss before the final assignment.

Best targeted change in `ppmclibs/tinycv_ast2100.cc`:
- In `idctqtab(...)`, line 303 region, update the RHS expression so the first term is explicitly converted to `double` using `static_cast<double>(...)`.
- No new headers/imports are needed.
- Keep logic and indexing unchanged.

Recommended replacement:
- From:
  - `qout[zig[i * 8 + j]] = qin[i * 8 + j] * aaidct[i] * aaidct[j] * scale;`
- To:
  - `qout[zig[i * 8 + j]] = static_cast<double>(qin[i * 8 + j]) * aaidct[i] * aaidct[j] * scale;`


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
