### PR TITLE
Improve pretty markers + fix script_sudo and become_root

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -85,6 +85,7 @@ sub ensure_installed ($self, @pkglist) {
 
 sub become_root ($self) {
     $self->script_sudo('bash', 0);
+    $self->invalidate_serial_marker_hook();
 
     my $console = testapi::current_console() // 'sut';
     my $level = $self->{_serial_marker_level}->{$console} // 1;

--- a/distribution.pm
+++ b/distribution.pm
@@ -84,11 +84,17 @@ sub ensure_installed ($self, @pkglist) {
 }
 
 sub become_root ($self) {
-    testapi::script_sudo('bash', 0);    # become root
-    testapi::enter_cmd('test $(id -u) -eq 0 && echo "imroot" > /dev/' . $testapi::serialdev, 0);
-    testapi::wait_serial('imroot') || die 'Root prompt not there';
-    testapi::enter_cmd('cd /tmp');
-    $self->invalidate_serial_marker_hook();
+    $self->script_sudo('bash', 0);
+
+    my $console = testapi::current_console() // 'sut';
+    my $level = $self->{_serial_marker_level}->{$console} // 1;
+
+    $self->install_serial_marker_hook($level) if $level > 1;
+
+    my $uid = $self->script_run('id -u');
+    die 'Failed to become root' unless defined $uid && $uid == 0;
+
+    $self->script_run('cd /tmp');
 }
 
 =head2 disable_key_repeat
@@ -144,7 +150,8 @@ sub script_run ($self, $cmd, @args) {
             check_typing_cmd => 1,
             output => '',
             quiet => undef,
-            max_interval => testapi::DEFAULT_MAX_INTERVAL
+            max_interval => testapi::DEFAULT_MAX_INTERVAL,
+            check_password => undef
         }, ['timeout'], @args);
 
     if (testapi::is_serial_terminal) {
@@ -168,6 +175,7 @@ sub script_run ($self, $cmd, @args) {
         if ($level == 3) {
             testapi::query_isotovideo('backend_clear_serial_buffer', {});
             testapi::type_string "$cmd\n", max_interval => $args{max_interval};
+            $self->_check_sudo_password(\%args);
             my $res = testapi::wait_serial(qr/OA:DONE-[0-9a-f]{4}-(\d+)-/, timeout => $args{timeout}, quiet => $args{quiet}, record_command => $cmd, internal_marker => 1, capture_name => 'Exit code');
             return undef unless $res;
             return ($res =~ /OA:DONE-[0-9a-f]{4}-(\d+)-/)[0];
@@ -191,6 +199,7 @@ sub script_run ($self, $cmd, @args) {
                 testapi::type_string "$marker > /dev/$testapi::serialdev\n", max_interval => $args{max_interval};
             }
         }
+        $self->_check_sudo_password(\%args);
         my $res = testapi::wait_serial($wait_pattern, timeout => $args{timeout}, quiet => $args{quiet}, record_command => $cmd, internal_marker => 1, capture_name => 'Exit code');
         return undef unless $res;
         return ($res =~ $wait_pattern)[0];
@@ -198,6 +207,7 @@ sub script_run ($self, $cmd, @args) {
     else {
         testapi::type_string "$cmd", max_interval => $args{max_interval};
         testapi::send_key 'ret';
+        $self->_check_sudo_password(\%args);
         return undef;
     }
 }
@@ -239,6 +249,13 @@ sub background_script_run ($self, $cmd, %args) {
     return $1;
 }
 
+sub _check_sudo_password ($self, $args) {
+    if ($args->{check_password} && testapi::check_screen('sudo-passwordprompt', 3)) {
+        testapi::type_password;
+        testapi::send_key 'ret';
+    }
+}
+
 =head2 script_sudo
 
 script_sudo($program, $wait_seconds)
@@ -250,20 +267,7 @@ $wait_seconds
 =cut
 
 sub script_sudo ($self, $prog, $wait = 10) {
-    my $str;
-    if ($wait > 0) {
-        $str = testapi::hashed_string("SS$prog$wait");
-        $prog = "$prog; echo $str > /dev/$testapi::serialdev";
-    }
-    testapi::type_string "sudo $prog\n";
-    if (testapi::check_screen 'sudo-passwordprompt', 3) {
-        testapi::type_password;
-        testapi::send_key 'ret';
-    }
-    if ($str) {
-        return testapi::wait_serial($str, $wait, internal_marker => 1);
-    }
-    return undef;
+    return $self->script_run("sudo $prog", timeout => $wait, check_password => 1);
 }
 
 =head2 script_output

--- a/distribution.pm
+++ b/distribution.pm
@@ -596,12 +596,7 @@ sub detect_serial_marker_capability ($self) {
     testapi::type_string "echo \"BASH:\$BASH_VERSION:\" > /dev/$testapi::serialdev\n";
     my $out = testapi::wait_serial(qr/BASH:([^:]*):/, 10);
     if ($out && $out =~ /BASH:(?:[3-9]|\d{2,})/) {
-        $level = 2;
-        # Check if bash and history features are available to use pretty serial markers
-        testapi::type_string "type fc && set -o | grep -q 'history.*on' && echo \"FC:OK:\" > /dev/$testapi::serialdev\n";
-        if (testapi::wait_serial(qr/FC:OK:/, 10)) {
-            $level = 3;
-        }
+        $level = 3;
         $self->install_serial_marker_hook($level);
         bmwqemu::log_call("serial_marker: console '$console' Level $level detected");
     }

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -623,11 +623,21 @@ subtest 'upload_logs' => sub {
 };
 
 subtest 'script_sudo' => sub {
+    my $mock_testapi = Test::MockModule->new('testapi');
+    $mock_testapi->redefine(hashed_string => 'XXX');
+    $mock_testapi->redefine(is_serial_terminal => 1);
+
     script_sudo 'rm /boot/grub/menu.lst';
     is_deeply $cmds, [
         {
-            text => "sudo rm /boot/grub/menu.lst; echo XXX > /dev/null\n",
-            cmd => 'backend_type_string'
+            cmd => 'backend_type_string',
+            text => 'sudo rm /boot/grub/menu.lst; echo XXX-$?-',
+            max_interval => 250
+        },
+        {
+            cmd => 'backend_type_string',
+            text => "\n",
+            max_interval => 250
         },
         {
             mustmatch => 'sudo-passwordprompt',
@@ -645,8 +655,8 @@ subtest 'script_sudo' => sub {
     ];
     $cmds = [];
     script_sudo('ls /', 0);
-    is $cmds->[0]{text}, "sudo ls /\n", 'text argument of script_sudo matched';
-    is_deeply $cmds->[0], {text => "sudo ls /\n", cmd => 'backend_type_string'}, 'sudo command is typed';
+    is $cmds->[0]{text}, 'sudo ls /', 'text argument of script_sudo matched';
+    is_deeply $cmds->[0], {text => 'sudo ls /', cmd => 'backend_type_string', max_interval => 250}, 'sudo command is typed';
     ok $cmds->[2]{secret}, 'password is treated as secret';
     $cmds = [];
 };
@@ -1283,6 +1293,7 @@ $bmwqemu::vars{CASEDIR} = 'foo';
 is get_test_data('foo'), undef, 'get_test_data can be called';
 $bmwqemu::vars{CASEDIR} = 't';
 like get_test_data('console.ref.json'), qr/area/, 'get_test_data can be called';
+$fake_exit = 0;
 lives_ok { become_root } 'become_root can be called';
 lives_ok { hold_key('ret') } 'hold_key can be called';
 lives_ok { release_key('ret') } 'release_key can be called';

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -91,6 +91,7 @@ subtest 'pretty_serial_marker' => sub {
     });
 
     $typed_string = '';
+    $d->{_serial_marker_level}->{'test-console'} = 2;
     $d->script_run('foo');
     like $typed_string, qr/export __OA_MARK=.*; foo\n/, 'Level 2 uses export marker';
 

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -363,6 +363,38 @@ subtest 'serial_terminal_redirection_guard' => sub {
     like $typed, qr/__oa_prompt\(\) \{ r=\$\?; if \[ -n "\$OA_NO_MARKER" \]/, '__oa_prompt must capture the exit status r=$? as the absolute first statement to prevent internal conditional checks from overwriting it';
 };
 
+subtest 'terminal_session_boundary' => sub {
+    my $d = distribution->new;
+    my $mock_testapi = Test::MockModule->new('testapi');
+    my $mock_bmwqemu = Test::MockModule->new('bmwqemu');
+    $mock_bmwqemu->noop('log_call');
+    my $typed = '';
+    $mock_testapi->redefine(query_isotovideo => sub { });
+    $mock_testapi->redefine(type_string => sub { $typed .= $_[0] });
+    $mock_testapi->redefine(is_serial_terminal => sub { 0 });
+    $mock_testapi->redefine(current_console => sub { 'x11' });
+    $mock_testapi->redefine(get_var => sub { $_[0] eq 'PRETTY_SERIAL_MARKER' ? 1 : undef });
+    $mock_testapi->redefine(check_screen => sub { undef });
+    $testapi::serialdev = 'ttyS0';
+
+    $mock_testapi->redefine(wait_serial => sub ($regexp, @) {
+            return 'BASH:4.4:' if ref($regexp) eq 'Regexp' && 'BASH:4.4:' =~ $regexp;
+            return 'OA:DONE-abcd-0-';
+    });
+
+    $d->script_run('first_cmd');
+    like $typed, qr/__oa_prompt/, 'pretty serial marker hook is initially configured and installed on the terminal session';
+
+    $typed = '';
+    $d->script_run('second_cmd');
+    unlike $typed, qr/__oa_prompt/, 'hook re-installation is skipped on subsequent commands if cached status is stale';
+
+    $d->invalidate_serial_marker_hook('x11');
+    $typed = '';
+    $d->script_run('third_cmd');
+    like $typed, qr/__oa_prompt/, 'hook is successfully re-installed on the next command after cached status is explicitly invalidated';
+};
+
 done_testing;
 
 1;


### PR DESCRIPTION
* fix: cleanly recreate virtio console pipe if already exists
* fix: suppress spurious virtio console unlink warnings
* test: assert terminal session boundary safety
* refactor: support pretty markers in script_sudo and become_root
* test: simplify Level 3 pretty marker detection
* test: assert Level 3 pretty serial markers
* fix: fallback pretty marker console to 'sut'

After:
* #2981
* #2983