### PR TITLE
Revert "fix: ensure serial buffer is cleared during backend_clear_serial_buffer"

### DIFF
--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -843,9 +843,6 @@ previous test's serial output. Call this before you start doing something new
 =cut
 
 sub clear_serial_buffer ($self, @) {
-    if (my $screen = $self->{current_screen}) {
-        $screen->clear_buffer() if $screen->can('clear_buffer');
-    }
     $self->{serial_offset} = -s $self->{serialfile};
     return $self->{serial_offset};
 }

--- a/consoles/serial_screen.pm
+++ b/consoles/serial_screen.pm
@@ -293,20 +293,6 @@ sub peak ($self, %nargs) {
     return $self->{carry_buffer};
 }
 
-=head2 clear_buffer
-
-Drain any pending data from the non-blocking socket and empty the internal carry buffer.
-
-=cut
-
-sub clear_buffer ($self) {
-    my $buf;
-    while (sysread $self->{fd_read}, $buf, SOCKET_READ_BUFFER_SIZE) {
-        # Drain the non-blocking socket
-    }
-    $self->{carry_buffer} = '';
-}
-
 sub current_screen ($self) { 0 }
 
 sub request_screen_update ($self, @) { }

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -616,33 +616,7 @@ subtest 'requesting full screen update' => sub {
 
 is($baseclass->get_wait_still_screen_on_here_doc_input({}), 0, 'wait_still_screen on here doc is off by default!');
 
-subtest 'clear_serial_buffer' => sub {
-    my $serialfile = tempfile;
-    $serialfile->spew('initial content');
-    local $baseclass->{serialfile} = $serialfile->to_string;
-
-    subtest 'with screen supporting clear_buffer' => sub {
-        my $mock_screen = Test::MockObject->new();
-        $mock_screen->mock('clear_buffer', sub { pass 'clear_buffer called on screen' });
-        local $baseclass->{current_screen} = $mock_screen;
-        $baseclass->clear_serial_buffer();
-        $mock_screen->called_ok('clear_buffer');
-    };
-
-    subtest 'without current_screen' => sub {
-        local $baseclass->{current_screen} = undef;
-        lives_ok { $baseclass->clear_serial_buffer() } 'works without current_screen';
-    };
-
-    subtest 'with screen without clear_buffer' => sub {
-        my $mock_screen = Test::MockObject->new();
-        local $baseclass->{current_screen} = $mock_screen;
-        lives_ok { $baseclass->clear_serial_buffer() } 'works with screen without clear_buffer';
-    };
-};
-
 subtest 'corner cases of do_capture/run_capture_loop' => sub {
-
     # note: This test covers a few corner cases of do_capture that are not otherwise covered anyways:
     #       using external video encoder, stall detection, screen update request, unresponsive console
 

--- a/t/26-serial_screen.t
+++ b/t/26-serial_screen.t
@@ -8,7 +8,6 @@ use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use consoles::serial_screen;
-use File::Temp ();
 
 my $screen = consoles::serial_screen->new('read', 'write');
 is($screen->{fd_write}, 'write', 'Check if channel was set for write fd');
@@ -24,18 +23,5 @@ dies_ok { $screen->release_key } 'release_key dies with error';
 dies_ok { $screen->send_key({key => 'space'}) } 'send_key dies for most keys';
 is $screen->current_screen, 0, 'no current screen';
 is $screen->request_screen_update, undef, 'can call request_screen_update';
-my ($fh_read, $filename) = File::Temp::tempfile();
-print $fh_read 'some data';
-seek $fh_read, 0, 0;
-$screen = consoles::serial_screen->new($fh_read);
-$screen->{carry_buffer} = 'stale data';
-$screen->clear_buffer();
-is $screen->{carry_buffer}, '', 'carry_buffer is cleared (with data)';
-my $res = sysread $fh_read, my $buf, 4096;
-is $res, 0, 'socket/fh is drained';
-seek $fh_read, 0, 2;
-$screen->{carry_buffer} = 'more stale data';
-$screen->clear_buffer();
-is $screen->{carry_buffer}, '', 'carry_buffer is cleared (without data)';
 
 done_testing;


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst#2920
as https://openqa.opensuse.org/tests/5928392
opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-jeos-ltp-containers@uefi_virtio-2G from
https://openqa.opensuse.org/tests/latest?arch=x86_64&distri=opensuse&flavor=JeOS-for-kvm-and-xen&machine=uefi_virtio-2G&test=jeos-ltp-containers&version=Tumbleweed
show a problem.

the issue is seen at https://openqa.opensuse.org/tests/5928392#step/install_ltp/1
isotovideo waits for `#` to identift the prompt on the serial console which the buffer clearing probably already consumed.