### PR TITLE
fix(testapi): apply timeout in assert_screen_change

### DIFF
--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -9,7 +9,7 @@ use Mojo::Base -strict, -signatures;
 # -> increment on every change of such APIs
 # -> never move that variable to another place (when refactoring)
 #    because it may be accessed by the tests itself
-our $version = 57;    ## no critic (Variables::ProhibitPackageVars)
+our $version = 58;    ## no critic (Variables::ProhibitPackageVars)
 
 # major version of the (web socket) API relevant to the developer mode
 # -> increment when making non-backward compatible changes to that API

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -298,6 +298,17 @@ subtest 'send_key with wait_screen_change' => sub {
 
 subtest 'assert_screen_change' => sub {
     combined_like { testapi::assert_screen_change { say 'something' } } qr/something/, 'callback invoked';
+
+    my $received_timeout = 'unset';
+    my $mock_wsc = Test::MockModule->new('testapi');
+    $mock_wsc->redefine(wait_screen_change => sub : prototype(&@) {
+            my ($callback, $timeout, %args) = @_;
+            $received_timeout = $timeout;
+            $callback->() if $callback;
+            return 1;
+    });
+    testapi::assert_screen_change(sub { }, 42);
+    is $received_timeout, 42, 'timeout forwarded to wait_screen_change';
 };
 
 is $autotest::current_test->{dents}, 0, 'no soft failures so far';

--- a/testapi.pm
+++ b/testapi.pm
@@ -644,7 +644,7 @@ sub assert_screen_change : prototype(&@) {    # no:style:signatures
     # wait_screen_change uses prototype which expects code block as an argument
     # This resolves compile time issues
     my ($coderef, @args) = @_;
-    wait_screen_change(\&{$coderef}, @_) or die 'assert_screen_change failed to detect a screen change';
+    wait_screen_change(\&{$coderef}, @args) or die 'assert_screen_change failed to detect a screen change';
 }
 
 


### PR DESCRIPTION
assert_screen_change use the original `@_` to wait_screen_change instead of the unpacked `@args`, using `@args` fixes this while the default timeout stays 10s.

reference: https://progress.opensuse.org/issues/50093