### PR TITLE
fix: script_run - type command and marker together on serial console

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -181,8 +181,7 @@ sub script_run ($self, $cmd, @args) {
             my $marker = "; echo $str-\$?-" . ($args{output} ? "Comment: $args{output}" : '');
             my $final_cmd = $skip_pretty ? "OA_NO_MARKER=1; $cmd" : $cmd;
             if (testapi::is_serial_terminal) {
-                testapi::type_string "$final_cmd", max_interval => $args{max_interval};
-                testapi::type_string $marker, max_interval => $args{max_interval};
+                testapi::type_string "$final_cmd$marker", max_interval => $args{max_interval};
                 testapi::wait_serial($final_cmd . $marker, no_regex => 1, quiet => $args{quiet}, buffer_size => (length $final_cmd) + 128, internal_marker => 1)
                   or _handle_cmd_typing_error($final_cmd, \%args);
                 testapi::type_string "\n", max_interval => $args{max_interval};

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -382,12 +382,7 @@ subtest 'script_run' => sub {
     is(assert_script_run('true', max_interval => 1), undef, 'nothing happens on success (slow typing)');
     is_deeply($cmds, [
             {
-                text => 'true',
-                cmd => 'backend_type_string',
-                max_interval => 1
-            },
-            {
-                text => '; echo XXX-$?-',
+                text => 'true; echo XXX-$?-',
                 cmd => 'backend_type_string',
                 max_interval => 1
             },
@@ -599,12 +594,7 @@ subtest 'upload_logs' => sub {
     upload_logs '/var/log/messages';
     is_deeply($cmds, [
             {
-                text => 'curl --form upload=@/var/log/messages --form upname=basetest-messages http://localhost:4243/LookAtMeImAToken/uploadlog/messages',
-                cmd => 'backend_type_string',
-                max_interval => 250
-            },
-            {
-                text => '; echo XXX-$?-',
+                text => 'curl --form upload=@/var/log/messages --form upname=basetest-messages http://localhost:4243/LookAtMeImAToken/uploadlog/messages; echo XXX-$?-',
                 cmd => 'backend_type_string',
                 max_interval => 250
             },
@@ -618,12 +608,7 @@ subtest 'upload_logs' => sub {
     upload_logs '/var/log/messages', failok => 1;
     is_deeply($cmds, [
             {
-                text => 'curl --form upload=@/var/log/messages --form upname=basetest-messages --max-time 90 http://localhost:4243/LookAtMeImAToken/uploadlog/messages',
-                cmd => 'backend_type_string',
-                max_interval => 250
-            },
-            {
-                text => '; echo XXX-$?-',
+                text => 'curl --form upload=@/var/log/messages --form upname=basetest-messages --max-time 90 http://localhost:4243/LookAtMeImAToken/uploadlog/messages; echo XXX-$?-',
                 cmd => 'backend_type_string',
                 max_interval => 250
             },


### PR DESCRIPTION
When doing script_run on a serial console, we "type" the command and then "type" the marker string in separate calls. Sometimes, somehow, extraneous characters seem to be added between the two in the output echoed back over the serial line, breaking the subsequent check. Typing them in one call should avoid this.

Related ticket: https://progress.opensuse.org/issues/201516