### PR TITLE
fix: fail explicitly on test module basename collisions

### DIFF
--- a/autotest.pm
+++ b/autotest.pm
@@ -27,6 +27,7 @@ our @EXPORT_OK = qw(loadtest $selected_console $last_milestone_console query_iso
 
 our %tests;    # scheduled or run tests
 our @testorder;    # for keeping them in order
+our %scheduled_basenames;    # keep track of scheduled basenames to their script path
 our $isotovideo;
 our $process;
 our $tests_running = 0;
@@ -288,6 +289,13 @@ sub loadtest ($script, %args) {
     no utf8;    # Inline Python fails on utf8, so let's exclude it here
     my $script_path = find_script($script);
     my ($name, $category) = parse_test_path($script_path);
+
+    my $abs_path = path($script_path)->to_abs->to_string;
+    if (exists $scheduled_basenames{$name} && $scheduled_basenames{$name} ne $abs_path) {
+        die "The test module basename '$name' is already used by '$scheduled_basenames{$name}', but you tried to load it from '$abs_path'. Using the same basename from different directories is not supported.\n";
+    }
+    $scheduled_basenames{$name} = $abs_path;
+
     my ($test, $is_python);
     my $fullname = "$category-$name";
     state %loaded;    # keep track of loaded packages

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -198,6 +198,7 @@ subtest 'test always_rollback flag' => sub {
     snapshot_subtest 'always_run flag ensures execution after fatal failure' => sub {
         local %autotest::tests = ();
         local @autotest::testorder = ();
+        local %autotest::scheduled_basenames = ();
         local $autotest::last_milestone = undef;
         local $autotest::last_milestone_active_consoles = [];
         local $autotest::activated_consoles = [];
@@ -224,7 +225,7 @@ subtest 'test always_rollback flag' => sub {
         $vm_stopped = 0;
         my $output = combined_from { autotest::run_all };
         like $output, qr/skipping tests-start#?[0-9]* \(after fatal failure\)/, 'skipped normal test';
-        like $output, qr/starting next tests\/next\.pm/, 'executed always_run cleanup test';
+        like $output, qr{starting next tests/next\.pm}, 'executed always_run cleanup test';
         ($died, $completed) = get_tests_done;
         is $died, 0, 'tests not considered died';
         is $completed, 0, 'tests did not complete successfully';
@@ -356,6 +357,7 @@ is(@{$autotest::tests{'tests-fatal'}}{@opts}, @{$autotest::tests{'tests-fatal' .
 subtest 'scheduling rules' => sub {
     %autotest::tests = ();
     @autotest::testorder = ();
+    %autotest::scheduled_basenames = ();
 
     $bmwqemu::vars{EXCLUDE_MODULES} = 'start';
     autotest::loadtest('tests/start.pm');
@@ -388,6 +390,7 @@ subtest 'test scheduling test modules at test runtime' => sub {
     $autotest::tests_running = 0;
     @autotest::testorder = ();
     %autotest::tests = ();
+    %autotest::scheduled_basenames = ();
 
     my %json_data;
     my $json_filename = bmwqemu::result_dir . '/test_order.json';
@@ -430,6 +433,8 @@ subtest python => sub {
     } qr{Using python version.*scheduling pythontest tests/pythontest}s, 'python pythontest module referenced';
 
     %autotest::tests = ();
+    %autotest::scheduled_basenames = ();
+
     loadtest 'pythontest.py';
     loadtest 'morepython.py';
     my $p1 = $autotest::tests{'tests-pythontest'};
@@ -449,6 +454,7 @@ subtest 'python run_args' => sub {
     plan skip_all => 'Inline::Python is not available' unless $has_python;
 
     %autotest::tests = ();
+    %autotest::scheduled_basenames = ();
     my $targs = OpenQA::Test::RunArgs->new();
     $targs->{data} = 23;
 
@@ -459,6 +465,7 @@ subtest 'python with bad run method' => sub {
     plan skip_all => 'Inline::Python is not available' unless $has_python;
 
     %autotest::tests = ();
+    %autotest::scheduled_basenames = ();
     my $targs = OpenQA::Test::RunArgs->new();
     $targs->{data} = 23;
 
@@ -565,6 +572,32 @@ subtest croak => sub {
 subtest 'test skipping tests' => sub {
     $bmwqemu::vars{SKIPTO} = 'pythontest.py';
     stderr_like { autotest::runalltests } qr/skipping/, 'Skipping Test Run';
+};
+
+subtest 'modules with same filename' => sub {
+    local %autotest::tests = ();
+    local @autotest::testorder = ();
+    local %autotest::scheduled_basenames = ();
+    local $bmwqemu::vars{CASEDIR} = "$Bin/data/collision";
+    stderr_like { autotest::loadtest('tests/dir1/collision.pm') } qr{scheduling collision tests/dir1/collision\.pm}, 'dir1/collision.pm scheduled';
+    throws_ok { autotest::loadtest('tests/dir2/collision.pm') } qr{The test module basename 'collision' is already used by '.*tests/dir1/collision\.pm', but you tried to load it from '.*tests/dir2/collision\.pm'}, 'collision detected';
+
+    ok exists $autotest::tests{'dir1-collision'}, 'dir1/collision scheduled';
+    ok !exists $autotest::tests{'dir2-collision'}, 'dir2/collision not scheduled after collision';
+};
+
+subtest 'python modules with same filename' => sub {
+    plan skip_all => 'Inline::Python is not available' unless $has_python;
+
+    local %autotest::tests = ();
+    local @autotest::testorder = ();
+    local %autotest::scheduled_basenames = ();
+    local $bmwqemu::vars{CASEDIR} = "$Bin/data/collision";
+    stderr_like { autotest::loadtest('pythontests/dir1/collision.py') } qr{scheduling collision pythontests/dir1/collision\.py}, 'dir1/collision.py scheduled';
+    throws_ok { autotest::loadtest('pythontests/dir2/collision.py') } qr{The test module basename 'collision' is already used by '.*pythontests/dir1/collision\.py', but you tried to load it from '.*pythontests/dir2/collision\.py'}, 'collision detected';
+
+    ok exists $autotest::tests{'dir1-collision'}, 'dir1/collision.py scheduled';
+    ok !exists $autotest::tests{'dir2-collision'}, 'dir2/collision.py not scheduled after collision';
 };
 
 subtest 'start_process' => sub {

--- a/t/data/collision/pythontests/dir1/collision.py
+++ b/t/data/collision/pythontests/dir1/collision.py
@@ -1,0 +1,2 @@
+def run(self):
+    return "dir1"

--- a/t/data/collision/pythontests/dir2/collision.py
+++ b/t/data/collision/pythontests/dir2/collision.py
@@ -1,0 +1,2 @@
+def run(self):
+    return "dir2"

--- a/t/data/collision/tests/dir1/collision.pm
+++ b/t/data/collision/tests/dir1/collision.pm
@@ -1,0 +1,4 @@
+package collision;
+use base 'basetest';
+sub run ($self) { return "dir1" }
+1;

--- a/t/data/collision/tests/dir2/collision.pm
+++ b/t/data/collision/tests/dir2/collision.pm
@@ -1,0 +1,4 @@
+package collision;
+use base 'basetest';
+sub run ($self) { return "dir2" }
+1;


### PR DESCRIPTION
Motivation:
When two test modules have the same filename but are in different folders, they
would overwrite each other's results and screenshots in openQA if allowed to
co-exist. To prevent confusing test results and incorrect artifact association,
we should fail explicitly during scheduling if such a collision is detected.

Design Choices:
- Introduced a tracking mechanism for scheduled basenames in autotest.pm.
- In loadtest, verify that any scheduled basename originates from the same
  file path. If the same basename is loaded from a different directory, the
  test execution now aborts with an explicit error message.
- Updated test suite to expect and verify the explicit failure on basename
  collisions instead of checking for co-existence.

Benefits:
- Provides clear and immediate feedback to the user when a naming collision
  occurs, preventing silent artifact overwrites.
- Enhances engine robustness by ensuring basename uniqueness across the
  schedule.

Related issue: https://progress.opensuse.org/issues/200886