### PR TITLE
feat: allow UEFI_PFLASH_CODE as asset

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -295,6 +295,7 @@ sub configure_pflash ($self, $vars) {
     return $self unless $vars->{UEFI};
     my $fw = $vars->{UEFI_PFLASH_CODE};
     if ($fw) {
+        $fw = path($vars->{UEFI_PFLASH_CODE})->to_abs;
         $bdc->add_pflash_drive('pflash-code', $fw, $self->get_img_size($fw))
           ->unit(0)
           ->readonly('on');


### PR DESCRIPTION
Treat it the same as UEFI_PFLASH_VARS: If it's a relative path, it's an asset, and needs to be converted to an absolute path first.