### PR TITLE
fix(test): use linuxboot_dma.bin in 18-backend-qemu.t

### DIFF
--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -685,7 +685,7 @@ subtest 'special cases when starting QEMU' => sub {
     # set certain variables to test special handling for them that is not otherwise tested
     $bmwqemu::topdir = "$Bin/..";    # for dmi data
     $bmwqemu::vars{ARCH} = 'x86_64';
-    $bmwqemu::vars{KERNEL} = 'linuxboot.bin';
+    $bmwqemu::vars{KERNEL} = 'linuxboot_dma.bin';
     $bmwqemu::vars{LAPTOP} = '1';
     $bmwqemu::vars{BOOT_HDD_IMAGE} = 1;
     $bmwqemu::vars{MULTIPATH} = 1;
@@ -713,7 +713,7 @@ subtest 'special cases when starting QEMU' => sub {
     my @invoked_cmds;
     $backend_mock->redefine(runcmd => sub (@cmd) { push @invoked_cmds, join ' ', @cmd });
     combined_like { $backend->start_qemu } qr{.*slirpvde --dhcp -s ./vde.ctl --port 87 started with pid 1.*not starting CPU}s, 'slirpvde started, DELAYED_START logged';
-    like $bmwqemu::vars{KERNEL}, qr{/.*/linuxboot\.bin}, 'KERNEL set to absolute location';
+    like $bmwqemu::vars{KERNEL}, qr{/.*/linuxboot_dma\.bin}, 'KERNEL set to absolute location';
     is $bmwqemu::vars{LAPTOP}, 'hp_elitebook_820g1', 'default laptop model assigned for LAPTOP=1';
     is $bmwqemu::vars{BOOTFROM}, 'c', 'BOOTFROM defaults to "c" for BOOT_HDD_IMAGE=1';
     is $bmwqemu::vars{HDDMODEL}, 'scsi-hd', 'HDDMODEL set for MULTIPATH=1';


### PR DESCRIPTION
linuxboot.bin is apparently a legacy implementation and has been removed in qemu 11:
https://lists.endsoftwarepatents.org/archive/html/qemu-devel/2025-12/msg00243.html

linuxboot_dma.bin should be present in all qemu versions we care about.