### PR TITLE
fix: stop deepening when repo is no longer shallow

### DIFF
--- a/OpenQA/Isotovideo/Utils.pm
+++ b/OpenQA/Isotovideo/Utils.pm
@@ -198,13 +198,15 @@ sub clone_git ($local_path, $clone_url, $clone_depth, $branch, $dir, $dir_variab
     # * https://stackoverflow.com/questions/18515488/how-to-check-if-the-commit-exists-in-a-git-repository-by-its-sha-1
     # * https://stackoverflow.com/questions/26135216/why-isnt-there-a-git-clone-specific-commit-option
     bmwqemu::diag "Fetching more remote objects to ensure availability of '$branch'";
-    while (qx[git -C $local_path cat-file -e $branch^{commit} 2>&1] =~ /Not a valid object/) {
+    my $branch_not_found_err = "Could not find '$branch' in complete history in cloned Git repository \"$dir\"";
+    while (qx{git -C "$local_path" cat-file -e "$branch^{commit}" 2>&1} =~ /Not a valid object/) {
+        die $branch_not_found_err if qx{git -C "$local_path" rev-parse --is-shallow-repository 2>&1} =~ /^false/m;
         $clone_depth *= 2;
-        @out = qx[git -C $local_path fetch --progress --depth=$clone_depth 2>&1];
+        @out = qx{git -C "$local_path" fetch --progress --depth=$clone_depth 2>&1};
         $handle_output->($?, @out);
-        die "Could not find '$branch' in complete history in cloned Git repository \"$dir\"" if grep { /remote: Total 0/ } @out;
+        die $branch_not_found_err if grep { /remote: Total 0/ } @out;
     }
-    @out = qx{git -C $local_path checkout $branch};
+    @out = qx{git -C "$local_path" checkout "$branch"};
     bmwqemu::diag "@out" if @out;
     die "Unable to check out branch '$branch' in cloned Git repository \"$dir\"" unless $? == 0;
     return 1;

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -120,7 +120,7 @@ subtest 'isotovideo with custom git repo parameters specified' => sub {
         my $state = decode_json($base_state->slurp);
         if (is ref $state, 'HASH', 'state file contains object') {
             is $state->{component}, 'isotovideo', 'state file contains component';
-            like $state->{msg}, qr/Unable to clone Git repository/, 'state file contains error message';
+            like $state->{msg}, qr/(?:Unable to clone Git repository|Could not find 'foo' in complete history)/, 'state file contains error message';
         }
     };
 };


### PR DESCRIPTION
Motivation:
On newer git versions, running fetch with an increasing depth on a repository
that has already been fully deepened can lead to unexpected exit failures or
hanging.

Design Choices:
Before each fetch attempt in the loop, check if the repository is already
non-shallow. If so, stop early and throw the correct error message.

Benefits:
Ensures robust clone error handling across various Git versions and
environments without unnecessary complexity or feature creep.

Related issue: https://progress.opensuse.org/issues/202134