### PR TITLE
test(t/34-git): prevent parallel fetch failures by disabling git auto-gc

### DIFF
--- a/t/34-git.t
+++ b/t/34-git.t
@@ -209,6 +209,8 @@ git init >/dev/null 2>&1 && \
 git config user.email "you\@example.com" >/dev/null && \
 git config user.name "Your Name" >/dev/null && \
 git config commit.gpgsign false >/dev/null && \
+git config gc.auto 0 >/dev/null && \
+git config maintenance.auto false >/dev/null && \
 touch README.md && \
 git add README.md && \
 git commit -mInit >/dev/null


### PR DESCRIPTION
Motivation:
During heavy parallel execution, `t/34-git.t` sporadically fails during
the 'failing clone' subtest with unexpected Git errors like:
`fatal: git upload-pack: not our ref <HEAD_HASH>`
and fails to properly fetch the requested refspec.

Design Choices:
The `initialize_git_repo` function creates 10 commits sequentially using
`git commit`. In newer Git versions, this can trigger a detached
background `git maintenance run --auto` or `git gc` process. If this
background cleanup/repack process is running concurrently when the test
attempts to `git clone` or fetch from the repository, loose objects can
be deleted mid-transfer, causing the client/server negotiation to crash
with `upload-pack: not our ref`.
We configure the test repository with `gc.auto=0` and
`maintenance.auto=false` upon initialization to completely disable these
background processes, ensuring the repository remains quiescent.

Benefits:
Resolves intermittent Git `upload-pack` clone and fetch failures under
high parallel test load, improving suite stability.