### PR TITLE
feat(autotest): run always_run modules after SIGTERM cancellation

### DIFF
--- a/OpenQA/Isotovideo/CommandHandler.pm
+++ b/OpenQA/Isotovideo/CommandHandler.pm
@@ -5,6 +5,7 @@ package OpenQA::Isotovideo::CommandHandler;
 use Mojo::Base 'Mojo::EventEmitter', -signatures;
 
 use bmwqemu;
+use Feature::Compat::Try;
 use log qw(diag fctwarn);
 use OpenQA::Isotovideo::Interface;
 use OpenQA::Isotovideo::NeedleDownloader;
@@ -118,9 +119,15 @@ sub _postpone_backend_command_until_resumed ($self, $response) {
     return 1;
 }
 
-sub _send_to_cmd_srv ($self, $data) { myjsonrpc::send_json($self->cmd_srv_fd, $data) }
+sub _send_to_cmd_srv ($self, $data) {
+    return undef unless defined $self->cmd_srv_fd;
+    myjsonrpc::send_json($self->cmd_srv_fd, $data);
+}
 
-sub _send_to_backend ($self, $data) { myjsonrpc::send_json($self->backend_fd, $data) }
+sub _send_to_backend ($self, $data) {
+    return undef unless defined $self->backend_fd;
+    myjsonrpc::send_json($self->backend_fd, $data);
+}
 
 sub send_to_backend_requester ($self, $data) {
     return unless $self->backend_requester;
@@ -151,7 +158,9 @@ sub _respond_ok_or_postpone_if_paused ($self) {
 }
 
 sub _pass_command_to_backend_unless_paused ($self, $response, $backend_cmd) {
-    return if $self->_postpone_backend_command_until_resumed($response);
+    return undef if $self->_postpone_backend_command_until_resumed($response);
+
+    return $self->_respond({ret => {}}) unless defined $self->backend_fd;
 
     die 'isotovideo: we need to implement a backend queue' if $self->backend_requester;
     $self->backend_requester($self->answer_fd);
@@ -288,7 +297,11 @@ sub _handle_command_resume_test_execution ($self, $response, @) {
 
 sub _handle_command_set_current_test ($self, $response, @) {
     # Note: It is unclear why we call set_serial_offset here
-    $bmwqemu::backend->_send_json({cmd => 'clear_serial_buffer'});
+    try { $bmwqemu::backend->_send_json({cmd => 'clear_serial_buffer'}) }
+    catch ($e) {
+        die $e unless $e =~ /remote end terminated|no backend running/;
+        diag('isotovideo: backend already gone during shutdown, skipping clear_serial_buffer');
+    }
 
     my ($test_name, $full_test_name) = ($response->{name}, $response->{full_name});
     my $pause_test_name = $self->pause_test_name;
@@ -392,6 +405,11 @@ sub _handle_command_send_clients ($self, $response, @) {
     delete $response->{cmd};
     delete $response->{json_cmd_token};
     $self->_send_to_cmd_srv($response);
+    $self->_respond_ok();
+}
+
+sub _handle_command_set_component_state ($self, $response, @) {
+    bmwqemu::serialize_state(component => $response->{component}, msg => $response->{msg});
     $self->_respond_ok();
 }
 

--- a/OpenQA/Isotovideo/Runner.pm
+++ b/OpenQA/Isotovideo/Runner.pm
@@ -34,6 +34,9 @@ has [qw(backend command_handler)];
 # the loop status
 has loop => 1;
 
+# track if we're in graceful shutdown (waiting for always_run modules)
+has graceful_shutdown => 0;
+
 use constant {
     EXIT_STATUS_OK => 0,
     EXIT_STATUS_ERR_NO_TESTS => 100,
@@ -54,7 +57,7 @@ sub run ($self) {
         my ($ready_for_read, $ready_for_write, $exceptions) = IO::Select::select($io_select, undef, $io_select, $ch->timeout);
         for my $readable (@$ready_for_read) {
             my $rsp = myjsonrpc::read_json($readable);
-            $self->_read_response($rsp, $readable);
+            $self->_read_response($rsp, $readable, $io_select);
             last unless defined $rsp;
         }
         $ch->check_asserted_screen if defined($ch->tags);
@@ -63,8 +66,22 @@ sub run ($self) {
     return 0;
 }
 
-sub _read_response ($self, $rsp, $fd) {
+sub _read_response ($self, $rsp, $fd, $io_select = undef) {
     if (!defined $rsp) {
+        if ($self->graceful_shutdown && $io_select && defined $self->testfd && $fd != $self->testfd) {
+            $io_select->remove($fd);
+            my $ch = $self->command_handler;
+            if (defined $self->cmd_srv_fd && $fd == $self->cmd_srv_fd) {
+                $ch->cmd_srv_fd(undef);
+            }
+            elsif (defined $ch->backend_out_fd && $fd == $ch->backend_out_fd) {
+                $ch->send_to_backend_requester({ret => {}}) if $ch->backend_requester;
+                $ch->backend_fd(undef);
+                $ch->backend_out_fd(undef);
+            }
+            diag('isotovideo: a helper connection closed during graceful shutdown, continuing to run remaining always_run modules');
+            return;
+        }
         fctwarn sprintf 'THERE IS NOTHING TO READ %d %d %d', fileno($fd), fileno($self->testfd), fileno $self->cmd_srv_fd;
         $self->loop(0);
     } elsif ($fd == $self->command_handler->backend_out_fd) {
@@ -116,9 +133,10 @@ sub handle_commands ($self) {
     my $command_handler;
     # stop main loop as soon as one of the child processes terminates
     my $stop_loop = sub (@) { $self->loop(0) if $self->loop; };
+    my $stop_loop_unless_graceful = sub (@) { $self->loop(0) if $self->loop && !$self->graceful_shutdown; };
     $self->testprocess->once(collected => $stop_loop);
-    $self->backend->process->once(collected => $stop_loop);
-    $self->cmd_srv_process->once(collected => $stop_loop);
+    $self->backend->process->once(collected => $stop_loop_unless_graceful);
+    $self->cmd_srv_process->once(collected => $stop_loop_unless_graceful);
 
     $command_handler = OpenQA::Isotovideo::CommandHandler->new(
         cmd_srv_fd => $self->cmd_srv_fd,
@@ -131,16 +149,18 @@ sub handle_commands ($self) {
             $self->testfd(undef);
             $self->loop(0);
             $self->stop_autotest();
+            # if shutdown mode than stop the backend
+            if ($self->graceful_shutdown) {    # uncoverable statement
+                bmwqemu::diag('isotovideo: stopping backend');    # uncoverable statement
+                $self->backend->stop if defined $self->backend;    # uncoverable statement
+                $self->stop_commands('graceful shutdown');    # uncoverable statement
+            }
     });
     # uncoverable statement count:1
     # uncoverable statement count:2
-    # uncoverable statement count:3
-    # uncoverable statement count:4
     $command_handler->on(signal => sub ($event, $sig) {
-            $self->backend->stop if defined $self->backend;    # uncoverable statement
-            $self->stop_commands("received signal $sig");    # uncoverable statement
-            $self->stop_autotest();    # uncoverable statement
-            _exit(1);    # uncoverable statement
+            $self->graceful_shutdown(1);    # uncoverable statement
+            bmwqemu::diag('isotovideo: backend shutdown');    # uncoverable statement
     });
     $self->setup_signal_handler;
 
@@ -156,7 +176,8 @@ sub setup_signal_handler ($self) {
 
 sub _signal_handler ($self, $sig) {
     bmwqemu::serialize_state(component => 'isotovideo', msg => "isotovideo received signal $sig", log => 1);
-    return $self->loop(0) if $self->loop;
+    return $self->loop(0) if $self->graceful_shutdown || !$self->loop;
+    $self->graceful_shutdown(1);
     $self->command_handler->emit(signal => $sig);
 }
 

--- a/autotest.pm
+++ b/autotest.pm
@@ -357,6 +357,7 @@ sub loadtest ($script, %args) {
 }
 
 our $current_test;    ## no critic (Variables::ProhibitPackageVars)
+our $fatal_reason;    ## no critic (Variables::ProhibitPackageVars)
 our $selected_console;    ## no critic (Variables::ProhibitPackageVars)
 our $last_milestone;    ## no critic (Variables::ProhibitPackageVars)
 our $last_milestone_active_consoles = [];    ## no critic (Variables::ProhibitPackageVars)
@@ -451,7 +452,10 @@ sub handle_sigterm ($sig) {    # uncoverable statement
         $current_test->result('canceled');    # uncoverable statement
         $current_test->save_test_result();    # uncoverable statement
     }
-    _exit(1);    # uncoverable statement
+    $fatal_reason = 'after test cancellation';    # uncoverable statement
+    bmwqemu::diag("scheduled stop of overall test execution $fatal_reason");    # uncoverable statement
+                                                                                # notify isotovideo to defer backend shutdown until complete
+    query_isotovideo('set_component_state', {component => 'autotest', msg => 'running modules after cancellation'}) if $isotovideo;    # uncoverable statement
 }
 
 sub start_process () {
@@ -547,7 +551,7 @@ sub runalltests () {
     bmwqemu::diag 'Snapshots are ' . ($snapshots_supported ? '' : 'not ') . 'supported';
 
     write_test_order();
-    my $fatal_reason;
+    $fatal_reason = undef;
 
     for (my $testindex = 0; $testindex <= $#testorder; $testindex++) {
         my $t = $testorder[$testindex];
@@ -628,6 +632,7 @@ sub runalltests () {
     if ($fatal_reason) {
         bmwqemu::diag "stopping overall test execution $fatal_reason";
         bmwqemu::stop_vm();
+        $fatal_reason = undef;
         return 0;
     }
     return 1;

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -96,9 +96,13 @@ sub die_handler ($msg) {
     $backend->close_pipes();
 }
 
+my $graceful_shutdown_requested = 0;
+
 sub backend_signalhandler ($sig) {
     bmwqemu::diag("backend got $sig");
-    $backend->stop_vm;
+    # set flag for graceful shutdown
+    $graceful_shutdown_requested = 1;
+    bmwqemu::diag('backend: deferring shutdown to allow modules to complete');
 }
 
 sub run ($self, $cmdpipe, $rsppipe) {
@@ -140,6 +144,9 @@ sub run ($self, $cmdpipe, $rsppipe) {
     }
 
     $self->run_capture_loop;
+
+    # clean up when shutdown requested
+    $self->stop_vm if $graceful_shutdown_requested;
 
     bmwqemu::diag('management process exit at ' . POSIX::strftime('%F %T', gmtime));    # uncoverable statement
 }
@@ -209,6 +216,7 @@ sub do_capture ($self, $buckets, $timeout = undef, $starttime = undef) {
     my $wait_time_limit = $self->{wait_time_limit};
     my $hits_limit = $self->{hits_limit};
     return 0 unless $self->{cmdpipe};
+    return 0 if $graceful_shutdown_requested;
     my $now = gettimeofday;
     my $time_to_timeout = 'Inf' + 0;
     if (defined $timeout && defined $starttime) {

--- a/basetest.pm
+++ b/basetest.pm
@@ -86,7 +86,7 @@ sub is_applicable ($self) {
 Return a hash of flags that are either there or not
 
   'fatal'          - abort whole test suite if this fails (and set overall state 'failed')
-  'always_run'      - requests that a test module is always executed regardless if a previous test module is set to 'fatal'
+  'always_run'      - requests that a test module is always executed regardless if a previous test module is set to 'fatal' or the test run is cancelled
   'ignore_failure' - if this module fails, it will not affect the overall result at all
   'milestone'      - after this test succeeds, update 'lastgood'
   'no_rollback'     - don't roll back to 'lastgood' snapshot if this fails

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -200,7 +200,7 @@ subtest 'test always_rollback flag' => sub {
         stderr_like { autotest::run_all } qr/.*stopping overall test execution because TESTDEBUG has been set.*/, 'reason logged (TESTDEBUG)';
         delete $bmwqemu::vars{TESTDEBUG};
     };
-    snapshot_subtest 'always_run flag ensures execution after fatal failure' => sub {
+    my $test_always_run = sub ($trigger_fatal_callback, $tests_to_load, $check_output_callback) {
         local %autotest::tests = ();
         local @autotest::testorder = ();
         local %autotest::scheduled_basenames = ();
@@ -208,9 +208,11 @@ subtest 'test always_rollback flag' => sub {
         local $autotest::last_milestone_active_consoles = [];
         local $autotest::activated_consoles = [];
         local $autotest::last_milestone_console = undef;
+        local $autotest::fatal_reason = undef;
 
-        loadtest $_ for qw(fatal start next);
-        my ($fatal_test, $normal_test, $cleanup_test) = @autotest::testorder;
+        loadtest $_ for @$tests_to_load;
+        my @tests = @autotest::testorder;
+
         $mock_autotest->redefine(query_isotovideo => sub ($command, $arguments) {
                 return 1 if $command eq 'backend_can_handle' && $arguments->{function} eq 'snapshots';
                 return {snapshot_done => 1} if $command eq 'backend_make_snapshot';
@@ -218,25 +220,46 @@ subtest 'test always_rollback flag' => sub {
         });
 
         $mock_basetest->redefine(test_flags => sub ($self) {
-                return {fatal => 1} if $self == $fatal_test;
-                return {always_run => 1} if $self == $cleanup_test;
+                return {fatal => 1} if $self == $tests[0];
+                return {always_run => 1} if $self == $tests[-1];
                 return {};
         });
-        $mock_basetest->redefine(runtest => sub ($self) {
-                die "fatal failure\n" if $self == $fatal_test;
-                return 1;
-        });
+        $mock_basetest->redefine(runtest => $trigger_fatal_callback);
 
         $vm_stopped = 0;
         my $output = combined_from { autotest::run_all };
-        like $output, qr/skipping tests-start#?[0-9]* \(after fatal failure\)/, 'skipped normal test';
+        $check_output_callback->($output);
         like $output, qr{starting next tests/next\.pm}, 'executed always_run cleanup test';
         ($died, $completed) = get_tests_done;
         is $died, 0, 'tests not considered died';
         is $completed, 0, 'tests did not complete successfully';
         ok $vm_stopped, 'VM was stopped eventually';
+    };
+    snapshot_subtest 'always_run flag ensures execution after fatal failure' => sub {
+        $test_always_run->(
+            sub ($self) {
+                die "fatal failure\n" if $self == $autotest::testorder[0];
+                return 1;
+            },
+            [qw(fatal start next)],
+            sub ($output) {
+                like $output, qr/scheduled stop of overall test execution after a fatal test failure/, 'fatal reason logged';
+            }
+        );
         is $reverts_done, 0, 'no snapshots loaded after fatal failure';
         is $snapshots_made, 0, 'no snapshots made after fatal failure';
+    };
+    snapshot_subtest 'SIGTERM cancellation allows always_run modules to execute' => sub {
+        $test_always_run->(
+            sub ($self) {
+                autotest::handle_sigterm('TERM') if $self == $autotest::testorder[0];
+                return 1;
+            },
+            [qw(start next)],
+            sub ($output) {
+                like $output, qr/scheduled stop of overall test execution after test cancellation/, 'cancellation reason logged';
+            }
+        );
     };
     snapshot_subtest 'fails by default if snapshots are not supported and always_rollback is requested' => sub {
         $mock_basetest->redefine(test_flags => {always_rollback => 1});

--- a/t/19-isotovideo-command-processing.t
+++ b/t/19-isotovideo-command-processing.t
@@ -41,6 +41,7 @@ $rpc_mock->redefine(read_json => sub {
 
 # mock bmwqemu/backend
 my $check_screen_token_echo;
+my $clear_serial_buffer_error;
 
 package FakeBackend {
     sub new ($class) { bless {messages => []}, $class }
@@ -50,6 +51,7 @@ package FakeBackend {
             return {found => 1} if $cmd->{cmd} eq 'check_asserted_screen';
             return {tags => [qw(some fake tags)]};
         }
+        die $clear_serial_buffer_error if $clear_serial_buffer_error && $cmd->{cmd} eq 'clear_serial_buffer';
         push @{$self->{messages}}, $cmd;
         return $cmd->{cmd} eq 'is_shutdown' ? 'down' : {tags => [qw(some fake tags)]};
     }
@@ -59,6 +61,11 @@ package FakeBackend {
 package bmwqemu {
     our $backend = FakeBackend->new();    ## no critic (Variables::ProhibitPackageVars)
 }
+
+package FakeSelect {
+    sub new ($class) { bless {removed => []}, $class }
+    sub remove ($self, $fd) { push @{$self->{removed}}, $fd }
+}    # uncoverable statement
 
 # setup a CommandHandler instance using the fake file descriptors
 my $command_handler = OpenQA::Isotovideo::CommandHandler->new(
@@ -394,16 +401,33 @@ subtest signalhandler => sub {
     $runner->command_handler($command_handler);
     $command_handler->once(signal => sub ($event, $sig) { $last_signal = $sig });
     $runner->loop(1);
+    # first signal: enter graceful shutdown, keep the loop alive so autotest can
+    # finish its always_run modules, and emit the signal event
     stderr_like {
         $runner->_signal_handler('TERM');
     } qr/isotovideo received signal TERM/, 'Signal logged';
-    is $runner->loop, 0, 'Loop was stopped';
-    is $last_signal, undef, 'No event emitted';
+    is $runner->loop, 1, 'Loop kept alive on first signal (graceful shutdown)';
+    is $runner->graceful_shutdown, 1, 'Graceful shutdown engaged on first signal';
+    is $last_signal, 'TERM', 'Event emitted on first signal';
 
+    # second signal: force an immediate stop
     stderr_like {
         $runner->_signal_handler('INT');
     } qr/isotovideo received signal INT/, 'Signal logged';
-    is $last_signal, 'INT', 'Event emitted';
+    is $runner->loop, 0, 'Loop stopped on second signal';
+};
+
+subtest set_component_state => sub {
+    reset_state();
+    # autotest handle_sigterm sends this command to defer shutdown. it must be
+    # handled (not die as an unknown command) and acknowledged
+    $command_handler->process_command($answer_fd, {
+            cmd => 'set_component_state',
+            component => 'autotest',
+            msg => 'running modules after cancellation',
+            json_cmd_token => 'scs-token',
+    });
+    is $last_received_msg_by_fd[$answer_fd]->{ret}, 1, 'set_component_state acknowledged';
 };
 subtest token_echo => sub {
     reset_state();
@@ -511,6 +535,61 @@ subtest 'No readable JSON' => sub {
     is $runner->loop, 0, 'Loop was stopped';
 };
 
+subtest 'graceful shutdown tolerates helper connections closing' => sub {
+    my $runner = OpenQA::Isotovideo::Runner->new;
+    open my $testfd, '<', $Bin or die $!;
+    open my $cmd_srv, '<', $Bin or die $!;
+    open my $backend_out, '<', $Bin or die $!;
+    my $ch = OpenQA::Isotovideo::CommandHandler->new(
+        cmd_srv_fd => $cmd_srv,
+        backend_out_fd => $backend_out,
+    );
+    $runner->command_handler($ch);
+    $runner->testfd($testfd);
+    $runner->cmd_srv_fd($cmd_srv);
+    $runner->graceful_shutdown(1);
+    $runner->loop(1);
+    my $io_select = FakeSelect->new;
+
+    # command server closing: drop it, clear its fd, keep the loop alive
+    stderr_like {
+        $runner->_read_response(undef, $cmd_srv, $io_select);
+    } qr/helper connection closed during graceful shutdown/, 'command server close logged';
+    is $runner->loop, 1, 'loop kept alive when command server closes during graceful shutdown';
+    ok !defined $ch->cmd_srv_fd, 'cmd_srv_fd cleared so status broadcasts become no-ops';
+    is scalar @{$io_select->{removed}}, 1, 'closed command-server fd removed from select set';
+
+    # backend closing with a pending requester: release the requester, clear backend fds
+    $last_received_msg_by_fd[$answer_fd] = undef;
+    $ch->backend_requester($answer_fd);
+    stderr_like {
+        $runner->_read_response(undef, $backend_out, $io_select);
+    } qr/helper connection closed during graceful shutdown/, 'backend close logged';
+    is $runner->loop, 1, 'loop kept alive when backend closes during graceful shutdown';
+    is_deeply $last_received_msg_by_fd[$answer_fd], {ret => {}}, 'pending backend requester released with empty result';
+    ok !defined $ch->backend_fd, 'backend_fd cleared';
+    ok !defined $ch->backend_out_fd, 'backend_out_fd cleared';
+};
+
+subtest 'backend/command-server commands tolerated when peers gone' => sub {
+    reset_state();
+    my ($orig_backend_fd, $orig_cmd_srv_fd) = ($command_handler->backend_fd, $command_handler->cmd_srv_fd);
+
+    # a backend command is answered with an empty result instead of blocking forever
+    $command_handler->backend_fd(undef);
+    $command_handler->process_command($answer_fd, {cmd => 'backend_last_screenshot_data'});
+    is_deeply $last_received_msg_by_fd[$answer_fd], {ret => {}}, 'backend command answered with empty result when backend gone';
+
+    # broadcasting to a gone command server is a no-op rather than a broken-pipe crash
+    $command_handler->cmd_srv_fd(undef);
+    $last_received_msg_by_fd[$cmd_srv_fd] = 'sentinel';
+    lives_ok { $command_handler->_send_to_cmd_srv({foo => 1}) } 'sending to a gone command server does not die';
+    is $last_received_msg_by_fd[$cmd_srv_fd], 'sentinel', 'no broadcast attempted when command server gone';
+
+    $command_handler->backend_fd($orig_backend_fd);
+    $command_handler->cmd_srv_fd($orig_cmd_srv_fd);
+};
+
 subtest 'shutdown handling' => sub {
     my $runner = OpenQA::Isotovideo::Runner->new;
     my $return_code = 1;
@@ -521,6 +600,26 @@ subtest 'shutdown handling' => sub {
         is $runner->handle_shutdown(\$return_code), 'down', 'backup shutdown state returned';
     } qr/state: down.*unable to stop VM: faking stop/s, 'shutdown state and error to stop VM logged';
     is $return_code, 1, 'return code set to 1 due to error';
+};
+
+subtest 'set_current_test tolerates backend gone during shutdown' => sub {
+    reset_state;
+    # During graceful shutdown the backend is torn down, so clear_serial_buffer
+    # fails. A "remote end terminated"/"no backend running" error must be swallowed
+    # so the remaining always_run module can still be set up and run.
+    $clear_serial_buffer_error = "myjsonrpc: remote end terminated connection\n";
+    stderr_like {
+        $command_handler->process_command($answer_fd, {cmd => 'set_current_test', name => 'cleanup', full_name => 'cleanup'})
+    } qr/backend already gone during shutdown/, 'backend teardown tolerated and logged';
+    is $command_handler->current_test_name, 'cleanup', 'set_current_test still applied after tolerated failure';
+
+    # Any other backend error must NOT be swallowed.
+    $clear_serial_buffer_error = "some other explosion\n";
+    throws_ok {
+        $command_handler->process_command($answer_fd, {cmd => 'set_current_test', name => 'boom', full_name => 'boom'})
+    } qr/some other explosion/, 'unexpected backend errors are re-thrown';
+
+    $clear_serial_buffer_error = undef;
 };
 
 done_testing;


### PR DESCRIPTION
On job cancellation the worker sends SIGTERM to the whole os-autoinst
process group. autotest's run _exit(1) immediately, so `always_run`
modules never ran properly on on cancellation, even if they run after a
fatal test failure. This makes cancellation act like a fatal failure:
stop scheduling normal modules but still run the always_run ones.

The issue is that keep autotest alive is not enough because the same
SIGTERM also put down isotovideo and the other services. This means that
`always_run` module died with "myjsonrpc: remote end terminated
connection".

This change add a graceful shutdown feature:
- autotest: handle_sigterm() sets $fatal_reason instead of _exit()
- isotovideo: _signal_handler() enters graceful shutdown on the first
  SIGTERM and keeps the main loop alive until tests_done peers, pending
  backend request, clear_serial_buffer).

All of this still keep `always_run` module related to the worker's
timeout.

Related: https://progress.opensuse.org/issues/197822