### PR TITLE
ci: Remove package builds for Leap 15.6 as it reached EOL

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -20,11 +20,6 @@ pr:
               - target_project: openSUSE:Factory
                 target_repository: snapshot
             architectures: [ x86_64 ]
-          - name: openSUSE_Leap_15.6
-            paths:
-              - target_project: devel:openQA:Leap:15.6
-                target_repository: openSUSE_Leap_15.6
-            architectures: [ x86_64 ]
           - name: '16.0'
             paths:
               - target_project: devel:openQA:Leap:16.0

--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -9,9 +9,9 @@ pr:
     - configure_repositories:
         project: devel:openQA:GitHub
         repositories:
-          - name: SLE_15_SP6_Backports
+          - name: SLE_15_SP7_Backports
             paths:
-              - target_project: openSUSE:Backports:SLE-15-SP6:Update
+              - target_project: openSUSE:Backports:SLE-15-SP7:Update
                 target_repository: standard
             architectures:
               - x86_64

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -73,7 +73,7 @@ Source0:        %{name}-%{version}.tar.xz
 %else
 %bcond_with python_support
 %endif
-%if 0%{?is_opensuse} && (0%{?suse_version} >= 1600 || 0%{?sle_version} >= 150600)
+%if 0%{?is_opensuse} && 0%{?suse_version} >= 1600
 %bcond_without lua_support
 %else
 %bcond_with lua_support

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -27,12 +27,12 @@ Source0:        %{name}-%{version}.tar.xz
 %{perl_requires}
 %define opencv_require pkgconfig(opencv4)
 # exclude additional sub packages that would pull in a lot of extra dependencies on SLE
-%if 0%{?suse_version} && !0%{?is_opensuse}
-%bcond_with devel_package
-%bcond_with deps_package
-%else
+%if 0%{?is_opensuse} && 0%{?suse_version} >= 1600
 %bcond_without devel_package
 %bcond_without deps_package
+%else
+%bcond_with devel_package
+%bcond_with deps_package
 %endif
 # The following line is generated from dependencies.yaml
 %define build_base_requires %opencv_require gcc-c++ perl(Pod::Html) pkg-config pkgconfig(fftw3) pkgconfig(libpng) pkgconfig(sndfile) pkgconfig(theoraenc)


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/200814