### PR TITLE
docs: document custom container execution for distribution tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,28 @@ within the container specified via `OS_AUTOINST_CONTAINER_IMAGE`. Additional dep
 (e.g. `os-autoinst-distri-opensuse-deps`) must be provided by that container image rather
 than the worker host.
 
+### Advanced testing with custom test-distribution dependencies
+
+If you are testing changes against tests that require custom dependencies not
+present in the default container image (e.g., custom dependencies like
+`os-autoinst-distri-opensuse-deps`), or if you need to run rootless Podman
+inside a restricted environment, you can bypass the default worker container
+wrap by manually overriding the `ISOTOVIDEO` command setting.
+
+For example, to run tests inside a rootless container while dynamically
+installing missing distribution dependencies and compiling your custom
+`os-autoinst` branch:
+
+```sh
+openqa-clone-job --skip-chained-deps --within-instance <target_job_url> \
+  _GROUP=0 \
+  BUILD+=-custom_suffix \
+  TEST+=-custom_suffix \
+  CASEDIR=https://github.com/<your_username>/os-autoinst-distri-opensuse.git#<your_test_branch> \
+  WORKER_CLASS=<suitable_worker_class> \
+  ISOTOVIDEO="p=/var/lib/openqa/cache/podman && mkdir -p \$p/run \$p/config \$p/data && env HOME=\$p XDG_CONFIG_HOME=\$p/config XDG_DATA_HOME=\$p/data XDG_RUNTIME_DIR=\$p/run podman --root \$p/data/containers/storage --runroot \$p/run/containers --storage-opt ignore_chown_errors=true --cgroup-manager=cgroupfs --events-backend=file run --init --rm --entrypoint \"\" --device /dev/kvm -v \$(pwd):/pool -w /pool -v /var/lib/openqa/cache:/var/lib/openqa/cache registry.opensuse.org/devel/openqa/containers/os-autoinst_dev:latest sh -c 'zypper -n in os-autoinst-distri-opensuse-deps && rm -rf os-autoinst && git clone --branch=<your_engine_branch> --depth=1 https://github.com/<your_username>/os-autoinst.git && make -C os-autoinst symlinks && os-autoinst/isotovideo -d'"
+```
+
 # Running isotovideo as CI check
 
 We provide a container to run `isotovideo` which can be used to run


### PR DESCRIPTION
Motivation:
Developers need to know how to execute openQA verification tests with custom
test-distribution dependencies (like osado) in rootless Podman containers.

Design Choices:
Extend the 'Testing os-autoinst modifications within openQA' section of the
README with a generalized, robust example of overriding ISOTOVIDEO.

Benefits:
Provides clear, reusable, and generalized documentation for testing custom
backend and test-suite dependencies.

Related issue: https://progress.opensuse.org/issues/199934