### PR TITLE
test: enable pretty serial markers in full-stack test

### DIFF
--- a/t/18-qemu.t
+++ b/t/18-qemu.t
@@ -140,7 +140,7 @@ $proc = qemu_proc('-foo', \%vars);
 @gcmdl = $proc->gen_cmdline();
 is_deeply(\@gcmdl, \@cmdl, 'Generate qemu command line for single existing UEFI disk using vars');
 
-@cmdl = ([qw(create -f qcow2 -F raw -b), "$Bin/data/Core-7.2.iso", qw(raid/hd0-overlay0 11116544)]);
+@cmdl = ([qw(create -f qcow2 -F raw -b), "$Bin/data/Core-7.2.iso", qw(raid/hd0-overlay0 11814912)]);
 @gcmdl = $proc->blockdev_conf->gen_qemu_img_cmdlines();
 is_deeply(\@gcmdl, \@cmdl, 'Generate qemu-img command line for single existing UEFI disk');
 
@@ -257,7 +257,7 @@ is_deeply(\@gcmdl, \@cmdl, 'Command line after snapshot and serialisation')
   || diag(explain(\@gcmdl));
 
 @cmdl = ([qw(create -f qcow2 -F qcow2 -b raid/hd0 raid/hd0-overlay1 10G)],
-    [qw(create -f qcow2 -F qcow2 -b raid/cd0-overlay0 raid/cd0-overlay1 11116544)]);
+    [qw(create -f qcow2 -F qcow2 -b raid/cd0-overlay0 raid/cd0-overlay1 11814912)]);
 @gcmdl = $bdc->gen_qemu_img_cmdlines();
 is_deeply(\@gcmdl, \@cmdl, 'Generate reverted snapshot images');
 
@@ -409,8 +409,8 @@ subtest 'relative assets' => sub {
     my @gcmdl = $proc->blockdev_conf->gen_qemu_img_cmdlines();
     @cmdl = (
         [qw(create -f qcow2 -F qcow2 -b), "$dir/some.qcow2", 'raid/hd0-overlay0', 512],
-        [qw(create -f qcow2 -F raw -b), "$dir/Core-7.2.iso", 'raid/cd0-overlay0', 11116544],
-        [qw(create -f qcow2 -F raw -b), "$dir/Core-7.2.iso", 'raid/cd1-overlay0', 11116544],
+        [qw(create -f qcow2 -F raw -b), "$dir/Core-7.2.iso", 'raid/cd0-overlay0', 11814912],
+        [qw(create -f qcow2 -F raw -b), "$dir/Core-7.2.iso", 'raid/cd1-overlay0', 11814912],
         [qw(create -f qcow2 -F raw -b), "$Bin/data/uefi-code.bin", 'raid/pflash-code-overlay0', 1966080],
         [qw(create -f qcow2 -F qcow2 -b), "$dir/some.qcow2", 'raid/pflash-vars-overlay0', 512],
     );

--- a/t/99-full-stack.t
+++ b/t/99-full-stack.t
@@ -40,6 +40,7 @@ path('vars.json')->spew(<<"EOV");
    "QEMU_NO_FDC_SET" : "1",
    "CASEDIR" : "$casedir",
    "ISO" : "$data_dir/Core-7.2.iso",
+   "PRETTY_SERIAL_MARKER" : "1",
    "CDMODEL" : "ide-cd",
    "HDDMODEL" : "ide-hd",
    "VERSION" : "1",

--- a/t/data/remaster_core_iso.sh
+++ b/t/data/remaster_core_iso.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -e
+
+VANILLA_ISO=$1
+OUTPUT_ISO=$2
+
+if [[ -z $VANILLA_ISO || -z $OUTPUT_ISO ]]; then
+    echo "Usage: $0 <vanilla_iso> <output_iso>"
+    exit 1
+fi
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# Unpack ISO
+mkdir -p "$WORK_DIR/iso"
+mounted=0
+if mount -o loop,ro "$VANILLA_ISO" "$WORK_DIR/iso"; then
+    mounted=1
+else
+    # If mount fails (e.g. no root), try extracting with xorriso.
+    echo "Failed to mount ISO. Trying extraction with xorriso..."
+    if command -v xorriso > /dev/null 2>&1; then
+        xorriso -osirrox on -indev "$VANILLA_ISO" -extract / "$WORK_DIR/iso_content"
+    else
+        echo "xorriso not found. Cannot extract ISO without root/mount."
+        exit 1
+    fi
+fi
+
+if [[ $mounted -eq 1 ]]; then
+    shopt -s nullglob
+    iso_files=("$WORK_DIR/iso"/*)
+    if [[ ${#iso_files[@]} -gt 0 ]]; then
+        mkdir -p "$WORK_DIR/iso_content"
+        cp -a "$WORK_DIR/iso/"* "$WORK_DIR/iso_content/"
+    fi
+    shopt -u nullglob
+    umount "$WORK_DIR/iso"
+fi
+chmod -R u+w "$WORK_DIR/iso_content"
+
+# Prepare extensions
+mkdir -p "$WORK_DIR/ext_merged"
+for ext in bash.tcz readline.tcz ncurses.tcz; do
+    if [[ ! -f t/data/$ext ]]; then
+        # Try ncursesw if ncurses not found
+        if [[ $ext == ncurses.tcz && -f t/data/ncursesw.tcz ]]; then
+            ext="ncursesw.tcz"
+        else
+            echo "Extension $ext not found in t/data/"
+            exit 1
+        fi
+    fi
+    unsquashfs -d "$WORK_DIR/ext_merged" -f -n "t/data/$ext"
+done
+
+# Unpack core.gz
+mkdir -p "$WORK_DIR/core"
+zcat "$WORK_DIR/iso_content/boot/core.gz" | (cd "$WORK_DIR/core" && fakeroot cpio -id)
+
+# Merge extensions into core
+cp -a "$WORK_DIR/ext_merged/"* "$WORK_DIR/core/"
+
+# Set default shell to bash for 'tc' user
+sed -i 's|tc:x:1001:50:Linux User,,,:/home/tc:/bin/sh|tc:x:1001:50:Linux User,,,:/home/tc:/usr/local/bin/bash|' "$WORK_DIR/core/etc/passwd"
+
+# Repack core.gz
+(cd "$WORK_DIR/core" && find . | fakeroot cpio -o -H newc | gzip -9) > "$WORK_DIR/iso_content/boot/core.gz"
+
+# Create new ISO
+mkisofs -l -J -R -V "Core-remastered" \
+    -no-emul-boot -boot-load-size 4 -boot-info-table \
+    -b boot/isolinux/isolinux.bin -c boot/isolinux/boot.cat \
+    -o "$OUTPUT_ISO" "$WORK_DIR/iso_content"
+
+echo "Remastered ISO created at $OUTPUT_ISO"

--- a/t/data/tests/tests/typing.pm
+++ b/t/data/tests/tests/typing.pm
@@ -34,8 +34,6 @@ END
     script_run "echo '$md5  text' > text.md5";
     assert_script_run 'md5sum -c text.md5';
 
-    # TinyCore busybox sh acts as bash but does not provide it so we do here
-    script_run 'alias bash=sh', 0;
     my $out = script_output('mount');
     die "mount does not show any mount points? output: $out" unless $out =~ /.*\/.*on/;
     die "^rootfs not found. output: $out" unless $out =~ qr{^rootfs};


### PR DESCRIPTION
Motivation:
We need automated end-to-end verification that the pretty serial marker
logic functions correctly in a real QEMU environment.

Design Choices:
- Enabled PRETTY_SERIAL_MARKER in the integration test environment.
- Removed the manual bash alias workaround in typing.pm since real
  bash is now available on the remastered Core ISO.

Benefits:
- Ensures the full stack (isotovideo, distribution, backend) correctly
  coordinates for Level 2/3 marker detection and usage.
- Increases the realism of the full-stack test suite.