### PR TITLE
feat: Log details about relevant port if cmd srv cannot be started

### DIFF
--- a/.github/workflows/openqa_fullstack.yml
+++ b/.github/workflows/openqa_fullstack.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     container:
-      image: registry.opensuse.org/devel/openqa/containers/opensuse/openqa_devel:latest
+      image: registry.opensuse.org/devel/openqa/containers/opensuse/openqa_ci:latest
     steps:
       - uses: actions/checkout@v6
       - name: Create additional user to avoid initdb error "cannot be run as root"

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -21,7 +21,7 @@ use Fcntl;
 use Net::DBus;
 use bmwqemu qw(diag);
 require IPC::System::Simple;
-use osutils qw(find_bin qv run_diag runcmd);
+use osutils qw(find_bin qv run_diag runcmd port_details);
 use List::Util qw(first max);
 use Data::Dumper;
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
@@ -1074,7 +1074,7 @@ sub start_qemu ($self) {
     my $ret = $self->select_console({testapi_console => 'sut'});
 
     if ($ret->{error}) {
-        bmwqemu::fctinfo("VNC port details:\n" . _port_details($vncport));
+        bmwqemu::fctinfo("VNC port details:\n" . port_details($vncport));
         die $ret->{error};
     }
     if ($vars->{NICTYPE} eq 'tap') {
@@ -1230,12 +1230,6 @@ sub check_socket ($self, $fh, $write = undef) {
 
 sub _extract_hostfwd_ports ($args) { return $args =~ /hostfwd=(?:tcp|udp)::(\d+)-/g; }
 
-sub _port_details ($port) {
-    my @ss_output = qx{ss -tlnp 2>/dev/null};
-    my @port_info = grep { /\b$port\b/ } @ss_output;
-    return @port_info ? join('', @port_info) : 'no details found';
-}
-
 sub _assert_port_availability ($port, $service) {
     bmwqemu::fctinfo("checking $port port availability");
     my $sock = IO::Socket::IP->new(
@@ -1246,7 +1240,7 @@ sub _assert_port_availability ($port, $service) {
     );
     if ($sock) {
         $sock->close;
-        die "Port $port ($service) is already in use\n" . _port_details($port);
+        die "Port $port ($service) is already in use\n" . port_details($port);
     }
     return 0;
 }

--- a/commands.pm
+++ b/commands.pm
@@ -15,6 +15,7 @@ use Mojo::JSON 'to_json';
 use Mojo::File 'path';
 use myjsonrpc;
 use bmwqemu;
+use osutils qw(port_details);
 use testapi ();
 
 BEGIN {
@@ -283,6 +284,7 @@ sub run_daemon ($port, $isotovideo) {
     try { $daemon->run }
     catch ($e) {
         print "cmdsrv: failed to run daemon on port $port: $e\n";    # uncoverable statement
+        print port_details($port) if $e =~ /already in use/i;    # uncoverable statement
         _exit(1);    # uncoverable statement
     }
 }

--- a/osutils.pm
+++ b/osutils.pm
@@ -21,6 +21,7 @@ our @EXPORT_OK = qw(
   run
   run_diag
   attempt
+  port_details
 );
 
 # An helper to lookup into a folder and find an executable file between given candidates
@@ -106,6 +107,12 @@ sub attempt {    # no:style:signatures
     }
     $or->() if $or && !$condition->();
     bmwqemu::diag "Finished after $attempts attempts";
+}
+
+sub port_details ($port) {
+    my @ss_output = qx{ss -tlnp 2>/dev/null};
+    my @port_info = grep { /\b$port\b/ } @ss_output;
+    return @port_info ? join('', @port_info) : 'no details found';
 }
 
 1;


### PR DESCRIPTION
This might help if we run again into `Can't create listen socket.*Address
already in use`.

Related ticket: https://progress.opensuse.org/issues/201384