### PR TITLE
fix(t/34-git): prevent t/34-git.t from leaking t/vars.json

### DIFF
--- a/t/34-git.t
+++ b/t/34-git.t
@@ -17,12 +17,14 @@ use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use Test::Warnings ':report_warnings';
 
-my $tmpdir = tempdir("/tmp/$FindBin::Script-XXXX");
+my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
 my $git_repo = 'tmpgitrepo';
-my $git_dir = "$tmpdir/$git_repo";
-my $clone_dir = "$Bin/$git_repo";
+my $git_dir = "$dir/source/$git_repo";
+my $clone_dir = "$dir/clone/$git_repo";
 
-chdir $Bin;
+path("$dir/source")->make_path;
+path("$dir/clone")->make_path;
+chdir "$dir/clone";
 # some git variables might be set if this test is
 # run during a `git rebase -x 'make test'`
 delete @ENV{qw(GIT_DIR GIT_REFLOG_ACTION GIT_WORK_TREE)};
@@ -42,10 +44,10 @@ subtest 'failure to clone results once' => sub {
 };
 
 subtest 'failure to clone results in repeated attempts' => sub {
-    my $chdir_guard = scope_guard sub { chdir $Bin; };
+    my $chdir_guard = scope_guard sub { chdir "$dir/clone"; };
     my $utils_mock = Test::MockModule->new('OpenQA::Isotovideo::Utils');
     my $failed_once = 0;
-    chdir $tmpdir;
+    chdir $dir;
     $utils_mock->redefine(clone_git => sub ($dir, @) {
             ok !-e $dir, "$dir cleaned up" or return 1;
             path($dir)->make_path;
@@ -109,7 +111,7 @@ subtest 'cloning with caching' => sub {
     my ($orga, $repo, $suffix) = (qw(os-autoinst os-autoinst-wheel-launcher .git));
     my $rev = '742bd0570a5d086be12fecb3b108bff15f4cb202';
     my $url = Mojo::URL->new("https://github.com/$orga/$repo$suffix");
-    ($orga, $repo, $rev, $suffix, $url) = ($tmpdir, $git_repo, $head, '', Mojo::URL->new("file://$git_dir"))
+    ($orga, $repo, $rev, $suffix, $url) = ("$dir/source", $git_repo, $head, '', Mojo::URL->new("file://$git_dir"))
       unless $ENV{OS_AUTOINST_TEST_GIT_ONLINE};
 
     my $orga_cache_dir = $git_cache_dir->child($orga);
@@ -229,5 +231,7 @@ sub cleanup () {
 }
 
 END {
+    chdir $Bin;
     cleanup();
+    undef $dir;
 }


### PR DESCRIPTION
Motivation:
xt/27-make-update-deps.t was failing due to t/vars.json being accidentally
tracked and then modified by t/34-git.t.

Design Choices:
Update t/34-git.t to use isolated workdir for everything and avoid chdir to t/.
Putting both source and clone repositories inside subdirectories of the
isolated workdir.

Benefits:
Stable and clean test execution. No more leaked files in the source tree.