### PR TITLE
feat: Add module name and step number to autoinst-log

### DIFF
--- a/OpenQA/Isotovideo/Runner.pm
+++ b/OpenQA/Isotovideo/Runner.pm
@@ -223,6 +223,8 @@ sub checkout_code ($self) {
     # git repo fail silently, i.e. store an empty variable
 
     ($bmwqemu::vars{TEST_GIT_URL}, $bmwqemu::vars{TEST_GIT_HASH}) = checkout_git_refspec($bmwqemu::vars{CASEDIR} => 'TEST_GIT_REFSPEC');
+    # For the frontend to display links to the source code
+    diag "TEST_GIT_HASH=$bmwqemu::vars{TEST_GIT_HASH} TEST_GIT_URL=$bmwqemu::vars{TEST_GIT_URL}";
 
     checkout_wheels($bmwqemu::vars{CASEDIR}, $bmwqemu::vars{WHEELS_DIR});
 }

--- a/basetest.pm
+++ b/basetest.pm
@@ -461,6 +461,8 @@ sub record_serialresult ($self, $ref, $res, $string = undef, %args) {
     if (defined $captured_val && $args{capture_name}) {
         $output .= "# $args{capture_name}: $captured_val\n";
     }
+    # log every step that is shown in the webui
+    bmwqemu::update_line_number();
     $self->record_resultfile('wait_serial', $output, result => $res);
     return undef;
 }

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -228,8 +228,8 @@ sub current_test () {
 }
 
 sub update_line_number () {
-    return unless current_test;
-    return unless current_test->{script};
+    return unless my $current_test = current_test;
+    return unless $current_test->{script};
     my @out;
     my $casedir = $vars{CASEDIR} // '';
     for (my $i = 10; $i > 0; $i--) {
@@ -238,7 +238,9 @@ sub update_line_number () {
         $filename =~ s@$casedir/?@@;
         push @out, "$filename:$line called $subroutine";
     }
-    log::logger->debug(join ' -> ', @out);
+    my $step_info = sprintf '[step:%s,%s,%s]',
+      $current_test->{category} // '-', $current_test->{name} // '-', ($current_test->{test_count} // 0) + 1;
+    log::logger->debug("$step_info " . join ' -> ', @out);
     return;
 }
 

--- a/t/12-bmwqemu.t
+++ b/t/12-bmwqemu.t
@@ -82,8 +82,8 @@ subtest 'update_line_number' => sub {
     $log::direct_output = 1;
     bmwqemu::init_logger();
     ok !bmwqemu::update_line_number(), 'update_line_number needs current_test defined';
-    $autotest::current_test = {script => 'my/module.pm'};
-    stderr_like { bmwqemu::update_line_number() } qr{bmwqemu.t.*called.*subtest}, 'update_line_number identifies caller scope';
+    $autotest::current_test = {script => 'my/module.pm', name => 'module'};
+    stderr_like { bmwqemu::update_line_number() } qr{\[step:-,module,1\].*bmwqemu.t.*called.*subtest}, 'update_line_number identifies caller scope';
 };
 
 subtest 'CASEDIR is mandatory' => sub {

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -132,6 +132,20 @@ subtest 'isotovideo with git refspec specified' => sub {
             opts => "casedir=$data_dir/tests test_git_refspec=deadbeef _exit_after_schedule=1") } qr/Checking.*local.*deadbeef/, 'refspec in local git repository would be checked out';
 };
 
+subtest 'log TEST_GIT_ vars' => sub {
+    my @diags;
+    my $runner_mock = Test::MockModule->new('OpenQA::Isotovideo::Runner');
+    $runner_mock->noop('checkout_wheels');
+    $runner_mock->noop('checkout_git_repo_and_branch');
+    $runner_mock->redefine(checkout_git_refspec => sub { ('url', 'c0ffee') });
+    $runner_mock->redefine(diag => sub { push @diags, $_[0] });
+    my $bmwqemu_mock = Test::MockModule->new('bmwqemu');
+    $bmwqemu_mock->noop('ensure_valid_vars');
+    local $bmwqemu::vars{HDDSIZEGB_1} = 1;
+    OpenQA::Isotovideo::Runner->checkout_code;
+    is $diags[0], 'TEST_GIT_HASH=c0ffee TEST_GIT_URL=url', 'vars are logged';
+};
+
 subtest 'isotovideo with wheels' => sub {
     chdir $pool_dir;
     unlink 'vars.json' if -e 'vars.json';

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -7,7 +7,7 @@ use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use Test::MockModule;
-use Test::Output qw(combined_like combined_from);
+use Test::Output qw(combined_like combined_from stderr_like);
 use File::Basename;
 use Mojo::File qw(path tempdir);
 use Mojo::JSON qw(decode_json);
@@ -536,6 +536,17 @@ subtest search_for_expected_serial_failures => sub {
     $mock_basetest->mock(parse_serial_output_qemu => sub { $basetest->{result} = 'successfully called function' });
     $basetest->runtest();
     is $basetest->{result}, 'successfully called function', 'search for expected serial failures is working';
+};
+
+subtest 'record_serialresult log step' => sub {
+    my $basetest = basetest->new();
+    $basetest->{name} = 'test';
+    $basetest->{category} = 'cat';
+    $basetest->{script} = 'foo';
+    local $autotest::current_test = $basetest;
+    my $mock_basetest_local = Test::MockModule->new('basetest');
+    $mock_basetest_local->noop('record_resultfile');
+    stderr_like { $basetest->record_serialresult('regex', 'ok', 'output', command => 'my_command') } qr/\[step:cat,test,2\].*called basetest::record_serialresult/, 'module step is logged';
 };
 
 subtest record_serialresult_with_command => sub {


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/197177

We might want to add the attempt number later, see #2850 for the retry test flag

Example log:
```
[2026-05-26T15:48:59.979489+02:00] [debug] [pid:42593] [step:install,boot,2] tests/install/boot.pm:6 called utils::wait_for_desktop -> lib/utils.pm:51 called testapi::assert_and_click
[2026-05-26T15:48:59.979606+02:00] [debug] [pid:42593] <<< testapi::assert_screen(mustmatch="openqa-desktop-login", timeout=30)
[2026-05-26T15:49:00.953900+02:00] [debug] [pid:42593] >>> testapi::_handle_found_needle: found openqa-desktop-minimalx-login-20231222, similarity 1.00 @ 547/347
[2026-05-26T15:49:00.954095+02:00] [debug] [pid:42593] [step:install,boot,3] tests/install/boot.pm:6 called utils::wait_for_desktop -> lib/utils.pm:51 called testapi::assert_and_click
[2026-05-26T15:49:00.954202+02:00] [debug] [pid:42593] <<< testapi::assert_and_click(mustmatch="openqa-desktop-login", timeout=30)
[2026-05-26T15:49:00.955908+02:00] [debug] [pid:42593] clicking at 563/370
[2026-05-26T15:49:00.956023+02:00] [debug] [pid:42593] [step:install,boot,3] tests/install/boot.pm:6 called utils::wait_for_desktop -> lib/utils.pm:51 called testapi::assert_and_click
[2026-05-26T15:49:00.956089+02:00] [debug] [pid:42593] <<< testapi::mouse_set(x=563, y=370)
[2026-05-26T15:49:00.956380+02:00] [debug] [pid:42608] mouse_move 563, 370
[2026-05-26T15:49:00.956448+02:00] [debug] [pid:42608] send_pointer_event 0, 563, 370, 1
[2026-05-26T15:49:00.956644+02:00] [debug] [pid:42593] [step:install,boot,3] tests/install/boot.pm:6 called utils::wait_for_desktop -> lib/utils.pm:51 called testapi::assert_and_click
[2026-05-26T15:49:00.956718+02:00] [debug] [pid:42593] <<< testapi::mouse_click(button="left", cursor_down="0.15")
```