### PR TITLE
feat: consolidate tidy targets into CMake

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ test scripts.
 
 ## Conventions
 
-- Code style: Run `tools/tidyall --all` (or `tools/tidyall --git` for changed
-  files only). This MUST be done before every commit and before claiming
-  completion.
+- Code style: Run `make tidy-perl` (or `tools/tidyall --git` for changed files
+  only) or `make tidy` to tidy all files (C++, Python, Perl). This MUST be
+  done before every commit and before claiming completion.
 - Linter: Always run `make test-perl-testsuite TESTS="xt/01-style.t xt/02-perlcritic.t"`
   for Perl changes before claiming completion.
 - Testing: Always add tests for new features or bug fixes in `t/`. Prefer

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,3 +285,18 @@ add_custom_target(
     COMMAND "${RUFF_PATH}" check --fix .
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 )
+
+# add target for formatting Perl source code
+add_custom_target(
+    tidy-perl
+    COMMENT "Formatting Perl source code"
+    COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tools/tidyall" --all
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+
+# unified tidy target
+add_custom_target(
+    tidy
+    COMMENT "Formatting all source code"
+    DEPENDS tidy-cpp tidy-python tidy-perl
+)

--- a/README.md
+++ b/README.md
@@ -322,9 +322,11 @@ Reset gathered coverage data: `make coverage-reset`
 
 Install files for packaging: `make install DESTDIR=…`
 
-Automatically tidy all perl files: `tools/tidyall`
+Automatically tidy all perl files: `make tidy-perl`
 
 Tidy all changed perl files: `tools/tidyall --git`
+
+Tidy all files (C++, Python, Perl): `make tidy`
 
 Further notes:
 


### PR DESCRIPTION
Motivation:
Previously, Perl tidying was done by calling tools/tidyall directly, while
C++ and Python had their own tidy targets in CMake. This consolidation
provides a unified way to tidy all source files in the project.

Design Choices:
- Added tidy-perl target to CMakeLists.txt that calls tools/tidyall --all.
- Added a unified tidy target that depends on tidy-cpp, tidy-python, and
  tidy-perl.
- Updated README.md and AGENTS.md to recommend the new make targets.
- Ran make tidy to ensure all files are properly formatted.

Benefits:
- Unified developer experience for code formatting.
- Easier to discover and run all necessary tidying commands.
- Consistent formatting across the codebase.