### PR TITLE
feat: prefer ffmpeg 7 on modern distributions

### DIFF
--- a/dist/rpm/os-autoinst.spec
+++ b/dist/rpm/os-autoinst.spec
@@ -157,7 +157,7 @@ Recommends:     python3-Pillow-tk
 # Optional dependency for QEMU's built-in samba service (enabled via QEMU_ENABLE_SMBD=1)
 Recommends:     samba
 # More efficient video encoding is done automatically if ffmpeg is present
-Recommends:     ffmpeg >= 4
+Recommends:     (ffmpeg >= 7 or ffmpeg >= 4)
 Requires(pre):  %{_bindir}/getent
 Requires(pre):  %{_sbindir}/useradd
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Motivation
Leap 16.0 and Tumbleweed support highly efficient AV1 encoding via
libsvtav1 but require ffmpeg version 7. Currently, os-autoinst only
recommends ffmpeg >= 4, which can cause Zypper to revert/downgrade to
v4 during updates.

Design Choices
Update the Recommends line in dist/rpm/os-autoinst.spec to utilize a
boolean rich dependency '(ffmpeg >= 7 or ffmpeg >= 4)'. This makes
Zypper prefer version 7 on newer systems while safely falling back to
version 4 on older platforms.

Benefits
Ensures production workers automatically pull in and maintain ffmpeg-7
for high-performance AV1 video compression without manual
intervention.

Related issue: https://progress.opensuse.org/issues/203847