### PR TITLE
fix(backend): bring back support for legacy BIOS

### DIFF
--- a/OpenQA/Qemu/Proc.pm
+++ b/OpenQA/Qemu/Proc.pm
@@ -293,6 +293,16 @@ sub configure_pflash ($self, $vars) {
     my $bdc = $self->blockdev_conf;
 
     return $self unless $vars->{UEFI};
+
+    if ($vars->{UEFI_PFLASH}) {
+        die 'Mixing old and new PFLASH variables'
+          if ($vars->{UEFI_PFLASH_CODE} || $vars->{UEFI_PFLASH_VARS});
+
+        my $file = $vars->{BIOS};
+        $bdc->add_pflash_drive('pflash', $file, $self->get_img_size($file));
+        return $self;
+    }
+
     my $fw = $vars->{UEFI_PFLASH_CODE};
     if ($fw) {
         $fw = path($vars->{UEFI_PFLASH_CODE})->to_abs;

--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -726,10 +726,10 @@ sub start_qemu ($self) {
     if ($vars->{UEFI} && ($arch eq 'x86_64')) {
         $vars->{UEFI_PFLASH_CODE} //= find_ovmf;
         $vars->{UEFI_PFLASH_VARS} //= $vars->{UEFI_PFLASH_CODE} =~ s/code/$&=~tr,CcOoDdEe,VvAaRrSs,r/eir;
-        die 'No UEFI firmware can be found! Please specify UEFI_PFLASH_CODE/UEFI_PFLASH_VARS or UEFI_BIOS or install an appropriate package' unless $vars->{UEFI_PFLASH_CODE};
+        die 'No UEFI firmware can be found! Please specify UEFI_PFLASH_CODE/UEFI_PFLASH_VARS or BIOS or UEFI_BIOS or install an appropriate package' unless $vars->{UEFI_PFLASH_CODE};
     }
 
-    foreach my $attribute (qw(KERNEL INITRD)) {
+    foreach my $attribute (qw(KERNEL INITRD BIOS)) {
         if ($vars->{$attribute} && $vars->{$attribute} !~ /^\//) {
             # Non-absolute paths are assumed relative to /usr/share/qemu
             $vars->{$attribute} = '/usr/share/qemu/' . $vars->{$attribute};
@@ -988,6 +988,10 @@ sub start_qemu ($self) {
             }
         }
         sp('boot', join ',', @boot_args) if @boot_args;
+
+        if (!$vars->{UEFI} && $vars->{BIOS}) {
+            sp('bios', $vars->{BIOS});
+        }
 
         foreach my $attribute (qw(KERNEL INITRD APPEND)) {
             sp(lc($attribute), $vars->{$attribute}) if $vars->{$attribute};

--- a/doc/backend_vars.md
+++ b/doc/backend_vars.md
@@ -111,6 +111,7 @@ Supported variables per backend
 | ARCH | x86_64\|i686\|aarch64\|... | depends on tested medium | Architecture of VM. |
 | APPEND | string |  | Kernel options to pass when using the KERNEL variable, see https://qemu-project.gitlab.io/qemu/system/linuxboot.html |
 | ATACONTROLLER | see qemu -device ?, e. g. for SATA: ich9-ahci |  | Controller for ATA devices, needed for connecting disks as SATA. |
+| BIOS | string |  | Set the filename for the BIOS |
 | BOOT_HDD_IMAGE | boolean |  | enables boot from HDD_1 (BOOTFROM has higher priority) |
 | BOOT_MENU | boolean | undef | enables boot menu for selection of boot device |
 | BOOT_MENU_TIMEOUT | integer | 5000 | boot menu timeout in ms. Needs BOOT_MENU |
@@ -206,6 +207,7 @@ Supported variables per backend
 | UEFI_PFLASH_SECURE_BOOT | boolean |  | Enable or disable secure boot in the UEFI firmware variables file using `virt-fw-vars`. |
 | UEFI_PFLASH_RESOLUTION | string |  | Specify the resolution to configure via UEFI firmware variables file using `virt-fw-vars`, e.g. `800x600` for a width of 800 pixels and a height of 600 pixels. |
 | PUBLISH_PFLASH_VARS | string |  | Specify the file name to publish the UEFI vars file as |
+| UEFI_PFLASH | boolean | 0 | (Deprecated, use UEFI_PFLASH_VARS) Enable the pflash mode to write the UEFI variables directly into the firmware file instead of NVvars in the EFI system partition |
 | UEFI_BIOS |  |  | Deprecated, use UEFI_PFLASH_CODE |
 | USBBOOT | boolean | 0 | Mount ISO as USB disk and boot VM from it |
 | USBSIZEGB | integer | size of ISO | Size of USB disk for USBBOOT |

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -784,6 +784,14 @@ subtest 'special cases when starting QEMU' => sub {
     unlike $qemu_params, qr{order=}, 'order parameter not present due to PXEBOOT';
     like $qemu_params, qr{once=n}, 'once=n parameter present due to PXEBOOT';
 
+    @qemu_params = ();
+    $bmwqemu::vars{PXEBOOT} = 0;
+    $bmwqemu::vars{UEFI} = 0;
+    $bmwqemu::vars{BIOS} = 'bios.bin';
+    combined_like { $backend->start_qemu } qr{.+}s, 'invoked with legacy BIOS';
+    $qemu_params = Mojo::Collection->new(\@qemu_params)->flatten->join(' ');
+    like $qemu_params, qr{bios /usr/share/qemu/bios\.bin}, 'bios parameter correctly configured';
+
     subtest 'various error cases' => sub {
         my %initial_vars = %bmwqemu::vars;
         $bmwqemu::vars{NICTYPE} = 'foo';

--- a/t/18-qemu.t
+++ b/t/18-qemu.t
@@ -581,6 +581,19 @@ subtest configure_pflash => sub {
 
     %vars = (UEFI => 1, UEFI_PFLASH_VARS => 'vars');
     throws_ok { $proc->configure_pflash(\%vars) } qr{Need UEFI_PFLASH_CODE with UEFI_PFLASH_VARS}, 'Fatal UEFI_PFLASH_VARS without UEFI_PFLASH_CODE';
+
+    @flash = ();
+    my $bios_file = tempfile->spew('bios');
+    %vars = (UEFI => 1, UEFI_PFLASH => 1, BIOS => $bios_file->to_string);
+    my $res_pflash = $proc->configure_pflash(\%vars);
+    is_deeply \@flash, [['pflash', $bios_file->to_string, 4]], 'add_pflash_drive correctly called for UEFI_PFLASH';
+    is $res_pflash, $proc, 'returns self';
+
+    %vars = (UEFI => 1, UEFI_PFLASH => 1, UEFI_PFLASH_CODE => 'code');
+    throws_ok { $proc->configure_pflash(\%vars) } qr{Mixing old and new PFLASH variables}, 'Mixing old and new PFLASH variables (code)';
+
+    %vars = (UEFI => 1, UEFI_PFLASH => 1, UEFI_PFLASH_VARS => 'vars');
+    throws_ok { $proc->configure_pflash(\%vars) } qr{Mixing old and new PFLASH variables}, 'Mixing old and new PFLASH variables (vars)';
 };
 
 subtest connect_qmp => sub {


### PR DESCRIPTION
Motivation
Commit 4585515 erroneously removed support for custom legacy BIOS when cleaning
up the deprecated UEFI_PFLASH logic. We need a way to provide custom firmware
images for non-UEFI VMs.

Design Choices
The `BIOS` variable is re-added to the checked attribute list to resolve its
path correctly. In start_qemu, if UEFI is not requested, the BIOS file path
is passed via the `-bios` parameter.

Benefits
This restores the ability to supply custom BIOS firmware files for legacy VMs,
satisfying use-cases that depend on non-UEFI custom firmwares.