### PR TITLE
fix: Fix comment about OVMF firmware locations

### DIFF
--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -40,16 +40,16 @@ our $screenshotpath = 'qemuscreenshot';    ## no critic (Variables::ProhibitPack
 
 # global vars
 
-# Known locations of OVMF (UEFI) firmware: first is openSUSE, second is
-# the kraxel.org nightly packages, third is Fedora's edk2-ovmf package,
-# fourth is Debian's ovmf package.
 our @ovmf_locations_no_secure_boot = (    ## no critic (Variables::ProhibitPackageVars)
-    '/usr/share/qemu/ovmf-x86_64-4m-code.bin', '/usr/share/qemu/ovmf-x86_64-ms-code.bin',
+    '/usr/share/qemu/ovmf-x86_64-4m-code.bin',    # openSUSE qemu-ovmf package
+    '/usr/share/qemu/ovmf-x86_64-ms-code.bin',    # openSUSE qemu-ovmf package
 );
 our @ovmf_locations = (    ## no critic (Variables::ProhibitPackageVars)
-    '/usr/share/qemu/ovmf-x86_64-ms-4m-code.bin', '/usr/share/qemu/ovmf-x86_64-ms-code.bin',
-    '/usr/share/edk2.git/ovmf-x64/OVMF_CODE-pure-efi.fd',
-    '/usr/share/edk2/ovmf/OVMF_CODE.fd', '/usr/share/OVMF/OVMF_CODE.fd'
+    '/usr/share/qemu/ovmf-x86_64-ms-4m-code.bin',    # openSUSE qemu-ovmf package
+    '/usr/share/qemu/ovmf-x86_64-ms-code.bin',    # openSUSE qemu-ovmf package
+    '/usr/share/edk2.git/ovmf-x64/OVMF_CODE-pure-efi.fd',    # kraxel.org nightly packages
+    '/usr/share/edk2/ovmf/OVMF_CODE.fd',    # Fedora's edk2-ovmf package
+    '/usr/share/OVMF/OVMF_CODE.fd',    # Debian's ovmf package
 );
 
 our %vars;    ## no critic (Variables::ProhibitPackageVars)


### PR DESCRIPTION
The comment was invalidated when `/usr/share/qemu/ovmf-x86_64-ms-4m-code.bin` was added. This change uses inline-comments to avoid this problem.