### PR TITLE
Style/155191/export blocklist

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -58,7 +58,7 @@ add_packages = autotest bmwqemu log needle testapi Carp OpenQA::Isotovideo::Inte
 allowed_modules = FindBin
 
 [TestingAndDebugging::ProhibitNoWarnings]
-allow = redefine
+allow = redefine once
 
 # The following policies might be interesting:
 # InputOutput::ProhibitInteractiveTest

--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,7 +1,11 @@
-theme = community + openqa
-severity = 4
+theme = community + openqa + core
+severity = 1
 
-include = strict ValuesAndExpressions::ProhibitInterpolationOfLiterals CodeLayout::ProhibitParensWithBuiltins BuiltinFunctions::RequireBlockMap BuiltinFunctions::ProhibitStringySplit ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions ValuesAndExpressions::RequireQuotedHeredocTerminator Variables::ProhibitPackageVars CodeLayout::RequireTidyCode Community::WarningsSwitch Community::EmptyReturn Variables::ProhibitUnusedVariables RegularExpressions::ProhibitUselessTopic BuiltinFunctions::ProhibitUselessTopic CodeLayout::ProhibitQuotedWordLists BuiltinFunctions::RequireBlockGrep Modules::ProhibitConditionalUseStatements BuiltinFunctions::ProhibitLvalueSubstr Community::OpenArgs Plicease::ProhibitArrayAssignAref Community::Wantarray ClassHierarchies::ProhibitExplicitISA Community::ConditionalImplicitReturn Documentation::RequirePackageMatchesPodName BuiltinFunctions::ProhibitStringyEval InputOutput::ProhibitOneArgSelect ErrorHandling::RequireCheckingReturnValueOfEval Community::Each ProhibitQuotesAsQuotelikeOperatorDelimiter BuiltinFunctions::ProhibitSleepViaSelects ValuesAndExpressions::ProhibitInterpolationOfLiterals Miscellanea::ProhibitUselessNoCritic RegularExpressions::ProhibitSingleCharAlternation
+exclude = BuiltinFunctions::ProhibitBooleanGrep BuiltinFunctions::ProhibitComplexMappings BuiltinFunctions::ProhibitReverseSortBlock BuiltinFunctions::ProhibitVoidMap ClassHierarchies::ProhibitAutoloading CodeLayout::RequireTrailingCommas Community::DiscouragedModules Community::Prototypes ControlStructures::ProhibitCStyleForLoops ControlStructures::ProhibitMutatingListFunctions ControlStructures::ProhibitPostfixControls ControlStructures::ProhibitUnlessBlocks ControlStructures::ProhibitUntilBlocks Documentation::PodSpelling Documentation::RequirePodAtEnd Documentation::RequirePodSections ErrorHandling::RequireCarping InputOutput::ProhibitBacktickOperators InputOutput::ProhibitExplicitStdin InputOutput::ProhibitInteractiveTest InputOutput::ProhibitJoinedReadline InputOutput::RequireBracedFileHandleWithPrint InputOutput::RequireBriefOpen InputOutput::RequireCheckedClose InputOutput::RequireCheckedOpen InputOutput::RequireCheckedSyscalls Miscellanea::ProhibitTies Modules::ProhibitMultiplePackages Modules::RequireBarewordIncludes Modules::RequireEndWithOne Modules::RequireExplicitPackage Modules::RequireFilenameMatchesPackage Modules::RequireNoMatchVarsWithUseEnglish Modules::RequireVersionVar NamingConventions::Capitalization NamingConventions::ProhibitAmbiguousNames References::ProhibitDoubleSigils RegularExpressions::ProhibitCaptureWithoutTest RegularExpressions::ProhibitComplexRegexes RegularExpressions::ProhibitEnumeratedClasses RegularExpressions::ProhibitEscapedMetacharacters RegularExpressions::ProhibitFixedStringMatches RegularExpressions::ProhibitUnusedCapture RegularExpressions::ProhibitUnusualDelimiters RegularExpressions::RequireBracesForMultiline RegularExpressions::RequireDotMatchAnything RegularExpressions::RequireExtendedFormatting RegularExpressions::RequireLineBoundaryMatching Subroutines::ProhibitBuiltinHomonyms Subroutines::ProhibitExplicitReturnUndef Subroutines::ProhibitSubroutinePrototypes Subroutines::ProhibitUnusedPrivateSubroutines Subroutines::ProtectPrivateSubs Subroutines::RequireFinalReturn ValuesAndExpressions::ProhibitCommaSeparatedStatements ValuesAndExpressions::ProhibitConstantPragma ValuesAndExpressions::ProhibitEmptyQuotes ValuesAndExpressions::ProhibitEscapedCharacters ValuesAndExpressions::ProhibitImplicitNewlines ValuesAndExpressions::ProhibitLeadingZeros ValuesAndExpressions::ProhibitLongChainsOfMethodCalls ValuesAndExpressions::ProhibitMagicNumbers ValuesAndExpressions::ProhibitMismatchedOperators ValuesAndExpressions::ProhibitMixedBooleanOperators ValuesAndExpressions::ProhibitNoisyQuotes ValuesAndExpressions::RequireConstantVersion ValuesAndExpressions::RequireInterpolationOfMetachars Variables::ProhibitAugmentedAssignmentInDeclaration Variables::ProhibitLocalVars Variables::ProhibitPunctuationVars Variables::ProhibitReusedNames Variables::RequireInitializationForLocalVars Variables::RequireLocalizedPunctuationVars
+
+# ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions
+# No operators like < =~ ! allowed in 'unless' or 'until', only simple
+# unless $x && @$y
 
 verbose = ::warning file=%f,line=%l,col=%c,title=%m - severity %s::[%p] %e\n
 
@@ -24,7 +28,6 @@ severity = 4
 add_themes = community
 max_nests = 4
 
-# == Community Policies
 # -- Test::Most brings in strict & warnings
 [Community::StrictWarnings]
 extra_importers = Test::Most
@@ -45,5 +48,38 @@ severity = 5
 [OpenQA::RedundantStrictWarning]
 equivalent_modules = Test::Most
 
+[ValuesAndExpressions::RequireNumberSeparators]
+min_value = 1000000
+
 [Variables::ProhibitPackageVars]
 add_packages = autotest bmwqemu log needle testapi Carp OpenQA::Isotovideo::Interface
+
+[Community::DiscouragedModules]
+allowed_modules = FindBin
+
+[TestingAndDebugging::ProhibitNoWarnings]
+allow = redefine
+
+# The following policies might be interesting:
+# InputOutput::ProhibitInteractiveTest
+# InputOutput::ProhibitExplicitStdin
+# BuiltinFunctions::ProhibitComplexMappings
+# RegularExpressions::ProhibitUnusedCapture
+
+[Modules::ProhibitExcessMainComplexity]
+# Reduce me! (backend/qemu.pm::start_qemu has 156)
+max_mccabe = 100
+
+[ControlStructures::ProhibitCascadingIfElse]
+# Reduce me! (t/03-testapi.t has 12 elsif, consoles/VNC.pm has 7 elsif)
+max_elsif = 12
+
+[Subroutines::ProhibitExcessComplexity]
+# Reduce me! (backend/qemu.pm::start_qemu has 156)
+max_mccabe = 160
+
+[Subroutines::ProhibitManyArgs]
+# Reduce me!
+max_arguments = 12
+# Ignore first arg if called $self or $class
+skip_object = 1

--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -83,3 +83,6 @@ max_mccabe = 160
 max_arguments = 12
 # Ignore first arg if called $self or $class
 skip_object = 1
+
+[Community::PreferredAlternatives]
+allowed_modules = List::MoreUtils

--- a/consoles/serial_screen.pm
+++ b/consoles/serial_screen.pm
@@ -136,7 +136,7 @@ just read once.
 
 =cut
 
-sub do_read {    # no:style:signatures
+sub do_read {    ## no critic (Subroutines::RequireArgUnpacking) # no:style:signatures
     my ($self, undef, %args) = @_;
     my $buffer = '';
     $args{timeout} //= undef;    # wait till data is available

--- a/consoles/ssh_screen.pm
+++ b/consoles/ssh_screen.pm
@@ -28,7 +28,7 @@ sub new ($class, @args) {
     return $self->SUPER::new($self->ssh_channel);
 }
 
-sub do_read {    # no:style:signatures
+sub do_read {    ## no critic (Subroutines::RequireArgUnpacking) # no:style:signatures
     my ($self, undef, %args) = @_;
     my $buffer = '';
     my %error_seen = (LIBSSH2_ERROR_EAGAIN => 1);

--- a/consoles/virtio_terminal.pm
+++ b/consoles/virtio_terminal.pm
@@ -99,7 +99,7 @@ there Fcntl bindings. See https://perldoc.perl.org/Fcntl.html
 
 sub F_GETPIPE_SZ () {
     eval {
-        no warnings 'all';
+        no warnings 'all';    ## no critic (TestingAndDebugging::ProhibitNoWarnings)
         Fcntl::F_GETPIPE_SZ;
     } || 1032;
 }
@@ -111,7 +111,7 @@ there Fcntl bindings. See: https://perldoc.perl.org/Fcntl.html
 
 sub F_SETPIPE_SZ () {
     eval {
-        no warnings 'all';
+        no warnings 'all';    ## no critic (TestingAndDebugging::ProhibitNoWarnings)
         Fcntl::F_SETPIPE_SZ;
     } || 1031;
 }

--- a/lockapi.pm
+++ b/lockapi.pm
@@ -8,8 +8,10 @@ use Mojo::Base 'Exporter', -signatures;
 use Scalar::Util 'looks_like_number';
 use List::Util qw(min);
 use Time::Seconds;
+## no critic (Modules::ProhibitAutomaticExportation)
 our @EXPORT = qw(mutex_create mutex_lock mutex_unlock mutex_try_lock mutex_wait
   barrier_create barrier_wait barrier_try_wait barrier_destroy);
+## use critic
 
 require bmwqemu;
 use mmapi qw(api_call_2 get_job_info);

--- a/mmapi.pm
+++ b/mmapi.pm
@@ -5,11 +5,13 @@
 package mmapi;
 
 use Mojo::Base 'Exporter', -signatures;
+## no critic (Modules::ProhibitAutomaticExportation)
 our @EXPORT = qw(get_children_by_state get_children get_parents
   get_job_info get_job_autoinst_url get_job_autoinst_vars
   wait_for_children wait_for_children_to_start api_call
   api_call_2 handle_api_error get_current_job_id
 );
+## use critic
 
 require bmwqemu;
 

--- a/osutils.pm
+++ b/osutils.pm
@@ -104,9 +104,9 @@ sub runcmd_out (@cmd) {
 
 sub wait_attempt () { sleep($ENV{OSUTILS_WAIT_ATTEMPT_INTERVAL} // 1) }
 
-sub attempt {    # no:style:signatures
+sub attempt (@args) {
     my $attempts = 0;
-    my ($total_attempts, $condition, $cb, $or) = ref $_[0] eq 'HASH' ? (@{$_[0]}{qw(attempts condition cb or)}) : @_;
+    my ($total_attempts, $condition, $cb, $or) = ref $args[0] eq 'HASH' ? (@{$args[0]}{qw(attempts condition cb or)}) : @args;
     while (!$condition->() && $attempts < $total_attempts) {
         bmwqemu::diag "Waiting for $attempts attempts";
         $cb->();

--- a/t/lib/CoverageWorkaround.pm
+++ b/t/lib/CoverageWorkaround.pm
@@ -79,8 +79,8 @@ sub pp_leave {    # fix https://rt.cpan.org/Ticket/Display.html?id=134812 # no:s
 
     my $enter = $op->first;
     no strict 'subs';    ## no critic (TestingAndDebugging::ProhibitNoStrict, TestingAndDebugging::ProhibitProlongedStrictureOverride)
-    no warnings;
-    return $self->$orig_pp_leave(@_) if $enter->type != OP_ENTER;
+    no warnings;    ## no critic (TestingAndDebugging::ProhibitNoWarnings)
+    return $self->$orig_pp_leave($op) if $enter->type != OP_ENTER;
 
     my $meth = ref $enter->sibling eq 'B::COP' ? $orig_pp_leave : $patched_pp_leave;
     return $self->$meth(@_);

--- a/t/lib/CoverageWorkaround.pm
+++ b/t/lib/CoverageWorkaround.pm
@@ -74,8 +74,7 @@ my $patched_pp_leave;    # apply 134812 fix below
 }
 
 sub pp_leave {    # fix https://rt.cpan.org/Ticket/Display.html?id=134812 # no:style:signatures
-    my $self = shift;
-    my ($op) = @_;
+    my ($self, $op) = @_;
 
     my $enter = $op->first;
     no strict 'subs';    ## no critic (TestingAndDebugging::ProhibitNoStrict, TestingAndDebugging::ProhibitProlongedStrictureOverride)
@@ -83,7 +82,7 @@ sub pp_leave {    # fix https://rt.cpan.org/Ticket/Display.html?id=134812 # no:s
     return $self->$orig_pp_leave($op) if $enter->type != OP_ENTER;
 
     my $meth = ref $enter->sibling eq 'B::COP' ? $orig_pp_leave : $patched_pp_leave;
-    return $self->$meth(@_);
+    return $self->$meth($op);
 }
 
 1;

--- a/testapi.pm
+++ b/testapi.pm
@@ -32,6 +32,7 @@ use constant DEFAULT_MAX_INTERVAL => 250;
 use constant DEFAULT_TIMEOUT => 90;
 use constant TIMEOUT_INCREASE => 10;
 
+## no critic (Modules::ProhibitAutomaticExportation)
 our @EXPORT = qw(
 
   $realname get_realname set_realname


### PR DESCRIPTION
This is the last commit to complete the migration from include to exclude, this should be merge after: #3019, #3021, #3022, #3023, #3024

- style(perlcriticrc): migrate to blocklist approach 
- style(perlcritic): apply TestingAndDebugging::ProhibitNoWarnings policy 
- style(perlcritic): apply Community::PreferredAlternatives 
- style(perlcritic): apply Subroutines::RequireArgUnpacking policy
- style(perlcritic): apply Modules::ProhibitAutomaticExportation policy

Related: https://progress.opensuse.org/issues/155191
