### PR TITLE
feat(ci): pin GitHub Actions by commit hash

### DIFF
--- a/.github/workflows/author-tests.yaml
+++ b/.github/workflows/author-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     container:
       image: registry.opensuse.org/devel/openqa/containers/os-autoinst_dev
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - name: make test-local
         run: |
           git config --global --add safe.directory '*'

--- a/.github/workflows/checklist.yml
+++ b/.github/workflows/checklist.yml
@@ -10,9 +10,9 @@ jobs:
     name: Checklist job
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - name: Checklist
-        uses: wyozi/contextual-qa-checklist-action@master
+        uses: wyozi/contextual-qa-checklist-action@dd4b6b51d85a59f537b7ca9e2f162164627ec811  # master
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           input-file: .github/checklist.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - name: Static checks, unit tests and integration tests
         run: tools/container_run_ci
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@a99c28d3f0da835de33ff2feb2e15691c7b9641f  # v7
         with:
           # should not be necessary for public repos, but might help avoid sporadic upload token errors
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -24,7 +24,7 @@ jobs:
           verbose: true
       - run: |
           tar cvf coverage.tar build/cover_db
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: coverage
           path: coverage.tar
@@ -35,6 +35,6 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - name: Test our container definitions
         run: tools/static_check_containers

--- a/.github/workflows/ci_extended.yml
+++ b/.github/workflows/ci_extended.yml
@@ -14,6 +14,6 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - name: Test our container definitions
         run: tools/test_containers

--- a/.github/workflows/commit-message-checker.yml
+++ b/.github/workflows/commit-message-checker.yml
@@ -12,4 +12,4 @@ jobs:
   check-commit-message:
     permissions:
       contents: read
-    uses: os-autoinst/os-autoinst-common/.github/workflows/base-commit-message-checker.yml@master
+    uses: os-autoinst/os-autoinst-common/.github/workflows/base-commit-message-checker.yml@e76072d144ca3313002006ff4ee8d4e5a7529aa9  # master

--- a/.github/workflows/obs-helper.yaml
+++ b/.github/workflows/obs-helper.yaml
@@ -12,7 +12,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - name: debug
         run: |
           env | sort

--- a/.github/workflows/openqa_fullstack.yml
+++ b/.github/workflows/openqa_fullstack.yml
@@ -22,7 +22,7 @@ jobs:
     container:
       image: registry.opensuse.org/devel/openqa/containers/opensuse/openqa_ci:latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - name: Create additional user to avoid initdb error "cannot be run as root"
         run: useradd "$TEST_USER"
       - name: Make project folder user-writable


### PR DESCRIPTION
Motivation:
Secure GitHub Actions workflows against git tag hijacking attacks.

Design Choices:
Replace version tags with full 40-character SHA-1 hashes.
Preserve tags as comments for easy reference.

Benefits:
Ensures workflow immutability and compliance with security
best practices.

Related issue: https://progress.opensuse.org/issues/203049