### PR TITLE
style(perlcritic): Add Modules::ProhibitConditionalUseStatements

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,7 +1,7 @@
 theme = community + openqa
 severity = 4
 
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitPackageVars CodeLayout::RequireTidyCode Community::WarningsSwitch Community::EmptyReturn Variables::ProhibitUnusedVariables RegularExpressions::ProhibitUselessTopic BuiltinFunctions::ProhibitUselessTopic CodeLayout::ProhibitQuotedWordLists BuiltinFunctions::RequireBlockGrep
+include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitPackageVars CodeLayout::RequireTidyCode Community::WarningsSwitch Community::EmptyReturn Variables::ProhibitUnusedVariables RegularExpressions::ProhibitUselessTopic BuiltinFunctions::ProhibitUselessTopic CodeLayout::ProhibitQuotedWordLists BuiltinFunctions::RequireBlockGrep Modules::ProhibitConditionalUseStatements
 
 verbose = ::warning file=%f,line=%l,col=%c,title=%m - severity %s::[%p] %e\n
 

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -34,6 +34,7 @@ use OpenQA::Exceptions;
 use Time::Seconds;
 use English -no_match_vars;
 use OpenQA::NamedIOSelect;
+use Data::Dumper;
 
 use constant FULL_SCREEN_SEARCH_FREQUENCY => $ENV{OS_AUTOINST_FULL_SCREEN_SEARCH_FREQUENCY} // 5;
 use constant FULL_UPDATE_REQUEST_FREQUENCY => $ENV{OS_AUTOINST_FULL_UPDATE_REQUEST_FREQUENCY} // 5;
@@ -637,7 +638,6 @@ sub check_socket ($self, $fh, $write = undef) {
         }
     }
     else {
-        use Data::Dumper;
         die 'no command in ' . Dumper($cmd);
     }
     return 1;


### PR DESCRIPTION
Replace `use <module>` with `require <module>` removing compile time imports

https://metacpan.org/pod/Perl::Critic::Policy::Modules::ProhibitConditionalUseStatements

> Modules included via "use" are loaded at compile-time. Placing
    conditional logic around the "use" statement has no effect on whether
    the module will be loaded. Doing so can also serve to confuse the reader
    as to the author's original intent.
>
> If you need to conditionally load a module you should be using "require"
    instead.

reference: https://progress.opensuse.org/issues/155191