### PR TITLE
feat: optimize and shorten pretty serial hook

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -184,11 +184,13 @@ sub script_run ($self, $cmd, @args) {
         $str = testapi::hashed_string('SR' . $cmd . $args{timeout});
         $wait_pattern = qr/$str-(\d+)-/;
         if ($level == 2) {
-            testapi::type_string "export __OA_MARK=$str; $cmd\n", max_interval => $args{max_interval};
+            # _OAM: openQA Marker, passes the expected marker string to the shell hook
+            testapi::type_string "export _OAM=$str; $cmd\n", max_interval => $args{max_interval};
         }
         else {
             my $marker = "; echo $str-\$?-" . ($args{output} ? "Comment: $args{output}" : '');
-            my $final_cmd = $skip_pretty ? "OA_NO_MARKER=1; $cmd" : $cmd;
+            # _OANM: openQA No Marker, skips printing the hook's done marker
+            my $final_cmd = $skip_pretty ? "_OANM=1; $cmd" : $cmd;
             if (testapi::is_serial_terminal) {
                 testapi::type_string "$final_cmd$marker", max_interval => $args{max_interval};
                 testapi::wait_serial($final_cmd . $marker, no_regex => 1, quiet => $args{quiet}, buffer_size => (length $final_cmd) + 128, internal_marker => 1)
@@ -456,18 +458,21 @@ sub install_serial_marker_hook ($self, $level) {
     return undef if $level < 2;
     my $dev = "/dev/$testapi::serialdev";
     my $func;
+    # _oap: openQA prompt hook function
+    # _OANM: openQA No Marker (skip hook done marker)
+    # _OAM: openQA Marker (custom marker string)
     if ($level == 3) {
-        $func = qq{__oa_prompt() { r=\$?; if [ -n "\$OA_NO_MARKER" ]; then unset OA_NO_MARKER; else c=\$(fc -ln -1 2>/dev/null); printf "OA:DONE-%04x-%d-%s\\nOA:START\\n" \$RANDOM \$r "\${c#\${c%%[![:space:]]*}}" > $dev; fi; }};
+        $func = qq{_oap(){ r=\$?;if [ -n "\$_OANM" ];then unset _OANM;else c=\$(fc -ln -1 2>/dev/null);printf "OA:DONE-%04x-%d-%s\\nOA:START\\n" \$RANDOM \$r "\${c#\${c%%[![:space:]]*}}">$dev;fi;}};
     }
     else {
-        $func = qq{__oa_prompt() { r=\$?; if [ -n "\$OA_NO_MARKER" ]; then unset OA_NO_MARKER; elif [ -n "\$__OA_MARK" ]; then echo "\${__OA_MARK}-\$r-" > $dev; unset __OA_MARK; fi; echo "OA:START" > $dev; }};
+        $func = qq{_oap(){ r=\$?;if [ -n "\$_OANM" ];then unset _OANM;elif [ -n "\$_OAM" ];then echo "\$_OAM-\$r-">$dev;unset _OAM;fi;echo "OA:START">$dev;}};
     }
-    my $pc = 'PROMPT_COMMAND=__oa_prompt';
+    my $pc = 'PROMPT_COMMAND=_oap';
 
     # Consolidate installation and persistence into a single typed line to minimize VNC overhead.
     # We append to both ~/.bashrc and ~/.profile to cover both interactive and login shells.
     # Sourcing ~/.bashrc then activates the hook in the current session.
-    testapi::type_string "grep -q __oa_prompt ~/.bashrc 2>/dev/null || { echo '$func; $pc' | tee -a ~/.bashrc ~/.profile >/dev/null; }; . ~/.bashrc\n";
+    testapi::type_string "grep -q _oap ~/.bashrc 2>/dev/null||{ echo '$func;$pc'|tee -a ~/.bashrc ~/.profile>/dev/null;};. ~/.bashrc\n";
 
     my $console = testapi::current_console() // 'sut';
     $self->{_serial_marker_hook_installed}->{$console} = 1;

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -93,7 +93,7 @@ subtest 'pretty_serial_marker' => sub {
     $typed_string = '';
     $d->{_serial_marker_level}->{'test-console'} = 2;
     $d->script_run('foo');
-    like $typed_string, qr/export __OA_MARK=.*; foo\n/, 'Level 2 uses export marker';
+    like $typed_string, qr/export _OAM=.*; foo\n/, 'Level 2 uses export marker';
 
     $mock_testapi->redefine(wait_serial => sub ($regexp, @) {
             return 'BASH:4.4:' if ref($regexp) eq 'Regexp' && 'BASH:4.4:' =~ $regexp;
@@ -147,7 +147,7 @@ subtest 'serial_marker_reinstall_cached_level' => sub {
     $d->invalidate_serial_marker_hook('test-console');
 
     is $d->detect_serial_marker_capability(), 2, 'Returns cached level 2';
-    like $typed, qr/grep -q __oa_prompt.*\. ~\/\.bashrc/, 'Calls install_serial_marker_hook (types consolidated setup with sourcing)';
+    like $typed, qr/grep -q _oap.*\. ~\/\.bashrc/, 'Calls install_serial_marker_hook (types consolidated setup with sourcing)';
     ok $d->{_serial_marker_hook_installed}->{'test-console'}, 'Hook marked as installed';
 };
 
@@ -173,7 +173,7 @@ subtest 'reboot_safety' => sub {
     });
 
     $d->script_run('foo');
-    like $typed_string, qr/grep -q __oa_prompt.*__oa_prompt\(\).*OA:DONE.*\. ~\/\.bashrc/s, 'Initial install';
+    like $typed_string, qr/grep -q _oap.*_oap\(\).*OA:DONE.*\. ~\/\.bashrc/s, 'Initial install';
     $typed_string = '';
 
     # Simulate console selection (e.g. after reboot/login)
@@ -189,7 +189,7 @@ subtest 'reboot_safety' => sub {
     $d->reset_serial_marker('test-console');
     $typed_string = '';
     $d->script_run('baz');
-    like $typed_string, qr/grep -q __oa_prompt.*__oa_prompt\(\).*OA:DONE.*\. ~\/\.bashrc/s, 'Re-detect and re-install after resetting the serial marker';
+    like $typed_string, qr/grep -q _oap.*_oap\(\).*OA:DONE.*\. ~\/\.bashrc/s, 'Re-detect and re-install after resetting the serial marker';
     like $typed_string, qr/baz\n/, 'Command typed after re-installation';
 
     # Case 3: select_console triggers reset
@@ -296,7 +296,7 @@ subtest 'serial_marker_hook_persistence' => sub {
 
     # First install
     $d->install_serial_marker_hook(3);
-    like $typed, qr/grep -q __oa_prompt.*\. ~\/\.bashrc/, 'Types consolidated setup with persistence and sourcing';
+    like $typed, qr/grep -q _oap.*\. ~\/\.bashrc/, 'Types consolidated setup with persistence and sourcing';
     ok $d->{_serial_marker_hook_persistent}->{'test-console'}, 'Persistence marked';
 
     # Invalidate hook but keep persistence
@@ -345,11 +345,11 @@ subtest 'serial_terminal_redirection_guard' => sub {
 
         $d->script_run($case->{cmd});
         if ($case->{guard}) {
-            like $typed, qr/OA_NO_MARKER=1; /, $case->{msg};
+            like $typed, qr/_OANM=1; /, $case->{msg};
             like $diag_msg, qr/Manual redirection to \/dev\/ttyS0 is deprecated/, 'deprecation warning shown';
         }
         else {
-            unlike $typed, qr/OA_NO_MARKER=1; /, $case->{msg};
+            unlike $typed, qr/_OANM=1; /, $case->{msg};
             unlike $diag_msg, qr/Manual redirection to \/dev\/ttyS0 is deprecated/, 'no deprecation warning for normal command';
         }
         is $vars{PRETTY_SERIAL_MARKER}, 1, "PRETTY_SERIAL_MARKER is active again after '$case->{cmd}'";
@@ -360,7 +360,7 @@ subtest 'serial_terminal_redirection_guard' => sub {
     delete $d->{_serial_marker_hook_persistent}->{'test-console'};
     $d->{_serial_marker_level}->{'test-console'} = 3;
     $d->install_serial_marker_hook(3);
-    like $typed, qr/__oa_prompt\(\) \{ r=\$\?; if \[ -n "\$OA_NO_MARKER" \]/, '__oa_prompt must capture the exit status r=$? as the absolute first statement to prevent internal conditional checks from overwriting it';
+    like $typed, qr/_oap\(\)\{ r=\$\?;if \[ -n "\$_OANM" \]/, '_oap must capture the exit status r=$? as the absolute first statement to prevent internal conditional checks from overwriting it';
 };
 
 subtest 'terminal_session_boundary' => sub {
@@ -383,16 +383,16 @@ subtest 'terminal_session_boundary' => sub {
     });
 
     $d->script_run('first_cmd');
-    like $typed, qr/__oa_prompt/, 'pretty serial marker hook is initially configured and installed on the terminal session';
+    like $typed, qr/_oap/, 'pretty serial marker hook is initially configured and installed on the terminal session';
 
     $typed = '';
     $d->script_run('second_cmd');
-    unlike $typed, qr/__oa_prompt/, 'hook re-installation is skipped on subsequent commands if cached status is stale';
+    unlike $typed, qr/_oap/, 'hook re-installation is skipped on subsequent commands if cached status is stale';
 
     $d->invalidate_serial_marker_hook('x11');
     $typed = '';
     $d->script_run('third_cmd');
-    like $typed, qr/__oa_prompt/, 'hook is successfully re-installed on the next command after cached status is explicitly invalidated';
+    like $typed, qr/_oap/, 'hook is successfully re-installed on the next command after cached status is explicitly invalidated';
 };
 
 done_testing;


### PR DESCRIPTION
Motivation:
Every character typed over VNC incurs latency and can lead to mistyping.
Optimizing hook names and removing whitespace speeds up test setup.

Design Choices:
Shortened variables and function names in bash hook (_oap, _OANM, _OAM).
Stripped redundant whitespaces around shell operators in the hook string.

Benefits:
Faster test setup phases and lower latency over VNC-based consoles.