### PR TITLE
refactor: Use Feature::Compat::Try consistently

### DIFF
--- a/script/os-autoinst-testmodules-strict
+++ b/script/os-autoinst-testmodules-strict
@@ -53,7 +53,7 @@ use Getopt::Long;
 use List::Util qw(max);
 use Mojo::File qw(path);
 use PPI;
-use Syntax::Keyword::Try;
+use Feature::Compat::Try;
 
 sub usage ($r) { require Pod::Usage; Pod::Usage::pod2usage($r) }
 

--- a/t/48-testmodules-style.t
+++ b/t/48-testmodules-style.t
@@ -6,7 +6,7 @@ use Test::Warnings qw(:report_warnings);
 use Test::Output qw(combined_like);
 use FindBin '$Bin';
 use YAML::PP qw(Load);
-use Syntax::Keyword::Try;
+use Feature::Compat::Try;
 
 my $script = "$Bin/../script/os-autoinst-testmodules-strict";
 require $script;


### PR DESCRIPTION
Syntax::Keyword::Try provides a `try` feature that is compatible with the `try` function builtin in newer perl versions. Feature::Compat::Try is a module that uses Syntax::Keyword::Try in older versions and automatically uses the builtin `try` in newer versions, and that is what we use elsewhere as well.

I had simply confused the two modules in those files.