### PR TITLE
test(03-testapi): robustify against env specific FQDN resolution

### DIFF
--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -26,6 +26,8 @@ use needle;
 require bmwqemu;
 require tinycv;
 
+$bmwqemu::vars{WORKER_HOSTNAME} = 'localhost';
+
 ok(looks_like_number($OpenQA::Isotovideo::Interface::version), 'isotovideo version set (variable is considered part of test API)');
 
 my $cmds;


### PR DESCRIPTION
Motivation:
The test failed in my current, local environment because
Net::Domain::hostfqdn returns undef, causing an uninitialized value
warning in testapi::autoinst_url whenever it is called before
WORKER_HOSTNAME is explicitly set. This warning is caught by
Test::Warnings. CI environments usually have a resolvable hostname,
masking this issue.

Design Choices:
Set WORKER_HOSTNAME to 'localhost' at the top level of the test script.
This provides a sane default for all tests while still allowing specific
tests to override it.