### PR TITLE
feat: ensure serial marker hook is persistent across become_root

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -84,6 +84,7 @@ sub ensure_installed ($self, @pkglist) {
 }
 
 sub become_root ($self) {
+    $self->_detect_serial_marker_capability() if testapi::get_var('PRETTY_SERIAL_MARKER');
     testapi::script_sudo('bash', 0);    # become root
     testapi::enter_cmd('test $(id -u) -eq 0 && echo "imroot" > /dev/' . $testapi::serialdev, 0);
     testapi::wait_serial('imroot') || die 'Root prompt not there';

--- a/distribution.pm
+++ b/distribution.pm
@@ -569,7 +569,6 @@ sub pretty_serial_marker_guard ($self, $value) {
             $self->set_pretty_serial_marker($old_value);
     });
 }
-
 =head2 _detect_serial_marker_capability
 
     _detect_serial_marker_capability()

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -365,7 +365,6 @@ subtest 'serial_terminal_redirection_guard' => sub {
     $d->install_serial_marker_hook(3);
     like $typed, qr/__oa_prompt\(\) \{ r=\$\?; if \[ -n "\$OA_NO_MARKER" \]/, '__oa_prompt must capture the exit status r=$? as the absolute first statement to prevent internal conditional checks from overwriting it';
 };
-
 done_testing;
 
 1;

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -318,6 +318,7 @@ subtest 'serial_terminal_redirection_guard' => sub {
     $mock_testapi->redefine(current_console => sub { 'test-console' });
     $mock_testapi->redefine(is_serial_terminal => sub { 1 });
     $mock_testapi->redefine(backend_get_wait_still_screen_on_here_doc_input => sub { 0 });
+    my $mock_bmwqemu = Test::MockModule->new('bmwqemu');
     my $typed = '';
     my $diag_msg = '';
     $mock_testapi->redefine(type_string => sub { $typed .= $_[0] });

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -146,9 +146,10 @@ subtest 'serial_marker_reinstall_cached_level' => sub {
 
     $d->{_serial_marker_level}->{'test-console'} = 2;
     $d->invalidate_serial_marker_hook('test-console');
+    $mock_testapi->redefine(wait_serial => sub { 'HM' });
 
     is $d->_detect_serial_marker_capability(), 2, 'Returns cached level 2';
-    like $typed, qr/grep -q __oa_prompt.*\. ~\/\.bashrc/, 'Calls install_serial_marker_hook (types consolidated setup with sourcing)';
+    like $typed, qr/grep -q __oa_prompt.*echo HM > \/dev\/ttyS0.*\{ echo .* \}; \. ~\/\.bashrc/s, 'Calls install_serial_marker_hook (types full setup when hook is missing)';
     ok $d->{_serial_marker_hook_installed}->{'test-console'}, 'Hook marked as installed';
 };
 
@@ -171,11 +172,12 @@ subtest 'reboot_safety' => sub {
             my ($regexp) = @_;
             return 'BASH:4.4:' if ref($regexp) eq 'Regexp' && 'BASH:4.4:' =~ $regexp;
             return 'FC:OK:' if ref($regexp) eq 'Regexp' && 'FC:OK:' =~ $regexp;
+            return 'HM' if ref($regexp) eq 'Regexp' && 'HM' =~ $regexp;
             return 'OA:DONE-abcd-0-';
     });
 
     $d->script_run('foo');
-    like $typed_string, qr/grep -q __oa_prompt.*__oa_prompt\(\).*OA:DONE.*\. ~\/\.bashrc/s, 'Initial install';
+    like $typed_string, qr/grep -q __oa_prompt.*\{ echo .* \}; \. ~\/\.bashrc/s, 'Initial install uses full setup when hook missing';
     $typed_string = '';
 
     # Simulate console selection (e.g. after reboot/login)
@@ -191,7 +193,7 @@ subtest 'reboot_safety' => sub {
     $d->reset_serial_marker('test-console');
     $typed_string = '';
     $d->script_run('baz');
-    like $typed_string, qr/grep -q __oa_prompt.*__oa_prompt\(\).*OA:DONE.*\. ~\/\.bashrc/s, 'Re-detect and re-install after resetting the serial marker';
+    like $typed_string, qr/grep -q __oa_prompt.*\{ echo .* \}; \. ~\/\.bashrc/s, 'Re-detect and re-install uses full setup when hook missing';
     like $typed_string, qr/baz\n/, 'Command typed after re-installation';
 
     # Case 3: select_console triggers reset
@@ -295,17 +297,20 @@ subtest 'serial_marker_hook_persistence' => sub {
     $mock_testapi->redefine(current_console => sub { 'test-console' });
     my $typed = '';
     $mock_testapi->redefine(type_string => sub { $typed .= $_[0] });
+    $mock_testapi->redefine(wait_serial => sub { 'HM' });
 
     # First install
     $d->install_serial_marker_hook(3);
-    like $typed, qr/grep -q __oa_prompt.*\. ~\/\.bashrc/, 'Types consolidated setup with persistence and sourcing';
+    like $typed, qr/grep -q __oa_prompt.*echo HM > \/dev\/ttyS0.*\{ echo .* \}; \. ~\/\.bashrc/s, 'Types consolidated setup with persistence when hook missing';
     ok $d->{_serial_marker_hook_persistent}->{'test-console'}, 'Persistence marked';
 
     # Invalidate hook but keep persistence
     $d->invalidate_serial_marker_hook('test-console');
     $typed = '';
+    $mock_testapi->redefine(wait_serial => sub { 'HC' });
     $d->install_serial_marker_hook(3);
-    like $typed, qr/\. ~\/\.bashrc/, 'Types setup again (with sourcing) when invalidated';
+    like $typed, qr/grep -q __oa_prompt.*echo HC > \/dev\/ttyS0.*\. ~\/\.bashrc/s, 'Only types sourcing when hook is already persistent';
+    unlike $typed, qr/\{ echo .* \}/, 'Does NOT re-type the full logic';
 };
 
 subtest 'serial_terminal_redirection_guard' => sub {


### PR DESCRIPTION
Motivation:
When switching from an unprivileged user to root via become_root, the
PRETTY_SERIAL_MARKER hook might not have been installed for the original
user if no script_run calls occurred yet. If the hook is then installed
only for root, it will be missing if the root terminal is closed and a
new terminal for the original user is opened.

Design Choices:
Modified become_root to proactively trigger shell capability detection
and hook installation before switching to root. Added an invalidation
after the switch to ensure the hook is also correctly applied to the
new root session.

Benefits:
Ensures that ~/.bashrc persistence is correctly populated for both the
original unprivileged user and the root user, preventing serial marker
timeouts in tests that open multiple terminal windows.

Related issue: https://openqa.opensuse.org/tests/5935252