### PR TITLE
style(perlcritic): Add BuiltinFunctions::RequireBlockGrep

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,7 +1,7 @@
 theme = community + openqa
 severity = 4
 
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitPackageVars CodeLayout::RequireTidyCode Community::WarningsSwitch Community::EmptyReturn Variables::ProhibitUnusedVariables RegularExpressions::ProhibitUselessTopic BuiltinFunctions::ProhibitUselessTopic CodeLayout::ProhibitQuotedWordLists
+include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitPackageVars CodeLayout::RequireTidyCode Community::WarningsSwitch Community::EmptyReturn Variables::ProhibitUnusedVariables RegularExpressions::ProhibitUselessTopic BuiltinFunctions::ProhibitUselessTopic CodeLayout::ProhibitQuotedWordLists BuiltinFunctions::RequireBlockGrep
 
 verbose = ::warning file=%f,line=%l,col=%c,title=%m - severity %s::[%p] %e\n
 

--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -179,7 +179,7 @@ sub clone_git ($local_path, $clone_url, $clone_depth, $branch, $dir, $dir_variab
     my $depth_args = $cache_dir ? '' : "--depth='$clone_depth'";    # cannot use `--depth` with $cache_dir
     if (!$cache_dir) {    # cannot use `--branch` with $cache_dir so just move to fallback directly
         my @out = qx{$clone_cmd $depth_args $branch_args $source_url 2>&1};
-        return $handle_output->($?, @out) unless ($branch && grep /fatal: Remote branch .* not found in upstream origin/, @out);
+        return $handle_output->($?, @out) unless ($branch && grep { /fatal: Remote branch .* not found in upstream origin/ } @out);
     }
 
     # if cloning with `--branch=…` does not work, just clone the default branch instead and fetch and check out the missing
@@ -189,7 +189,7 @@ sub clone_git ($local_path, $clone_url, $clone_depth, $branch, $dir, $dir_variab
     if ($direct_fetch) {
         bmwqemu::diag "Fetching '$branch' from origin manually";
         @out = qx{git -C "$local_path" fetch origin "$branch" 2>&1 && git -C "$local_path" checkout FETCH_HEAD 2>&1};
-        return $handle_output->($?, @out) unless (grep /could(n't| not) find remote ref/, @out);
+        return $handle_output->($?, @out) unless (grep { /could(n't| not) find remote ref/ } @out);
     }
 
     # if fetching the specified rev did not work, take yet another approach (maybe we just misspelled, though)
@@ -202,7 +202,7 @@ sub clone_git ($local_path, $clone_url, $clone_depth, $branch, $dir, $dir_variab
         $clone_depth *= 2;
         @out = qx[git -C $local_path fetch --progress --depth=$clone_depth 2>&1];
         $handle_output->($?, @out);
-        die "Could not find '$branch' in complete history in cloned Git repository \"$dir\"" if grep /remote: Total 0/, @out;
+        die "Could not find '$branch' in complete history in cloned Git repository \"$dir\"" if grep { /remote: Total 0/ } @out;
     }
     @out = qx{git -C $local_path checkout $branch};
     bmwqemu::diag "@out" if @out;

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -114,7 +114,7 @@ sub save_vars (%args) {
         $write_vars = {};
         my $hide_re = '^_SECRET_|_PASSWORD';
         $hide_re .= "|$vars{_HIDE_SECRETS_REGEX}" if $vars{_HIDE_SECRETS_REGEX};
-        $write_vars->{$_} = $vars{$_} for (grep !/($hide_re)/, keys %vars);
+        $write_vars->{$_} = $vars{$_} for grep { !/$hide_re/ } keys %vars;
     }
 
     # make sure the JSON is sorted

--- a/consoles/s3270.pm
+++ b/consoles/s3270.pm
@@ -9,6 +9,7 @@ use feature 'say';
 use Data::Dumper 'Dumper';
 use YAML::PP 'Dump';
 use Carp qw(confess cluck carp croak);
+use List::Util 'any';
 require IPC::Run;
 use IPC::Run::Debug;    # set IPCRUNDEBUG=data in shell environment for trace
 use Thread::Queue;
@@ -47,7 +48,7 @@ sub finish ($self) { IPC::Run::finish($self->{connection}) }
 sub send_3270 ($self, $command = '', %arg) {
     $arg{command_status} //= 'ok';
     confess "command_status must be 'ok' or 'error' or 'any', got $arg{command_status}."
-      unless (grep $arg{command_status}, ['ok', 'error', 'any']);
+      unless (any { $arg{command_status} eq $_ } qw(ok error any));
 
     $self->{in} .= $command . "\n";
     $self->{connection}->IPC::Run::pump until $self->{out} =~ /^(ok|error)/mg;
@@ -98,7 +99,7 @@ sub _handle_expect_3270_cycle ($self, $result, $start_time, %arg) {
         my $input_line = pop @$co;
         my @output_area = @$co;
 
-        @output_area = grep !/$arg{delete_lines}/, @output_area if defined $arg{delete_lines};
+        @output_area = grep { !/$arg{delete_lines}/ } @output_area if defined $arg{delete_lines};
 
         if (@output_area > 0) {
             $self->{raw_expect_queue}->enqueue(@output_area);
@@ -304,7 +305,7 @@ sub _connect_3270 ($self, $host) {
     confess "connect to host >$host< failed.\n" . Dump($sent) if $sent->{terminal_status} !~ / C\($host\) /;
     $self->send_3270('Wait(InputField)');
     my $lines = $self->expect_3270();
-    confess "doesn't look like zVM login prompt." unless grep /Fill in your USERID and PASSWORD and press ENTER/, @$lines;
+    confess "doesn't look like zVM login prompt." unless grep { /Fill in your USERID and PASSWORD and press ENTER/ } @$lines;
     return $lines;
 }
 

--- a/t/39-dewebsockify.t
+++ b/t/39-dewebsockify.t
@@ -137,7 +137,7 @@ subtest 'WebSocket handshake fails (no HTTP code)' => sub {
     mock_build_ws_tx($mock_ua, 'MockTxFailNoCode');
     start_dewebsockify();
     accept_client('dummy_socket_1');
-    ok grep(/Unable to upgrade to WebSocket connection/, @log_messages),
+    ok + (grep { /Unable to upgrade to WebSocket connection/ } @log_messages),
       'WebSocket upgrade failed without HTTP code';
     like $log_messages[-1], qr/Client accepted/,
       'First client accepted before failing handshake';
@@ -161,7 +161,7 @@ subtest 'WebSocket handshake succeeds' => sub {
 
     start_dewebsockify();
     accept_client('dummy_socket_1');
-    ok grep(/WebSocket connection established/, @log_messages),
+    ok + (grep { /WebSocket connection established/ } @log_messages),
       'WebSocket connection established';
 
     $WS_ON_TEXT->(undef, 'dummy text message');
@@ -169,7 +169,7 @@ subtest 'WebSocket handshake succeeds' => sub {
     $WS_ON_BINARY->(undef, 'dummy binary data');
     pass 'Binary message received via WebSocket';
     $WS_ON_FINISH->(undef, 1000, 'Normal closure');
-    ok grep(/WebSocket closed with status 1000/, @log_messages),
+    ok + (grep { /WebSocket closed with status 1000/ } @log_messages),
       'WebSocket closed as expected';
 };
 
@@ -179,7 +179,7 @@ subtest 'WebSocket handshake fails with error code' => sub {
     mock_build_ws_tx($mock_ua, 'MockTxFailWithCode');
     start_dewebsockify();
     accept_client('dummy_socket_1');
-    ok grep(/WebSocket 403 response: Forbidden/, @log_messages),
+    ok + (grep { /WebSocket 403 response: Forbidden/ } @log_messages),
       'WebSocket upgrade failed with error code';
 };
 
@@ -194,10 +194,10 @@ subtest 'Client connection closure' => sub {
 
     start_dewebsockify();
     accept_client('dummy_socket_1');
-    ok grep(/WebSocket connection established/, @log_messages),
+    ok + (grep { /WebSocket connection established/ } @log_messages),
       'WebSocket connection established';
     $stream_close_cb->('dummy_stream') if $stream_close_cb;
-    ok grep(/Client closed connection/, @log_messages),
+    ok + (grep { /Client closed connection/ } @log_messages),
       'Client connection closure logged';
 };
 
@@ -215,10 +215,10 @@ subtest 'Client connection error' => sub {
 
     start_dewebsockify();
     accept_client('dummy_socket_1');
-    ok grep(/WebSocket connection established/, @log_messages),
+    ok + (grep { /WebSocket connection established/ } @log_messages),
       'WebSocket connection established';
     $stream_error_cb->('dummy_stream', 'Something went wrong') if $stream_error_cb;
-    ok grep(/Client error: Something went wrong/, @log_messages),
+    ok + (grep { /Client error: Something went wrong/ } @log_messages),
       'Client error was logged';
 };
 


### PR DESCRIPTION
Create block around grep string messages

https://metacpan.org/pod/Perl::Critic::Policy::BuiltinFunctions::RequireBlockGrep

> The expression forms of grep and map are awkward and hard to read. Use
    the block forms instead.

reference: https://progress.opensuse.org/issues/155191