### PR TITLE
style(perlcritic): Add RegularExpressions::ProhibitUselessTopic

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,7 +1,7 @@
 theme = community + openqa
 severity = 4
 
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitPackageVars CodeLayout::RequireTidyCode Community::WarningsSwitch Community::EmptyReturn Variables::ProhibitUnusedVariables ValuesAndExpressions::RequireNumberSeparators ValuesAndExpressions::RequireUpperCaseHeredocTerminator BuiltinFunctions::ProhibitUselessTopic
+include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitPackageVars CodeLayout::RequireTidyCode Community::WarningsSwitch Community::EmptyReturn Variables::ProhibitUnusedVariables RegularExpressions::ProhibitUselessTopic BuiltinFunctions::ProhibitUselessTopic
 
 verbose = ::warning file=%f,line=%l,col=%c,title=%m - severity %s::[%p] %e\n
 

--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -391,7 +391,9 @@ sub load_test_schedule (@) {
         unshift @INC, '.' unless path($bmwqemu::vars{CASEDIR})->is_abs;
         bmwqemu::fctinfo 'Enforced test schedule by \'SCHEDULE\' variable in action';
         $bmwqemu::vars{INCLUDE_MODULES} = undef;
-        autotest::loadtest($_ =~ qr/\./ ? $_ : $_ . '.pm') foreach split /[, \n]+/, $bmwqemu::vars{SCHEDULE};
+        for my $test (split /[, \n]+/, $bmwqemu::vars{SCHEDULE}) {
+            autotest::loadtest($test =~ /\./ ? $test : $test . '.pm');
+        }
         $bmwqemu::vars{INCLUDE_MODULES} = 'none';
     }
     my $productdir = $bmwqemu::vars{PRODUCTDIR};

--- a/consoles/s3270.pm
+++ b/consoles/s3270.pm
@@ -67,7 +67,7 @@ sub send_3270 ($self, $command = '', %arg) {
         command_output => \@out_array,
     };
 
-    $_ =~ s/^data: // for @{$out->{command_output}};
+    s/^data: // for @{$out->{command_output}};
     confess "expected command exit status $arg{command_status}, got $out->{command_status}"
       if $arg{command_status} ne 'any' && $out->{command_status} ne $arg{command_status};
     return $out;

--- a/t/00-compile-check-all.t
+++ b/t/00-compile-check-all.t
@@ -35,7 +35,7 @@ if (-d '.git' and which('git')) {
     my @all_git_files = qx{git ls-files};
     chomp @all_git_files;
     my %skip = map { $_ => undef } @$TEST_SKIP;
-    @files = map { $root . $_ } grep { !exists $skip{$_} && $_ !~ /^t\// } @all_git_files;    # Exclude files to skip
+    @files = map { $root . $_ } grep { !exists $skip{$_} && !/^t\// } @all_git_files;    # Exclude files to skip
 }
 else {
     @files = ($test->all_pm_files('.'), $test->all_pl_files('.'));    # uncoverable statement

--- a/t/04-check_vars_docu.t
+++ b/t/04-check_vars_docu.t
@@ -94,7 +94,7 @@ EO_HEADER
 }
 
 sub read_backend_pm {    # no:style:signatures
-    my ($backend) = $_ =~ /^([^\.]+)\.pm/;
+    my ($backend) = /^([^\.]+)\.pm/;
     return unless $backend;
     # uncoverable statement count:2
     return if (grep { /$backend/i } @backend_blocklist);


### PR DESCRIPTION
Remove variable $_ when matching against a regular expression.

https://metacpan.org/pod/Perl::Critic::Policy::RegularExpressions::ProhibitUselessTopic

> It is not necessary to specify the topic variable $_ when matching
    against a regular expression.

reference: https://progress.opensuse.org/issues/155191