### PR TITLE
style(perlcritic): Add RequireUpperCaseHeredocTerminator

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,7 +1,7 @@
 theme = community + openqa
 severity = 4
 
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitPackageVars CodeLayout::RequireTidyCode Community::WarningsSwitch Community::EmptyReturn Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators
+include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitPackageVars CodeLayout::RequireTidyCode Community::WarningsSwitch Community::EmptyReturn Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators ValuesAndExpressions::RequireUpperCaseHeredocTerminator
 
 verbose = ::warning file=%f,line=%l,col=%c,title=%m - severity %s::[%p] %e\n
 

--- a/consoles/serial_screen.pm
+++ b/consoles/serial_screen.pm
@@ -31,11 +31,11 @@ sub new ($class, $fd_read, $fd_write = undef) {
     return $self;
 }
 
-my $trying_to_use_keys = <<'FIN.';
+my $trying_to_use_keys = <<'FIN';
 Virtio terminal and svirt serial terminal do not support send_key. Use
 type_string (possibly with an ANSI/XTERM escape sequence), or switch to a
 console which sends key presses, not terminal codes.
-FIN.
+FIN
 
 =head2 send_key
 

--- a/t/10-terminal.t
+++ b/t/10-terminal.t
@@ -32,12 +32,12 @@ our $VERSION;
 $testapi::password = 'd*97Jlk/.d';
 my $socket_path = './virtio_console';
 my $sharefile = "$Bin/fork-share.txt";
-my $login_prompt_data = <<'FIN.';
+my $login_prompt_data = <<'FIN';
 
 
 Welcome to SUSE Linux Enterprise Server 12 SP2 RC3 (x86_64) - Kernel 4.4.21-65-default (hvc0).
 
-FIN.
+FIN
 $login_prompt_data .= 'linux-5rw7 login: ';
 my $user_name_prompt_data = 'login: ';
 my $user_name_data = "root\n";
@@ -50,12 +50,12 @@ my $normalised_prompt_data = '# ';
 my $C0_EOT = "\cD";
 my $C0_ETX = "\cC";
 my $C1_control_code = qq(\eQ\n);
-my $US_keyboard_data = <<'FIN.';
+my $US_keyboard_data = <<'FIN';
 !@\#$%^&*()-_+={}[]|:;"'<>,.?/~`
 abcdefghijklmnopqrstuvwxyz
 ABCDEFGHIJKLMNOPQRSTUVWXYZ
 0123456789
-FIN.
+FIN
 my $stop_code_data = "FIN.\n";
 my $repeat_sequence_count = 1000;
 my $next_test = "GOTO NEXT\n";


### PR DESCRIPTION
HEREDOC terminators should be all UPPER CASE letters (and numbers), without any whitespace.

https://metacpan.org/pod/Perl::Critic::Policy::ValuesAndExpressions::RequireUpperCaseHeredocTerminator

> For legibility, HEREDOC terminators should be all UPPER CASE letters
    (and numbers), without any whitespace. Conway also recommends using a
    standard prefix like "END_" but this policy doesn't enforce that.

reference: https://progress.opensuse.org/issues/155191