### PR TITLE
fix: use ruff:file-ignore for file-level suppressions

### DIFF
--- a/t/fake/tests/faulty.py
+++ b/t/fake/tests/faulty.py
@@ -1,2 +1,2 @@
-# ruff: noqa: F401, D100, CPY001, INP001
+# ruff:file-ignore[F401, D100, CPY001, INP001]
 import thismoduleshouldnotexist


### PR DESCRIPTION
Motivation:
A recent update in Ruff (0.15.22+) introduced the RUF105 rule, which flags the
use of 'ruff: noqa' in favor of 'ruff:file-ignore'.

Design Choices:
Replaced '# ruff: noqa: <rules>' with '# ruff:file-ignore[<rules>]' in the only
affected Python test file.

Benefits:
Ensures compatibility with newer Ruff releases and passes the style check in CI.

Related issue: https://github.com/os-autoinst/os-autoinst/pull/3044