### PR TITLE
fix: Check also hidden files in checklist plugin

### DIFF
--- a/.github/workflows/checklist.yml
+++ b/.github/workflows/checklist.yml
@@ -16,3 +16,4 @@ jobs:
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           input-file: .github/checklist.yml
+          include-hidden-files: true


### PR DESCRIPTION
include-hidden-files is false by default, so it would not complain about
e.g. .gitlint