### PR TITLE
fix: look for KERNEL and INITRD as asset

### DIFF
--- a/backend/qemu.pm
+++ b/backend/qemu.pm
@@ -730,14 +730,14 @@ sub start_qemu ($self) {
         die 'No UEFI firmware can be found! Please specify UEFI_PFLASH_CODE/UEFI_PFLASH_VARS or BIOS or UEFI_BIOS or install an appropriate package' unless $vars->{UEFI_PFLASH_CODE};
     }
 
+    # A non-absolute path is relative to /usr/share/qemu
+    $vars->{BIOS} = '/usr/share/qemu/' . $vars->{BIOS} if $vars->{BIOS} && $vars->{BIOS} !~ /^\//;
+
+    # Convert those vars to absolute paths and check for existence
     foreach my $attribute (qw(KERNEL INITRD BIOS)) {
-        if ($vars->{$attribute} && $vars->{$attribute} !~ /^\//) {
-            # Non-absolute paths are assumed relative to /usr/share/qemu
-            $vars->{$attribute} = '/usr/share/qemu/' . $vars->{$attribute};
-        }
-        if ($vars->{$attribute} && !-e $vars->{$attribute}) {
-            die "'$vars->{$attribute}' missing, check $attribute\n";
-        }
+        next unless $vars->{$attribute};
+        $vars->{$attribute} = path($vars->{$attribute})->to_abs->to_string;
+        die "'$vars->{$attribute}' missing, check $attribute\n" unless -e $vars->{$attribute};
     }
 
     if ($vars->{LAPTOP}) {

--- a/doc/backend_vars.md
+++ b/doc/backend_vars.md
@@ -111,7 +111,7 @@ Supported variables per backend
 | ARCH | x86_64\|i686\|aarch64\|... | depends on tested medium | Architecture of VM. |
 | APPEND | string |  | Kernel options to pass when using the KERNEL variable, see https://qemu-project.gitlab.io/qemu/system/linuxboot.html |
 | ATACONTROLLER | see qemu -device ?, e. g. for SATA: ich9-ahci |  | Controller for ATA devices, needed for connecting disks as SATA. |
-| BIOS | string |  | Set the filename for the BIOS |
+| BIOS | string |  | Set the filename for the BIOS. Relative paths are assumed to be relative to `/usr/share/qemu/`. |
 | BOOT_HDD_IMAGE | boolean |  | enables boot from HDD_1 (BOOTFROM has higher priority) |
 | BOOT_MENU | boolean | undef | enables boot menu for selection of boot device |
 | BOOT_MENU_TIMEOUT | integer | 5000 | boot menu timeout in ms. Needs BOOT_MENU |
@@ -126,10 +126,10 @@ Supported variables per backend
 | HDDNUMQUEUES_$i | integer | -1 | see qemu-system-x86_64 -device nvme,help - set the number of queues for HDD_$i |
 | HDDSECTORSIZE_$i | integer | undef | specifies the physical and logical block size and boot sector size of the HDD image |
 | ISO | filename |  | Filename of ISO file to be attached to VM |
-| INITRD | filename |  | Path to the initrd (initial ramdisk) image for direct kernel boot. Relative paths are assumed to be relative to `/usr/share/qemu/`. |
+| INITRD | filename |  | Path to the initrd (initial ramdisk) image for direct kernel boot. |
 | ISO_$i | filename |  | Additional ISO to be attached to VM. Up to 9 |
 | KEEPHDDS | boolean |  | Leave created HDD after test finishes. Useful for debugging tests |
-| KERNEL | filename |  | Path to kernel image for direct kernel boot. When specified, QEMU will boot directly into this kernel without using a bootloader. Relative paths are assumed to be relative to `/usr/share/qemu/`. |
+| KERNEL | filename |  | Path to kernel image for direct kernel boot. When specified, QEMU will boot directly into this kernel without using a bootloader. |
 | LAPTOP | boolean or filename | 0 | If 1, loads HP EliteBook 820 G1 DMI. If filename, loads specified DMI |
 | MAKETESTSNAPSHOTS | boolean | 0 | Save snapshot for each test module in qcow image |
 | MULTIPATH | boolean | 0 | Add HDD drives as multipath devices. Override HDDMODEL to virtio-scsi-pci |

--- a/t/18-backend-qemu.t
+++ b/t/18-backend-qemu.t
@@ -685,7 +685,7 @@ subtest 'special cases when starting QEMU' => sub {
     # set certain variables to test special handling for them that is not otherwise tested
     $bmwqemu::topdir = "$Bin/..";    # for dmi data
     $bmwqemu::vars{ARCH} = 'x86_64';
-    $bmwqemu::vars{KERNEL} = 'linuxboot_dma.bin';
+    $bmwqemu::vars{BIOS} = 'bios.bin';
     $bmwqemu::vars{LAPTOP} = '1';
     $bmwqemu::vars{BOOT_HDD_IMAGE} = 1;
     $bmwqemu::vars{MULTIPATH} = 1;
@@ -713,7 +713,7 @@ subtest 'special cases when starting QEMU' => sub {
     my @invoked_cmds;
     $backend_mock->redefine(runcmd => sub (@cmd) { push @invoked_cmds, join ' ', @cmd });
     combined_like { $backend->start_qemu } qr{.*slirpvde --dhcp -s ./vde.ctl --port 87 started with pid 1.*not starting CPU}s, 'slirpvde started, DELAYED_START logged';
-    like $bmwqemu::vars{KERNEL}, qr{/.*/linuxboot_dma\.bin}, 'KERNEL set to absolute location';
+    like $bmwqemu::vars{BIOS}, qr{/.*/bios\.bin}, 'BIOS set to absolute location';
     is $bmwqemu::vars{LAPTOP}, 'hp_elitebook_820g1', 'default laptop model assigned for LAPTOP=1';
     is $bmwqemu::vars{BOOTFROM}, 'c', 'BOOTFROM defaults to "c" for BOOT_HDD_IMAGE=1';
     is $bmwqemu::vars{HDDMODEL}, 'scsi-hd', 'HDDMODEL set for MULTIPATH=1';
@@ -807,7 +807,7 @@ subtest 'special cases when starting QEMU' => sub {
         combined_like { throws_ok { $backend->start_qemu } qr{no dmi data for 'auslaufmoDELL'}, 'dies on unknown LAPTOP' }
           qr/qemu version/si, 'expected logs until exception thrown (4)';
         $bmwqemu::vars{KERNEL} = 'does-not-exist';
-        combined_like { throws_ok { $backend->start_qemu } qr{'/.*/does-not-exist' missing, check KERNEL}, 'dies on non-existant BOOT/KERNEL/INITRD' }
+        combined_like { throws_ok { $backend->start_qemu } qr{'/.*/does-not-exist' missing, check KERNEL}, 'dies on non-existant BIOS/KERNEL/INITRD' }
           qr/qemu version/si, 'expected logs until exception thrown (5)';
         $bmwqemu::vars{UEFI} = 1;
         $bmwqemu::vars{UEFI_PFLASH_CODE} = 0;


### PR DESCRIPTION
The openQA worker treats them as asset and downloads them, but then os-autoinst ignored them and used the file from /usr/share/qemu instead. (Yes, apparently it never worked in the past.)

Treat them as downloaded assets, just like UEFI_PFLASH_{CODE,VARS}, but keep the behaviour for BIOS.

Adjust the documentation accordingly.

Related ticket: https://progress.opensuse.org/issues/194609

Verification run: http://10.168.5.231/tests/2081