### PR TITLE
refactor: avoid external testapi internally

### DIFF
--- a/OpenQA/Isotovideo/Runner.pm
+++ b/OpenQA/Isotovideo/Runner.pm
@@ -85,7 +85,7 @@ sub prepare ($self) {
 
 sub load_schedule ($self) {
     # set a default distribution if the tests don't have one
-    $testapi::distri = distribution->new;
+    bmwqemu::_set_distribution(distribution->new);
 
     load_test_schedule;
 }

--- a/autotest.pm
+++ b/autotest.pm
@@ -324,8 +324,9 @@ sub loadtest ($script, %args) {
     $test = $name->new($category);
     $test->{script} = $script;
     $test->{fullname} = $fullname;
-    $test->{serial_failures} = $testapi::distri->{serial_failures} // [];
-    $test->{autoinst_failures} = $testapi::distri->{autoinst_failures} // [];
+    my $distri = bmwqemu::distribution();
+    $test->{serial_failures} = $distri ? $distri->{serial_failures} // [] : [];
+    $test->{autoinst_failures} = $distri ? $distri->{autoinst_failures} // [] : [];
 
     if (defined $args{run_args}) {
         unless (blessed($args{run_args}) && $args{run_args}->isa('OpenQA::Test::RunArgs')) {
@@ -657,6 +658,16 @@ sub rollback_activated_consoles () {
         die $ret->{error} if $ret->{error};
     }
     return;
+}
+
+sub is_serial_terminal () {
+    state $ret;
+    state $last_seen = '';
+    if (defined $selected_console && $selected_console ne $last_seen) {
+        $last_seen = $selected_console;
+        $ret = query_isotovideo('backend_is_serial_terminal', {});
+    }
+    return $ret->{yesorno};
 }
 
 1;

--- a/basetest.pm
+++ b/basetest.pm
@@ -10,7 +10,6 @@ use Feature::Compat::Try;
 
 use bmwqemu ();
 use ocr;
-use testapi ();
 use autotest ();
 use MIME::Base64 'decode_base64';
 use OpenQA::Exceptions;
@@ -435,9 +434,10 @@ sub record_resultfile ($self, $title, $output, %nargs) {
 sub record_serialresult ($self, $ref, $res, $string = undef, %args) {
     $string //= '';
     # take screenshot for documentation (screenshot does not represent fail itself)
-    $self->take_screenshot() unless (testapi::is_serial_terminal);
+    $self->take_screenshot() unless (autotest::is_serial_terminal);
 
-    my $pretty = $testapi::distri ? $testapi::distri->get_pretty_serial_marker() : (testapi::get_var('PRETTY_SERIAL_MARKER') || testapi::get_var('HIDE_MARKER_EVALUATION'));
+    my $distri = bmwqemu::distribution();
+    my $pretty = $distri ? $distri->get_pretty_serial_marker() : ($bmwqemu::vars{PRETTY_SERIAL_MARKER} || $bmwqemu::vars{HIDE_MARKER_EVALUATION});
     my $internal = $args{internal_marker};
     my $output_string = $string;
     my $captured_val;

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -216,10 +216,19 @@ sub ensure_valid_vars () {
 # local vars
 
 our $backend;    ## no critic (Variables::ProhibitPackageVars)
+my $distribution_object;
 
 # local vars end
 
 # util and helper functions
+
+sub distribution () {
+    return $distribution_object;
+}
+
+sub _set_distribution ($distri) {
+    $distribution_object = $distri;
+}
 
 sub current_test () {
     require autotest;

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -611,6 +611,7 @@ subtest record_serialresult_hiding => sub {
     );
 
     foreach my $case (@test_cases) {
+        local %bmwqemu::vars = %{$case->{vars}};
         $mock_testapi->mock(get_var => sub ($var) { return $case->{vars}->{$var} });
         $basetest->record_serialresult(@{$case->{params}});
         like $recorded_output, $_, "$case->{name} (contains expected)" for @{$case->{expected}};

--- a/testapi.pm
+++ b/testapi.pm
@@ -75,7 +75,14 @@ our @EXPORT_OK = qw(is_serial_terminal);
 
 our %cmd;    ## no critic (Variables::ProhibitPackageVars)
 
+package testapi::tieddistri {
+    sub TIESCALAR ($class) { bless {}, $class }
+    sub FETCH ($self) { bmwqemu::distribution() }
+    sub STORE ($self, $value) { bmwqemu::_set_distribution($value) }
+}
+
 our $distri;    ## no critic (Variables::ProhibitPackageVars)
+tie $distri, 'testapi::tieddistri';
 
 our $realname = 'Bernhard M. Wiedemann';    ## no critic (Variables::ProhibitPackageVars)
 our $username;    ## no critic (Variables::ProhibitPackageVars)
@@ -816,15 +823,7 @@ For more info see consoles/virtio_console.pm and consoles/serial_screen.pm.
 
 =cut
 
-sub is_serial_terminal () {
-    state $ret;
-    state $last_seen = '';
-    if (defined current_console() && current_console() ne $last_seen) {
-        $last_seen = current_console();
-        $ret = query_isotovideo('backend_is_serial_terminal', {});
-    }
-    return $ret->{yesorno};
-}
+sub is_serial_terminal () { autotest::is_serial_terminal }
 
 
 =head2 wait_serial


### PR DESCRIPTION
Motivation:
basetest.pm improperly used testapi.pm, which defines the external test API.
Internal modules should not rely on external-facing APIs to respect Design by
Contract principles.

Design Choices:
Move is_serial_terminal to the internal autotest.pm module. Update
basetest.pm to use autotest::is_serial_terminal and access $bmwqemu::vars
directly, making testapi delegate to it to preserve the public API.

Benefits:
Establishes a clean architectural boundary between internal code and public
test APIs, preventing circular dependencies and ensuring contract boundaries.