### PR TITLE
style: enforce signatures in anonymous subroutines

### DIFF
--- a/backend/driver.pm
+++ b/backend/driver.pm
@@ -50,8 +50,7 @@ sub start ($self) {
         blocking_stop => 1,
         separate_err => 0,
         subreaper => 1,
-        code => sub {
-            my $process = shift;
+        code => sub ($process) {
             $0 = "$0: backend";
 
             open STDOUT, '>&', $STDOUTPARENT;

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -460,11 +460,10 @@ sub save_snapshot ($self, $args) {
     $self->save_console_snapshots($vmname);
 
     my $snapshot = $self->{proc}->snapshot_conf->add_snapshot($vmname);
-    $bdc->for_each_drive(sub {
+    $bdc->for_each_drive(sub ($drive) {
             local $Data::Dumper::Indent = 0;
             local $Data::Dumper::Terse = 1;
             local $Data::Dumper::Sortkeys = 1;
-            my $drive = shift;
 
             my $overlay = $bdc->add_snapshot_to_drive($drive, $snapshot);
             my $req = {execute => 'blockdev-snapshot-sync',

--- a/commands.pm
+++ b/commands.pm
@@ -264,8 +264,7 @@ sub run_daemon ($port, $isotovideo) {
     # Use same log format as isotovideo
     app->log->format(\&bmwqemu::log_format_callback);
     # process json messages from isotovideo
-    Mojo::IOLoop->singleton->reactor->io($isotovideo => sub {
-            my ($reactor, $writable) = @_;
+    Mojo::IOLoop->singleton->reactor->io($isotovideo => sub ($reactor, $writable) {
 
             my @isotovideo_responses = myjsonrpc::read_json($isotovideo, undef, 1);
             my $clients = app->defaults('clients');

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -84,8 +84,7 @@ subtest 'pretty_serial_marker' => sub {
     $mock_testapi->redefine(get_var => sub { $_[0] eq 'PRETTY_SERIAL_MARKER' ? 1 : undef });
     $testapi::serialdev = 'ttyS0';
 
-    $mock_testapi->redefine(wait_serial => sub {
-            my ($regexp) = @_;
+    $mock_testapi->redefine(wait_serial => sub ($regexp, @) {
             return 'BASH:4.4:' if ref($regexp) eq 'Regexp' && 'BASH:4.4:' =~ $regexp;
             return undef if ref($regexp) eq 'Regexp' && $regexp =~ /FC/;
             return 'SRfoo-0-';
@@ -95,8 +94,7 @@ subtest 'pretty_serial_marker' => sub {
     $d->script_run('foo');
     like $typed_string, qr/export __OA_MARK=.*; foo\n/, 'Level 2 uses export marker';
 
-    $mock_testapi->redefine(wait_serial => sub {
-            my ($regexp) = @_;
+    $mock_testapi->redefine(wait_serial => sub ($regexp, @) {
             return 'BASH:4.4:' if ref($regexp) eq 'Regexp' && 'BASH:4.4:' =~ $regexp;
             return 'FC:OK:' if ref($regexp) eq 'Regexp' && 'FC:OK:' =~ $regexp;
             return 'OA:DONE-abcd-0-foo';
@@ -130,7 +128,7 @@ subtest 'pretty_serial_marker' => sub {
     $d->script_run('foo');
     like $typed_string, qr/foo; echo SR.*-.*-\n/, 'Level 1 uses classic marker on serial terminal';
 
-    $mock_testapi->redefine(wait_serial => sub ($pat, %args) {
+    $mock_testapi->redefine(wait_serial => sub ($pat, %) {
             return 0 if $pat =~ /foo; echo SR.*-\$\?-/;
             return 'SRfoo-0-';
     });
@@ -167,8 +165,7 @@ subtest 'reboot_safety' => sub {
     $testapi::serialdev = 'ttyS0';
 
     # Initial detection (Level 3)
-    $mock_testapi->redefine(wait_serial => sub {
-            my ($regexp) = @_;
+    $mock_testapi->redefine(wait_serial => sub ($regexp, @) {
             return 'BASH:4.4:' if ref($regexp) eq 'Regexp' && 'BASH:4.4:' =~ $regexp;
             return 'FC:OK:' if ref($regexp) eq 'Regexp' && 'FC:OK:' =~ $regexp;
             return 'OA:DONE-abcd-0-';
@@ -324,8 +321,7 @@ subtest 'serial_terminal_redirection_guard' => sub {
     $mock_testapi->redefine(query_isotovideo => sub { });
     $mock_bmwqemu->redefine(diag => sub { $diag_msg .= $_[0] });
     $mock_bmwqemu->redefine(log_call => sub { });
-    $mock_testapi->redefine(wait_serial => sub {
-            my ($regexp) = @_;
+    $mock_testapi->redefine(wait_serial => sub ($regexp, @) {
             return 'BASH:4.4:' if ref($regexp) eq 'Regexp' && 'BASH:4.4:' =~ $regexp;
             return 'FC:OK:' if ref($regexp) eq 'Regexp' && 'FC:OK:' =~ $regexp;
             return 'OA:DONE-abcd-0-';

--- a/t/10-virtio_terminal.t
+++ b/t/10-virtio_terminal.t
@@ -84,8 +84,7 @@ subtest 'Test open_pipe() error condition' => sub {
     my $size = 1024;
     $file_mock->redefine(slurp => sub { return 65_536; });
     $vterminal_mock->redefine('get_pipe_sz', sub { return 1024; });
-    $vterminal_mock->redefine('set_pipe_sz', sub {
-            my ($self, $fd, $newsize) = @_;
+    $vterminal_mock->redefine('set_pipe_sz', sub ($self, $fd, $newsize) {
             return if ($newsize > 2048);
             return $size = $newsize;
     });
@@ -104,8 +103,7 @@ subtest 'Test open_pipe() error condition' => sub {
     is $size, 1024, "Size didn't changed";
 
     $size = 1024;
-    $vterminal_mock->redefine('set_pipe_sz', sub {
-            my ($self, $fd, $newsize) = @_;
+    $vterminal_mock->redefine('set_pipe_sz', sub ($self, $fd, $newsize) {
             return $size = $newsize;
     });
 

--- a/t/17-basetest.t
+++ b/t/17-basetest.t
@@ -124,8 +124,7 @@ subtest parse_serial_output => sub {
     });
     my $basetest = basetest->new('installation');
     my $message;
-    $mock_basetest->redefine(record_resultfile => sub {
-            my ($self, $title, $output, %nargs) = @_;
+    $mock_basetest->redefine(record_resultfile => sub ($self, $title, $output, %nargs) {
             $message = $output;
     });
 

--- a/t/19-isotovideo-command-processing.t
+++ b/t/19-isotovideo-command-processing.t
@@ -28,8 +28,7 @@ my @last_received_msg_by_fd = (undef, undef, undef);
 
 # mock the json rpc
 my $rpc_mock = Test::MockModule->new('myjsonrpc');
-$rpc_mock->redefine(send_json => sub {
-        my ($fd, $cmd) = @_;
+$rpc_mock->redefine(send_json => sub ($fd, $cmd) {
         if (!defined($fd) || ($fd != $cmd_srv_fd && $fd != $backend_fd && $fd != $answer_fd)) {
             fail 'invalid file descriptor passed to send_json: ' . ($fd ? $fd : 'undef');    # uncoverable statement
             return;    # uncoverable statement

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -103,10 +103,10 @@ sub _mock_svirt_vmware ($cmds_ref, $ssh_cmds_ref) {
     my $backend_mock = Test::MockModule->new('backend::svirt');
     my $console_mock = Test::MockModule->new('consoles::sshVirtsh');
     my $tmp_mock = Test::MockModule->new('File::Temp');
-    $console_mock->redefine(run_cmd => sub ($self, $cmd, %args) { push @$cmds_ref, $cmd; 0 });
-    $console_mock->redefine(get_cmd_output => sub ($self, $cmd, %args) { push @$cmds_ref, $cmd; 0 });
-    $backend_mock->redefine(run_ssh_cmd => sub ($self, $cmd, %args) { push @$cmds_ref, $cmd; 0 });
-    $backend_mock->redefine(run_ssh => sub ($self, $cmd, %args) { push @$ssh_cmds_ref, $cmd; (undef, $chan_mock) });
+    $console_mock->redefine(run_cmd => sub ($self, $cmd, %) { push @$cmds_ref, $cmd; 0 });
+    $console_mock->redefine(get_cmd_output => sub ($self, $cmd, %) { push @$cmds_ref, $cmd; 0 });
+    $backend_mock->redefine(run_ssh_cmd => sub ($self, $cmd, %) { push @$cmds_ref, $cmd; 0 });
+    $backend_mock->redefine(run_ssh => sub ($self, $cmd, %) { push @$ssh_cmds_ref, $cmd; (undef, $chan_mock) });
     $backend_mock->redefine(start_serial_grab => 1);
     $console_mock->redefine(get_ssh_credentials => sub { (hostname => 'foo', username => 'root', password => '123') });
     $tmp_mock->redefine(tempfile => sub { (undef, '/t') });
@@ -442,10 +442,8 @@ subtest 'Method backend::svirt::open_serial_console_via_ssh()' => sub {
     my $test_log_cnt = 0;
     my $grep_return = 1;
     my @deleted_logs;
-    $module->redefine(run_ssh_cmd => sub {
-            my $self = shift;
-            @LAST_ = @_;
-            my $cmd = shift;
+    $module->redefine(run_ssh_cmd => sub ($self, $cmd, @args) {
+            @LAST_ = ($cmd, @args);
             return !!($test_log_cnt > 0 ? --$test_log_cnt : 0) if ($cmd =~ m/^test -e/);
             return $grep_return if ($cmd =~ m/^grep -q/);
             push @deleted_logs, ($cmd =~ /(\S+)$/) if ($cmd =~ / && rm /);
@@ -454,8 +452,7 @@ subtest 'Method backend::svirt::open_serial_console_via_ssh()' => sub {
     });
 
     my $run_ssh_expect = '$a';
-    $module->redefine(run_ssh => sub {
-            my ($self, $cmd, %args) = @_;
+    $module->redefine(run_ssh => sub ($self, $cmd, %) {
             like $cmd, qr/$run_ssh_expect/, "run_ssh() command is like qr/$run_ssh_expect/";
             return ('A', 'B');
     });
@@ -545,8 +542,7 @@ subtest 'Method consoles::sshVirtsh::add_disk()' => sub {
     $console_mock->redefine(which => 1);
 
     my $mock_baseclass = Test::MockModule->new('backend::baseclass');
-    $mock_baseclass->redefine('run_ssh_cmd' => sub {
-            my ($self, $cmd, %args) = @_;
+    $mock_baseclass->redefine('run_ssh_cmd' => sub ($self, $cmd, %args) {
             push @last_ssh_commands, $cmd;
             push @last_ssh_args, [%args];
 

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -107,15 +107,13 @@ subtest 'SSH utilities' => sub {
     my @timeouts = ();
     my $net_ssh2 = Test::MockModule->new('Net::SSH2');
     my @agent;
-    $net_ssh2->redefine(new => sub {
-            my ($class, %opts) = @_;
+    $net_ssh2->redefine(new => sub ($class, %opts) {
             my $self = Test::MockObject->new();
             my $id = $self->{my_custom_id} = bmwqemu::random_string(32);
             die 'Identifier not unique' if exists $ssh_obj_data->{$id};
             $ssh_obj_data->{$id} = $self;
 
-            $self->mock(connect => sub {
-                    my ($self, $hostname, $port) = @_;
+            $self->mock(connect => sub ($self, $hostname, $port) {
                     return 0 if $ssh_connect_error;
                     is $hostname, $ssh_expect->{hostname}, 'Connect to correct hostname';
                     # if unspecified, default to port 22
@@ -126,20 +124,17 @@ subtest 'SSH utilities' => sub {
                     return 1;
             });
             $self->mock(hostname => sub { return $ssh_obj_data->{refaddr(shift)}->{hostname} });
-            $self->mock(auth => sub {
-                    my ($self, %args) = @_;
+            $self->mock(auth => sub ($self, %args) {
                     is $args{username}, $ssh_expect->{username}, 'Correct username for ssh connection';
                     is $args{password}, $ssh_expect->{password}, 'Correct password for ssh connection';
                     return 1;
             });
             $self->mock(auth_agent => sub { push @agent, [@_]; return 1 });
-            $self->mock(auth_ok => sub {
-                    my $self = shift;
+            $self->mock(auth_ok => sub ($self) {
                     $self->{connected} = !!$ssh_auth_ok;
                     return $ssh_auth_ok;
             });
-            $self->mock(blocking => sub {
-                    my ($self, $v) = @_;
+            $self->mock(blocking => sub ($self, $v = undef) {
                     $self->{blocking} = $v if defined $v;
                     return $self->{blocking};
             });
@@ -148,8 +143,7 @@ subtest 'SSH utilities' => sub {
                     return 1;
             });
             $self->mock(error => sub { wantarray ? @net_ssh2_error : ($net_ssh2_error[0] // 0) });
-            $self->mock(sock => sub {
-                    my $self = shift;
+            $self->mock(sock => sub ($self) {
                     unless ($self->{sock}) {
                         my $mock_sock = Test::MockObject->new();
                         $mock_sock->{ssh} = $self;
@@ -157,14 +151,12 @@ subtest 'SSH utilities' => sub {
                     }
                     return $self->{sock};
             });
-            $self->mock(channel => sub {
-                    my $self = shift;
+            $self->mock(channel => sub ($self) {
                     die 'Not connected' unless ($self->{connected});
                     return $fail_on_channel_call = undef if $fail_on_channel_call;
                     my $mock_channel = Test::MockObject->new();
                     $mock_channel->{ssh} = $self;
-                    $mock_channel->mock(exec => sub {
-                            my ($self, $cmd) = @_;
+                    $mock_channel->mock(exec => sub ($self, $cmd) {
                             $self->{cmd} = $cmd;
                             $self->{eof} = 0;
                             return 1 unless $cmd =~ /^(echo|test)/;
@@ -321,7 +313,7 @@ subtest 'SSH utilities' => sub {
         $baseclass->truncate_serial_file();
         my $expect_output = "FOO$/" x backend::baseclass::SSH_SERIAL_READ_BUFFER_SIZE;
         my $channel_read_string = $expect_output;
-        $chan->mock(read => sub {
+        $chan->mock(read => sub {    # no:style:signatures
                 my ($self, undef, $max) = @_;
                 return unless (defined $channel_read_string);
                 $max //= backend::baseclass::SSH_SERIAL_READ_BUFFER_SIZE;

--- a/t/25-spvm.t
+++ b/t/25-spvm.t
@@ -14,8 +14,7 @@ use testapi qw(set_var power);
 subtest 'SSH credentials in spvm' => sub {
     my $expected_credentials = {username => 'root', password => 'foo', hostname => 'my_foo_hostname'};
     my $mock_spvm = Test::MockModule->new('backend::spvm');
-    $mock_spvm->mock(run_ssh_cmd => sub {
-            my ($self, $cmd, %args) = @_;
+    $mock_spvm->mock(run_ssh_cmd => sub ($self, $cmd, %args) {
             for my $k (keys %{$expected_credentials}) {
                 is $args{$k}, $expected_credentials->{$k}, "Correct $k parameter";
             }
@@ -40,8 +39,7 @@ subtest 'SSH credentials in spvm' => sub {
 
 subtest 'PowerVM power actions' => sub {
     my $mock_spvm = Test::MockModule->new('backend::spvm');
-    $mock_spvm->redefine('run_cmd', sub {
-            my ($self, $cmd) = @_;
+    $mock_spvm->redefine('run_cmd', sub ($self, $cmd) {
             return $cmd;
     });
     my $spvm = backend::spvm->new();

--- a/t/30-mmapi.t
+++ b/t/30-mmapi.t
@@ -61,12 +61,10 @@ subtest 'lockapi: server not reachable' => sub {
 # setup a fake server
 my $mock_srv = Mojolicious->new;
 $mock_srv->log->unsubscribe('message')->on(
-    message => sub {
-        my ($log, $level, @lines) = @_;
+    message => sub ($log, $level, @lines) {
         note "[$level] " . join "\n", @lines, '';
     });
-$mock_srv->helper(render_mutex => sub {
-        my ($self, %args) = @_;
+$mock_srv->helper(render_mutex => sub ($self, %) {
         my $name = $self->param('name') // '';
         return $self->render(status => 200, text => 'ok') if $name eq 'lucky_lock';
         return $self->render(status => 404, text => 'error') if $name eq 'prone_lock';
@@ -76,8 +74,7 @@ $mock_srv->helper(render_mutex => sub {
 my $routes = $mock_srv->routes;
 my $fake_api = $routes->any('/api/v1');
 my $wait_for_children_state;
-$fake_api->get('/mm/children' => sub {
-        my ($self) = @_;
+$fake_api->get('/mm/children' => sub ($self) {
         if ($wait_for_children_state) {
             return $self->render(json => {jobs => {1 => 'scheduled'}}) if $wait_for_children_state->{interations_left}--;
             return $self->render(json => {jobs => {1 => $wait_for_children_state->{state}}});
@@ -85,8 +82,7 @@ $fake_api->get('/mm/children' => sub {
         return $self->render(status => 403, text => 'not authorized') if ($self->tx->req->headers->header('X-API-JobToken') || '') ne 'fake-jobtoken';
         return $self->render(json => {jobs => [1, 2, 3]});
 });
-$fake_api->get('/mm/children/#state' => sub {
-        my ($self) = @_;
+$fake_api->get('/mm/children/#state' => sub ($self) {
         return $self->render(status => 404, json => {jobs => []}) if $self->stash('state') ne 'some-state';
         return $self->render(json => {jobs => [1]});
 });
@@ -102,22 +98,19 @@ $fake_api->get('/workers' => sub {
 });
 $fake_api->post('/mutex' => sub { shift->render_mutex });
 $fake_api->post('/mutex/foo' => sub { shift->render(json => {some => 'mutex'}) });
-$fake_api->post('/mutex/#name' => sub {
-        my ($self) = @_;
+$fake_api->post('/mutex/#name' => sub ($self) {
         my $name = $self->param('name') // '';
         my $action = $self->param('action') // '';
         return $self->render(status => 200, text => 'ok') if ($name eq 'lockable' && $action eq 'lock') || ($name eq 'unlockable' && $action eq 'unlock');
         return $self->render_mutex;
 });
-$fake_api->post('/barrier' => sub {
-        my ($self) = @_;
+$fake_api->post('/barrier' => sub ($self) {
         my $name = $self->param('name') // '';
         my $tasks = $self->param('tasks') // '';
         return $self->render(status => 200, text => 'ok') if $name eq 'lucky_barrier' && $tasks eq '41';
         return $self->render_mutex;
 });
-$fake_api->post('/barrier/#name' => sub {
-        my ($self) = @_;
+$fake_api->post('/barrier/#name' => sub ($self) {
         state $counter = 0;
         my $name = $self->param('name') // '';
         return $self->render(status => (++$counter % 3 == 0) == 0 ? 200 : 409, text => 'ok') if $name eq 'unblocked_next';
@@ -127,8 +120,7 @@ $fake_api->post('/barrier/#name' => sub {
         return $self->render(status => 200, text => 'ok') if $name eq 'check_dead_job_barrier' && ($self->param('check_dead_job') // '' eq '1');
         return $self->render_mutex;
 });
-$fake_api->delete('/barrier/#name' => sub {
-        my ($self) = @_;
+$fake_api->delete('/barrier/#name' => sub ($self) {
         my $name = $self->param('name') // '';
         return $self->render(status => 200, text => 'ok') if $name eq 'deletable';
         return $self->render_mutex;

--- a/t/32-console_proxy.t
+++ b/t/32-console_proxy.t
@@ -33,8 +33,7 @@ $console->mock('ret_undef', sub { return; });
 $console->mock('ret_list', sub { qw(a b c d); });
 $console->mock('ret_list_empty', sub { return; });
 $console->mock('ret_die', sub { die '!!Urgs!!'; });
-$console->mock('check_args', sub {
-        my ($self, @args) = @_;
+$console->mock('check_args', sub ($self, @args) {
         is_deeply \@args, $console_check_args, 'Got expected (' . join(',', @args) . ') arguments';
 });
 

--- a/xt/01-style.t
+++ b/xt/01-style.t
@@ -20,7 +20,7 @@ is qx{git grep -I -l '^use \\(Try::Tiny\\|TryCatch\\)'}, '', 'No Try::Tiny or Tr
 is qx{git grep -I -l '\\<spurt\\>' ':!xt/01-style.t'}, '', 'No deprecated "Mojo::File::spurt", use "spew" instead';
 is qx{git grep -I -l '^use testapi' backend/ consoles/}, '', 'No backend or console files use external facing testapi';
 is qx[git grep -l -e '^\\s*sub \\S\\+ [^(]\\+' --and --not -e 'sub [(\{]' --and --not -e 'sub \\S\\+\\s*[:(]' --and --not -e 'sub \\S\\+;' --and --not -e '# no:style:signatures' ':!external/' ':!t/48-testmodules-style.t'], '', 'All files use sub signatures everywhere (nameless and in-place definitions still allowed)';
-is qx[git grep -l -P 'sub\\s*\\{\\s*my\\s*\\(?\\\$' t/], '', 'Anonymous subs in tests should use signatures instead of manual unpacking of @_';
+is qx(perl -0777 -ne 'print "\$ARGV\n" if /sub\\s*\\{(?!\\s*#\\s*no:style:signatures)[^{}]*?\\bmy\\s+[^=]+=\\s*(?:\\x40_|shift\\b)/s' \$(git ls-files | grep -E '\\.(t|pm)\$' | grep -v '^external/')), '', 'All files use signatures in anonymous subroutines (no manual @_ unpacking or shift)';
 is qx{git grep -L '^#!.*perl' t/**.t}, '', 'All test files have shebang';
 is qx{git ls-files -s t/**.t | grep -v ^1007}, '', 'All test modules are executable';
 is qx{git grep -l '^use POSIX;'}, '', 'Use of bare POSIX import is discouraged, see https://perldoc.perl.org/POSIX';


### PR DESCRIPTION
Motivation:
Ensure code consistency and leverage modern Perl signatures in all anonymous
subroutines across the codebase.

Design Choices:
Extended xt/01-style.t to use a multiline Perl-based check for signature
compliance, and resolved all violations in modules and tests.

Benefits:
Uniform coding standards are automatically enforced by CI, preventing regression
to manual parameter unpacking.

Related issue: https://progress.opensuse.org/issues/202818