### PR TITLE
feat: Avoid silent fallback to MS certs with `UEFI_PFLASH_CERTS`

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -305,7 +305,7 @@ sub configure_pflash ($self, $vars) {
         my @secureboot_args = _make_secure_boot_configuration($vars->{UEFI_PFLASH_SECURE_BOOT});
         my @certs = split qr/;/, $vars->{UEFI_PFLASH_CERTS} // '';
         my $uuid = '37adf63d-93fb-4af5-9901-12f8767d3841';    # fixed "well-known" UUID
-        my @cert_args = map { ('--enroll-cert' => $_, '--add-db', $uuid, $_) } shift @certs // ();
+        my @cert_args = map { ('--enroll-cert' => $_, '--no-microsoft', '--microsoft-kek', 'none', '--add-db', $uuid, $_) } shift @certs // ();
         push @cert_args, map { ('--add-db', $uuid, $_, '--add-kek', $uuid, $_) } @certs;
         my @res_args = _make_resolution_configuration($vars->{UEFI_PFLASH_RESOLUTION});
         if (@secureboot_args || @cert_args || @res_args) {

--- a/t/18-qemu.t
+++ b/t/18-qemu.t
@@ -553,7 +553,7 @@ subtest configure_pflash => sub {
         my $expected_uuid = '37adf63d-93fb-4af5-9901-12f8767d3841';
         my @expected_commands = ([
                 @expected_base_args, '--set-true', 'SecureBootEnable', '--set-false', 'CustomMode',
-                '--enroll-cert', $certs[0], '--add-db', $expected_uuid, $certs[0],
+                '--enroll-cert', $certs[0], '--no-microsoft', '--microsoft-kek', 'none', '--add-db', $expected_uuid, $certs[0],
                 '--add-db', $expected_uuid, $certs[1], '--add-kek', $expected_uuid, $certs[1]
         ]);
         is_deeply \@commands, \@expected_commands, 'virt-fw-vars called' or always_explain \@commands;


### PR DESCRIPTION
* Remove Microsoft certificates when certificates are specified explicitly via `UEFI_PFLASH_CERTS` to prevent tests from silently falling back to using them
* See https://github.com/os-autoinst/os-autoinst/pull/2976#discussion_r3401490825

Related ticket: https://progress.opensuse.org/issues/200156