### PR TITLE
style(perlcritic): Add CodeLayout::RequireTidyCode

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,6 +1,6 @@
 theme = community + openqa
 severity = 4
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitPackageVars
+include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitPackageVars CodeLayout::RequireTidyCode
 
 verbose = ::warning file=%f,line=%l,col=%c,title=%m - severity %s::[%p] %e\n
 

--- a/.tidyallrc
+++ b/.tidyallrc
@@ -1,4 +1,4 @@
 [PerlTidy]
-select = **/*.{pl,pm,t} script/check_qemu_oom script/imgsearch script/isotovideo script/os-autoinst-openvswitch
+select = **/*.{pl,pm,t} script/check_qemu_oom script/dewebsockify script/imgsearch script/isotovideo script/os-autoinst-generate-needle-preview script/os-autoinst-openvswitch script/os-autoinst-testmodules-strict script/vnctest
 ignore = external/**/*
 argv = --profile=$ROOT/.perltidyrc

--- a/script/dewebsockify
+++ b/script/dewebsockify
@@ -6,7 +6,7 @@ use Mojo::Base -strict, -signatures;
 
 use Getopt::Long;
 use FindBin;
-use lib "$FindBin::Bin/.."; # Ensure OpenQA namespace is in @INC
+use lib "$FindBin::Bin/..";    # Ensure OpenQA namespace is in @INC
 use OpenQA::Isotovideo::Dewebsockify;
 
 OpenQA::Isotovideo::Dewebsockify::main(parse_args()) unless caller;
@@ -30,7 +30,7 @@ END_USAGE
 sub parse_args () {
     my %options;
     GetOptions(\%options, 'websocketurl=s', 'listenport=s', 'cookie=s', 'loglevel=s', 'insecure', 'help|h|?')
-        or usage;
+      or usage;
     usage if $options{help};
     return \%options;
 }

--- a/script/os-autoinst-generate-needle-preview
+++ b/script/os-autoinst-generate-needle-preview
@@ -84,10 +84,10 @@ sub process_file ($filename) {
             say '     style="fill:#000000;fill-opacity:0.5;stroke:#808080;stroke-width:2;stroke-opacity:0.75"';
         }
         printf "     id=\"rect%d\"\n", $area_counter;
-        printf "     width=\"%d\"\n",  $area->{width};
+        printf "     width=\"%d\"\n", $area->{width};
         printf "     height=\"%d\"\n", $area->{height};
-        printf "     x=\"%d\"\n",      $area->{xpos};
-        printf "     y=\"%d\" />\n",   $area->{ypos};
+        printf "     x=\"%d\"\n", $area->{xpos};
+        printf "     y=\"%d\" />\n", $area->{ypos};
         if ($area->{click_point}) {
             say '  <circle';
             say '     style="fill:#ffffff;fill-opacity:0.5;stroke:#ffffff;stroke-width:2;stroke-opacity:0.75"';
@@ -113,7 +113,7 @@ my %options;
 sub usage ($r)
 {
     require Pod::Usage;
-    Pod::Usage::pod2usage($r)
+    Pod::Usage::pod2usage($r);
 }
 
 GetOptions(\%options, 'help|h|?') or usage(1);

--- a/script/os-autoinst-testmodules-strict
+++ b/script/os-autoinst-testmodules-strict
@@ -65,6 +65,7 @@ unless (caller) {
     usage(1) unless @ARGV;
     $rc = main(\%options, @ARGV);
 }
+
 END {
     $? = 2 if $rc;
 }

--- a/script/vnctest
+++ b/script/vnctest
@@ -44,7 +44,7 @@ sub main ($args) {
     my $incremental = 0;
     $vnc->login;
 
-    while(1) {
+    while (1) {
         $log->info('Send update request');
         $vnc->send_update_request($incremental);
         $incremental = 1;


### PR DESCRIPTION
Adopt consistent layout on the code.

https://metacpan.org/pod/Perl::Critic::Policy::CodeLayout::RequireTidyCode

> Conway does make specific recommendations for whitespace and curly-braces in your code, but the most important thing is to adopt a consistent layout, regardless of the specifics. And the easiest way to do that is to use Perl::Tidy. This policy will complain if your code hasn't been run through Perl::Tidy.

reference: https://progress.opensuse.org/issues/155191