### PR TITLE
test: Disable unstable `t/28-signalblocker.t` on ppc64le OBS builds

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -269,10 +269,13 @@ rm t/02-test_ocr.t
 # qemu emulation always starts a separate thread
 rm t/28-signalblocker.t
 %endif
-%ifarch aarch64 s390x
+%ifarch aarch64 s390x ppc64le
 # https://progress.opensuse.org/issues/194359
 # https://progress.opensuse.org/issues/199940
+# https://progress.opensuse.org/issues/202836
 rm -f t/28-signalblocker.t
+%endif
+%ifarch aarch64 s390x
 # https://progress.opensuse.org/issues/200949
 rm -f t/26-video_stream.t
 %endif


### PR DESCRIPTION
It sometimes fails on OBS for ppc64le:
```
[  107s] 4: not ok 3 - no new threads after searching for a needle
```

Related ticket: https://progress.opensuse.org/issues/202836