### PR TITLE
feat: integrate C++ style checks into CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,7 +272,7 @@ find_program(CLANG_FORMAT_PATH clang-format)
 add_custom_target(
     tidy-cpp
     COMMENT "Formatting C++ source code"
-    COMMAND sh -c "'${CLANG_FORMAT_PATH}" "--style=WebKit" "-i" "$$(find" "." "-name" "\*.h" "-o" "-name" "\*.cc" "-o" "-name" "\*.cpp)'"
+    COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tools/check-cpp-style" "${CLANG_FORMAT_PATH}" --fix
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 )
 

--- a/cmake/test-targets.cmake
+++ b/cmake/test-targets.cmake
@@ -33,6 +33,18 @@ else ()
     message(STATUS "Set YAMLLINT_PATH to the path of the yamllint executable to enable YAML syntax checks.")
 endif ()
 
+# add test for C++ code style
+find_program(CLANG_FORMAT_PATH clang-format)
+if (CLANG_FORMAT_PATH)
+    add_test(
+        NAME test-local-cpp-style
+        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tools/check-cpp-style" "${CLANG_FORMAT_PATH}"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+else ()
+    message(STATUS "Set CLANG_FORMAT_PATH to the path of the clang-format executable to enable C++ style checks.")
+endif ()
+
 # add test for python code style
 find_program(RUFF_PATH ruff)
 if (RUFF_PATH)

--- a/ppmclibs/tinycv.h
+++ b/ppmclibs/tinycv.h
@@ -9,63 +9,63 @@
 struct Image;
 int opencv_default_thread_count();
 void create_opencv_threads(int thread_count);
-void image_destroy(Image *s);
-Image *image_new(long width, long height);
-Image *image_read(const char *filename);
+void image_destroy(Image* s);
+Image* image_new(long width, long height);
+Image* image_read(const char* filename);
 bool image_write(const Image* const s, const char* filename);
 // returns copy to static buffer
-std::vector<unsigned char> *image_ppm(Image *s);
-Image *image_from_ppm(const unsigned char *data, size_t len);
+std::vector<unsigned char>* image_ppm(Image* s);
+Image* image_from_ppm(const unsigned char* data, size_t len);
 
-std::vector<int> image_search(Image *s, Image *needle, long x, long y, long width, long height, long margin, double &similarity);
+std::vector<int> image_search(Image* s, Image* needle, long x, long y, long width, long height, long margin, double& similarity);
 // std::vector<int> image_search_fuzzy(Image *s, Image *needle);
 
-Image *image_copy(Image *s);
+Image* image_copy(Image* s);
 
-long image_xres(Image *s);
-long image_yres(Image *s);
+long image_xres(Image* s);
+long image_yres(Image* s);
 
-void image_replacerect(Image *s, long x, long y, long width, long height);
-Image *image_copyrect(Image *s, long x, long y, long width, long height);
-void image_threshold(Image *s, int level);
+void image_replacerect(Image* s, long x, long y, long width, long height);
+Image* image_copyrect(Image* s, long x, long y, long width, long height);
+void image_threshold(Image* s, int level);
 std::tuple<long, long, long> image_get_pixel(Image* a, long x, long y);
-std::vector<float> image_avgcolor(Image *s);
-bool image_differ(Image *a, Image *b, unsigned char maxdiff);
+std::vector<float> image_avgcolor(Image* s);
+bool image_differ(Image* a, Image* b, unsigned char maxdiff);
 
-Image *image_scale(Image *a, int width, int height);
-double image_similarity(Image *a, Image *b);
+Image* image_scale(Image* a, int width, int height);
+double image_similarity(Image* a, Image* b);
 
-Image *image_absdiff(Image *a, Image*b);
+Image* image_absdiff(Image* a, Image* b);
 
 class VNCInfo;
 
-VNCInfo *image_vncinfo(bool do_endian_conversion,
-		       bool true_color,
-		       unsigned int bytes_per_pixel,
-		       unsigned int red_mask,   unsigned int red_shift,
-		       unsigned int green_mask, unsigned int green_shift,
-		       unsigned int blue_mask,  unsigned int blue_shift);
+VNCInfo* image_vncinfo(bool do_endian_conversion,
+    bool true_color,
+    unsigned int bytes_per_pixel,
+    unsigned int red_mask, unsigned int red_shift,
+    unsigned int green_mask, unsigned int green_shift,
+    unsigned int blue_mask, unsigned int blue_shift);
 std::tuple<long, long, long> image_get_vnc_color(VNCInfo* info, unsigned int index);
-void image_set_vnc_color(VNCInfo *info, unsigned int index, unsigned int red, unsigned int green, unsigned int blue);
+void image_set_vnc_color(VNCInfo* info, unsigned int index, unsigned int red, unsigned int green, unsigned int blue);
 
-void image_fill_pixel(Image* a, const unsigned char *data, VNCInfo* info,
+void image_fill_pixel(Image* a, const unsigned char* data, VNCInfo* info,
     long x, long y, long width, long height);
 // this is for VNC support - RAW encoding
-void image_map_raw_data(Image *a, const unsigned char *data, unsigned int x, unsigned int y, unsigned int width, unsigned int height, VNCInfo *info);
+void image_map_raw_data(Image* a, const unsigned char* data, unsigned int x, unsigned int y, unsigned int width, unsigned int height, VNCInfo* info);
 
 // this is for IPMI Supermicro X9 support - RGB555 is 16bits, the rest is like above
-void image_map_raw_data_rgb555(Image *a, const unsigned char *data);
+void image_map_raw_data_rgb555(Image* a, const unsigned char* data);
 // this is for IPMI Supermicro X10 support - ast2100 (don't ask)
-void image_map_raw_data_ast2100(Image *a, const unsigned char *data, size_t len);
+void image_map_raw_data_ast2100(Image* a, const unsigned char* data, size_t len);
 
 // ZRLE encoding for VNC
 long image_map_raw_data_zrle(Image* a, long x, long y, long w, long h,
-			     VNCInfo *info,
-			     unsigned char *data,
-			     size_t len);
+    VNCInfo* info,
+    unsigned char* data,
+    size_t len);
 
 // raw data from v4l2
-void image_map_raw_data_uyvy(Image *a, const unsigned char *data);
+void image_map_raw_data_uyvy(Image* a, const unsigned char* data);
 
 // copy the s image into a at x,y
-void image_blend_image(Image *a, Image *s, long x, long y);
+void image_blend_image(Image* a, Image* s, long x, long y);

--- a/ppmclibs/tinycv_ast2100.cc
+++ b/ppmclibs/tinycv_ast2100.cc
@@ -310,7 +310,8 @@ static void setpalette(int* co, int cy, int cb, int cr)
     co[2] = cr - 128;
 }
 
-static inline int clamp(int x) { return x > 255 ? 255 : x < 0 ? 0 : x; }
+static inline int clamp(int x) { return x > 255 ? 255 : x < 0 ? 0
+                                                              : x; }
 
 void decode_ast2100(cv::Mat* pic, const unsigned char* data, size_t datal)
 {

--- a/ppmclibs/tinycv_impl.cc
+++ b/ppmclibs/tinycv_impl.cc
@@ -1,19 +1,19 @@
 // Copyright SUSE LLC
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <byteswap.h>
 #include <condition_variable>
-#include <functional>
-#include <mutex>
-#include <exception>
-#include <iostream>
 #include <cstdint>
 #include <cstdio>
+#include <exception>
+#include <functional>
+#include <iostream>
+#include <mutex>
 #include <sys/time.h>
-#include <byteswap.h>
 
 #include <algorithm> // std::min
-#include <vector>
 #include <cmath> // std::isnan
+#include <vector>
 
 #include <opencv2/calib3d/calib3d.hpp>
 #include <opencv2/core/core.hpp>
@@ -159,8 +159,8 @@ std::vector<int> search_TEMPLATE(const Image* scene, const Image* object,
     long x, long y, long width, long height,
     long margin, double& similarity)
 {
-// cvSetErrMode(CV_ErrModeParent);
-// cvRedirectError(MyErrorHandler);
+    // cvSetErrMode(CV_ErrModeParent);
+    // cvRedirectError(MyErrorHandler);
 
 #if DEBUG
     struct timeval tv1, tv2;
@@ -304,14 +304,18 @@ double getPSNR(const Mat& I1, const Mat& I2)
     return 10.0 * log10(signal / (noise * noise));
 }
 
-using OpenCVParallelFunction = std::function<void(const Range &)>;
+using OpenCVParallelFunction = std::function<void(const Range&)>;
 #if defined(CV_VERSION_MAJOR) && (CV_VERSION_MAJOR >= 4)
 using RunFunctionInParallel = OpenCVParallelFunction;
 #else
 class RunFunctionInParallel : public ParallelLoopBody {
 public:
-    explicit RunFunctionInParallel(OpenCVParallelFunction &&functor) : functor(std::move(functor)) {}
-    void operator() (const Range &range) const override { functor(range); }
+    explicit RunFunctionInParallel(OpenCVParallelFunction&& functor)
+        : functor(std::move(functor))
+    {
+    }
+    void operator()(const Range& range) const override { functor(range); }
+
 private:
     OpenCVParallelFunction functor;
 };
@@ -363,7 +367,7 @@ void create_opencv_threads(int thread_count)
     std::mutex m;
     std::condition_variable cv;
     int threads_spawned = 0;
-    parallel_for_(Range(0, thread_count), RunFunctionInParallel([&] (const Range &) {
+    parallel_for_(Range(0, thread_count), RunFunctionInParallel([&](const Range&) {
         // keep the thread idling until the expected number of threads has been spawned
         std::unique_lock<std::mutex> lock(m);
         if (++threads_spawned >= thread_count) {
@@ -583,7 +587,8 @@ public:
 
     Vec3b read_cpixel(const unsigned char* data, size_t& offset);
     Vec3b read_pixel(const unsigned char* data, size_t& offset);
-    const Vec3b &get_colour(unsigned int index) const {
+    const Vec3b& get_colour(unsigned int index) const
+    {
         assert(index < 256);
         return colourMap[index];
     }
@@ -597,7 +602,7 @@ public:
 
 std::tuple<long, long, long> image_get_vnc_color(VNCInfo* info, unsigned int index)
 {
-    const auto &color = info->get_colour(index);
+    const auto& color = info->get_colour(index);
     return std::make_tuple(color[0], color[1], color[2]);
 }
 
@@ -622,7 +627,7 @@ VNCInfo* image_vncinfo(bool do_endian_conversion, bool true_colour,
  * Fill given rectangle with pixel value read from 'data' and interpreted
  * according to 'info'. Number of bytes read from 'data' depends on 'info'.
  */
-void image_fill_pixel(Image* a, const unsigned char *data, VNCInfo* info,
+void image_fill_pixel(Image* a, const unsigned char* data, VNCInfo* info,
     long x, long y, long width, long height)
 {
     size_t offset = 0;
@@ -673,9 +678,9 @@ void image_map_raw_data_uyvy(Image* a, const unsigned char* data)
     for (int y = 0; y < a->img.rows; y++) {
         for (int x = 0; x < a->img.cols; x += 2) {
             int offset = (y * a->img.cols + x) * 2;
-            int u  = data[offset + 0];
+            int u = data[offset + 0];
             int y1 = data[offset + 1];
-            int v  = data[offset + 2];
+            int v = data[offset + 2];
             int y2 = data[offset + 3];
 
             y1 -= 16;
@@ -741,9 +746,7 @@ Vec3b VNCInfo::read_pixel(const unsigned char* data, size_t& offset)
         if (!true_colour)
             return colourMap[pixel];
     } else if (bytes_per_pixel == 3) {
-        pixel = *(data + offset++) |
-                *(data + offset++) << 8 |
-                *(data + offset++) << 16;
+        pixel = *(data + offset++) | *(data + offset++) << 8 | *(data + offset++) << 16;
     } else {
         // just fail miserably for unsupported bytes per pixel
         abort();
@@ -806,7 +809,7 @@ long image_map_raw_data_zrle(Image* a, long x, long y, long w, long h,
     VNCInfo* info, unsigned char* data, size_t bytes)
 {
     /* ZRLE implementation is described pretty straight forward in the RFB 3.8
-   * protocol */
+     * protocol */
 
     size_t offset = 0;
     int orig_w = w;

--- a/snd2png/snd2png.cpp
+++ b/snd2png/snd2png.cpp
@@ -27,7 +27,7 @@ static double imabs(fftw_complex cpx)
 // boring linear interpolation
 double valueForFreq(double* points, int bin, double ratio)
 {
-   if (bin == 0)
+    if (bin == 0)
         return points[0];
 
     double next_value = points[bin];
@@ -68,7 +68,7 @@ int main(int argc, char* argv[])
     }
 
     fprintf(stderr, "snd2png: %d channels, samplerate %d Hz, %ld frames (%.2f seconds)\n", info_in.channels,
-            info_in.samplerate, info_in.frames, (float)(info_in.frames)/info_in.samplerate);
+        info_in.samplerate, info_in.frames, (float)(info_in.frames) / info_in.samplerate);
 
     float* infile_data = (float*)fftw_malloc(sizeof(float) * info_in.frames * info_in.channels);
     if (!infile_data) {
@@ -130,7 +130,7 @@ int main(int argc, char* argv[])
     // https://en.wikipedia.org/wiki/Voice_frequency
     double max_freq = 3200.;
     double fft_max_freq = info_in.samplerate / 2.0;
-    int last_bin = std::min(int(1 + ceil(max_freq / fft_max_freq * (nDftSamples/2.0))), int(1 + nDftSamples/2.0));
+    int last_bin = std::min(int(1 + ceil(max_freq / fft_max_freq * (nDftSamples / 2.0))), int(1 + nDftSamples / 2.0));
     double fft_bw = fft_max_freq / (nDftSamples / 2.0);
 
     double** points = (double**)malloc(sizeof(double*) * times);
@@ -182,8 +182,8 @@ int main(int argc, char* argv[])
     fprintf(stderr, "silences: %d %d\n", first_non_silence, last_non_silence);
     for (int i = 1; i < freqs; ++i) {
         double freq = i * max_freq / freqs;
-        int bin = ceil(freq/fft_bw);
-        double ratio = bin - (freq/fft_bw);
+        int bin = ceil(freq / fft_bw);
+        double ratio = bin - (freq / fft_bw);
 
         for (int TimePos = first_non_silence; TimePos < last_non_silence; TimePos++) {
             double value = valueForFreq(points[TimePos], bin, ratio);

--- a/tools/check-cpp-style
+++ b/tools/check-cpp-style
@@ -1,0 +1,14 @@
+#!/bin/sh -e
+# fall back to find if there is no git, e.g. in package builds
+# shellcheck disable=SC2046
+CLANG_FORMAT="${1:-clang-format}"
+shift
+if [ "$1" = "--fix" ]; then
+    FIX="-i"
+    shift
+else
+    FIX="--dry-run --Werror"
+fi
+# shellcheck disable=SC2046,SC2086
+set -- $FIX $(git ls-files "*.h" "*.cc" "*.cpp" 2> /dev/null || find . -name '*.h' -o -name '*.cc' -o -name '*.cpp')
+"$CLANG_FORMAT" --style=WebKit "$@"

--- a/videoencoder.cpp
+++ b/videoencoder.cpp
@@ -45,8 +45,8 @@ video.
 #include <opencv2/core/core.hpp>
 #include <opencv2/opencv.hpp>
 
-#include <theora/theoraenc.h>
 #include <ogg/ogg.h>
+#include <theora/theoraenc.h>
 
 #include <getopt.h>
 #include <sys/stat.h>
@@ -100,7 +100,6 @@ static int theora_write_frame(th_ycbcr_buffer ycbcr, int last)
             fwrite(og.header, og.header_len, 1, ogg_fp);
             fwrite(og.body, og.body_len, 1, ogg_fp);
         }
-
     }
 }
 
@@ -205,7 +204,7 @@ int main(int argc, char* argv[])
         ogg_fp = fopen(option_output, "wb");
         if (!ogg_fp) {
             fprintf(stderr, "%s: error: %s\n", option_output,
-                    "couldn't open output file");
+                "couldn't open output file");
             return 1;
         }
     }
@@ -393,7 +392,6 @@ int main(int argc, char* argv[])
             symlink(basename(path), "qemuscreenshot/last.png");
             last_frame_converted = true;
         }
-
     }
 
     // send last frame


### PR DESCRIPTION
Motivation:
C++ files were found to be untidied because there was no automated check
ensuring they follow the project's style. Integrating this check into
the test suite prevents style regressions.

Design Choices:
- Created tools/check-cpp-style to verify C++ formatting using clang-format.
- Added test-local-cpp-style to cmake/test-targets.cmake to include it in
  the standard test suite.
- Refactored tidy-cpp in CMakeLists.txt to use the new check script with
  the --fix flag for consistency.
- Tidied snd2png/snd2png.cpp which was previously missed.

Benefits:
- Automated enforcement of C++ code style in CI.
- Unified file discovery logic between checking and tidying.