### PR TITLE
style(perlcritic): Add Community::EmptyReturn

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,6 +1,7 @@
 theme = community + openqa
 severity = 4
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitPackageVars CodeLayout::RequireTidyCode Community::WarningsSwitch
+
+include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitPackageVars CodeLayout::RequireTidyCode Community::WarningsSwitch Community::EmptyReturn
 
 verbose = ::warning file=%f,line=%l,col=%c,title=%m - severity %s::[%p] %e\n
 

--- a/OpenQA/Isotovideo/CommandHandler.pm
+++ b/OpenQA/Isotovideo/CommandHandler.pm
@@ -101,7 +101,7 @@ sub _postpone_backend_command_until_resumed ($self, $response) {
         $self->reason_for_pause($reason_for_pause = "reached $cmd and pause on next command enabled");
     }
 
-    return unless $reason_for_pause;
+    return undef unless $reason_for_pause;
 
     # emit info
     $self->_send_to_cmd_srv({paused => $response, reason => $reason_for_pause});
@@ -260,7 +260,7 @@ sub _handle_command_resume_test_execution ($self, $response, @) {
     # skip resuming last command if receiving a resume command without having previously postponed an answer
     # note: This should normally not be the case. However, the JavaScript client can technically send the command
     #       to resume at any time and that apparently also happens sometimes in the fullstack test (see poo#101734).
-    return undef unless defined $postponed_answer_fd;
+    return unless defined $postponed_answer_fd;
 
     # if no command has been postponed (because paused due to timeout or on set_current_test) just return 1
     if (!$postponed_command) {

--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -331,7 +331,7 @@ configuration variables.
 sub handle_generated_assets ($command_handler, $clean_shutdown) {
     my $return_code = 0;
     # mark hard disks for upload if test finished
-    return unless $bmwqemu::vars{BACKEND} =~ m/^(qemu|generalhw)$/;
+    return undef unless $bmwqemu::vars{BACKEND} =~ m/^(qemu|generalhw)$/;
     my @toextract;
     my $nd = $bmwqemu::vars{NUMDISKS} // 1;
     if ($command_handler->test_completed) {

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -758,7 +758,7 @@ sub console ($self, $testapi_console) {
 
 sub bouncer ($self, $call, $args) {
     # forward to the current VNC console
-    return unless $self->{current_screen};
+    return undef unless $self->{current_screen};
     return $self->{current_screen}->$call($args);
 }
 
@@ -1018,7 +1018,7 @@ sub _reset_asserted_screen_check_variables ($self) {
 }
 
 sub check_asserted_screen ($self, $args) {
-    return unless my $img = $self->last_image;    # no screenshot yet to search on
+    return undef unless my $img = $self->last_image;    # no screenshot yet to search on
     my $watch = OpenQA::Benchmark::Stopwatch->new();
     my $timestamp = $self->last_screenshot;
     my $n = $self->_time_to_assert_screen_deadline;
@@ -1028,7 +1028,7 @@ sub check_asserted_screen ($self, $args) {
     my $search_ratio = $n < 0 || $n % FULL_SCREEN_SEARCH_FREQUENCY == 0 ? 1 : 0.02;
     my ($oldimg, $old_search_ratio) = @{$self->assert_screen_last_check || [undef, 0]};
 
-    bmwqemu::diag('no change: ' . time_remaining_str($n)) and return if $n >= 0 && $oldimg && $oldimg eq $img && $old_search_ratio >= $search_ratio;
+    bmwqemu::diag('no change: ' . time_remaining_str($n)) and return undef if $n >= 0 && $oldimg && $oldimg eq $img && $old_search_ratio >= $search_ratio;
 
     $watch->start();
     $watch->{debug} = 0;
@@ -1117,7 +1117,7 @@ sub check_asserted_screen ($self, $args) {
         }
     }
     $self->assert_screen_last_check([$img, $search_ratio]);
-    return;
+    return undef;
 }
 
 sub _reduce_to_biggest_changes ($imglist, $limit) {

--- a/backend/driver.pm
+++ b/backend/driver.pm
@@ -129,7 +129,7 @@ sub _send_json ($self, $cmd) {
     close $self->{backend_process}->channel_out;
     $self->{backend_process}->channel_out(undef);
     $self->{backend_process}->stop;
-    return;
+    return undef;
 }
 
 1;

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -168,8 +168,8 @@ sub do_stop_vm ($self, @) {
 sub can_handle ($self, $args) {
     my $vars = \%bmwqemu::vars;
 
-    return unless $args->{function} eq 'snapshots';
-    return if $vars->{QEMU_DISABLE_SNAPSHOTS};
+    return undef unless $args->{function} eq 'snapshots';
+    return undef if $vars->{QEMU_DISABLE_SNAPSHOTS};
     my @models = ($vars->{HDDMODEL}, map { $vars->{"HDDMODEL_$_"} } (1 .. $vars->{NUMDISKS}));
     my $nvme = first { ($_ // '') eq 'nvme' } @models;
     return {ret => 1} unless $nvme;
@@ -341,7 +341,7 @@ sub save_memory_dump ($self, $args) {
 
     my $rsp = $self->handle_qmp_command({execute => 'query-status'}, fatal => 1);
     bmwqemu::diag("Migrating the machine (Current VM state is $rsp->{return}->{status})");
-    my $was_running = $rsp->{return}->{status} eq 'running';
+    my $was_running = $rsp->{return}->{status} eq 'running';    ## no critic (Community::EmptyReturn)
 
     mkpath('ulogs');
     $self->_migrate_to_file(compress_level => $compress_method eq 'internal' ? $compress_level : 0,
@@ -1209,7 +1209,7 @@ sub close_pipes ($self, $closeall = 0) {
 }
 
 sub is_shutdown ($self, @) {
-    my $ret = $self->handle_qmp_command({execute => 'query-status'})->{return}->{status}
+    my $ret = $self->handle_qmp_command({execute => 'query-status'})->{return}->{status}    ## no critic (Community::EmptyReturn)
       || 'unknown';
 
     diag("QEMU status is not 'shutdown', it is '$ret'") if $ret ne 'shutdown';

--- a/basetest.pm
+++ b/basetest.pm
@@ -600,7 +600,7 @@ sub verify_sound_image ($self, $imgpath, $mustmatch, $check) {
     else {
         $self->record_screenfail(@needles_params, result => 'fail', overall => 'fail');
     }
-    return;
+    return undef;
 }
 
 sub search_for_expected_serial_failures ($self) {

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -304,7 +304,7 @@ sub log_call (@args) {
 # backend management
 
 sub stop_vm () {
-    return unless $backend;
+    return undef unless $backend;
     my $ret = $backend->stop();
     return $ret;
 }

--- a/commands.pm
+++ b/commands.pm
@@ -173,7 +173,7 @@ sub isotovideo_command ($mojo_lite_controller, $commands) {
     return $mojo_lite_controller->reply->not_found unless grep { $cmd eq $_ } @$commands;
 
     my $app = $mojo_lite_controller->app;
-    return unless my $isotovideo = $app->defaults('isotovideo');
+    return undef unless my $isotovideo = $app->defaults('isotovideo');
 
     # send command to isotovideo and block until a response arrives
     myjsonrpc::send_json($isotovideo, {cmd => $cmd, params => $mojo_lite_controller->req->query_params->to_hash});

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -810,7 +810,7 @@ sub _receive_message ($self) {
     $socket->blocking(0);
     my $ret = $socket->read(my $message_type, 1);
     $socket->blocking(1);
-    return unless $ret;
+    return undef unless $ret;
     $self->_vnc_stalled(0);
 
     die "socket closed: $ret\n${\Dumper $self}" if $ret <= 0;

--- a/consoles/ipmiSol.pm
+++ b/consoles/ipmiSol.pm
@@ -78,7 +78,7 @@ sub activate ($self) {
 }
 
 sub disable ($self) {
-    return unless $self->{serialpid};
+    return undef unless $self->{serialpid};
     $self->{serial_pipe}->print("GO!\n");
     $self->{serial_pipe}->close;
     bmwqemu::diag "waiting for termination of ipmiconsole $self->{serialpid}";

--- a/consoles/video_stream.pm
+++ b/consoles/video_stream.pm
@@ -155,7 +155,7 @@ sub connect_remote_video ($self, $url) {
         if (!_v4l2_ctl($url, $self->{args}->{video_cmd_prefix}, '--set-dv-bt-timings query')) {
             bmwqemu::diag('No video signal');
             $self->{dv_timings} = '';
-            return;
+            return undef;
         }
         $self->{dv_timings} = _v4l2_ctl($url, $self->{args}->{video_cmd_prefix}, '--get-dv-timings');
     }
@@ -435,7 +435,7 @@ sub update_framebuffer ($self) {
 
 sub current_screen ($self) {
     $self->update_framebuffer();
-    return unless $self->{_framebuffer};
+    return undef unless $self->{_framebuffer};
     return $self->{_framebuffer};
 }
 
@@ -513,7 +513,7 @@ sub mouse_move_to ($self, $x, $y) {
 }
 
 sub mouse_button ($self, $args) {
-    return unless $self->{input_pipe};
+    return undef unless $self->{input_pipe};
     my $button = $args->{button};
     my $bstate = $args->{bstate};
     # careful: the bits order is different than in VNC

--- a/consoles/vnc_base.pm
+++ b/consoles/vnc_base.pm
@@ -19,7 +19,7 @@ sub disable ($self) {
 }
 
 sub disable_vnc_stalls ($self) {
-    return unless $self->{vnc};
+    return undef unless $self->{vnc};
     $self->{vnc}->check_vnc_stalls(0);
     return 0;
 }
@@ -43,7 +43,7 @@ sub request_screen_update ($self, $args = undef) {
 }
 
 sub current_screen ($self) {
-    return unless $self->{vnc};
+    return undef unless $self->{vnc};
 
     unless ($self->{vnc}->_framebuffer) {
         # No _framebuffer yet.  First connect?  Tickle vnc server to
@@ -58,7 +58,7 @@ sub current_screen ($self) {
     }
 
     $self->{vnc}->update_framebuffer();
-    return unless $self->{vnc}->_framebuffer;
+    return undef unless $self->{vnc}->_framebuffer;
     return $self->{vnc}->_framebuffer;
 }
 

--- a/distribution.pm
+++ b/distribution.pm
@@ -169,7 +169,7 @@ sub script_run ($self, $cmd, @args) {
             testapi::query_isotovideo('backend_clear_serial_buffer', {});
             testapi::type_string "$cmd\n", max_interval => $args{max_interval};
             my $res = testapi::wait_serial(qr/OA:DONE-[0-9a-f]{4}-(\d+)-/, timeout => $args{timeout}, quiet => $args{quiet}, record_command => $cmd, internal_marker => 1, capture_name => 'Exit code');
-            return unless $res;
+            return undef unless $res;
             return ($res =~ /OA:DONE-[0-9a-f]{4}-(\d+)-/)[0];
         }
         $str = testapi::hashed_string('SR' . $cmd . $args{timeout});
@@ -192,13 +192,13 @@ sub script_run ($self, $cmd, @args) {
             }
         }
         my $res = testapi::wait_serial($wait_pattern, timeout => $args{timeout}, quiet => $args{quiet}, record_command => $cmd, internal_marker => 1, capture_name => 'Exit code');
-        return unless $res;
+        return undef unless $res;
         return ($res =~ $wait_pattern)[0];
     }
     else {
         testapi::type_string "$cmd", max_interval => $args{max_interval};
         testapi::send_key 'ret';
-        return;
+        return undef;
     }
 }
 
@@ -263,7 +263,7 @@ sub script_sudo ($self, $prog, $wait = 10) {
     if ($str) {
         return testapi::wait_serial($str, $wait, internal_marker => 1);
     }
-    return;
+    return undef;
 }
 
 =head2 script_output
@@ -448,7 +448,7 @@ markers to serial.
 =cut
 
 sub install_serial_marker_hook ($self, $level) {
-    return if $level < 2;
+    return undef if $level < 2;
     my $dev = "/dev/$testapi::serialdev";
     my $func;
     if ($level == 3) {

--- a/myjsonrpc.pm
+++ b/myjsonrpc.pm
@@ -106,7 +106,7 @@ sub read_json ($socket, $cmd_token = undef, $multi = undef) {
         handle_read_error($fd) until (my @res = $s->can_read);
 
         my $qbuffer;
-        if (!sysread $socket, $qbuffer, READ_BUFFER) { bmwqemu::fctwarn("sysread failed: $!") if is_debug(); return }
+        if (!sysread $socket, $qbuffer, READ_BUFFER) { bmwqemu::fctwarn("sysread failed: $!") if is_debug(); return $multi ? () : undef }
         $cjx->incr_parse($qbuffer);
     }
 

--- a/needle.pm
+++ b/needle.pm
@@ -84,11 +84,11 @@ sub new ($classname, $jsonfile) {
         if (my $click_point = $area_from_json->{click_point}) {
             if ($got_click_point) {
                 warn "$jsonfile has more than one area with a click point without assigning IDs to each\n";
-                return;
+                return undef;
             }
             if (!is_click_point_valid($click_point)) {
                 warn "$jsonfile has an area with invalid click point\n";
-                return;
+                return undef;
             }
             if (ref $click_point ne 'HASH' || !defined $click_point->{id}) {
                 $got_click_point = 1;
@@ -97,7 +97,7 @@ sub new ($classname, $jsonfile) {
             }
             if ($got_click_point && $got_click_point_with_id) {
                 warn "$jsonfile has more than one area with a click point without assigning IDs to each\n";
-                return;
+                return undef;
             }
             $area->{click_point} = $click_point;
         }
@@ -109,13 +109,13 @@ sub new ($classname, $jsonfile) {
     }
 
     # one match is mandatory
-    warn "$jsonfile missing match area\n" and return unless $gotmatch;
+    warn "$jsonfile missing match area\n" and return undef unless $gotmatch;
 
     $self->{name} = basename($jsonfile, '.json');
     my $png = $self->{png} || $self->{name} . '.png';
 
     $self->{png} = path(dirname($jsonfile), $png)->to_string;
-    warn "$self->{png} is empty or not found" and return unless -s $self->{png};
+    warn "$self->{png} is empty or not found" and return undef unless -s $self->{png};
     $self = bless $self, $classname;
     $self->register();
     return $self;

--- a/ppmclibs/tinycv.pm
+++ b/ppmclibs/tinycv.pm
@@ -50,7 +50,7 @@ sub search_ ($self, $needle, $threshold, $search_ratio, $stopwatch = undef) {
     my ($sim, $xmatch, $ymatch);
     my (@exclude, @match, @ocr);
 
-    return unless $needle;
+    return undef unless $needle;
 
     my $needle_image = $needle->get_image;
     unless ($needle_image) {
@@ -141,7 +141,7 @@ sub cmp_by_error_type_ {    # no:style:signatures
 # in array context returns array with two elements. First element is best match
 # or undefined, second element are candidates that did not match.
 sub search ($self, $needle, $threshold = undef, $search_ratio = undef, $stopwatch = undef) {
-    return unless $needle;
+    return undef unless $needle;
 
     $stopwatch->lap('Searching for needles') if $stopwatch;
 
@@ -171,12 +171,12 @@ sub search ($self, $needle, $threshold = undef, $search_ratio = undef, $stopwatc
     else {
         my $found = $self->search_($needle, $threshold, $search_ratio, $stopwatch);
         $stopwatch->lap("** search_: single needle: $needle->{name}") if $stopwatch;
-        return unless $found;
+        return undef unless $found;
         if (wantarray) {
             return ($found, undef) if ($found->{ok});
             return (undef, [$found]);
         }
-        return unless $found->{ok};
+        return undef unless $found->{ok};
         return $found;
     }
 }

--- a/script/os-autoinst-openvswitch
+++ b/script/os-autoinst-openvswitch
@@ -194,11 +194,11 @@ sub _ovs_version () { qx{ovs-vsctl --version} }
 
 sub check_min_ovs_version ($min_ver) {
     my $out = _ovs_version;
-    return if ($out !~ /\(Open vSwitch\)\s+(\d+\.\d+\.\d+)/m);
+    return undef if ($out !~ /\(Open vSwitch\)\s+(\d+\.\d+\.\d+)/m);
 
     my @ver = split /\./, $1;
     my @min_ver = split /\./, $min_ver;
-    return if (@ver != @min_ver);
+    return undef if (@ver != @min_ver);
 
     return (sprintf '%04d%04d%04d', @ver) >= sprintf '%04d%04d%04d', @min_ver;
 }

--- a/t/10-terminal.t
+++ b/t/10-terminal.t
@@ -386,7 +386,7 @@ sub report_child_test ($method, @args) {
 }
 
 sub retrieve_child_tests () {
-    return unless -e $sharefile;
+    return undef unless -e $sharefile;
     my $fd = path($sharefile)->open('<');
     flock $fd, LOCK_SH;
     my %tests;

--- a/testapi.pm
+++ b/testapi.pm
@@ -359,7 +359,7 @@ sub _check_backend_response ($rsp, $check, $timeout, $mustmatch) {
             $autotest::current_test->save_test_result();
             # now back into waiting for the backend
             $rsp = myjsonrpc::read_json($autotest::isotovideo);
-            return unless $rsp;
+            return undef unless $rsp;
             $rsp = $rsp->{ret};
             $rsp->{tags} = $tags;
             return _check_backend_response($rsp, $check, $timeout, $mustmatch);
@@ -368,7 +368,7 @@ sub _check_backend_response ($rsp, $check, $timeout, $mustmatch) {
     else {
         die 'unexpected response ' . bmwqemu::pp($rsp);
     }
-    return;
+    return undef;
 }
 
 sub _check_or_assert ($mustmatch, $check, %args) {
@@ -521,7 +521,7 @@ sub click_lastmatch (%args) {
     $args{mousehide} //= 0;
     $args{point_id} //= undef;
 
-    return unless $last_matched_needle;
+    return undef unless $last_matched_needle;
 
     my $old_mouse_coords = query_isotovideo('backend_get_last_mouse_set');
 
@@ -890,7 +890,7 @@ sub wait_serial ($regexp, @args) {
     $autotest::current_test->record_serialresult(bmwqemu::pp($regexp), $matched, $ret->{string}, command => $args{record_command}, internal_marker => $args{internal_marker}, marker_pattern => $regexp, capture_name => $args{capture_name}) unless ($args{quiet});
     bmwqemu::fctres("$regexp: $matched");
     return $ret->{string} if ($matched eq 'ok');
-    return;    # false
+    return undef;    # false
 }
 
 =head2 x11_start_program
@@ -1167,7 +1167,7 @@ sub get_test_data ($path) {
     bmwqemu::log_call(path => $path);
     unless (-e $path) {
         bmwqemu::diag("File doesn't exist: $path");
-        return;
+        return undef;
     }
     return path($path)->slurp;
 }
@@ -2173,7 +2173,7 @@ sub upload_logs ($file, %args) {
 
     if (get_var('OFFLINE_SUT')) {
         record_info('upload skipped', "Skipped uploading log file '$file' as we are offline");
-        return;
+        return undef;
     }
     bmwqemu::log_call(file => $file, failok => $failok, timeout => $timeout, %args);
     my $basename = basename($file);
@@ -2225,7 +2225,7 @@ C<$nocheck> parameter:
 sub upload_asset ($file, $public = undef, $nocheck = undef) {
     if (get_var('OFFLINE_SUT')) {
         record_info('upload skipped', "Skipped uploading asset '$file' as we are offline");
-        return;
+        return undef;
     }
     bmwqemu::log_call(file => $file, public => $public, nocheck => $nocheck);
     my $cmd = "curl --form upload=\@$file ";


### PR DESCRIPTION
Add return arguments to all returns without any

https://metacpan.org/pod/Perl::Critic::Policy::Community::EmptyReturn

> Context-sensitive functions, while one way to write functions that
    DWIM (Do What I Mean), tend to instead lead to unexpected behavior when
    the function is accidentally used in a different context, especially if
    the function's behavior changes significantly based on context. This
    also can lead to vulnerabilities when a function is intended to be used
    as a scalar, but is used in a list, such as a hash constructor or
    function parameter list. return with no arguments will return either
    undef or an empty list depending on context. Instead, return the
    appropriate value explicitly.

reference: https://progress.opensuse.org/issues/155191