### PR TITLE
fix: Replace deprecated Mojo::File::spurt with spew

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -265,7 +265,7 @@ sub _make_resolution_configuration ($resolution) {
     my $data = _make_resolution_hex_data($+{width}, $+{height});
     my %vars = (name => 'PlatformConfig', guid => '7235c51c-0c80-4cab-87ac-3b084a6304b1', attr => 7, data => $data);
     my %json = (version => 2, variables => [\%vars]);
-    my $json_path = path('resolution-fw-conf.json')->spurt(encode_json(\%json));
+    my $json_path = path('resolution-fw-conf.json')->spew(encode_json(\%json));
     return ('--set-json' => $json_path->to_abs->to_string);
 }
 

--- a/xt/01-style.t
+++ b/xt/01-style.t
@@ -17,7 +17,7 @@ is qx{git grep -I -l '^\\(throws\\|dies\\|lives\\)_ok.*\<sub\>' t/**.t}, '', 'On
 is qx{git grep -I -l 'like.*\$\@' t/**.t}, '', 'Use throws_ok instead of manual checks of exceptions';
 is qx{git grep -I -l ' if \$\@'}, '', 'Use try/catch instead of manual \$\@ checks';
 is qx{git grep -I -l '^use \\(Try::Tiny\\|TryCatch\\)'}, '', 'No Try::Tiny or TryCatch necessary, use Feature::Compat::Try and later native Perl';
-is qx{git grep -I -l '\<spurt\>'}, '', 'No deprecated "Mojo::File::spurt", use "spew" instead';
+is qx{git grep -I -l '\\<spurt\\>' ':!xt/01-style.t'}, '', 'No deprecated "Mojo::File::spurt", use "spew" instead';
 is qx{git grep -I -l '^use testapi' backend/ consoles/}, '', 'No backend or console files use external facing testapi';
 is qx[git grep -l -e '^\\s*sub \\S\\+ [^(]\\+' --and --not -e 'sub [(\{]' --and --not -e 'sub \\S\\+\\s*[:(]' --and --not -e 'sub \\S\\+;' --and --not -e '# no:style:signatures' ':!external/' ':!t/48-testmodules-style.t'], '', 'All files use sub signatures everywhere (nameless and in-place definitions still allowed)';
 is qx[git grep -l -P 'sub\\s*\\{\\s*my\\s*\\(?\\\$' t/], '', 'Anonymous subs in tests should use signatures instead of manual unpacking of @_';


### PR DESCRIPTION
I got this warning:

    t/18-qemu.t ............................. 49/? Mojo::File::spurt is
    deprecated in favor of Mojo::File::spew at .../OpenQA/Qemu/Proc.pm line
    268.

Also fix the according style check.