### PR TITLE
fix: Make command and token handling more reliable

### DIFF
--- a/OpenQA/Isotovideo/CommandHandler.pm
+++ b/OpenQA/Isotovideo/CommandHandler.pm
@@ -17,7 +17,7 @@ use constant AUTOINST_STATUSFILE => 'autoinst-status.json';
 
 # io handles for sending data to command server and backend
 has [qw(test_fd cmd_srv_fd backend_fd backend_out_fd answer_fd)] => undef;
-has [qw(current_command_token backend_requester_token postponed_token)];
+has [qw(current_command_token backend_requester_token postponed_token active_check_screen_token)];
 
 # the name of the current test (full name includes category prefix, eg. installation-)
 has [qw(current_test_name current_test_full_name)];
@@ -70,6 +70,7 @@ sub new ($class, @args) {
 sub clear_tags_and_timeout ($self) {
     $self->tags(undef);
     $self->timeout(undef);
+    $self->active_check_screen_token(undef);
 }
 
 # processes the $response and send the answer back via $answer_fd by invoking one of the subsequent handler methods
@@ -122,6 +123,7 @@ sub _send_to_cmd_srv ($self, $data) { myjsonrpc::send_json($self->cmd_srv_fd, $d
 sub _send_to_backend ($self, $data) { myjsonrpc::send_json($self->backend_fd, $data) }
 
 sub send_to_backend_requester ($self, $data) {
+    return unless $self->backend_requester;
     local $self->{current_command_token} = $self->backend_requester_token;
     $self->_send_response($self->backend_requester, $data);
     $self->backend_requester(undef);
@@ -313,6 +315,12 @@ sub _handle_command_set_current_test ($self, $response, @) {
 sub _handle_command_tests_done ($self, $response, @) {
     $self->test_died($response->{died});
     $self->test_completed($response->{completed});
+    $self->clear_tags_and_timeout();
+    $self->backend_requester(undef);
+    $self->backend_requester_token(undef);
+    $self->postponed_command(undef);
+    $self->postponed_answer_fd(undef);
+    $self->postponed_token(undef);
     $self->_respond_ok();
     $self->emit(tests_done => $response);
     $self->current_test_name('');
@@ -323,6 +331,7 @@ sub _handle_command_tests_done ($self, $response, @) {
 sub _handle_command_check_screen ($self, $response, @) {
     $self->no_wait($response->{no_wait} // 0);
     return if $self->_postpone_backend_command_until_resumed($response);
+    $self->active_check_screen_token($self->current_command_token);
 
     my %arguments = (
         mustmatch => $response->{mustmatch},
@@ -430,7 +439,8 @@ sub check_asserted_screen ($self) {
     # the test needs that information
     $rsp->{tags} = $self->tags;
     if ($rsp->{found} || $rsp->{timeout}) {
-        myjsonrpc::send_json($self->test_fd, {ret => $rsp});
+        local $self->{current_command_token} = $self->active_check_screen_token;
+        $self->_send_response($self->test_fd, {ret => $rsp});
         $self->clear_tags_and_timeout();
     }
     else {

--- a/t/19-isotovideo-command-processing.t
+++ b/t/19-isotovideo-command-processing.t
@@ -41,10 +41,16 @@ $rpc_mock->redefine(read_json => sub {
 });
 
 # mock bmwqemu/backend
+my $check_screen_token_echo;
+
 package FakeBackend {
     sub new ($class) { bless {messages => []}, $class }
 
     sub _send_json ($self, $cmd) {
+        if ($check_screen_token_echo) {
+            return {found => 1} if $cmd->{cmd} eq 'check_asserted_screen';
+            return {tags => [qw(some fake tags)]};
+        }
         push @{$self->{messages}}, $cmd;
         return $cmd->{cmd} eq 'is_shutdown' ? 'down' : {tags => [qw(some fake tags)]};
     }
@@ -64,6 +70,7 @@ my $command_handler = OpenQA::Isotovideo::CommandHandler->new(
 );
 
 sub reset_state () {
+    $check_screen_token_echo = 0;
     $command_handler->tags(undef);
     $command_handler->pause_test_name(undef);
     $last_received_msg_by_fd[$answer_fd] = undef;
@@ -421,6 +428,41 @@ subtest token_echo => sub {
 
         $command_handler->send_to_backend_requester({ret => 1});
         is $last_received_msg_by_fd[$answer_fd]->{json_cmd_token}, $token1, 'deferred backend response gets correct token';
+    };
+
+    subtest 'check_screen token echo' => sub {
+        reset_state();
+        $command_handler->test_fd($answer_fd);
+        $check_screen_token_echo = 1;
+
+        my $token = 'check-screen-token';
+        $command_handler->process_command($answer_fd, {cmd => 'check_screen', json_cmd_token => $token, mustmatch => ['some-tag']});
+        is $command_handler->active_check_screen_token, $token, 'active_check_screen_token is stored';
+
+        $command_handler->no_wait(1);
+        $command_handler->check_asserted_screen();
+        is $last_received_msg_by_fd[$answer_fd]->{json_cmd_token}, $token, 'check_screen token is echoed back in check_asserted_screen response';
+        is $command_handler->active_check_screen_token, undef, 'active_check_screen_token is cleared after responding';
+    };
+
+    subtest 'tests_done clears pending state' => sub {
+        reset_state();
+        $command_handler->test_fd($answer_fd);
+        $command_handler->backend_requester($answer_fd);
+        $command_handler->backend_requester_token('some-backend-token');
+        $command_handler->postponed_command({cmd => 'status'});
+        $command_handler->postponed_answer_fd($answer_fd);
+        $command_handler->postponed_token('some-postponed-token');
+        $command_handler->active_check_screen_token('some-check-token');
+
+        $command_handler->process_command($answer_fd, {cmd => 'tests_done', json_cmd_token => 'tests-done-token'});
+
+        is $command_handler->backend_requester, undef, 'backend_requester is cleared upon tests_done';
+        is $command_handler->backend_requester_token, undef, 'backend_requester_token is cleared upon tests_done';
+        is $command_handler->postponed_command, undef, 'postponed_command is cleared upon tests_done';
+        is $command_handler->postponed_answer_fd, undef, 'postponed_answer_fd is cleared upon tests_done';
+        is $command_handler->postponed_token, undef, 'postponed_token is cleared upon tests_done';
+        is $command_handler->active_check_screen_token, undef, 'active_check_screen_token is cleared upon tests_done';
     };
 };
 


### PR DESCRIPTION
Motivation:
Previous attempts to address `ERROR: the token does not match` (d9bd02e7) lacked robust handling for deferred responses (like `check_screen`) and didn't guard against race conditions during the shutdown sequence when autotest is waiting for the tests_done reply.

Explanation:
- `current_command_token` was localized correctly but lost its context for asynchronous calls, notably bypassing token echoing entirely in `check_asserted_screen`.
- A shutdown race condition existed where interleaved or delayed backend responses leaked to autotest while it blocked waiting for `tests_done`, triggering token mismatch errors.

Design Choices:
- Introduced `active_check_screen_token` to explicitly store and restore the token for screen checks so `check_asserted_screen` echoes it back via `_send_response`.
- Added defensive state clearing inside `_handle_command_tests_done` to disarm any pending backend requests, tags, and postponed commands before sending the final acknowledgment to autotest.
- Added a `backend_requester` safeguard to avoid writing to dead file descriptors during unexpected shutdowns.
- Expanded `19-isotovideo-command-processing.t` unit tests to explicitly cover both the `check_screen` token echo behavior and the `tests_done` state-clearing mechanisms.

Related ticket: https://progress.opensuse.org/issues/201972

---

~~Still a draft because I still want to test this for real. Whether it really helps with `ERROR: the token does not match` is something that's hard to verify because the issue cannot be reliably reproduced.~~ I now tested this with a real test run where I also used many features of the developer mode (that does some special command processing). I haven't noticed any regressions.