### PR TITLE
test: Prevent `xt/02-perlcritic.t` from failing due to untracked files

### DIFF
--- a/xt/02-perlcritic.t
+++ b/xt/02-perlcritic.t
@@ -8,4 +8,7 @@ use Test::Perl::Critic;
 use Perl::Critic::Utils qw(all_perl_files);
 
 my @files = grep { not m{^(?:t/fake|t/data|t/temp-.*|external/|install/|build/|local/|_Inline/|cover_db/|dist/)} } all_perl_files('.');
+chomp(my @git_files = qx{git ls-files});
+my %seen;
+@files = grep { $seen{$_}++ } @files, @git_files if @git_files;    # exclude files not in Git
 all_critic_ok(@files);


### PR DESCRIPTION
It is often useful to have some additional test scripts around but so far this can lead to `xt/02-perlcritic.t` failing. With this change this test only considers files that are tracked in Git if it is a Git checkout.