### PR TITLE
fix(test): fix Test::More precedence in autotest

### DIFF
--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -350,7 +350,7 @@ is $completed, 0, 'fatal test failure should not complete';
 loadtest 'fatal', 'rescheduling same step later' for 1 .. 10;
 my @opts = qw(script fullname category class);
 is @{$autotest::tests{'tests-fatal'}}{@opts}, @{$autotest::tests{'tests-fatal' . $_}}{@opts}, "tests-fatal$_ share same options with tests-fatal"
-  && is @{$autotest::tests{'tests-fatal' . $_}}{name}, 'fatal#' . $_
+  and is $autotest::tests{'tests-fatal' . $_}->{name}, 'fatal#' . $_
   for 1 .. 10;
 
 subtest 'scheduling rules' => sub {


### PR DESCRIPTION
Motivation:
Removing parentheses from Test::More calls in a previous style commit introduced
a bug where `&&` takes precedence over comma in a nested logical statement,
evaluating to an unexpected test name.

Design Choices:
Change the `&&` logical operator to `and`, which has lower precedence than
the comma. This ensures the expressions are parsed correctly without needing
parentheses.

Benefits:
Resolves the `Test::Builder` warning ("You named your test '1'...") and ensures
both assertions are executed properly under the parenthesis-free project style.

Related issue: https://github.com/os-autoinst/os-autoinst/pull/2962