### PR TITLE
ci: Fix fullstack test after removal of `tools/ci/build_cache.sh`

### DIFF
--- a/.github/workflows/openqa_fullstack.yml
+++ b/.github/workflows/openqa_fullstack.yml
@@ -12,9 +12,7 @@ on:
 env:
   # Set to 1 to temporarily ignore warnings
   PERL_TEST_WARNINGS_ONLY_REPORT_WARNINGS: 0
-  # Default user in the used container image from
-  # https://github.com/os-autoinst/openQA/blob/master/container/devel%3AopenQA%3Aci/base/Dockerfile
-  NORMAL_USER: squamata
+  TEST_USER: testuser
 
 jobs:
   fullstack:
@@ -22,22 +20,20 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     container:
-      image: registry.opensuse.org/devel/openqa/ci/containers/base:latest
-      # See https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user
-      options: --user root
+      image: registry.opensuse.org/devel/openqa/containers/opensuse/openqa_devel:latest
     steps:
       - uses: actions/checkout@v6
+      - name: Create additional user to avoid initdb error "cannot be run as root"
+        run: useradd "$TEST_USER"
       - name: Make project folder user-writable
-        run: chown -R $NORMAL_USER ../../os-autoinst
+        run: chown -R $TEST_USER ../../os-autoinst
       - name: Clone openQA
-        run: >-
-          sudo -u $NORMAL_USER
-          git clone --depth 1 https://github.com/os-autoinst/openQA.git ../openQA
-      - name: Install dependencies
-        run: (cd ../openQA; bash -x tools/ci/build_cache.sh; sudo npm install)
+        run: sudo -u "$TEST_USER" git clone --depth 1 https://github.com/os-autoinst/openQA.git ../openQA
+      - name: Install node modules
+        run: sudo -u "$TEST_USER" make -C ../openQA node_modules
       - name: Build os-autoinst
-        run: sudo -u $NORMAL_USER make symlinks
+        run: sudo -u "$TEST_USER" make symlinks
       - name: Run unit tests
-        run: sudo -u $NORMAL_USER make -C ../openQA test-fullstack
+        run: sudo -u "$TEST_USER" make -C ../openQA test-fullstack
         env:
           STABILITY_TEST: ${{ github.event.inputs.stability_test }}


### PR DESCRIPTION
* Switch to using devel container which is also used in openQA now
* Streamline user setup with what we do now in openQA
* Avoid `sudo npm install`; use `Makefile` target instead to benefit from recent improvements

Related ticket: https://progress.opensuse.org/issues/200609