### PR TITLE
test: Cover uncovered serial_screen methods

### DIFF
--- a/t/26-serial_screen.t
+++ b/t/26-serial_screen.t
@@ -18,8 +18,8 @@ $screen = consoles::serial_screen->new('same', 'same');
 is $screen->{fd_read}, 'same', 'Fd read member was set.';
 is $screen->{fd_read}, $screen->{fd_write}, 'If only one fd give, read and write are equal';
 
-dies_ok { $screen->hold_key } 'hold_key dies with error';
-dies_ok { $screen->release_key } 'release_key dies with error';
+throws_ok { $screen->hold_key(23) } qr/Virtio terminal and svirt serial terminal do not support send_key/, 'hold_key dies with error';
+throws_ok { $screen->release_key(23) } qr/Virtio terminal and svirt serial terminal do not support send_key/, 'release_key dies with error';
 dies_ok { $screen->send_key({key => 'space'}) } 'send_key dies for most keys';
 is $screen->current_screen, 0, 'no current screen';
 is $screen->request_screen_update, undef, 'can call request_screen_update';


### PR DESCRIPTION
`hold_key` and `release_key` were uncovered, but so far under perl <= 5.42 they were reported as covered, which changed now with perl 5.44.

They were uncovered because just calling `$screen->hold_key` without any
arguments complained about

    Too few arguments for subroutine 'consoles::serial_screen::hold_key'

but the test didn't actually check the content of the exception, so
the code died without actually executing the method.

Now the code checks the actual exception.