### PR TITLE
test: allow shortening long typing in full-stack tests

### DIFF
--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -43,6 +43,7 @@ path('vars.json')->spew(<<"EOV");
    "CDMODEL" : "ide-cd",
    "HDDMODEL" : "ide-hd",
    "VERSION" : "1",
+   "FAST_TYPING" : "@{[ $ENV{OS_AUTOINST_FAST_TYPING} // 0 ]}",
    "SSH_CONNECT_RETRY"  : "2",
    "SSH_CONNECT_RETRY_INTERVAL"  : ".001",
    "VNC_CONNECT_SLEEP" : "0",

--- a/t/data/tests/tests/typing.pm
+++ b/t/data/tests/tests/typing.pm
@@ -23,9 +23,15 @@ RFB found a second and more enduring use when VNC was developed. VNC was release
 When ORL was closed in 2002 some of the key people behind VNC and RFB formed [[RealVNC]], Ltd., in order to continue development of VNC and to maintain the RFB protocol. The current RFB protocol is published on the RealVNC website.
 END
 
+    my $md5 = '924095f2cb4d622a8796de66a5e0a44a';
+    if (get_var('FAST_TYPING')) {
+        $text = "==Description==\nShort text for fast typing.\n";
+        $md5 = 'e5e578ebcb49c765134bcfa1640b3821';
+    }
+
     type_string $text;
     type_string "\nEOF\n";
-    script_run "echo '924095f2cb4d622a8796de66a5e0a44a  text' > text.md5";
+    script_run "echo '$md5  text' > text.md5";
     assert_script_run 'md5sum -c text.md5';
 
     # TinyCore busybox sh acts as bash but does not provide it so we do here


### PR DESCRIPTION
Motivation:
The full-stack integration test is currently slow (taking ~180s) due
to a large block of text being typed over VNC in typing.pm.

Design Choices:
Introduced a FAST_TYPING environment variable to
t/data/tests/tests/typing.pm. When enabled, it swaps the massive
description text for a minimal one and adjusts MD5 verification
dynamically.

Benefits:
Reduces t/99-full-stack.t runtime by ~60 seconds (from ~180s to ~118s).
Maintains the ability to run the full VNC stability test by default.
Enable with env variable OS_AUTOINST_FAST_TYPING=1.