### PR TITLE
style(perlcritic): Add ValuesAndExpressions::RequireNumberSeparators

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,7 +1,7 @@
 theme = community + openqa
 severity = 4
 
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitPackageVars CodeLayout::RequireTidyCode Community::WarningsSwitch Community::EmptyReturn Variables::ProhibitUnusedVariables
+include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitPackageVars CodeLayout::RequireTidyCode Community::WarningsSwitch Community::EmptyReturn Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators
 
 verbose = ::warning file=%f,line=%l,col=%c,title=%m - severity %s::[%p] %e\n
 

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -373,7 +373,7 @@ sub save_memory_dump ($self, $args) {
 sub inflate_balloon ($self) {
     my $vars = \%bmwqemu::vars;
     return unless $vars->{QEMU_BALLOON_TARGET};
-    my $target_bytes = $vars->{QEMU_BALLOON_TARGET} * 1048576;
+    my $target_bytes = $vars->{QEMU_BALLOON_TARGET} * 1_048_576;
     $self->handle_qmp_command({execute => 'balloon', arguments => {value => $target_bytes}}, fatal => 1);
     my $rsp = $self->handle_qmp_command({execute => 'query-balloon'}, fatal => 1);
     my $prev_actual = $rsp->{return}->{actual};
@@ -390,7 +390,7 @@ sub inflate_balloon ($self) {
 sub deflate_balloon ($self) {
     my $vars = \%bmwqemu::vars;
     return unless $vars->{QEMU_BALLOON_TARGET};
-    my $ram_bytes = $vars->{QEMURAM} * 1048576;
+    my $ram_bytes = $vars->{QEMURAM} * 1_048_576;
     $self->handle_qmp_command({execute => 'balloon', arguments => {value => $ram_bytes}}, fatal => 1);
 }
 

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -196,7 +196,7 @@ sub _abort_if_storage_limit_exceeded () {
 
 sub ensure_valid_vars () {
     # defaults
-    $vars{QEMUPORT} ||= 15222;
+    $vars{QEMUPORT} ||= 15_222;
     $vars{VNC} ||= 90;
     # openQA already sets a random string we can reuse
     $vars{JOBTOKEN} ||= random_string(10);

--- a/commands.pm
+++ b/commands.pm
@@ -37,7 +37,7 @@ sub _makecpiohead ($name = undef, $s = undef) {
     #        magic ino
     my $h = '07070100000000';
     # mode                S_IFREG
-    $h .= sprintf '%08x', oct(100000) | $s->[2] & oct 777;
+    $h .= sprintf '%08x', oct(100_000) | $s->[2] & oct 777;
     #      uid     gid     nlink
     $h .= '000000000000000000000001';
     $h .= sprintf '%08x%08x', $s->[9], $s->[7];

--- a/consoles/VNC.pm
+++ b/consoles/VNC.pm
@@ -309,7 +309,7 @@ sub _handshake_security ($self) {
 
         $num_tunnels = unpack 'N', $num_tunnels;
         # found in https://github.com/kanaka/noVNC
-        $self->old_ikvm($num_tunnels > 0x1000000 ? 1 : 0);
+        $self->old_ikvm($num_tunnels > 0x1_000_000 ? 1 : 0);
         $socket->read(my $ikvm_session, 20) || die 'unexpected end of data';
         my @bytes = unpack 'C20', $ikvm_session;
         print 'Session info: ';
@@ -1009,7 +1009,7 @@ sub _receive_ikvm_encoding ($self, $encoding_type, $x, $y, $w, $h) {
     $socket->read(my $aten_data, 8);
     my ($data_prefix, $data_len) = unpack 'NN', $aten_data;
 
-    $self->screen_on($w < 33000);    # screen is off is signaled by negative numbers
+    $self->screen_on($w < 33_000);    # screen is off is signaled by negative numbers
 
     # ikvm doesn't bother sending screen size changes
     if ($w != $self->width || $h != $self->height) {

--- a/consoles/video_stream.pm
+++ b/consoles/video_stream.pm
@@ -321,7 +321,7 @@ sub _receive_frame_ustreamer ($self) {
 
         my ($magic, $version, $id, $used) = unpack 'QLx4QQ', $ustreamer_map;
         # This is US_MEMSINK_MAGIC, but perl considers hex literals over 32bits non-portable
-        if ($magic != 14627333968358193854) {
+        if ($magic != 14_627_333_968_358_193_854) {
             bmwqemu::diag "Invalid ustreamer magic: $magic";
             return undef;
         }

--- a/mmapi.pm
+++ b/mmapi.pm
@@ -186,7 +186,7 @@ sub get_job_autoinst_url ($target_id) {
             my $properties = $worker->{properties};
             my $hostname = $properties->{WORKER_HOSTNAME} // $worker->{host};
             my $token = $properties->{JOBTOKEN};
-            my $workerport = $worker->{instance} * 10 + 20002 + 1;    # the same as in openqa/script/worker
+            my $workerport = $worker->{instance} * 10 + 20_002 + 1;    # the same as in openqa/script/worker
             my $url = "http://$hostname:$workerport/$token";
             return $url;
         }

--- a/t/10-virtio_terminal.t
+++ b/t/10-virtio_terminal.t
@@ -82,7 +82,7 @@ subtest 'Test open_pipe() error condition' => sub {
     cleanup_pipes($helper);
 
     my $size = 1024;
-    $file_mock->redefine(slurp => sub { return 65536; });
+    $file_mock->redefine(slurp => sub { return 65_536; });
     $vterminal_mock->redefine('get_pipe_sz', sub { return 1024; });
     $vterminal_mock->redefine('set_pipe_sz', sub {
             my ($self, $fd, $newsize) = @_;
@@ -113,7 +113,7 @@ subtest 'Test open_pipe() error condition' => sub {
     $term = consoles::virtio_terminal->new('unit-test-console', {socked_path => $socket_path});
     combined_like { $term->open_pipe() } qr/Set PIPE_SZ from 1024 to 65536/, 'Log mention new size';
     cleanup_pipes($helper);
-    is $size, 65536, 'PIPE_SZ is 65536';
+    is $size, 65_536, 'PIPE_SZ is 65536';
 
     testapi::set_var('VIRTIO_CONSOLE_PIPE_SZ', 5555);
     $helper = prepare_pipes($socket_path);

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -537,13 +537,13 @@ subtest '"balloon" handling' => sub {
     $bmwqemu::vars{QEMU_BALLOON_TARGET} = 1;
     $backend->inflate_balloon;
     is_deeply $$invoked_qmp_cmds, [
-        {execute => 'balloon', arguments => {value => 1048576}}, {execute => 'query-balloon'}, {execute => 'query-balloon'}
+        {execute => 'balloon', arguments => {value => 1_048_576}}, {execute => 'query-balloon'}, {execute => 'query-balloon'}
     ], 'expected QMP commands invoked when "inflating balloon"' or always_explain $$invoked_qmp_cmds;
 
     $$invoked_qmp_cmds = undef;
     $backend->deflate_balloon;
     is_deeply $$invoked_qmp_cmds, [
-        {execute => 'balloon', arguments => {value => 1073741824}}    # QEMURAM * 1048576
+        {execute => 'balloon', arguments => {value => 1_073_741_824}}    # QEMURAM * 1048576
     ], 'expected QMP commands invoked when "deflating balloon"' or always_explain $$invoked_qmp_cmds;
 };
 
@@ -815,9 +815,9 @@ subtest 'special cases when starting QEMU' => sub {
 };
 
 subtest 'extract hostfwd ports from NICTYPE_USER_OPTIONS' => sub {
-    is_deeply [backend::qemu::_extract_hostfwd_ports('hostfwd=tcp::39100-:39100')], [39100], 'single tcp hostfwd';
+    is_deeply [backend::qemu::_extract_hostfwd_ports('hostfwd=tcp::39100-:39100')], [39_100], 'single tcp hostfwd';
     is_deeply [backend::qemu::_extract_hostfwd_ports('hostfwd=tcp::39100-:39100,hostfwd=tcp::5555-:22')],
-      [39100, 5555], 'multiple tcp hostfwd';
+      [39_100, 5555], 'multiple tcp hostfwd';
     is_deeply [backend::qemu::_extract_hostfwd_ports('hostfwd=udp::1234-:1234')], [1234], 'udp hostfwd';
     is_deeply [backend::qemu::_extract_hostfwd_ports('restrict=on')], [], 'no hostfwd options';
     is_deeply [backend::qemu::_extract_hostfwd_ports('')], [], 'empty string';
@@ -838,7 +838,7 @@ subtest 'port availability checks' => sub {
     subtest hostfwd => sub {
         $bmwqemu::vars{NICTYPE} = 'user';
         $bmwqemu::vars{NICTYPE_USER_OPTIONS} = 'hostfwd=tcp::39100-:39100';
-        combined_like { lives_ok { backend::qemu::_assert_port_availability(39100, 'test') } 'free port passes' }
+        combined_like { lives_ok { backend::qemu::_assert_port_availability(39_100, 'test') } 'free port passes' }
         qr/checking 39100 port availability/, 'logs port pre-qemu check with hostfwd';
         $sock_mock->redefine(new => sub { Test::MockObject->new->set_true('close') });
         combined_like { throws_ok { $backend->start_qemu } qr/Port 39100 \(hostfwd\) is already in use/, 'dies on hostfwd port conflict' }

--- a/t/18-qemu.t
+++ b/t/18-qemu.t
@@ -103,13 +103,13 @@ is_deeply \@gcmdl, \@cmdl, 'Generate qemu-img command line for multiple new driv
     '-blockdev', 'driver=qcow2,node-name=hd1-overlay0,file=hd1-overlay0-file,cache.no-flush=on,discard=unmap',
     '-device', 'virtio-blk,id=hd1-device,drive=hd1-overlay0');
 $bdc = OpenQA::Qemu::BlockDevConf->new();
-$bdc->add_existing_drive('hd1', '/abs/path/sle15-minimal.qcow2', 'virtio-blk', 22548578304);
+$bdc->add_existing_drive('hd1', '/abs/path/sle15-minimal.qcow2', 'virtio-blk', 22_548_578_304);
 @gcmdl = $bdc->gen_cmdline();
 is_deeply \@gcmdl, \@cmdl, 'Generate qemu command line for single existing drive';
 
 $cmdl[-1] .= ',logical_block_size=4096,physical_block_size=4096';
 $bdc = OpenQA::Qemu::BlockDevConf->new();
-$bdc->add_existing_drive('hd1', '/abs/path/sle15-minimal.qcow2', 'virtio-blk', 22548578304, undef, 4096);
+$bdc->add_existing_drive('hd1', '/abs/path/sle15-minimal.qcow2', 'virtio-blk', 22_548_578_304, undef, 4096);
 @gcmdl = $bdc->gen_cmdline();
 is_deeply \@gcmdl, \@cmdl, 'Generate qemu command line for existing drive with 4k sector size';
 
@@ -409,9 +409,9 @@ subtest 'relative assets' => sub {
     my @gcmdl = $proc->blockdev_conf->gen_qemu_img_cmdlines();
     @cmdl = (
         [qw(create -f qcow2 -F qcow2 -b), "$dir/some.qcow2", 'raid/hd0-overlay0', 512],
-        [qw(create -f qcow2 -F raw -b), "$dir/Core-7.2.iso", 'raid/cd0-overlay0', 11814912],
-        [qw(create -f qcow2 -F raw -b), "$dir/Core-7.2.iso", 'raid/cd1-overlay0', 11814912],
-        [qw(create -f qcow2 -F raw -b), "$Bin/data/uefi-code.bin", 'raid/pflash-code-overlay0', 1966080],
+        [qw(create -f qcow2 -F raw -b), "$dir/Core-7.2.iso", 'raid/cd0-overlay0', 11_814_912],
+        [qw(create -f qcow2 -F raw -b), "$dir/Core-7.2.iso", 'raid/cd1-overlay0', 11_814_912],
+        [qw(create -f qcow2 -F raw -b), "$Bin/data/uefi-code.bin", 'raid/pflash-code-overlay0', 1_966_080],
         [qw(create -f qcow2 -F qcow2 -b), "$dir/some.qcow2", 'raid/pflash-vars-overlay0', 512],
     );
     is_deeply \@gcmdl, \@cmdl, 'find the asset real path' or always_explain \@gcmdl;

--- a/t/21-needle-downloader.t
+++ b/t/21-needle-downloader.t
@@ -73,8 +73,8 @@ subtest 'add relevant downloads' => sub {
     my $touch = sub ($timestamp, $path) {
         path($path)->touch and utime 0, $timestamp, $path or BAIL_OUT("unable to set modification time of $path: $!");
     };
-    $touch->(1514764800, "$needles_dir/foo.png");    # … already up to date (to the exact second)
-    $touch->(1514764799, "$needles_dir/bar.png");    # … is present but outdated (by one second)
+    $touch->(1_514_764_800, "$needles_dir/foo.png");    # … already up to date (to the exact second)
+    $touch->(1_514_764_799, "$needles_dir/bar.png");    # … is present but outdated (by one second)
 
     # define expected downloads: everything from @new_needles except foo.png
     my @expected_downloads = (

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -50,7 +50,7 @@ $baseclass_mock->redefine(request_screen_update => sub ($self, $args) {
 my $baseclass = backend::baseclass->new();
 
 subtest 'format_vtt_timestamp' => sub {
-    my $timestamp = 1543917024.24791;
+    my $timestamp = 1_543_917_024.24_791;
     $baseclass->{video_frame_number} = 0;
     is $baseclass->format_vtt_timestamp($timestamp),
       "\n0\n00:00:00.000 --> 00:00:00.041\n[2018-12-04T09:50:24.247]\n",
@@ -269,7 +269,7 @@ subtest 'SSH utilities' => sub {
     # test handling read errors and timeout parameter of run_ssh_cmd()
     ($fail_on_read2, @net_ssh2_error) = (1, -9, 'LIBSSH2_ERROR_TIMEOUT', 'Time out waiting for data');
     throws_ok { $baseclass->run_ssh_cmd('sleep infinity', %ssh_creds, timeout => 100) } qr/waiting for data.*timeout/i, 'read timeout is fatal error';
-    is_deeply \@timeouts, [100000, 42], 'timeout increased to specified value, then set back to mocked default again';
+    is_deeply \@timeouts, [100_000, 42], 'timeout increased to specified value, then set back to mocked default again';
     ($fail_on_read2, @net_ssh2_error) = ();
     @output = $baseclass->run_ssh_cmd('test foo', %ssh_creds, timeout => 100, wantarray => 1);
     is_deeply \@output, [0, '', ''], 'command successful exit without output';

--- a/t/27-consoles-vmware.t
+++ b/t/27-consoles-vmware.t
@@ -48,7 +48,7 @@ subtest 'test configuration with fake URL' => sub {
     $fake_vnc->set_always(vmware_vnc_over_ws_url => 'https://root:secret%23@foo.bar');
     $fake_vnc->set_always(hostname => 'original-hostname');
     $fake_vnc->set_always(original_hostname => undef);
-    $fake_vnc->set_always(port => 12345);
+    $fake_vnc->set_always(port => 12_345);
     $fake_vnc->set_true(qw(description));
     $fake_vnc->clear;
 
@@ -62,7 +62,7 @@ subtest 'test configuration with fake URL' => sub {
     $fake_vnc->called_args_pos_is(5, 2, '127.0.0.1', 'hostname set to localhost');
     $fake_vnc->called_pos_ok(6, 'description', 'description assigned');
     $fake_vnc->called_args_pos_is(6, 2, 'VNC over WebSockets server provided by VMWare', 'description set accordingly');
-    is_deeply \@dewebsockify_args, [12345, 'wss://foo', 'session'], 'dewebsockify called with expected args'
+    is_deeply \@dewebsockify_args, [12_345, 'wss://foo', 'session'], 'dewebsockify called with expected args'
       or always_explain \@dewebsockify_args;
     is $vmware->host, 'foo.bar', 'hostname set';
     is $vmware->vm_id, undef, 'no VM-ID set (as our URL did not include one)';

--- a/t/27-consoles-vnc.t
+++ b/t/27-consoles-vnc.t
@@ -340,7 +340,7 @@ subtest 'security handshake: DES' => sub {
     $c->_handshake_security;
     my @expected = (
         pack(C => 2),    # client confirms to use DES
-        pack(NNNN => 0x80D03992, 0xB0DB4495, 0x80D03992, 0xB0DB4495),    # client solves challenge
+        pack(NNNN => 0x80_D03_992, 0xB0_DB4_495, 0x80_D03_992, 0xB0_DB4_495),    # client solves challenge
     );
     is_deeply \@printed, \@expected, 'expected response' or always_explain \@printed;
 };

--- a/t/34-git.t
+++ b/t/34-git.t
@@ -181,7 +181,7 @@ subtest 'cloning with caching' => sub {
         my $fake_checkout2 = $git_cache_dir->child('bar')->make_path;
 
         subtest 'below limit' => sub {
-            $bmwqemu::vars{GIT_CACHE_DIR_LIMIT} = 10000000;
+            $bmwqemu::vars{GIT_CACHE_DIR_LIMIT} = 10_000_000;
             combined_unlike { limit_git_cache_dir($git_cache_dir, $fake_checkout1, $fake_checkout_relative1, $handle_du) }
             qr/removing/i, 'no cleanup was logged';
             ok -d $repo_cache_dir, 'no cleanup has happened yet';

--- a/t/44-llm-failure-analysis.t
+++ b/t/44-llm-failure-analysis.t
@@ -61,11 +61,11 @@ subtest 'Prompt generation' => sub {
     my $prompt = OpenQA::Isotovideo::LLMAnalysis::build_prompt($ctx);
     like $prompt, qr/D V A.*F.*L.*S/s, 'Prompt contains all context';
 
-    my $long = 'A' x 10000;
+    my $long = 'A' x 10_000;
     $ctx->{log_tail} = $long;
     $ctx->{serial_tail} = $long;
     $prompt = OpenQA::Isotovideo::LLMAnalysis::build_prompt($ctx);
-    ok length($prompt) < 17000, 'Prompt truncated';
+    ok length($prompt) < 17_000, 'Prompt truncated';
     like $prompt, qr/sentences answering/s, 'Instructions preserved at end';
 };
 


### PR DESCRIPTION
Split numbers into groups of digits separated by underscores.

https://metacpan.org/pod/Perl::Critic::Policy::ValuesAndExpressions::RequireNumberSeparators

> Long numbers can be difficult to read. To improve legibility, Perl
    allows numbers to be split into groups of digits separated by
    underscores. This policy requires number sequences of more than three
    digits to be separated.

reference: https://progress.opensuse.org/issues/155191