### PR TITLE
test: fix race condition in t/29-backend-driver.t

### DIFF
--- a/t/29-backend-driver.t
+++ b/t/29-backend-driver.t
@@ -44,9 +44,9 @@ is $driver->extract_assets, undef, 'extract_assets';
 ok $driver->start_vm, 'start_vm';
 is $driver->mouse_hide, 0, 'mouse_hide';
 $out = combined_from { is $driver->stop_backend, undef, 'stop_backend' };
+is $driver->stop, undef, 'stop';
 like "@diag", qr/backend.*exited/, 'exit logged';
 reset_logs();
-is $driver->stop, undef, 'stop';
 
 my $process = process(process_id => 42, _status => (5 << 8));
 reset_logs;

--- a/t/29-backend-driver.t
+++ b/t/29-backend-driver.t
@@ -30,12 +30,12 @@ sub reset_logs () { @diag = (); @fctinfo = () }
 
 my $driver;
 logger->handle->autoflush(1);
-my $out = combined_from { $driver = backend::driver->new('null') };
+combined_from { $driver = backend::driver->new('null') };
 like "@diag", qr/channel_out.+channel_in/, 'log output for backend driver creation';
 reset_logs();
 
 ok $driver, 'can create driver';
-$out = combined_from { ok $driver->start, 'can start driver' };
+combined_from { ok $driver->start, 'can start driver' };
 like "@diag", qr/channel_out.+channel_in/, 'log content again';
 reset_logs();
 
@@ -43,13 +43,15 @@ isnt $driver->{backend_process}, {}, 'backend process was started' or explain $d
 is $driver->extract_assets, undef, 'extract_assets';
 ok $driver->start_vm, 'start_vm';
 is $driver->mouse_hide, 0, 'mouse_hide';
-$out = combined_from { is $driver->stop_backend, undef, 'stop_backend' };
-is $driver->stop, undef, 'stop';
+combined_from {
+    is $driver->stop_backend, undef, 'stop_backend';
+    is $driver->stop, undef, 'stop';
+};
 like "@diag", qr/backend.*exited/, 'exit logged';
 reset_logs();
 
 my $process = process(process_id => 42, _status => (5 << 8));
-reset_logs;
+reset_logs();
 backend::driver::_collect_orphan(undef, $process);
 like $fctinfo[0], qr/collected.*pid.*42.*exit status.*5/, 'message for collected orphan logged';
 


### PR DESCRIPTION
Motivation:
The stop_backend call returns immediately before the process is fully collected.
Under some timing conditions, the expected "backend exited" message is not yet
logged at the subsequent assertion. Observed during my work on
* #2819

Design Choices:
Call $driver->stop (which blocks on the process exiting) before checking the
diagnostic log arrays, ensuring a deterministic sequence of events.

Benefits:
Fixes a flaky test failure in driver tests, ensuring robust and reliable build
runs.