### PR TITLE
feature: Show stacktrace for failed assert_script_run and needle match

### DIFF
--- a/OpenQA/Exceptions.pm
+++ b/OpenQA/Exceptions.pm
@@ -25,6 +25,9 @@ use Exception::Class (
     'OpenQA::Exception::ConsoleReadError' => {
         description => 'Failed to receive data from console'
     },
+    'OpenQA::Exception::TestapiError' => {
+        description => 'A testapi function failed'
+    },
 );
 
 1;

--- a/autotest.pm
+++ b/autotest.pm
@@ -516,9 +516,8 @@ sub croak ($command, $error) {
     return bmwqemu::diag "ignoring failure via developer mode: $error"
       if autotest::pause_on_failure("$command failed: $error", $command)->{ignore_failure};
 
-    # … or escalate the failure as usual via croak
-    local $Carp::CarpLevel = 2;    # omit this helper function in the trace
-    Carp::croak $error;
+    # … or escalate the failure as usual via Exception
+    OpenQA::Exception::TestapiError->throw(error => $error);
 }
 
 my $failed_command;

--- a/basetest.pm
+++ b/basetest.pm
@@ -328,15 +328,32 @@ sub runtest ($self) {
     catch ($e) {
         # copy the exception early
         my $internal = Exception::Class->caught('OpenQA::Exception::InternalException');
-        $error_message = $e;
+
+        my $stacktrace = [];
+        $error_message = "$e";
+        if ((ref $e) =~ 'OpenQA::Exception::(?:TestapiError|FailedNeedle)') {
+            my $s = $e->error;
+            while (my $frame = $e->trace->next_frame) {
+                push @$stacktrace, {filename => $frame->filename, line => $frame->line, sub => $frame->subroutine, frame => $frame->as_string};
+            }
+            $stacktrace = bmwqemu::filter_stack_trace($stacktrace);
+        }
+        else {
+            if ($error_message =~ m/ at ((\S+) line (\d+))/) {
+                $stacktrace = bmwqemu::filter_stack_trace([{filename => $2, line => $3, frame => $1}]);
+            }
+        }
+
         $self->{result} = 'fail';
         # add a fail screenshot in case there is none
         if (!@{$self->{details}} || ($self->{details}->[-1]->{result} || '') ne 'fail') {
+            bmwqemu::update_line_number([reverse @$stacktrace]);
             $self->take_screenshot();
         }
-        if (!$internal && $e =~ /Can't locate .+ in \@INC/) {
+        if (!$internal && $error_message =~ /Can't locate .+ in \@INC/) {
             my $msg = "# Test died with missing dependency: $e";
             bmwqemu::fctinfo($msg);
+            bmwqemu::update_line_number();
             $self->record_resultfile('Failed', $msg, result => 'fail');
             $self->{fatal_failure} = 1;
             bmwqemu::serialize_state(component => 'tests', msg => "Missing Perl module: $e", result => 'incomplete');
@@ -344,8 +361,12 @@ sub runtest ($self) {
         }
         # show a text result with the die message unless the die was internally generated
         if (!$internal) {
-            my $msg = "# Test died: $e";
+            my $msg = "# Test died: $error_message";
+            if (@$stacktrace) {
+                $msg .= "\n--- # stack trace\n" . (join '', map { $_->{frame} . "\n" } @$stacktrace);
+            }
             bmwqemu::fctinfo($msg);
+            bmwqemu::update_line_number([reverse @$stacktrace]);
             $self->record_resultfile('Failed', $msg, result => 'fail');
             $died = 1;
         }

--- a/bmwqemu.pm
+++ b/bmwqemu.pm
@@ -227,16 +227,35 @@ sub current_test () {
     return $autotest::current_test;
 }
 
-sub update_line_number () {
+sub filter_stack_trace ($stacktrace, $casedir = $vars{CASEDIR}) {
+    my @filtered;
+    $casedir //= '';
+    for my $frame (@$stacktrace) {
+        my $filename = $frame->{filename};
+        next unless $filename && $filename =~ /\Q$casedir/;
+        $frame->{filename} =~ s{$casedir/?}{};
+        $frame->{frame} =~ s{$casedir/?}{} if $frame->{frame};
+        push @filtered, $frame;
+    }
+    return \@filtered;
+}
+
+sub update_line_number ($stacktrace = undef) {
     return unless my $current_test = current_test;
     return unless $current_test->{script};
     my @out;
-    my $casedir = $vars{CASEDIR} // '';
-    for (my $i = 10; $i > 0; $i--) {
-        my ($package, $filename, $line, $subroutine) = caller $i;
-        next unless $filename && $filename =~ /\Q$casedir/;
-        $filename =~ s@$casedir/?@@;
-        push @out, "$filename:$line called $subroutine";
+    unless ($stacktrace) {
+        my @stack;
+        for (my $i = 10; $i > 0; $i--) {
+            my ($package, $filename, $line, $subroutine) = caller $i;
+            push @stack, {filename => $filename, line => $line, sub => $subroutine};
+        }
+        $stacktrace = filter_stack_trace(\@stack);
+    }
+    for my $st (@$stacktrace) {
+        my $out = sprintf '%s:%d', $st->{filename}, $st->{line};
+        $out .= " called $st->{sub}" if $st->{sub};
+        push @out, $out;
     }
     my $step_info = sprintf '[step:%s,%s,%s]',
       $current_test->{category} // '-', $current_test->{name} // '-', ($current_test->{test_count} // 0) + 1;

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -349,6 +349,7 @@ subtest 'script_run' => sub {
         throws_ok { assert_script_run 'false', 7, 'my custom fail message'; }
         qr/command.*false.*failed: my custom fail message/,
           'custom message on die';
+        throws_ok { assert_script_run 'false', 42 } 'OpenQA::Exception::TestapiError', 'throws exception';
     };
 
     subtest failures => sub {
@@ -363,6 +364,8 @@ subtest 'script_run' => sub {
         throws_ok { script_run('sleep 13', timeout => 10, quiet => 1) } qr/command.*timed out/, 'exception occurred on script_run() timeout';
         throws_ok { script_run('sleep 13', timeout => 10, quiet => 1) } qr/command.*timed out/, 'exception occurred on script_run() timeout';
         throws_ok { assert_script_run('sleep 13', timeout => 10, quiet => 1) } qr/command.*timed out/, 'exception occurs on assert_script_run() timeout by default';
+
+        throws_ok { assert_script_run 'false', 0; } 'OpenQA::Exception::TestapiError', 'throws exception';
     };
 
     $fake_matched = 1;
@@ -486,6 +489,7 @@ subtest 'check_assert_screen' => sub {
 
     subtest 'handle check_screen timeout' => sub {
         $cmds = [];
+        local $autotest::current_test->{test_count} = 0;
         $autotest::current_test->{details} = [];
 
         ok !check_screen('foo', 3, timeout => 2);
@@ -510,7 +514,7 @@ subtest 'check_assert_screen' => sub {
         is_deeply $autotest::current_test->{details}, [
             {
                 result => 'unk',
-                screenshot => 'basetest-14.png',
+                screenshot => 'basetest-1.png',
                 frametime => [qw(1.75 1.79)],
                 tags => [qw(fake tags)],
             }
@@ -521,13 +525,14 @@ subtest 'check_assert_screen' => sub {
     $report_timeout_called = 0;
 
     subtest 'module step logging' => sub {
+        local $autotest::current_test->{test_count} = 0;
         local $autotest::current_test->{script} = 'dummy';
         local $autotest::current_test->{category} = 'cat';
         combined_like {
             throws_ok { assert_screen('foo', 3, timeout => 2) }
             qr/no candidate needle/,
               'error message like expeected';
-        } qr{\Q[step:cat,basetest,16]\E.*called testapi::assert_screen}, 'module step logged in case of failed assert_screen';
+        } qr{\Q[step:cat,basetest,2]\E.*called testapi::assert_screen}, 'module step logged in case of failed assert_screen';
     };
 
     subtest 'handle assert_screen timeout' => sub {

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -249,7 +249,6 @@ subtest 'test always_rollback flag' => sub {
     undef $mock_basetest;
 };
 
-
 subtest run_args => sub {
     my $mock_autotest = Test::MockModule->new('autotest', no_auto => 1);
     $mock_autotest->noop('_terminate');
@@ -370,6 +369,28 @@ subtest 'failing tests' => sub {
     is @{$autotest::tests{'tests-fatal'}}{@opts}, @{$autotest::tests{'tests-fatal' . $_}}{@opts}, "tests-fatal$_ share same options with tests-fatal"
       and is $autotest::tests{'tests-fatal' . $_}->{name}, 'fatal#' . $_
       for 1 .. 10;
+
+};
+
+subtest 'exceptions' => sub {
+    my $mock_autotest = Test::MockModule->new('autotest');
+    $mock_autotest->noop('_terminate');
+    %autotest::tests = ();
+    @autotest::testorder = ();
+    %autotest::scheduled_basenames = ();
+    my $stepinfo = qr{\[step:tests,exc,1\] tests/exception.pm:\d+ called exception::something -> tests/exception.pm:\d+ called .*throw};
+    my $stack = qr{Test died: ON PURPOSE\n.*--- \# stack trace\n.*throw.*called at tests/exception.pm line \d+\n.*exception::something at tests/exception.pm line \d+};
+    subtest 'exception' => sub {
+        local $ENV{THROW_EXCEPTION} = 1;
+        stderr_like { autotest::loadtest('tests/exception.pm', name => 'exc'); autotest::run_all } qr{$stack.*$stepinfo}s, 'OpenQA::Exception::TestapiError produces step info and stack trace';
+    };
+    subtest 'perl die' => sub {
+        $stepinfo = qr{\[step:tests,exc,2\] tests/exception.pm:\d+};
+
+        $stack = qr{Test died: Illegal division by zero.*\n.*--- \# stack trace\n.*tests/exception.pm line \d+}s;
+        local $ENV{PERL_DIE} = 1;
+        stderr_like { autotest::loadtest('tests/exception.pm', name => 'exc'); autotest::run_all } qr{$stack.*$stepinfo}s, 'perl internal error produces step info and stack trace';
+    };
 };
 
 subtest 'scheduling rules' => sub {

--- a/t/fake/tests/exception.pm
+++ b/t/fake/tests/exception.pm
@@ -1,0 +1,16 @@
+use Mojo::Base 'basetest', -signatures;
+
+sub run ($) {
+    something();
+}
+
+sub something () {
+    OpenQA::Exception::TestapiError->throw(error => 'ON PURPOSE') if $ENV{THROW_EXCEPTION};
+    my $x = 23;
+    if ($ENV{PERL_DIE}) {
+        my $y = $x / 0;
+    }
+}
+
+1;
+


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/201840

For failed assert_script_run and failed needle matches this adds
`[step:category,testname,line]` info to autoinst-log.txt and a stack trace
(only files from the test distribution) to the text result.

    # Test died: command 'some command' failed
    --- # stack trace
    testapi::assert_script_run('some command') called at tests/x/y.pm line 19
    prepare::something at tests/install/prepare.pm line 7


Right now we only get this which points to a location in autotest:
```
# Test died: command 'openqa-clone-job ...' timed out at /usr/lib/os-autoinst/autotest.pm line 582.
```

Also in the log file the call stack is now shown with links to the source code.

For plain `die`s or `croak`s or perl errors it at least strips the full path, and it shows the link to the source code in the log too.

Also I'm thinking about a common format of such error messages in the text result file, so that we can also generate the links to the source code directly from the module step without the detour over the log file.


<img width="698" height="232" alt="module-step-stacktrace-assert-screen" src="https://github.com/user-attachments/assets/ddcdc8d2-2e5f-4383-b413-2d77925231b8" />
<img width="803" height="224" alt="module-step-stacktrace-assert-script-run" src="https://github.com/user-attachments/assets/189afe16-166f-4148-a1ee-90f5701b277e" />
<img width="1025" height="237" alt="module-step-stacktrace-die" src="https://github.com/user-attachments/assets/41d6e254-5554-40e2-a347-a963c5bc7e42" />
