### PR TITLE
style(perlcritic): Add Community::WarningsSwitch

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,6 +1,6 @@
 theme = community + openqa
 severity = 4
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitPackageVars CodeLayout::RequireTidyCode
+include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitPackageVars CodeLayout::RequireTidyCode Community::WarningsSwitch
 
 verbose = ::warning file=%f,line=%l,col=%c,title=%m - severity %s::[%p] %e\n
 

--- a/script/check_qemu_oom
+++ b/script/check_qemu_oom
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/perl
 # Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/script/imgsearch
+++ b/script/imgsearch
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/perl
 # Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/script/isotovideo
+++ b/script/isotovideo
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/perl
 # Copyright 2009-2013 Bernhard M. Wiedemann
 # Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later

--- a/script/os-autoinst-generate-needle-preview
+++ b/script/os-autoinst-generate-needle-preview
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/perl
 # Copyright Roland Clobus <rclobus@rclobus.nl>
 # SPDX-License-Identifier: GPL-2.0-or-later
 #


### PR DESCRIPTION
Community::WarningsSwitch forbids using -W switch to prevent enable warnings even in modules where should be disabled.

https://metacpan.org/pod/Perl::Critic::Policy::Community::WarningsSwitch

> The -w switch enables warnings globally in a perl program, including for any modules that did not explicitly enable or disable any warnings. The -W switch enables warnings even for modules that explicitly disabled them. The primary issue with this is enabling warnings for code that you did not write. Some of these modules may not be designed to run with warnings enabled, but still work fine. Instead, use [warnings](https://metacpan.org/pod/warnings) within your own code only.

reference: https://progress.opensuse.org/issues/155191