### PR TITLE
test: Prevent test failures due to language setting

### DIFF
--- a/t/13-osutils.t
+++ b/t/13-osutils.t
@@ -12,6 +12,8 @@ use Test::MockModule;
 use Test::Warnings qw(:all :report_warnings);
 use Test::Output qw(stderr_like stderr_unlike);
 
+BEGIN { $ENV{LANG} = 'C.utf8' }
+
 subtest qv => sub {
     use osutils 'qv';
 

--- a/t/34-git.t
+++ b/t/34-git.t
@@ -17,6 +17,8 @@ use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use Test::Warnings ':report_warnings';
 
+BEGIN { $ENV{LANG} = 'C.utf8' }
+
 my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
 my $git_repo = 'tmpgitrepo';
 my $git_dir = "$dir/source/$git_repo";

--- a/xt/30-make.t
+++ b/xt/30-make.t
@@ -11,6 +11,8 @@ use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '20';
 
+BEGIN { $ENV{LANG} = 'C.utf8' }
+
 my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
 my $srcdir = path("$Bin/..")->realpath;
 # some git variables might be set if this test is


### PR DESCRIPTION
Ensure tests that rely on English output have the language configured accordingly.

The CMake build script and Makefile don't override `LANG` so far so using these wrappers doesn't help.

This change adds the override on test level so one can just use plain `prove` and tests won't fail.