### PR TITLE
fix: exclude virt-firmware on all older Leap archs

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -139,11 +139,7 @@ BuildRequires:  expect
 Requires:       %main_requires
 # For dynamically generating UEFI/secureboot assets, not available in all
 # OS+arch combinations
-%if 0%{?suse_version} > 0 && 0%{?suse_version} < 1600
-%ifnarch ppc64 ppc64le
-Requires:       virt-firmware
-%endif
-%else
+%if 0%{?suse_version} >= 1600 || 0%{?suse_version} == 0
 Requires:       virt-firmware
 %endif
 %if %{with ocr}


### PR DESCRIPTION
Motivation
The package virt-firmware is not available on openSUSE Leap 15.6 and older for
any architecture, not just ppc64/ppc64le.

Design Choices
Simplify the conditional in os-autoinst.spec to exclude virt-firmware on all
architectures when building for openSUSE/SLE < 16.0.

Benefits
Ensures os-autoinst can be successfully built and installed on older Leap/SLE
for any architecture, preventing package resolution issues.