### PR TITLE
style(perlcritic): Add Variables::ProhibitPackageVars

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -43,3 +43,6 @@ severity = 5
 # -- Superfluous use strict/warning.
 [OpenQA::RedundantStrictWarning]
 equivalent_modules = Test::Most
+
+[Variables::ProhibitPackageVars]
+add_packages = autotest bmwqemu log needle testapi Carp OpenQA::Isotovideo::Interface

--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,6 +1,6 @@
 theme = community + openqa
 severity = 4
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator
+include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitPackageVars
 
 verbose = ::warning file=%f,line=%l,col=%c,title=%m - severity %s::[%p] %e\n
 

--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -9,14 +9,14 @@ use Mojo::Base -strict, -signatures;
 # -> increment on every change of such APIs
 # -> never move that variable to another place (when refactoring)
 #    because it may be accessed by the tests itself
-our $version = 56;
+our $version = 56;    ## no critic (Variables::ProhibitPackageVars)
 
 # major version of the (web socket) API relevant to the developer mode
 # -> increment when making non-backward compatible changes to that API
-our $developer_mode_major_version = 1;
+our $developer_mode_major_version = 1;    ## no critic (Variables::ProhibitPackageVars)
 # minor version of the (web socket) API relevant to the developer mode
 # -> reset to 0 when making non-backward compatible changes to that API
 # -> increment when making backward compatible changes to that API
-our $developer_mode_minor_version = 1;
+our $developer_mode_minor_version = 1;    ## no critic (Variables::ProhibitPackageVars)
 
 1;

--- a/autotest.pm
+++ b/autotest.pm
@@ -27,12 +27,15 @@ use constant FAIL_ON_ALWAYS_ROLLBACK_NOT_SUPPORTED => 1;
 
 our @EXPORT_OK = qw(loadtest $selected_console $last_milestone_console query_isotovideo);
 
-our %tests;    # scheduled or run tests
-our @testorder;    # for keeping them in order
-our %scheduled_basenames;    # keep track of scheduled basenames to their script path
-our $isotovideo;
-our $process;
-our $tests_running = 0;
+# scheduled or run tests
+our %tests;    ## no critic (Variables::ProhibitPackageVars)
+# for keeping them in order
+our @testorder;    ## no critic (Variables::ProhibitPackageVars)
+# keep track of scheduled basenames to their script path
+our %scheduled_basenames;    ## no critic (Variables::ProhibitPackageVars)
+our $isotovideo;    ## no critic (Variables::ProhibitPackageVars)
+our $process;    ## no critic (Variables::ProhibitPackageVars)
+our $tests_running = 0;    ## no critic (Variables::ProhibitPackageVars)
 
 =head1 Introduction
 
@@ -354,12 +357,12 @@ sub loadtest ($script, %args) {
     bmwqemu::diag("scheduling $test->{name} $script");
 }
 
-our $current_test;
-our $selected_console;
-our $last_milestone;
-our $last_milestone_active_consoles = [];
-our $activated_consoles = [];
-our $last_milestone_console;
+our $current_test;    ## no critic (Variables::ProhibitPackageVars)
+our $selected_console;    ## no critic (Variables::ProhibitPackageVars)
+our $last_milestone;    ## no critic (Variables::ProhibitPackageVars)
+our $last_milestone_active_consoles = [];    ## no critic (Variables::ProhibitPackageVars)
+our $activated_consoles = [];    ## no critic (Variables::ProhibitPackageVars)
+our $last_milestone_console;    ## no critic (Variables::ProhibitPackageVars)
 
 sub parse_test_path ($script_path) {
     unless ($script_path =~ m,(\w+)/([^/]+)\.(p[my]|lua)$,) {

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -42,7 +42,7 @@ use constant DEFAULT_FFMPEG_CMD => FFMPEG_BIN . ' -y -hide_banner -nostats -r 24
 use constant SSH_SERIAL_READ_BUFFER_SIZE => 4096;
 
 # should be a singleton - and only useful in backend process
-our $backend;
+our $backend;    ## no critic (Variables::ProhibitPackageVars)
 
 has [qw(
       update_request_interval last_update_request screenshot_interval

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -32,28 +32,29 @@ sub mydie;
 $| = 1;
 
 
-our $default_timeout = 30;    # assert timeout, 0 is a valid timeout
-our $openqa_default_share = '/var/lib/openqa/share';
+# assert timeout, 0 is a valid timeout
+our $default_timeout = 30;    ## no critic (Variables::ProhibitPackageVars)
+our $openqa_default_share = '/var/lib/openqa/share';    ## no critic (Variables::ProhibitPackageVars)
 
 my @ocrrect;
 
-our $screenshotpath = 'qemuscreenshot';
+our $screenshotpath = 'qemuscreenshot';    ## no critic (Variables::ProhibitPackageVars)
 
 # global vars
 
 # Known locations of OVMF (UEFI) firmware: first is openSUSE, second is
 # the kraxel.org nightly packages, third is Fedora's edk2-ovmf package,
 # fourth is Debian's ovmf package.
-our @ovmf_locations_no_secure_boot = (
+our @ovmf_locations_no_secure_boot = (    ## no critic (Variables::ProhibitPackageVars)
     '/usr/share/qemu/ovmf-x86_64-4m-code.bin', '/usr/share/qemu/ovmf-x86_64-ms-code.bin',
 );
-our @ovmf_locations = (
+our @ovmf_locations = (    ## no critic (Variables::ProhibitPackageVars)
     '/usr/share/qemu/ovmf-x86_64-ms-4m-code.bin', '/usr/share/qemu/ovmf-x86_64-ms-code.bin',
     '/usr/share/edk2.git/ovmf-x64/OVMF_CODE-pure-efi.fd',
     '/usr/share/edk2/ovmf/OVMF_CODE.fd', '/usr/share/OVMF/OVMF_CODE.fd'
 );
 
-our %vars;
+our %vars;    ## no critic (Variables::ProhibitPackageVars)
 tie %vars, 'bmwqemu::tiedvars', %vars;
 
 sub ovmf_locations () { ($vars{UEFI_SECURE_BOOT} // 1) ? \@ovmf_locations : \@ovmf_locations_no_secure_boot }
@@ -125,7 +126,7 @@ sub save_vars (%args) {
 }
 
 # set from isotovideo during initialization
-our $topdir;
+our $topdir;    ## no critic (Variables::ProhibitPackageVars)
 
 sub init () {
     load_vars();
@@ -216,7 +217,7 @@ sub ensure_valid_vars () {
 
 # local vars
 
-our $backend;
+our $backend;    ## no critic (Variables::ProhibitPackageVars)
 
 # local vars end
 

--- a/log.pm
+++ b/log.pm
@@ -14,8 +14,8 @@ use Term::ANSIColor;
 use Exporter 'import';
 our @EXPORT_OK = qw(logger init_logger diag fctres fctinfo fctwarn modstate);
 
-our $logger;
-our $direct_output;
+our $logger;    ## no critic (Variables::ProhibitPackageVars)
+our $direct_output;    ## no critic (Variables::ProhibitPackageVars)
 
 sub logger () { $logger //= Mojo::Log->new(level => 'debug', format => \&log_format_callback) }
 

--- a/mmapi.pm
+++ b/mmapi.pm
@@ -20,7 +20,7 @@ our $retry_count = $ENV{OS_AUTOINST_MMAPI_RETRY_COUNT} // 30;
 our $retry_interval = $ENV{OS_AUTOINST_MMAPI_RETRY_INTERVAL} // 10;
 our $poll_interval = $ENV{OS_AUTOINST_MMAPI_POLL_INTERVAL} // 1;
 
-our $url;
+my $url;
 
 # private ua
 my $ua;

--- a/mmapi.pm
+++ b/mmapi.pm
@@ -16,9 +16,9 @@ require bmwqemu;
 use Mojo::UserAgent;
 use Mojo::URL;
 
-our $retry_count = $ENV{OS_AUTOINST_MMAPI_RETRY_COUNT} // 30;
-our $retry_interval = $ENV{OS_AUTOINST_MMAPI_RETRY_INTERVAL} // 10;
-our $poll_interval = $ENV{OS_AUTOINST_MMAPI_POLL_INTERVAL} // 1;
+use constant RETRY_COUNT => $ENV{OS_AUTOINST_MMAPI_RETRY_COUNT} // 30;
+use constant RETRY_INTERVAL => $ENV{OS_AUTOINST_MMAPI_RETRY_INTERVAL} // 10;
+use constant POLL_INTERVAL => $ENV{OS_AUTOINST_MMAPI_POLL_INTERVAL} // 1;
 
 my $url;
 
@@ -67,14 +67,14 @@ sub api_call_2 ($method, $action, $params = undef, $expected_codes = undef) {
     $ua_url->path($action);
     $ua_url->query($params) if $params;
 
-    my $tries = $retry_count;
+    my $tries = RETRY_COUNT;
     my ($tx, $res);
     while ($tries--) {
         $tx = $ua->$method($ua_url);
         $res = $tx->res;
         last if $res->code && ($expected_codes // $CODES_EXPECTED_BY_DEFAULT)->{$res->code};
-        bmwqemu::diag("api_call_2 failed, retries left: $tries of $retry_count");
-        sleep $retry_interval;
+        bmwqemu::diag("api_call_2 failed, retries left: $tries of " . RETRY_COUNT);
+        sleep RETRY_INTERVAL;
     }
     return $tx;
 }
@@ -238,7 +238,7 @@ sub wait_for_children () {
 
         bmwqemu::diag("Waiting for $n jobs to finish");
         last unless $n;
-        sleep $poll_interval;
+        sleep POLL_INTERVAL;
     }
 }
 
@@ -261,7 +261,7 @@ sub wait_for_children_to_start () {
 
         bmwqemu::diag("Waiting for $n jobs to start");
         last unless $n;
-        sleep $poll_interval;
+        sleep POLL_INTERVAL;
     }
 }
 

--- a/myjsonrpc.pm
+++ b/myjsonrpc.pm
@@ -15,7 +15,7 @@ use constant DEBUG_JSON => $ENV{PERL_MYJSONRPC_DEBUG} || 0;
 use constant READ_BUFFER => $ENV{PERL_MYJSONRPC_BYTES} || 8_000_000;
 
 # hash for keeping state
-our $sockets;
+my $sockets;
 
 sub _syswrite ($to_fd, $json, $length = undef, $offset = undef) { syswrite $to_fd, $json, $length, $offset }
 

--- a/needle.pm
+++ b/needle.pm
@@ -18,9 +18,9 @@ require IPC::System::Simple;
 use OpenQA::Benchmark::Stopwatch;
 use OpenQA::Isotovideo::Utils 'checkout_git_refspec';
 
-our %needles;
-our %tags;
-our $cleanuphandler;
+our %needles;    ## no critic (Variables::ProhibitPackageVars)
+our %tags;    ## no critic (Variables::ProhibitPackageVars)
+our $cleanuphandler;    ## no critic (Variables::ProhibitPackageVars)
 
 my $needles_dir;
 

--- a/t/07-commands.t
+++ b/t/07-commands.t
@@ -29,7 +29,7 @@ use File::Which;
 use Data::Dumper;
 use POSIX '_exit';
 
-our $mojoport = Mojo::IOLoop::Server->generate_port;
+my $mojoport = Mojo::IOLoop::Server->generate_port;
 my $base_url = "http://localhost:$mojoport";
 my $job = 'Hallo';
 my $toplevel_dir = path(__FILE__)->dirname->realpath;

--- a/t/19-isotovideo-command-processing.t
+++ b/t/19-isotovideo-command-processing.t
@@ -52,7 +52,7 @@ package FakeBackend {
 }    # uncoverable statement
 
 package bmwqemu {
-    our $backend = FakeBackend->new();
+    our $backend = FakeBackend->new();    ## no critic (Variables::ProhibitPackageVars)
 }
 
 # setup a CommandHandler instance using the fake file descriptors

--- a/t/39-dewebsockify.t
+++ b/t/39-dewebsockify.t
@@ -21,7 +21,7 @@ my $args_common = {
 };
 
 my ($accept_callback, @log_messages);
-our ($ws_on_text, $ws_on_binary, $ws_on_finish);
+our ($WS_ON_TEXT, $WS_ON_BINARY, $WS_ON_FINISH);
 
 my $mock_log = Test::MockModule->new('Mojo::Log');
 $mock_log->redefine(info => sub ($self, $msg) { push @log_messages, $msg });
@@ -65,9 +65,9 @@ $mock_ua->mock(start => sub ($ua, $tx, $cb) {
     sub req ($self, @args) { bless {}, 'MockTxGenericReq' }
 
     sub on ($self, $event, $cb) {
-        if ($event eq 'text') { $main::ws_on_text = $cb }
-        elsif ($event eq 'binary') { $main::ws_on_binary = $cb }
-        elsif ($event eq 'finish') { $main::ws_on_finish = $cb }
+        if ($event eq 'text') { $main::WS_ON_TEXT = $cb }
+        elsif ($event eq 'binary') { $main::WS_ON_BINARY = $cb }
+        elsif ($event eq 'finish') { $main::WS_ON_FINISH = $cb }
     }
     sub send ($self, @args) { }
     sub finish ($self) { }
@@ -164,11 +164,11 @@ subtest 'WebSocket handshake succeeds' => sub {
     ok(grep(/WebSocket connection established/, @log_messages),
         'WebSocket connection established');
 
-    $ws_on_text->(undef, 'dummy text message');
+    $WS_ON_TEXT->(undef, 'dummy text message');
     pass('Text message received via WebSocket');
-    $ws_on_binary->(undef, 'dummy binary data');
+    $WS_ON_BINARY->(undef, 'dummy binary data');
     pass('Binary message received via WebSocket');
-    $ws_on_finish->(undef, 1000, 'Normal closure');
+    $WS_ON_FINISH->(undef, 1000, 'Normal closure');
     ok(grep(/WebSocket closed with status 1000/, @log_messages),
         'WebSocket closed as expected');
 };

--- a/testapi.pm
+++ b/testapi.pm
@@ -73,16 +73,16 @@ our @EXPORT = qw(
 );
 our @EXPORT_OK = qw(is_serial_terminal);
 
-our %cmd;
+our %cmd;    ## no critic (Variables::ProhibitPackageVars)
 
-our $distri;
+our $distri;    ## no critic (Variables::ProhibitPackageVars)
 
-our $realname = 'Bernhard M. Wiedemann';
-our $username;
-our $password;
+our $realname = 'Bernhard M. Wiedemann';    ## no critic (Variables::ProhibitPackageVars)
+our $username;    ## no critic (Variables::ProhibitPackageVars)
+our $password;    ## no critic (Variables::ProhibitPackageVars)
 
-our $last_matched_needle;
-our $serialdev;
+our $last_matched_needle;    ## no critic (Variables::ProhibitPackageVars)
+our $serialdev;    ## no critic (Variables::ProhibitPackageVars)
 
 sub check_screen;
 sub enter_cmd;
@@ -1670,7 +1670,7 @@ I<The implementation is distribution specific and not always available.>
 =cut
 
 require backend::console_proxy;
-our %testapi_console_proxies;
+our %testapi_console_proxies;    ## no critic (Variables::ProhibitPackageVars)
 
 =head2 select_console
 


### PR DESCRIPTION
Variables::ProhibitPackageVars forbids using global package variables.

https://metacpan.org/pod/Perl::Critic::Policy::Variables::ProhibitPackageVars

> Conway suggests avoiding package variables completely, because they expose
> your internals to other packages. Never use a package variable when a lexical
> variable will suffice. If your package needs to keep some dynamic state,
> consider using an object or closures to keep the state private.
>
> This policy assumes that you're using `strict vars` so that naked variable
> declarations are not package variables by default. Thus, it complains you
> declare a variable with our or use vars, or if you make reference to variable
> with a fully-qualified package name.

Issue: https://progress.opensuse.org/issues/155191