### PR TITLE
style(perlcritic): Add CodeLayout::ProhibitQuotedWordLists

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,7 +1,7 @@
 theme = community + openqa
 severity = 4
 
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitPackageVars CodeLayout::RequireTidyCode Community::WarningsSwitch Community::EmptyReturn Variables::ProhibitUnusedVariables RegularExpressions::ProhibitUselessTopic BuiltinFunctions::ProhibitUselessTopic
+include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitPackageVars CodeLayout::RequireTidyCode Community::WarningsSwitch Community::EmptyReturn Variables::ProhibitUnusedVariables RegularExpressions::ProhibitUselessTopic BuiltinFunctions::ProhibitUselessTopic CodeLayout::ProhibitQuotedWordLists
 
 verbose = ::warning file=%f,line=%l,col=%c,title=%m - severity %s::[%p] %e\n
 

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -659,7 +659,7 @@ sub _set_graphics_backend ($self) {
         $device = 'virtio-gpu';
     }
     $device //= 'VGA';
-    my @edids = ('VGA', 'virtio-vga', 'virtio-vga-gl', 'virtio-gpu-pci', 'bochs-display', 'virtio-gpu');
+    my @edids = qw(VGA virtio-vga virtio-vga-gl virtio-gpu-pci bochs-display virtio-gpu);
     if (grep { $device eq $_ } @edids) {
         # these devices support EDID
         $options = ",edid=on,xres=$self->{xres},yres=$self->{yres}";

--- a/consoles/s3270.pm
+++ b/consoles/s3270.pm
@@ -246,7 +246,7 @@ sub sequence_3270 ($self, @commands) { $self->send_3270($_) for @commands }
 # map the terminal status of x3270 to a hash
 sub nice_3270_status ($self, $status_string) {
     my (@raw_status) = split ' ', $status_string;
-    my @status_names = (
+    my @status_names = (    ## no critic (CodeLayout::ProhibitQuotedWordLists)
         'keyboard_state',
         ## If the keyboard is unlocked, the letter U. If the
         ## keyboard is locked waiting for a response from the

--- a/consoles/video_stream.pm
+++ b/consoles/video_stream.pm
@@ -146,7 +146,7 @@ sub _get_ustreamer_cmd ($self, $url, $sink_name) {
         '--dv-timings',    # enable using DV timings (getting resolution, and reacting to changes)
     ];
     # workaround for https://github.com/raspberrypi/linux/issues/6068
-    push @$cmd, ('--format-swap-rgb', '1') if ($swap);
+    push @$cmd, qw(--format-swap-rgb 1) if ($swap);
     return $cmd;
 }
 


### PR DESCRIPTION
Replace quoted word list with `qw()`

https://metacpan.org/pod/Perl::Critic::Policy::CodeLayout::ProhibitQuotedWordLists

> Conway doesn't mention this, but I think qw() is an underused feature
    of Perl. Whenever you need to declare a list of one-word literals, the
    qw() operator is wonderfully concise, and makes it easy to add to the
    list in the future.

reference: https://progress.opensuse.org/issues/155191