### PR TITLE
Require perl(Syntax::Keyword::Try) for tests

### DIFF
--- a/container/os-autoinst_dev/Dockerfile
+++ b/container/os-autoinst_dev/Dockerfile
@@ -141,6 +141,7 @@ RUN zypper in -y -C \
        'perl(Scalar::Util)' \
        'perl(Socket)' \
        'perl(Socket::MsgHdr)' \
+       'perl(Syntax::Keyword::Try)' \
        'perl(Template::Toolkit)' \
        'perl(Term::ANSIColor)' \
        'perl(Test::CheckGitStatus)' \

--- a/cpanfile
+++ b/cpanfile
@@ -85,6 +85,7 @@ on 'test' => sub {
     requires 'Perl::Critic::Policy';
     requires 'Perl::Critic::Utils';
     requires 'Pod::Coverage';
+    requires 'Syntax::Keyword::Try';
     requires 'Test::Compile';
     requires 'Test::Mock::Time';
     requires 'Test::MockModule';

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -149,6 +149,7 @@ test_base_requires:
   perl(Devel::Cover):
   perl(FindBin):
   perl(Pod::Coverage):
+  perl(Syntax::Keyword::Try):
   perl(Test::MockModule):
   perl(Test::MockObject):
   perl(Test::MockRandom):

--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -117,7 +117,7 @@ Source0:        %{name}-%{version}.tar.xz
 %define test_non_s390_requires %{nil}
 %endif
 # The following line is generated from dependencies.yaml
-%define test_base_requires %main_requires cpio icewm perl(Benchmark) perl(Devel::Cover) perl(FindBin) perl(Pod::Coverage) perl(Test::Compile) perl(Test::Mock::Time) perl(Test::MockModule) perl(Test::MockObject) perl(Test::MockRandom) perl(Test::Mojo) perl(Test::Most) perl(Test::Output) perl(Test::Perl::Critic) perl(Test::Pod) perl(Test::Warnings) >= 0.029 procps python3-setuptools qemu >= 4.0 qemu-tools socat xorg-x11-Xvnc xterm xterm-console
+%define test_base_requires %main_requires cpio icewm perl(Benchmark) perl(Devel::Cover) perl(FindBin) perl(Pod::Coverage) perl(Syntax::Keyword::Try) perl(Test::Compile) perl(Test::Mock::Time) perl(Test::MockModule) perl(Test::MockObject) perl(Test::MockRandom) perl(Test::Mojo) perl(Test::Most) perl(Test::Output) perl(Test::Perl::Critic) perl(Test::Pod) perl(Test::Warnings) >= 0.029 procps python3-setuptools qemu >= 4.0 qemu-tools socat xorg-x11-Xvnc xterm xterm-console
 # The following line is generated from dependencies.yaml
 %define test_version_only_requires perl(Mojo::IOLoop::ReadWriteProcess) >= 0.28
 # The following line is generated from dependencies.yaml


### PR DESCRIPTION
60ef460ff1cd0a1da7021a7a89115ce8d48e30c2 added a use of Syntax::Keyword::Try in t/48-testmodules-style.t , but did not add it to the test requirements.