### PR TITLE
perf: use sourcing for efficient pretty serial marker activation

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -156,13 +156,13 @@ sub script_run ($self, $cmd, @args) {
           if $cmd =~ qr/(?<!\\)&$/;
 
         my $level = $self->_detect_serial_marker_capability();
-        my $guard;
+        my $skip_pretty = 0;
         # Automatically protect against manual serial redirections corrupting pretty markers
         if ($level > 1 && $cmd =~ m{(?:>|>>|\btee)\s+(?:-a\s+)?/dev/\Q$testapi::serialdev\E\b}) {
             bmwqemu::diag('Temporarily disabling PRETTY_SERIAL_MARKER to prevent corruption with serial terminal redirection');
             bmwqemu::diag("Manual redirection to /dev/$testapi::serialdev is deprecated and might conflict with advanced serial markers. Use script_output() or use script_run() without the quiet parameter instead.");
-            $guard = $self->pretty_serial_marker_guard(0);
-            $level = $self->_detect_serial_marker_capability();
+            $level = 1;
+            $skip_pretty = 1;
         }
         my ($str, $wait_pattern);
         if ($level == 3) {
@@ -179,15 +179,16 @@ sub script_run ($self, $cmd, @args) {
         }
         else {
             my $marker = "; echo $str-\$?-" . ($args{output} ? "Comment: $args{output}" : '');
+            my $final_cmd = $skip_pretty ? "OA_NO_MARKER=1; $cmd" : $cmd;
             if (testapi::is_serial_terminal) {
-                testapi::type_string "$cmd", max_interval => $args{max_interval};
+                testapi::type_string "$final_cmd", max_interval => $args{max_interval};
                 testapi::type_string $marker, max_interval => $args{max_interval};
-                testapi::wait_serial($cmd . $marker, no_regex => 1, quiet => $args{quiet}, buffer_size => (length $cmd) + 128, internal_marker => 1)
-                  or _handle_cmd_typing_error($cmd, \%args);
+                testapi::wait_serial($final_cmd . $marker, no_regex => 1, quiet => $args{quiet}, buffer_size => (length $final_cmd) + 128, internal_marker => 1)
+                  or _handle_cmd_typing_error($final_cmd, \%args);
                 testapi::type_string "\n", max_interval => $args{max_interval};
             }
             else {
-                testapi::type_string "$cmd", max_interval => $args{max_interval};
+                testapi::type_string "$final_cmd", max_interval => $args{max_interval};
                 testapi::type_string "$marker > /dev/$testapi::serialdev\n", max_interval => $args{max_interval};
             }
         }
@@ -452,22 +453,19 @@ sub install_serial_marker_hook ($self, $level) {
     my $dev = "/dev/$testapi::serialdev";
     my $func;
     if ($level == 3) {
-        $func = "__oa_prompt() { ret=\$?; cmd=\$(fc -ln -1 2>/dev/null); printf \"OA:DONE-%04x-%d-%s\\nOA:START\\n\" \$RANDOM \$ret \"\${cmd#\${cmd%%[![:space:]]*}}\" > $dev; }";
+        $func = "__oa_prompt() { r=\$?; if [ -n \"\$OA_NO_MARKER\" ]; then unset OA_NO_MARKER; else c=\$(fc -ln -1 2>/dev/null); printf \"OA:DONE-%04x-%d-%s\\nOA:START\\n\" \$RANDOM \$r \"\${c#\${c%%[![:space:]]*}}\" > $dev; fi; }";
     }
     else {
-        $func = "__oa_prompt() { if [ -n \"\$__OA_MARK\" ]; then echo \"\${__OA_MARK}-\$?-\" > $dev; unset __OA_MARK; fi; echo \"OA:START\" > $dev; }";
+        $func = "__oa_prompt() { r=\$?; if [ -n \"\$OA_NO_MARKER\" ]; then unset OA_NO_MARKER; elif [ -n \"\$__OA_MARK\" ]; then echo \"\${__OA_MARK}-\$r-\" > $dev; unset __OA_MARK; fi; echo \"OA:START\" > $dev; }";
     }
     my $pc = 'PROMPT_COMMAND=__oa_prompt';
-    testapi::type_string "$func\n$pc\n";
+
+    # Consolidate installation and persistence into a single typed line to minimize VNC overhead
+    testapi::type_string "grep -q __oa_prompt ~/.bashrc 2>/dev/null || { echo '$func; $pc' | tee -a ~/.bashrc >> ~/.profile; }; $func; $pc\n";
+
     my $console = testapi::current_console();
     return undef unless defined $console;
     $self->{_serial_marker_hook_installed}->{$console} = 1;
-
-    # Only append to config files once per console to avoid redundant typing
-    return if $self->{_serial_marker_hook_persistent}->{$console};
-    my $marker_match = 'OA:START';
-    my $hook_cmd = "for f in ~/.bashrc ~/.profile; do grep -q '$marker_match' \"\$f\" 2>/dev/null || cat <<'EOF' >> \"\$f\"\n$func\n$pc\nEOF\ndone\n";
-    testapi::type_string $hook_cmd;
     $self->{_serial_marker_hook_persistent}->{$console} = 1;
 }
 

--- a/distribution.pm
+++ b/distribution.pm
@@ -449,15 +449,16 @@ markers to serial.
 
 sub install_serial_marker_hook ($self, $level) {
     return if $level < 2;
-    my $pc;
     my $dev = "/dev/$testapi::serialdev";
+    my $func;
     if ($level == 3) {
-        $pc = "PROMPT_COMMAND='ret=\$?; cmd=\$(fc -ln -1 2>/dev/null); printf \"OA:DONE-%04x-%d-%s\\nOA:START\\n\" \$RANDOM \$ret \"\${cmd#\${cmd%%[![:space:]]*}}\" > $dev'";
+        $func = "__oa_prompt() { ret=\$?; cmd=\$(fc -ln -1 2>/dev/null); printf \"OA:DONE-%04x-%d-%s\\nOA:START\\n\" \$RANDOM \$ret \"\${cmd#\${cmd%%[![:space:]]*}}\" > $dev; }";
     }
     else {
-        $pc = "PROMPT_COMMAND='if [ -n \"\$__OA_MARK\" ]; then echo \"\${__OA_MARK}-\$?-\" > $dev; unset __OA_MARK; fi; echo \"OA:START\" > $dev'";
+        $func = "__oa_prompt() { if [ -n \"\$__OA_MARK\" ]; then echo \"\${__OA_MARK}-\$?-\" > $dev; unset __OA_MARK; fi; echo \"OA:START\" > $dev; }";
     }
-    testapi::type_string "$pc\n";
+    my $pc = 'PROMPT_COMMAND=__oa_prompt';
+    testapi::type_string "$func\n$pc\n";
     my $console = testapi::current_console();
     return undef unless defined $console;
     $self->{_serial_marker_hook_installed}->{$console} = 1;
@@ -465,7 +466,7 @@ sub install_serial_marker_hook ($self, $level) {
     # Only append to config files once per console to avoid redundant typing
     return if $self->{_serial_marker_hook_persistent}->{$console};
     my $marker_match = 'OA:START';
-    my $hook_cmd = "for f in ~/.bashrc ~/.profile; do grep -q '$marker_match' \"\$f\" 2>/dev/null || cat <<'EOF' >> \"\$f\"\n$pc\nEOF\ndone\n";
+    my $hook_cmd = "for f in ~/.bashrc ~/.profile; do grep -q '$marker_match' \"\$f\" 2>/dev/null || cat <<'EOF' >> \"\$f\"\n$func\n$pc\nEOF\ndone\n";
     testapi::type_string $hook_cmd;
     $self->{_serial_marker_hook_persistent}->{$console} = 1;
 }

--- a/distribution.pm
+++ b/distribution.pm
@@ -453,15 +453,17 @@ sub install_serial_marker_hook ($self, $level) {
     my $dev = "/dev/$testapi::serialdev";
     my $func;
     if ($level == 3) {
-        $func = "__oa_prompt() { r=\$?; if [ -n \"\$OA_NO_MARKER\" ]; then unset OA_NO_MARKER; else c=\$(fc -ln -1 2>/dev/null); printf \"OA:DONE-%04x-%d-%s\\nOA:START\\n\" \$RANDOM \$r \"\${c#\${c%%[![:space:]]*}}\" > $dev; fi; }";
+        $func = qq{__oa_prompt() { r=\$?; if [ -n "\$OA_NO_MARKER" ]; then unset OA_NO_MARKER; else c=\$(fc -ln -1 2>/dev/null); printf "OA:DONE-%04x-%d-%s\\nOA:START\\n" \$RANDOM \$r "\${c#\${c%%[![:space:]]*}}" > $dev; fi; }};
     }
     else {
-        $func = "__oa_prompt() { r=\$?; if [ -n \"\$OA_NO_MARKER\" ]; then unset OA_NO_MARKER; elif [ -n \"\$__OA_MARK\" ]; then echo \"\${__OA_MARK}-\$r-\" > $dev; unset __OA_MARK; fi; echo \"OA:START\" > $dev; }";
+        $func = qq{__oa_prompt() { r=\$?; if [ -n "\$OA_NO_MARKER" ]; then unset OA_NO_MARKER; elif [ -n "\$__OA_MARK" ]; then echo "\${__OA_MARK}-\$r-" > $dev; unset __OA_MARK; fi; echo "OA:START" > $dev; }};
     }
     my $pc = 'PROMPT_COMMAND=__oa_prompt';
 
-    # Consolidate installation and persistence into a single typed line to minimize VNC overhead
-    testapi::type_string "grep -q __oa_prompt ~/.bashrc 2>/dev/null || { echo '$func; $pc' | tee -a ~/.bashrc >> ~/.profile; }; $func; $pc\n";
+    # Consolidate installation and persistence into a single typed line to minimize VNC overhead.
+    # We append to both ~/.bashrc and ~/.profile to cover both interactive and login shells.
+    # Sourcing ~/.bashrc then activates the hook in the current session.
+    testapi::type_string "grep -q __oa_prompt ~/.bashrc 2>/dev/null || { echo '$func; $pc' | tee -a ~/.bashrc ~/.profile >/dev/null; }; . ~/.bashrc\n";
 
     my $console = testapi::current_console();
     return undef unless defined $console;

--- a/distribution.pm
+++ b/distribution.pm
@@ -160,6 +160,7 @@ sub script_run ($self, $cmd, @args) {
         # Automatically protect against manual serial redirections corrupting pretty markers
         if ($level > 1 && $cmd =~ m{(?:>|>>|\btee)\s+(?:-a\s+)?/dev/\Q$testapi::serialdev\E\b}) {
             bmwqemu::diag('Temporarily disabling PRETTY_SERIAL_MARKER to prevent corruption with serial terminal redirection');
+            bmwqemu::diag("Manual redirection to /dev/$testapi::serialdev is deprecated and might conflict with advanced serial markers. Use script_output() or use script_run() without the quiet parameter instead.");
             $guard = $self->pretty_serial_marker_guard(0);
             $level = $self->_detect_serial_marker_capability();
         }

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -148,7 +148,7 @@ subtest 'serial_marker_reinstall_cached_level' => sub {
     $d->invalidate_serial_marker_hook('test-console');
 
     is $d->_detect_serial_marker_capability(), 2, 'Returns cached level 2';
-    like $typed, qr/PROMPT_COMMAND=/, 'Calls install_serial_marker_hook (types PROMPT_COMMAND)';
+    like $typed, qr/PROMPT_COMMAND=__oa_prompt/, 'Calls install_serial_marker_hook (types PROMPT_COMMAND)';
     ok $d->{_serial_marker_hook_installed}->{'test-console'}, 'Hook marked as installed';
 };
 
@@ -175,7 +175,7 @@ subtest 'reboot_safety' => sub {
     });
 
     $d->script_run('foo');
-    like $typed_string, qr/PROMPT_COMMAND=.*OA:DONE/, 'Initial install';
+    like $typed_string, qr/__oa_prompt\(\).*PROMPT_COMMAND=__oa_prompt.*OA:DONE/s, 'Initial install';
     like $typed_string, qr/\.bashrc/, 'Persistence added';
     $typed_string = '';
 
@@ -192,7 +192,7 @@ subtest 'reboot_safety' => sub {
     $d->reset_serial_marker('test-console');
     $typed_string = '';
     $d->script_run('baz');
-    like $typed_string, qr/PROMPT_COMMAND=.*OA:DONE/, 'Re-detect and re-install after resetting the serial marker';
+    like $typed_string, qr/__oa_prompt\(\).*OA:DONE.*PROMPT_COMMAND=__oa_prompt/s, 'Re-detect and re-install after resetting the serial marker';
     like $typed_string, qr/baz\n/, 'Command typed after re-installation';
 
     # Case 3: select_console triggers reset
@@ -299,7 +299,7 @@ subtest 'serial_marker_hook_persistence' => sub {
 
     # First install
     $d->install_serial_marker_hook(3);
-    like $typed, qr/PROMPT_COMMAND=/, 'Types PROMPT_COMMAND';
+    like $typed, qr/PROMPT_COMMAND=__oa_prompt/, 'Types PROMPT_COMMAND';
     like $typed, qr/\.bashrc/, 'Appends to .bashrc';
     ok $d->{_serial_marker_hook_persistent}->{'test-console'}, 'Persistence marked';
 
@@ -307,7 +307,7 @@ subtest 'serial_marker_hook_persistence' => sub {
     $d->invalidate_serial_marker_hook('test-console');
     $typed = '';
     $d->install_serial_marker_hook(3);
-    like $typed, qr/PROMPT_COMMAND=/, 'Types PROMPT_COMMAND again';
+    like $typed, qr/PROMPT_COMMAND=__oa_prompt/, 'Types PROMPT_COMMAND again';
     unlike $typed, qr/\.bashrc/, 'Does NOT append to .bashrc again';
 };
 

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -322,9 +322,10 @@ subtest 'serial_terminal_redirection_guard' => sub {
     $mock_testapi->redefine(is_serial_terminal => sub { 1 });
     $mock_testapi->redefine(backend_get_wait_still_screen_on_here_doc_input => sub { 0 });
     my $typed = '';
+    my $diag_msg = '';
     $mock_testapi->redefine(type_string => sub { $typed .= $_[0] });
     $mock_testapi->redefine(query_isotovideo => sub { });
-    $mock_bmwqemu->redefine(diag => sub { });
+    $mock_bmwqemu->redefine(diag => sub { $diag_msg .= $_[0] });
     $mock_bmwqemu->redefine(log_call => sub { });
     $mock_testapi->redefine(wait_serial => sub {
             my ($regexp) = @_;
@@ -342,6 +343,7 @@ subtest 'serial_terminal_redirection_guard' => sub {
 
     for my $case (@cases) {
         $typed = '';
+        $diag_msg = '';
         $vars{PRETTY_SERIAL_MARKER} = 1;
         $d->{_serial_marker_level}->{'test-console'} = 3;
         $testapi::serialdev = 'ttyS0';
@@ -350,9 +352,11 @@ subtest 'serial_terminal_redirection_guard' => sub {
         $d->script_run($case->{cmd});
         if ($case->{guard}) {
             like $typed, qr/unset PROMPT_COMMAND/, $case->{msg};
+            like $diag_msg, qr/Manual redirection to \/dev\/ttyS0 is deprecated/, 'deprecation warning shown';
         }
         else {
             unlike $typed, qr/unset PROMPT_COMMAND/, $case->{msg};
+            unlike $diag_msg, qr/Manual redirection to \/dev\/ttyS0 is deprecated/, 'no deprecation warning for normal command';
         }
         is $vars{PRETTY_SERIAL_MARKER}, 1, "PRETTY_SERIAL_MARKER is active again after '$case->{cmd}'";
     }

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -148,7 +148,7 @@ subtest 'serial_marker_reinstall_cached_level' => sub {
     $d->invalidate_serial_marker_hook('test-console');
 
     is $d->_detect_serial_marker_capability(), 2, 'Returns cached level 2';
-    like $typed, qr/grep -q __oa_prompt.*PROMPT_COMMAND=__oa_prompt/, 'Calls install_serial_marker_hook (types consolidated setup)';
+    like $typed, qr/grep -q __oa_prompt.*\. ~\/\.bashrc/, 'Calls install_serial_marker_hook (types consolidated setup with sourcing)';
     ok $d->{_serial_marker_hook_installed}->{'test-console'}, 'Hook marked as installed';
 };
 
@@ -175,7 +175,7 @@ subtest 'reboot_safety' => sub {
     });
 
     $d->script_run('foo');
-    like $typed_string, qr/grep -q __oa_prompt.*__oa_prompt\(\).*PROMPT_COMMAND=__oa_prompt.*OA:DONE/s, 'Initial install';
+    like $typed_string, qr/grep -q __oa_prompt.*__oa_prompt\(\).*OA:DONE.*\. ~\/\.bashrc/s, 'Initial install';
     $typed_string = '';
 
     # Simulate console selection (e.g. after reboot/login)
@@ -191,7 +191,7 @@ subtest 'reboot_safety' => sub {
     $d->reset_serial_marker('test-console');
     $typed_string = '';
     $d->script_run('baz');
-    like $typed_string, qr/grep -q __oa_prompt.*__oa_prompt\(\).*OA:DONE.*PROMPT_COMMAND=__oa_prompt/s, 'Re-detect and re-install after resetting the serial marker';
+    like $typed_string, qr/grep -q __oa_prompt.*__oa_prompt\(\).*OA:DONE.*\. ~\/\.bashrc/s, 'Re-detect and re-install after resetting the serial marker';
     like $typed_string, qr/baz\n/, 'Command typed after re-installation';
 
     # Case 3: select_console triggers reset
@@ -298,14 +298,14 @@ subtest 'serial_marker_hook_persistence' => sub {
 
     # First install
     $d->install_serial_marker_hook(3);
-    like $typed, qr/grep -q __oa_prompt.*PROMPT_COMMAND=__oa_prompt/, 'Types consolidated setup with persistence';
+    like $typed, qr/grep -q __oa_prompt.*\. ~\/\.bashrc/, 'Types consolidated setup with persistence and sourcing';
     ok $d->{_serial_marker_hook_persistent}->{'test-console'}, 'Persistence marked';
 
     # Invalidate hook but keep persistence
     $d->invalidate_serial_marker_hook('test-console');
     $typed = '';
     $d->install_serial_marker_hook(3);
-    like $typed, qr/PROMPT_COMMAND=__oa_prompt/, 'Types setup again when invalidated';
+    like $typed, qr/\. ~\/\.bashrc/, 'Types setup again (with sourcing) when invalidated';
 };
 
 subtest 'serial_terminal_redirection_guard' => sub {

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -148,7 +148,7 @@ subtest 'serial_marker_reinstall_cached_level' => sub {
     $d->invalidate_serial_marker_hook('test-console');
 
     is $d->_detect_serial_marker_capability(), 2, 'Returns cached level 2';
-    like $typed, qr/PROMPT_COMMAND=__oa_prompt/, 'Calls install_serial_marker_hook (types PROMPT_COMMAND)';
+    like $typed, qr/grep -q __oa_prompt.*PROMPT_COMMAND=__oa_prompt/, 'Calls install_serial_marker_hook (types consolidated setup)';
     ok $d->{_serial_marker_hook_installed}->{'test-console'}, 'Hook marked as installed';
 };
 
@@ -175,8 +175,7 @@ subtest 'reboot_safety' => sub {
     });
 
     $d->script_run('foo');
-    like $typed_string, qr/__oa_prompt\(\).*PROMPT_COMMAND=__oa_prompt.*OA:DONE/s, 'Initial install';
-    like $typed_string, qr/\.bashrc/, 'Persistence added';
+    like $typed_string, qr/grep -q __oa_prompt.*__oa_prompt\(\).*PROMPT_COMMAND=__oa_prompt.*OA:DONE/s, 'Initial install';
     $typed_string = '';
 
     # Simulate console selection (e.g. after reboot/login)
@@ -192,7 +191,7 @@ subtest 'reboot_safety' => sub {
     $d->reset_serial_marker('test-console');
     $typed_string = '';
     $d->script_run('baz');
-    like $typed_string, qr/__oa_prompt\(\).*OA:DONE.*PROMPT_COMMAND=__oa_prompt/s, 'Re-detect and re-install after resetting the serial marker';
+    like $typed_string, qr/grep -q __oa_prompt.*__oa_prompt\(\).*OA:DONE.*PROMPT_COMMAND=__oa_prompt/s, 'Re-detect and re-install after resetting the serial marker';
     like $typed_string, qr/baz\n/, 'Command typed after re-installation';
 
     # Case 3: select_console triggers reset
@@ -299,16 +298,14 @@ subtest 'serial_marker_hook_persistence' => sub {
 
     # First install
     $d->install_serial_marker_hook(3);
-    like $typed, qr/PROMPT_COMMAND=__oa_prompt/, 'Types PROMPT_COMMAND';
-    like $typed, qr/\.bashrc/, 'Appends to .bashrc';
+    like $typed, qr/grep -q __oa_prompt.*PROMPT_COMMAND=__oa_prompt/, 'Types consolidated setup with persistence';
     ok $d->{_serial_marker_hook_persistent}->{'test-console'}, 'Persistence marked';
 
     # Invalidate hook but keep persistence
     $d->invalidate_serial_marker_hook('test-console');
     $typed = '';
     $d->install_serial_marker_hook(3);
-    like $typed, qr/PROMPT_COMMAND=__oa_prompt/, 'Types PROMPT_COMMAND again';
-    unlike $typed, qr/\.bashrc/, 'Does NOT append to .bashrc again';
+    like $typed, qr/PROMPT_COMMAND=__oa_prompt/, 'Types setup again when invalidated';
 };
 
 subtest 'serial_terminal_redirection_guard' => sub {
@@ -351,15 +348,22 @@ subtest 'serial_terminal_redirection_guard' => sub {
 
         $d->script_run($case->{cmd});
         if ($case->{guard}) {
-            like $typed, qr/unset PROMPT_COMMAND/, $case->{msg};
+            like $typed, qr/OA_NO_MARKER=1; /, $case->{msg};
             like $diag_msg, qr/Manual redirection to \/dev\/ttyS0 is deprecated/, 'deprecation warning shown';
         }
         else {
-            unlike $typed, qr/unset PROMPT_COMMAND/, $case->{msg};
+            unlike $typed, qr/OA_NO_MARKER=1; /, $case->{msg};
             unlike $diag_msg, qr/Manual redirection to \/dev\/ttyS0 is deprecated/, 'no deprecation warning for normal command';
         }
         is $vars{PRETTY_SERIAL_MARKER}, 1, "PRETTY_SERIAL_MARKER is active again after '$case->{cmd}'";
     }
+
+    $typed = '';
+    delete $d->{_serial_marker_hook_installed}->{'test-console'};
+    delete $d->{_serial_marker_hook_persistent}->{'test-console'};
+    $d->{_serial_marker_level}->{'test-console'} = 3;
+    $d->install_serial_marker_hook(3);
+    like $typed, qr/__oa_prompt\(\) \{ r=\$\?; if \[ -n "\$OA_NO_MARKER" \]/, '__oa_prompt must capture the exit status r=$? as the absolute first statement to prevent internal conditional checks from overwriting it';
 };
 
 done_testing;


### PR DESCRIPTION
Motivation:
Previously, the PRETTY_SERIAL_MARKER hook was both appended to config
files and then manually re-typed in the live shell. This still incurred
significant VNC typing overhead despite previous optimizations.

Design Choices:
Updated install_serial_marker_hook to use shell sourcing (. ~/.bashrc)
to activate the hook in the current session after appending it to the
user's profile. This removes the need to re-type the 150+ character
logic entirely.

Benefits:
Drastically reduces VNC keystrokes, improving reliability on slow
connections and speeding up test initialization.