### PR TITLE
feat: Upgrade VM compatibility by VMWARE_VM_HWVERSION

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -624,6 +624,10 @@ __END'
         my $nvram_path = sprintf '/vmfs/volumes/%s/openQA/%s', $bmwqemu::vars{VMWARE_DATASTORE} // 'datastore1', $nvram;
         $ret = $self->run_cmd("test -e $nvram_path", domain => 'sshVMwareServer');
         $self->run_cmd(qq{echo 'nvram = "$nvram"' >> $vmx}, domain => 'sshVMwareServer') unless ($ret);
+        # set virtual hardware version if specified
+        if ($bmwqemu::vars{VMWARE_VM_HWVERSION}) {
+            $self->run_cmd(qq{sed -i 's/^virtualHW.version = ".*"/virtualHW.version = "$bmwqemu::vars{VMWARE_VM_HWVERSION}"/' $vmx}, domain => 'sshVMwareServer');
+        }
 
         my $fb_tool = $bmwqemu::vars{GUESTINFO_CONFIG};
 

--- a/doc/backend_vars.md
+++ b/doc/backend_vars.md
@@ -243,6 +243,7 @@ Supported variables per backend
 | VMWARE_REMOTE_VMM | string |  | Set the vmware Virtual Machine Manager |
 | VMWARE_VNC_OVER_WS | boolean | 0 | Whether to use VNC over WebSockets (instead of raw VNC connection) |
 | VMWARE_VNC_OVER_WS_INSECURE | boolean | 0 | Do not require a valid TLS certificate for VNC over WebSockets |
+| VMWARE_VM_HWVERSION | integer |  | VM hardware version |
 | GUESTINFO_COMBUSTION | string |  | Set the location of combustion's bash script file among the data folder |
 | GUESTINFO_IGNITION | string |  | Set the location of ignition's config file formated in json, among the data folder |
 | GUESTINFO_CLOUD_INIT | string |  | Set the location of user-data and meta-data files, separated by a comma in data folder |

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -241,6 +241,14 @@ subtest 'starting VMware console' => sub {
     _check_vmware_cmds(\@cmds);
 };
 
+subtest 'starting VMware console with a specified hardware version' => sub {
+    local $bmwqemu::vars{VMWARE_VM_HWVERSION} = '13';
+    my (@cmds, @ssh_cmds);
+    my $mocks = _mock_svirt_vmware(\@cmds, \@ssh_cmds);
+    $svirt_console->define_and_start;
+    _check_vmware_cmds(\@cmds, [qq{sed -i 's/^virtualHW.version = ".*"/virtualHW.version = "$bmwqemu::vars{VMWARE_VM_HWVERSION}"/' /vmfs/volumes/datastore1/openQA/openQA-SUT-1.vmx}]);
+};
+
 subtest 'test config encoding' => sub {
     $bmwqemu::vars{GUESTINFO_COMBUSTION} = 'someTestScript';
     my $test_script_dir = path(File::Temp->newdir('testXXXX'));


### PR DESCRIPTION
The default virtual hardware version of VM by creating from libvirt is ESXi 5.0. To keep the VM configuration consistent with the latest ESXi server version, introduced a new variable VMWARE_VM_HWVERSION for upgrading before VM starting up.
https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html

- Related ticket: https://progress.opensuse.org/issues/200051
- Verification run: [default_svirt_sle16@svirt-vmware80](http://10.146.15.126/tests/11)