### PR TITLE
feat: add optimized helpers for per-module PRETTY_SERIAL_MARKER control

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -437,7 +437,7 @@ sub record_serialresult ($self, $ref, $res, $string = undef, %args) {
     # take screenshot for documentation (screenshot does not represent fail itself)
     $self->take_screenshot() unless (testapi::is_serial_terminal);
 
-    my $pretty = testapi::get_var('PRETTY_SERIAL_MARKER') || testapi::get_var('HIDE_MARKER_EVALUATION');
+    my $pretty = $testapi::distri ? $testapi::distri->get_pretty_serial_marker() : (testapi::get_var('PRETTY_SERIAL_MARKER') || testapi::get_var('HIDE_MARKER_EVALUATION'));
     my $internal = $args{internal_marker};
     my $output_string = $string;
     my $captured_val;

--- a/distribution.pm
+++ b/distribution.pm
@@ -4,6 +4,7 @@
 
 package distribution;
 use Mojo::Base -strict, -signatures;
+use Mojo::Util 'scope_guard';
 
 use testapi ();
 use log 'fctwarn';
@@ -16,6 +17,8 @@ sub new ($class, @) {
     $self->{autoinst_failures} = [];
     $self->{_serial_marker_level} = {};
     $self->{_serial_marker_hook_installed} = {};
+    $self->{_serial_marker_hook_persistent} = {};
+    $self->{_pretty_serial_marker} = undef;
 
 =head2 serial_term_prompt
 
@@ -447,12 +450,16 @@ sub install_serial_marker_hook ($self, $level) {
         $pc = "PROMPT_COMMAND='if [ -n \"\$__OA_MARK\" ]; then echo \"\${__OA_MARK}-\$?-\" > $dev; unset __OA_MARK; fi; echo \"OA:START\" > $dev'";
     }
     testapi::type_string "$pc\n";
-    my $marker_match = 'OA:START';
-    my $hook_cmd = "for f in ~/.bashrc ~/.profile; do grep -q '$marker_match' \"\$f\" 2>/dev/null || cat <<'EOF' >> \"\$f\"\n$pc\nEOF\ndone\n";
-    testapi::type_string $hook_cmd;
     my $console = testapi::current_console();
     return undef unless defined $console;
     $self->{_serial_marker_hook_installed}->{$console} = 1;
+
+    # Only append to config files once per console to avoid redundant typing
+    return if $self->{_serial_marker_hook_persistent}->{$console};
+    my $marker_match = 'OA:START';
+    my $hook_cmd = "for f in ~/.bashrc ~/.profile; do grep -q '$marker_match' \"\$f\" 2>/dev/null || cat <<'EOF' >> \"\$f\"\n$pc\nEOF\ndone\n";
+    testapi::type_string $hook_cmd;
+    $self->{_serial_marker_hook_persistent}->{$console} = 1;
 }
 
 =head2 reset_serial_marker
@@ -496,6 +503,65 @@ sub invalidate_serial_marker_hook ($self, $console = undef) {
     delete $self->{_serial_marker_hook_installed}->{$console};
 }
 
+=head2 get_pretty_serial_marker
+
+    get_pretty_serial_marker()
+
+Return the current C<PRETTY_SERIAL_MARKER> state. Falls back to the test variable.
+
+=cut
+
+sub get_pretty_serial_marker ($self) {
+    return $self->{_pretty_serial_marker} // testapi::get_var('PRETTY_SERIAL_MARKER');
+}
+
+=head2 set_pretty_serial_marker
+
+    set_pretty_serial_marker($value)
+
+Set C<PRETTY_SERIAL_MARKER> to C<$value> and reset the cached marker state.
+
+=cut
+
+sub set_pretty_serial_marker ($self, $value) {
+    my $old_value = $self->get_pretty_serial_marker();
+    return if defined $old_value && $old_value eq $value;
+
+    bmwqemu::log_call(value => $value);
+    $self->{_pretty_serial_marker} = $value;
+
+    # If we are turning it OFF, we MUST tell the SUT to stop sending markers
+    # to avoid polluting the fallback mode.
+    testapi::type_string "unset PROMPT_COMMAND\n" if !$value;
+
+    $self->reset_serial_marker();
+}
+
+=head2 pretty_serial_marker_guard
+
+    pretty_serial_marker_guard($value)
+
+Return a RAII guard to temporarily set C<PRETTY_SERIAL_MARKER> to C<$value>.
+Restores the original value when the guard goes out of scope.
+
+Example:
+    sub run ($self) {
+        # Disable pretty markers for this module
+        $self->{marker_guard} = $testapi::distri->pretty_serial_marker_guard(0);
+        ...
+    }
+
+=cut
+
+sub pretty_serial_marker_guard ($self, $value) {
+    my $old_value = $self->get_pretty_serial_marker();
+    $self->set_pretty_serial_marker($value);
+
+    return scope_guard(sub {
+            $self->set_pretty_serial_marker($old_value);
+    });
+}
+
 =head2 _detect_serial_marker_capability
 
     _detect_serial_marker_capability()
@@ -519,7 +585,7 @@ sub _detect_serial_marker_capability ($self) {
     }
 
     my $level = 1;
-    my $pretty = testapi::get_var('PRETTY_SERIAL_MARKER');
+    my $pretty = $self->get_pretty_serial_marker();
     my $serial_term = testapi::is_serial_terminal();
     return $self->{_serial_marker_level}->{$console} = $level if !$pretty || $serial_term;
 

--- a/distribution.pm
+++ b/distribution.pm
@@ -156,6 +156,13 @@ sub script_run ($self, $cmd, @args) {
           if $cmd =~ qr/(?<!\\)&$/;
 
         my $level = $self->_detect_serial_marker_capability();
+        my $guard;
+        # Automatically protect against manual serial redirections corrupting pretty markers
+        if ($level > 1 && $cmd =~ m{(?:>|>>|\btee)\s+(?:-a\s+)?/dev/\Q$testapi::serialdev\E\b}) {
+            bmwqemu::diag('Temporarily disabling PRETTY_SERIAL_MARKER to prevent corruption with serial terminal redirection');
+            $guard = $self->pretty_serial_marker_guard(0);
+            $level = $self->_detect_serial_marker_capability();
+        }
         my ($str, $wait_pattern);
         if ($level == 3) {
             testapi::query_isotovideo('backend_clear_serial_buffer', {});

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -208,48 +208,30 @@ subtest 'reboot_safety' => sub {
 
 subtest 'sut_marker' => sub {
     my $d = distribution->new;
-    is $d->sut_marker('ls -la /tmp'), 'OA:ls -11/tmp', 'sut_marker for normal command';
-    is $d->sut_marker('  ls  '), 'OA:ls2ls', 'sut_marker trims and handles short command';
-    is $d->sut_marker('a'), 'OA:a1a', 'sut_marker for very short command';
+    my @test_cases = (
+        {cmd => 'ls -la /tmp', expected => 'OA:ls -11/tmp', msg => 'normal command'},
+        {cmd => '  ls  ', expected => 'OA:ls2ls', msg => 'trims and handles short command'},
+        {cmd => 'a', expected => 'OA:a1a', msg => 'very short command'},
+    );
+    for my $case (@test_cases) {
+        is $d->sut_marker($case->{cmd}), $case->{expected}, "sut_marker: $case->{msg}";
+    }
 };
 
 subtest 'set expected serial and autoinst failures' => sub {
     my $d = distribution->new;
-    # Define the expected failures data
     my @failures = (
         {type => 'Soft', message => '%s Failure Message 1', pattern => 'Test Pattern1'},
         {type => 'Hard', message => '%s Failure Message 2', pattern => 'Test Pattern2'},
     );
-    # Subroutine to generate failure data with formatted messages
-    my sub _generate_failures ($type, %details) {
-        return [
-            map {
-                {
-                    message => sprintf($details{message}, $type),
-                    pattern => qr/$details{pattern}/
-                }
-            } @failures
-        ];
-    }
-    my %soft_failure = (
-        message => "$failures[0]->{message}",
-        pattern => "$failures[0]->{pattern}"
-    );
-    # Set and test Soft failures
-    $d->set_expected_serial_failures(_generate_failures('Soft', %soft_failure));
-    is_deeply($d->{serial_failures}, _generate_failures('Soft', %soft_failure), 'Expected Soft serial_failures matched');
-    $d->set_expected_autoinst_failures(_generate_failures('Soft', %soft_failure));
-    is_deeply($d->{autoinst_failures}, _generate_failures('Soft', %soft_failure), 'Expected Soft autoinst_failures matched');
 
-    my %hard_failure = (
-        message => "$failures[1]->{message}",
-        pattern => "$failures[1]->{pattern}"
-    );
-    # Set and test Hard failures
-    $d->set_expected_serial_failures(_generate_failures('Hard', %hard_failure));
-    is_deeply($d->{serial_failures}, _generate_failures('Hard', %hard_failure), 'Expected Hard serial_failures matched');
-    $d->set_expected_autoinst_failures(_generate_failures('Hard', %hard_failure));
-    is_deeply($d->{autoinst_failures}, _generate_failures('Hard', %hard_failure), 'Expected Hard autoinst_failures matched');
+    for my $f (@failures) {
+        my $expected = [{message => sprintf($f->{message}, $f->{type}), pattern => qr/$f->{pattern}/}];
+        $d->set_expected_serial_failures($expected);
+        is_deeply $d->{serial_failures}, $expected, "set_expected_serial_failures: $f->{type}";
+        $d->set_expected_autoinst_failures($expected);
+        is_deeply $d->{autoinst_failures}, $expected, "set_expected_autoinst_failures: $f->{type}";
+    }
 };
 
 subtest 'disable_key_repeat' => sub {
@@ -259,6 +241,74 @@ subtest 'disable_key_repeat' => sub {
     $mock_testapi->noop('type_string');
     distribution->new->disable_key_repeat;
     like "@called", qr/kbdrate/, 'disable_key_repeat calls kbdrate';
+};
+
+subtest 'pretty_serial_marker_helpers' => sub {
+    my $d = distribution->new;
+    my $mock_testapi = Test::MockModule->new('testapi');
+    my $mock_bmwqemu = Test::MockModule->new('bmwqemu');
+    my %vars;
+    $mock_testapi->redefine(get_var => sub { $vars{$_[0]} });
+    $mock_testapi->redefine(set_var => sub { $vars{$_[0]} = $_[1] });
+    $mock_testapi->redefine(current_console => sub { 'test-console' });
+    my $typed = '';
+    $mock_testapi->redefine(type_string => sub { $typed .= $_[0] });
+    my $log_called = 0;
+    $mock_bmwqemu->redefine(log_call => sub { $log_called++ });
+
+    # set_pretty_serial_marker
+    $d->{_serial_marker_level}->{'test-console'} = 3;
+    $vars{PRETTY_SERIAL_MARKER} = 1;
+    $d->set_pretty_serial_marker(1);
+    is $d->get_pretty_serial_marker(), 1, 'get_pretty_serial_marker returns 1';
+    is $vars{PRETTY_SERIAL_MARKER}, 1, 'PRETTY_SERIAL_MARKER var still 1';
+    is $log_called, 0, 'no log_call if state matches fallback';
+
+    $d->set_pretty_serial_marker(0);
+    is $d->get_pretty_serial_marker(), 0, 'get_pretty_serial_marker returns 0 after override';
+    is $vars{PRETTY_SERIAL_MARKER}, 1, 'PRETTY_SERIAL_MARKER var UNCHANGED (no pollution)';
+    is $log_called, 1, 'log_call invoked when state changes';
+    ok !exists $d->{_serial_marker_level}->{'test-console'}, 'marker level reset';
+    $log_called = 0;
+
+    $d->set_pretty_serial_marker(0);
+    is $log_called, 0, 'no-op if value is the same';
+
+    $typed = '';
+    $d->{_pretty_serial_marker} = 1;    # Force state change for test
+    $d->set_pretty_serial_marker(0);
+    like $typed, qr/unset PROMPT_COMMAND/, 'unset PROMPT_COMMAND typed when turning off';
+
+    # pretty_serial_marker_guard
+    $vars{PRETTY_SERIAL_MARKER} = 1;
+    $d->{_pretty_serial_marker} = undef;
+    {
+        my $guard = $d->pretty_serial_marker_guard(0);
+        is $d->get_pretty_serial_marker(), 0, 'Value changed by guard';
+        is $vars{PRETTY_SERIAL_MARKER}, 1, 'Global var remains unchanged';
+    }
+    is $d->get_pretty_serial_marker(), 1, 'Value restored after guard scope';
+};
+
+subtest 'serial_marker_hook_persistence' => sub {
+    my $d = distribution->new;
+    my $mock_testapi = Test::MockModule->new('testapi');
+    $mock_testapi->redefine(current_console => sub { 'test-console' });
+    my $typed = '';
+    $mock_testapi->redefine(type_string => sub { $typed .= $_[0] });
+
+    # First install
+    $d->install_serial_marker_hook(3);
+    like $typed, qr/PROMPT_COMMAND=/, 'Types PROMPT_COMMAND';
+    like $typed, qr/\.bashrc/, 'Appends to .bashrc';
+    ok $d->{_serial_marker_hook_persistent}->{'test-console'}, 'Persistence marked';
+
+    # Invalidate hook but keep persistence
+    $d->invalidate_serial_marker_hook('test-console');
+    $typed = '';
+    $d->install_serial_marker_hook(3);
+    like $typed, qr/PROMPT_COMMAND=/, 'Types PROMPT_COMMAND again';
+    unlike $typed, qr/\.bashrc/, 'Does NOT append to .bashrc again';
 };
 
 done_testing;

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -311,6 +311,53 @@ subtest 'serial_marker_hook_persistence' => sub {
     unlike $typed, qr/\.bashrc/, 'Does NOT append to .bashrc again';
 };
 
+subtest 'serial_terminal_redirection_guard' => sub {
+    my $d = distribution->new;
+    my $mock_testapi = Test::MockModule->new('testapi');
+    my $mock_bmwqemu = Test::MockModule->new('bmwqemu');
+    my %vars = (PRETTY_SERIAL_MARKER => 1);
+    $mock_testapi->redefine(get_var => sub { $vars{$_[0]} });
+    $mock_testapi->redefine(set_var => sub { $vars{$_[0]} = $_[1] });
+    $mock_testapi->redefine(current_console => sub { 'test-console' });
+    $mock_testapi->redefine(is_serial_terminal => sub { 1 });
+    $mock_testapi->redefine(backend_get_wait_still_screen_on_here_doc_input => sub { 0 });
+    my $typed = '';
+    $mock_testapi->redefine(type_string => sub { $typed .= $_[0] });
+    $mock_testapi->redefine(query_isotovideo => sub { });
+    $mock_bmwqemu->redefine(diag => sub { });
+    $mock_bmwqemu->redefine(log_call => sub { });
+    $mock_testapi->redefine(wait_serial => sub {
+            my ($regexp) = @_;
+            return 'BASH:4.4:' if ref($regexp) eq 'Regexp' && 'BASH:4.4:' =~ $regexp;
+            return 'FC:OK:' if ref($regexp) eq 'Regexp' && 'FC:OK:' =~ $regexp;
+            return 'OA:DONE-abcd-0-';
+    });
+
+    my @cases = (
+        {cmd => 'foo', guard => 0, msg => 'normal command without serial redirection does not trigger the guard'},
+        {cmd => 'foo | tee /dev/ttyS0', guard => 1, msg => 'piping to the serial terminal triggers the guard'},
+        {cmd => 'bar > /dev/ttyS0', guard => 1, msg => 'redirection to the serial terminal triggers the guard'},
+        {cmd => 'baz >> /dev/ttyS0', guard => 1, msg => 'appending to the serial terminal triggers the guard'},
+    );
+
+    for my $case (@cases) {
+        $typed = '';
+        $vars{PRETTY_SERIAL_MARKER} = 1;
+        $d->{_serial_marker_level}->{'test-console'} = 3;
+        $testapi::serialdev = 'ttyS0';
+        $d->{serial_term_prompt} = '# ';
+
+        $d->script_run($case->{cmd});
+        if ($case->{guard}) {
+            like $typed, qr/unset PROMPT_COMMAND/, $case->{msg};
+        }
+        else {
+            unlike $typed, qr/unset PROMPT_COMMAND/, $case->{msg};
+        }
+        is $vars{PRETTY_SERIAL_MARKER}, 1, "PRETTY_SERIAL_MARKER is active again after '$case->{cmd}'";
+    }
+};
+
 done_testing;
 
 1;


### PR DESCRIPTION
Motivation:
Some test modules or specific code sections are known to be incompatible
with advanced serial markers. Testers need a convenient way to disable
pretty markers for these specific scopes and have them automatically
restored afterwards.

Design Choices:
1. Add set_pretty_serial_marker($value) to distribution.pm. This method
   updates the test variable and immediately resets the cached marker
   state. It also types "unset PROMPT_COMMAND" in the SUT when disabling
   to avoid serial buffer pollution.
2. Add pretty_serial_marker_guard($value) to distribution.pm. This
   returns a RAII scope_guard that restores the previous value.
3. Track hook persistence in the SUT config files via
   _serial_marker_hook_persistent to avoid redundant typing during
   state transitions.

Benefits:
Provides test authors with a robust, clean, and automatic way to handle
problematic scenarios with pretty serial markers. Using the RAII guard
prevents accidental state leaks, and the optimizations ensure minimal
log clutter and maximum reliability.

Before:
* #2928