### PR TITLE
feat: gracefully handle temporarily unreachable hypervisors

### DIFF
--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -41,6 +41,13 @@ sub activate ($self) {
     # initialize SSH console(s)
     $self->_init_ssh($args);
 
+    # Pre-check: Ensure hypervisor is reachable before starting Xvnc/activating console
+    my $hostname = $self->{ssh_credentials}->{default}->{hostname};
+    my $timeout = $bmwqemu::vars{SVIRT_HYPERVISOR_SSH_TIMEOUT} // 1800;
+    if (!$self->wait_for_ssh_port($hostname, timeout => $timeout)) {
+        die "backend died: hypervisor host $hostname is not reachable after $timeout seconds\n";
+    }
+
     # start Xvnc
     $self->SUPER::activate;
 

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -35,6 +35,7 @@ set_var(SVIRT_WORKER_CACHE => 1);
 
 my $ssh_xterm_vt_mock = Test::MockModule->new('consoles::sshXtermVt');
 $ssh_xterm_vt_mock->noop('activate');
+$ssh_xterm_vt_mock->mock(wait_for_ssh_port => 1);
 
 my $distri = $testapi::distri = distribution->new;
 my $svirt = backend::svirt->new;
@@ -51,6 +52,13 @@ is_deeply +{$ssh_virtsh->get_ssh_credentials}, {
     username => 'root',
     password => 'foo',
 }, 'reading SSH credentials via sshVirtsh console, username defaults to "root"';
+
+subtest 'activate dies if ssh port unreachable' => sub {
+    my $mock = Test::MockModule->new('consoles::sshXtermVt');
+    $mock->mock(wait_for_ssh_port => 0);
+    my $ssh_virtsh_unreachable = consoles::sshVirtsh->new(undef, {hostname => 'unreachable-host', password => 'foo'});
+    throws_ok { $ssh_virtsh_unreachable->activate } qr/backend died: hypervisor host unreachable-host is not reachable after 1800 seconds/, 'activate dies when hypervisor is unreachable';
+};
 
 $svirt->do_start_vm;
 $distri->add_console('root-sut-serial', 'ssh-virtsh-serial', {});


### PR DESCRIPTION
Motivation
Due to maintenance or periodic reboots, remote hypervisor hosts may be
temporarily unavailable when an openQA worker attempts to run a job.
Since openQA jobs can run for hours, a brief reboot window shouldn't
cause an immediate, unrecoverable job failure.

Design Choices
We add a pre-check for reachability using `wait_for_ssh_port` in
`sshVirtsh::activate` before initiating VNC or XML generation. If the
host is unreachable after `SVIRT_HYPERVISOR_SSH_TIMEOUT` (default 1800),
we die with a clear message.

Benefits
- Prevents starting Xvnc or parsing XML when the backend is unreachable.
- Sets up the ability for openQA to automatically clone/retry jobs that
  hit this error.

Related issue: https://progress.opensuse.org/issues/204510