### PR TITLE
feat: expose detect_serial_marker_capability as public

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -155,7 +155,7 @@ sub script_run ($self, $cmd, @args) {
         die "Terminator '&' found in script_run call. script_run can not check script success. Use 'background_script_run' instead."
           if $cmd =~ qr/(?<!\\)&$/;
 
-        my $level = $self->_detect_serial_marker_capability();
+        my $level = $self->detect_serial_marker_capability();
         my $skip_pretty = 0;
         # Automatically protect against manual serial redirections corrupting pretty markers
         if ($level > 1 && $cmd =~ m{(?:>|>>|\btee)\s+(?:-a\s+)?/dev/\Q$testapi::serialdev\E\b}) {
@@ -570,9 +570,9 @@ sub pretty_serial_marker_guard ($self, $value) {
     });
 }
 
-=head2 _detect_serial_marker_capability
+=head2 detect_serial_marker_capability
 
-    _detect_serial_marker_capability()
+    detect_serial_marker_capability()
 
 Detect the SUT's shell capabilities for pretty serial markers.
 Returns:
@@ -582,7 +582,7 @@ Returns:
 
 =cut
 
-sub _detect_serial_marker_capability ($self) {
+sub detect_serial_marker_capability ($self) {
     my $console = testapi::current_console();
     return 1 unless defined $console;
     if (my $level = $self->{_serial_marker_level}->{$console}) {

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -111,7 +111,7 @@ subtest 'pretty_serial_marker' => sub {
     $mock_testapi->redefine(wait_serial => sub { undef });
     $d->{_serial_marker_level} = {};
     $typed_string = '';
-    is $d->_detect_serial_marker_capability(), 1, 'Fallback to Level 1 if BASH detection fails';
+    is $d->detect_serial_marker_capability(), 1, 'Fallback to Level 1 if BASH detection fails';
 
     $d->{_serial_marker_level}->{'test-console'} = 3;
     $mock_testapi->redefine(wait_serial => sub { undef });
@@ -147,7 +147,7 @@ subtest 'serial_marker_reinstall_cached_level' => sub {
     $d->{_serial_marker_level}->{'test-console'} = 2;
     $d->invalidate_serial_marker_hook('test-console');
 
-    is $d->_detect_serial_marker_capability(), 2, 'Returns cached level 2';
+    is $d->detect_serial_marker_capability(), 2, 'Returns cached level 2';
     like $typed, qr/grep -q __oa_prompt.*\. ~\/\.bashrc/, 'Calls install_serial_marker_hook (types consolidated setup with sourcing)';
     ok $d->{_serial_marker_hook_installed}->{'test-console'}, 'Hook marked as installed';
 };


### PR DESCRIPTION
Motivation:
Calling private methods from subclasses violates clean OOP principles.
The `susedistribution` subclass needs to trigger capability detection.

Design Choices:
Renamed `_detect_serial_marker_capability` to `detect_serial_marker_capability`.
Updated its internal calls, documentation, and the test suite.

Benefits:
Clean OOP design and safe, public visibility for subclass consumption.

Related issue: https://progress.opensuse.org/issues/199934

Needed for:
* https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25817