### PR TITLE
style(perlcritic): Add BuiltinFunctions::ProhibitUselessTopic

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,7 +1,7 @@
 theme = community + openqa
 severity = 4
 
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitPackageVars CodeLayout::RequireTidyCode Community::WarningsSwitch Community::EmptyReturn Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators ValuesAndExpressions::RequireUpperCaseHeredocTerminator
+include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitPackageVars CodeLayout::RequireTidyCode Community::WarningsSwitch Community::EmptyReturn Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators ValuesAndExpressions::RequireUpperCaseHeredocTerminator BuiltinFunctions::ProhibitUselessTopic
 
 verbose = ::warning file=%f,line=%l,col=%c,title=%m - severity %s::[%p] %e\n
 

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -595,7 +595,7 @@ sub console_fifo ($name) {
 
 sub create_virtio_console_fifo () { console_fifo($_) for virtio_console_fifo_names }
 
-sub delete_virtio_console_fifo () { unlink $_ or bmwqemu::fctwarn("Could not unlink $_ $!") for grep { -e } virtio_console_fifo_names }
+sub delete_virtio_console_fifo () { unlink or bmwqemu::fctwarn("Could not unlink $_ $!") for grep { -e } virtio_console_fifo_names }
 
 sub qemu_params_ofw ($self) {
     my $vars = \%bmwqemu::vars;
@@ -1050,8 +1050,7 @@ sub start_qemu ($self) {
     # The first item will have '-' prepended to it.
     if ($vars->{QEMU_APPEND}) {
         # Split multiple options, if needed
-        my @spl = split / -/, $vars->{QEMU_APPEND};
-        sp(split ' ', $_) for @spl;
+        sp(split ' ') for split / -/, $vars->{QEMU_APPEND};
     }
 
     create_virtio_console_fifo();

--- a/needle.pm
+++ b/needle.pm
@@ -228,7 +228,7 @@ sub has_tag ($self, $tag) {
 }
 
 sub has_property ($self, $property_name) {
-    return grep { ref($_) eq 'HASH' ? $_->{name} eq $property_name : $_ eq $property_name } @{$self->{properties}};
+    return grep { ref eq 'HASH' ? $_->{name} eq $property_name : $_ eq $property_name } @{$self->{properties}};
 }
 
 sub get_property_value ($self, $property_name) {

--- a/t/10-terminal.t
+++ b/t/10-terminal.t
@@ -325,9 +325,9 @@ sub check_child ($child, $expected_exit_status = 0) {
 my $pipe_in = $socket_path . '.in';
 my $pipe_out = $socket_path . '.out';
 
-for (($pipe_in, $pipe_out)) {
-    unlink $_ if -p $_;
-    mkfifo $_, 0666 or die "Cannot create fifo pipe $_";
+for my $pipe ($pipe_in, $pipe_out) {
+    unlink $pipe if -p $pipe;
+    mkfifo $pipe, 0666 or die "Cannot create fifo pipe $pipe";
 }
 
 my $fpid = fork || do {

--- a/t/10-virtio_terminal.t
+++ b/t/10-virtio_terminal.t
@@ -24,9 +24,9 @@ sub prepare_pipes ($socket_path, $write_buffer = undef) {
     my $pipe_in = $socket_path . '.in';
     my $pipe_out = $socket_path . '.out';
 
-    for (($pipe_in, $pipe_out)) {
-        unlink $_ if (-e $_);
-        mkfifo($_, 0666) or die "Cannot create fifo pipe $_";
+    for my $pipe ($pipe_in, $pipe_out) {
+        unlink $pipe if -e $pipe;
+        mkfifo($pipe, 0666) or die "Cannot create fifo pipe $_";
     }
 
     $pipe_data_written = 0;


### PR DESCRIPTION
Remove unnecessary `$_` variable.

https://metacpan.org/pod/Perl::Critic::Policy::BuiltinFunctions::ProhibitUselessTopic

> There are a number of places where $_, or "the topic" variable, is
    unnecessary.

reference: https://progress.opensuse.org/issues/155191