### PR TITLE
feat!: fail by default if always_rollback is not supported

### DIFF
--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -9,7 +9,7 @@ use Mojo::Base -strict, -signatures;
 # -> increment on every change of such APIs
 # -> never move that variable to another place (when refactoring)
 #    because it may be accessed by the tests itself
-our $version = 55;
+our $version = 56;
 
 # major version of the (web socket) API relevant to the developer mode
 # -> increment when making non-backward compatible changes to that API

--- a/autotest.pm
+++ b/autotest.pm
@@ -23,6 +23,8 @@ use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 use Mojo::File qw(path);
 use File::Glob qw(bsd_glob);
 
+use constant FAIL_ON_ALWAYS_ROLLBACK_NOT_SUPPORTED => 1;
+
 our @EXPORT_OK = qw(loadtest $selected_console $last_milestone_console query_isotovideo);
 
 our %tests;    # scheduled or run tests
@@ -548,7 +550,7 @@ sub runalltests () {
     for (my $testindex = 0; $testindex <= $#testorder; $testindex++) {
         my $t = $testorder[$testindex];
         my $flags = $t->test_flags();
-        if ($flags->{always_rollback} && !$snapshots_supported && $bmwqemu::vars{FAIL_ON_ALWAYS_ROLLBACK_NOT_SUPPORTED}) {
+        if ($flags->{always_rollback} && !$snapshots_supported && ($bmwqemu::vars{FAIL_ON_ALWAYS_ROLLBACK_NOT_SUPPORTED} // FAIL_ON_ALWAYS_ROLLBACK_NOT_SUPPORTED)) {
             die "always_rollback requested but snapshots are not supported by the backend\n";
         }
         my $fullname = $t->{fullname};

--- a/doc/backend_vars.md
+++ b/doc/backend_vars.md
@@ -62,7 +62,7 @@ Supported variables per backend
 | _HIDE_SECRETS_REGEX | string |  | If set, any test variables whose **NAME** (key) matches the specified regular expression, in addition to the default '^_SECRET_' and '_PASSWORD', are excluded from being saved into vars.json or further processing. For example, to hide all variables starting with 'SCC_REGCODE', use '^SCC_REGCODE'. |
 | STORAGE_KEEP_FREE_RATIO | float | 0.2 | Ratio of total storage space to keep free (e.g. 0.2 for 20%). If the total requested HDD size exceeds the available space while keeping this ratio of total storage size free, the job is aborted early with "incomplete" status. Set to 0 to disable this check. Automatically disabled in CI environments (if `CI` or `GITHUB_ACTIONS` is set in the environment). |
 | STORAGE_KEEP_FREE_GB | integer | 50 | Absolute free space threshold in GiB. If the total requested HDD size leaves less than this amount of free space, the job can only run if the relative check (`STORAGE_KEEP_FREE_RATIO`) is also satisfied. Set to 0 to disable the absolute threshold. Automatically disabled in CI environments (if `CI` or `GITHUB_ACTIONS` is set in the environment). |
-| FAIL_ON_ALWAYS_ROLLBACK_NOT_SUPPORTED | boolean | 0 | Fail explicitly if a test module is scheduled with the `always_rollback` flag but snapshots are not supported by the backend. |
+| FAIL_ON_ALWAYS_ROLLBACK_NOT_SUPPORTED | boolean | 1 | Fail explicitly if a test module is scheduled with the `always_rollback` flag but snapshots are not supported by the backend. |
 |  |
 
 ## ZVM backend

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -138,6 +138,7 @@ subtest 'test always_rollback flag' => sub {
         $mock_basetest->redefine(test_flags => {always_rollback => 1, milestone => 1});
         $mock_autotest->redefine(query_isotovideo => 0);
         $mock_autotest->redefine(load_snapshot => sub { $reverts_done++; });
+        local $bmwqemu::vars{FAIL_ON_ALWAYS_ROLLBACK_NOT_SUPPORTED} = 0;
         stderr_like { autotest::run_all } qr/finished/, 'run_all outputs status on stderr';
         ($died, $completed) = get_tests_done;
         is $died, 0, 'start+next+start should not die when always_rollback flag is set';
@@ -233,14 +234,12 @@ subtest 'test always_rollback flag' => sub {
         is $reverts_done, 0, 'no snapshots loaded after fatal failure';
         is $snapshots_made, 0, 'no snapshots made after fatal failure';
     };
-    snapshot_subtest 'fails if snapshots are not supported and FAIL_ON_ALWAYS_ROLLBACK_NOT_SUPPORTED is set' => sub {
+    snapshot_subtest 'fails by default if snapshots are not supported and always_rollback is requested' => sub {
         $mock_basetest->redefine(test_flags => {always_rollback => 1});
         $mock_autotest->redefine(query_isotovideo => sub { 0 });
-        $bmwqemu::vars{FAIL_ON_ALWAYS_ROLLBACK_NOT_SUPPORTED} = 1;
         my $w;
         stderr_like { $w = warning { autotest::run_all } } qr/Snapshots are not supported/, 'run_all outputs on stderr';
         like $w, qr/always_rollback requested but snapshots are not supported by the backend/, 'fails with explicit error message';
-        delete $bmwqemu::vars{FAIL_ON_ALWAYS_ROLLBACK_NOT_SUPPORTED};
     };
     $mock_basetest->unmock($_) for qw(runtest test_flags);
     $mock_autotest->unmock($_) for qw(load_snapshot make_snapshot query_isotovideo);


### PR DESCRIPTION
Motivation:
Previously, if a test module requested `always_rollback` but snapshots
were not supported by the backend, it would only warn. This can lead to
unexpected behavior where snapshots are assumed to be taken but are
actually skipped.

Design Choices:
Changed the default value of `FAIL_ON_ALWAYS_ROLLBACK_NOT_SUPPORTED` from
0 to 1. Incremented the interface version in
`OpenQA/Isotovideo/Interface.pm` to reflect this change in behavior.
Updated documentation and tests accordingly. Used `local` in tests to
ensure clean state.

Benefits:
Ensures that test developers are explicitly aware when a requested
rollback mechanism is not available, preventing silent failures of the
rollback logic.

BREAKING CHANGE: test modules with `always_rollback` executed in an
environment where snapshots are not supported fail now explicitly. Adapt
the test schedule accordingly (or temporarily mute the behaviour with
FAIL_ON_ALWAYS_ROLLBACK_NOT_SUPPORTED=0).