### PR TITLE
feat: Add backend and console for OVA image tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(PERL_FILES
     backend/generalhw.pm
     backend/ipmi.pm
     backend/null.pm
+    backend/ova.pm
     backend/pvm_hmc.pm
     backend/qemu.pm
     backend/s390x.pm
@@ -37,6 +38,7 @@ set(PERL_FILES
     consoles/ssh_screen.pm
     consoles/sshSerial.pm
     consoles/sshVirtsh.pm
+    consoles/sshVirtshOVA.pm
     consoles/sshVirtshSUT.pm
     consoles/sshX3270.pm
     consoles/sshXtermIPMI.pm

--- a/backend/ova.pm
+++ b/backend/ova.pm
@@ -1,0 +1,28 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package backend::ova;
+use Mojo::Base 'backend::svirt', -signatures;
+use bmwqemu;
+
+sub do_start_vm ($self, @) {
+    my $vars = \%bmwqemu::vars;
+    my $n = $vars->{NUMDISKS} // 1;
+    $vars->{NUMDISKS} //= defined($vars->{RAIDLEVEL}) ? 4 : $n;
+    $self->truncate_serial_file;
+    my $ssh = $testapi::distri->add_console(
+        'svirt',
+        'ssh-virtsh-ova',
+        {
+            hostname => $bmwqemu::vars{VIRSH_HOSTNAME} || die('Need variables VIRSH_HOSTNAME'),
+            username => $bmwqemu::vars{VIRSH_USERNAME},
+            password => $bmwqemu::vars{VIRSH_PASSWORD},
+        });
+
+    $ssh->backend($self);
+
+    bmwqemu::save_vars();    # update variables
+    return {};
+}
+
+1;

--- a/consoles/sshVirtshOVA.pm
+++ b/consoles/sshVirtshOVA.pm
@@ -89,6 +89,17 @@ __END}
             $self->run_cmd(qq{sed -i 's/^virtualHW.version = ".*"/virtualHW.version = "$bmwqemu::vars{VMWARE_VM_HWVERSION}"/' $vmx}, domain => 'sshVMwareServer');
         }
 
+        # Enable VNC for direct console access if VMWARE_VNC_OVER_WS is not set
+        if (!$bmwqemu::vars{VMWARE_VNC_OVER_WS}) {
+            my $vnc_offset = $bmwqemu::vars{VNC} // ($bmwqemu::vars{WORKER_ID} // 0);
+            my $vncport = 5900 + $vnc_offset;
+            $self->run_cmd(qq{echo 'RemoteDisplay.vnc.enabled = "TRUE"' >> $vmx}, domain => 'sshVMwareServer');
+            $self->run_cmd(qq{echo 'RemoteDisplay.vnc.port = "$vncport"' >> $vmx}, domain => 'sshVMwareServer');
+            if (my $vnc_password = $testapi::password) {
+                $self->run_cmd(qq{echo 'RemoteDisplay.vnc.password = "$vnc_password"' >> $vmx}, domain => 'sshVMwareServer');
+            }
+        }
+
         # provisioning (guestinfo combustion/ignition/cloud-init)
         my $fb_tool = $bmwqemu::vars{GUESTINFO_CONFIG};
         if ($fb_tool && $fb_tool ne 'wizard') {

--- a/consoles/sshVirtshOVA.pm
+++ b/consoles/sshVirtshOVA.pm
@@ -1,0 +1,137 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package consoles::sshVirtshOVA;
+
+use Mojo::Base 'consoles::sshVirtsh', -signatures;
+use autodie ':all';
+use Feature::Compat::Try;
+use File::Temp 'tempfile';
+use Mojo::DOM;
+use Mojo::URL;
+use Carp 'croak';
+use bmwqemu;
+
+sub _shell_escape ($arg) {
+    if ($arg =~ m{^[a-zA-Z0-9_.-]+$}) {
+        return $arg;
+    }
+    $arg =~ s{'}{'\\''}g;
+    return "'$arg'";
+}
+
+sub define_and_start ($self, %args) {
+    $args{pre_cleanup} //= 1;
+
+    # 1. Destroy and undefine previous VM if pre_cleanup is set
+    $self->backend->do_stop_vm_svirt() if $args{pre_cleanup};
+
+    # 2. Extract parameters for deployment
+    my $ova_path = $bmwqemu::vars{OVA} // $bmwqemu::vars{HDD_1} or die 'Need variable OVA or HDD_1';
+    my $vmware_host = $bmwqemu::vars{VMWARE_HOST} or die 'Need variable VMWARE_HOST';
+    my $vmware_username = $bmwqemu::vars{VMWARE_USERNAME} // 'root';
+    my $vmware_password = $bmwqemu::vars{VMWARE_PASSWORD} or die 'Need variable VMWARE_PASSWORD';
+    my $vmware_datastore = $bmwqemu::vars{VMWARE_DATASTORE};
+    my $vmware_network = $bmwqemu::vars{VMWARE_NETWORK};
+
+    my $target_url = Mojo::URL->new();
+    $target_url->scheme('vi');
+    $target_url->userinfo("$vmware_username:$vmware_password");
+    $target_url->host($vmware_host);
+
+    # Build the ovftool command
+    my @ovf_cmd = qw(ovftool --acceptAllEulas --noSSLVerify --overwrite --powerOffTarget);
+    push @ovf_cmd, '--name=' . $self->name;
+    push @ovf_cmd, '--datastore=' . $vmware_datastore if $vmware_datastore;
+    if ($vmware_network) {
+        my $source_net = $bmwqemu::vars{VMWARE_SOURCE_NETWORK} // 'VM Network';
+        push @ovf_cmd, "--net:$source_net=$vmware_network";
+    }
+    if (my $extra_args = $bmwqemu::vars{OVFTOOL_ARGS}) {
+        push @ovf_cmd, split /\s+/, $extra_args;
+    }
+    push @ovf_cmd, $ova_path;
+    push @ovf_cmd, $target_url->to_unsafe_string;
+
+    my $cmd_str = join ' ', map { _shell_escape($_) } @ovf_cmd;
+    bmwqemu::diag("Deploying OVA using ovftool: $cmd_str");
+
+    # Run the command with retries on timeouts if configured
+    my $ret = $self->run_cmd_retrying_on_timeouts($cmd_str);
+    die "ovftool deployment failed: $ret\n" if $ret;
+
+    # 3. Write guestinfo and other customizations to the .vmx file on ESXi host
+    if ($self->vmm_family eq 'vmware') {
+        my ($fh, $libvirtauthfilename) = File::Temp::tempfile('libvirtauth-XXXX', DIR => '/tmp/');
+        $self->run_cmd(
+            qq{cat > $libvirtauthfilename <<__END
+[credentials-vmware]
+username=$vmware_username
+password=$vmware_password
+[auth-esx-$vmware_host]
+credentials=vmware
+__END}
+        );
+        my $remote_vmm = "-c esx://$vmware_username\@$vmware_host/?no_verify=1\\&authfile=$libvirtauthfilename ";
+        $bmwqemu::vars{VMWARE_REMOTE_VMM} = $remote_vmm;
+
+        my $vmx = sprintf '/vmfs/volumes/%s/%s/%s.vmx', $vmware_datastore // 'datastore1', $self->name, $self->name;
+
+        # set default boot delay
+        $self->run_cmd(qq{echo 'bios.bootDelay = "10000"' >> $vmx}, domain => 'sshVMwareServer');
+        # set default nvram
+        my $nvram = $self->name . '.nvram';
+        my $nvram_path = sprintf '/vmfs/volumes/%s/%s/%s', $vmware_datastore // 'datastore1', $self->name, $nvram;
+        $ret = $self->run_cmd("test -e $nvram_path", domain => 'sshVMwareServer');
+        $self->run_cmd(qq{echo 'nvram = "$nvram"' >> $vmx}, domain => 'sshVMwareServer') unless ($ret);
+        # set virtual hardware version if specified
+        if ($bmwqemu::vars{VMWARE_VM_HWVERSION}) {
+            $self->run_cmd(qq{sed -i 's/^virtualHW.version = ".*"/virtualHW.version = "$bmwqemu::vars{VMWARE_VM_HWVERSION}"/' $vmx}, domain => 'sshVMwareServer');
+        }
+
+        # provisioning (guestinfo combustion/ignition/cloud-init)
+        my $fb_tool = $bmwqemu::vars{GUESTINFO_CONFIG};
+        if ($fb_tool && $fb_tool ne 'wizard') {
+            my $encoding = 'gzip+base64';
+            if ($fb_tool =~ /combustion|ignition/) {
+                if ($bmwqemu::vars{GUESTINFO_COMBUSTION}) {
+                    my $conf = $self->_encode_config($bmwqemu::vars{GUESTINFO_COMBUSTION}, 'GUESTINFO_COMBUSTION');
+                    $self->run_cmd(qq{echo 'guestinfo.combustion.script = "$conf"' >> $vmx}, domain => 'sshVMwareServer');
+                }
+                if ($bmwqemu::vars{GUESTINFO_IGNITION}) {
+                    my $conf = $self->_encode_config($bmwqemu::vars{GUESTINFO_IGNITION}, 'GUESTINFO_IGNITION');
+                    $self->run_cmd(qq{echo 'guestinfo.ignition.config.data.encoding = "$encoding"' >> $vmx}, domain => 'sshVMwareServer');
+                    $self->run_cmd(qq{echo 'guestinfo.ignition.config.data = "$conf"' >> $vmx}, domain => 'sshVMwareServer');
+                }
+            } elsif ($fb_tool eq 'cloud-init') {
+                croak 'GUESTINFO_CLOUD_INIT is unset, or does not contain user-data and meta-data configs' unless ($bmwqemu::vars{GUESTINFO_CLOUD_INIT});
+
+                my ($conf, $meta) = split /,/, $bmwqemu::vars{GUESTINFO_CLOUD_INIT};
+                $self->run_cmd(qq{echo 'guestinfo.userdata.encoding = "$encoding"' >> $vmx}, domain => 'sshVMwareServer');
+                $self->run_cmd(qq{echo 'guestinfo.metadata.encoding = "$encoding"' >> $vmx}, domain => 'sshVMwareServer');
+                $conf = $self->_encode_config($conf, 'GUESTINFO_CLOUD_INIT');
+                $self->run_cmd(qq{echo 'guestinfo.userdata = "$conf"' >> $vmx}, domain => 'sshVMwareServer');
+                $meta = $self->_encode_config($meta, 'GUESTINFO_CLOUD_INIT');
+                $self->run_cmd(qq{echo 'guestinfo.metadata = "$meta"' >> $vmx}, domain => 'sshVMwareServer');
+            } else {
+                croak 'Unknown provisioning option has been passed through GUESTINFO_CONFIG test variable';
+            }
+        }
+    }
+
+    # 4. Start the VM using virsh
+    $ret = $self->run_cmd(backend::svirt::virsh() . ' start ' . $self->name . ' 2> >(tee /tmp/os-autoinst-' . $self->name . '-stderr.log >&2)');
+    bmwqemu::diag('Dump actually used libvirt configuration file ' . ($ret ? '(broken)' : '(working)'));
+    my $config = $self->get_cmd_output(backend::svirt::virsh() . ' dumpxml ' . $self->name);
+    die "virsh start failed: $ret\n\nvirsh domain XML:\n$config" if $ret;
+    my $config_domain = Mojo::DOM->new($config)->at('domain');
+    my $vm_id = $config_domain ? $config_domain->attr('id') : '';
+    die "virsh domain XML does not specify VM ID which is required from VNC over WebSockets:\n$config" if !$vm_id && $bmwqemu::vars{VMWARE_VNC_OVER_WS};
+    $bmwqemu::vars{VIRSH_VM_ID} = $vm_id;
+
+    $self->backend->start_serial_grab($self->name);
+
+    return;
+}
+
+1;

--- a/distribution.pm
+++ b/distribution.pm
@@ -44,6 +44,7 @@ sub add_console ($self, $testapi_console, $backend_console, $backend_args = unde
         'ssh-serial' => 'sshSerial',
         'ssh-xterm' => 'sshXtermVt',
         'ssh-virtsh' => 'sshVirtsh',
+        'ssh-virtsh-ova' => 'sshVirtshOVA',
         'ssh-virtsh-serial' => 'sshVirtshSUT',
         'vnc-base' => 'vnc_base',
         'local-Xvnc' => 'localXvnc',

--- a/doc/backend_vars.md
+++ b/doc/backend_vars.md
@@ -250,6 +250,9 @@ Supported variables per backend
 | VMWARE_VNC_OVER_WS | boolean | 0 | Whether to use VNC over WebSockets (instead of raw VNC connection) |
 | VMWARE_VNC_OVER_WS_INSECURE | boolean | 0 | Do not require a valid TLS certificate for VNC over WebSockets |
 | VMWARE_VM_HWVERSION | integer |  | VM hardware version |
+| VMWARE_SOURCE_NETWORK | string | VM Network | Source network name inside the OVA package |
+| OVA | string |  | Path or filename of the OVA image (fallback to HDD_1 if not set) |
+| OVFTOOL_ARGS | string |  | Optional extra arguments to pass directly to ovftool |
 | GUESTINFO_COMBUSTION | string |  | Set the location of combustion's bash script file among the data folder |
 | GUESTINFO_IGNITION | string |  | Set the location of ignition's config file formated in json, among the data folder |
 | GUESTINFO_CLOUD_INIT | string |  | Set the location of user-data and meta-data files, separated by a comma in data folder |

--- a/doc/backends.md
+++ b/doc/backends.md
@@ -172,6 +172,37 @@ config should apply automatically so jobs can be cloned as-is.
   the timeout in the user menu (if you are annoyed by having to re-login all the
   time).
 
+## OVA
+
+The `ova` backend is designed to test OVA (Open Virtual Appliance) images on
+VMware ESXi. While the `svirt` backend manages standard VMs using `virsh` (via
+the libvirt `esx://` driver), `virsh` cannot import OVA images directly.
+
+The `ova` backend solves this by using VMware's `ovftool` on the linux worker
+host to deploy/import the OVA image to the ESXi host, and then uses the
+standard `svirt` / `virsh` infrastructure to configure, start, and manage the
+VM.
+
+The `ova` backend is enabled via `BACKEND=ova`.
+
+### Worker configuration
+
+Example configuration for using the `ova` backend (add to
+`$OPENQA_CONFIG/workers.ini`):
+```ini
+[4]
+BACKEND=ova
+WORKER_CLASS=svirt-vmware-ova
+VIRSH_HOSTNAME=127.0.0.1
+VIRSH_USERNAME=root
+VIRSH_PASSWORD=$THE_ROOT_PASSWORD
+VMWARE_HOST=$THE_HYPERVISOR_HOSTNAME
+VMWARE_PASSWORD=$THE_HYPERVISOR_PASSWORD
+VMWARE_DATASTORE=$THE_HYPERVISOR_DATASTORE
+VMWARE_NETWORK=$THE_VMWARE_TARGET_NETWORK
+OVA=suse-16.ova
+```
+
 ## Vagrant
 
 The vagrant backend leverages [vagrant](https://www.vagrantup.com/) to launch

--- a/t/04-check_vars_docu.t
+++ b/t/04-check_vars_docu.t
@@ -27,6 +27,7 @@ my %var_blocklist = (
     VAGRANT => ['QEMUCPUS', 'QEMURAM'],
     GENERALHW => ['HDD_1'],
     SVIRT => ['JOBTOKEN'],
+    OVA => [qw(NUMDISKS RAIDLEVEL VIRSH_HOSTNAME VIRSH_PASSWORD VIRSH_USERNAME)],
 );
 # in case we want to present backend under different name, place it here
 my %backend_renames = (BASECLASS => 'Common', IKVM => 'IPMI');

--- a/t/30-backend-ova.t
+++ b/t/30-backend-ova.t
@@ -1,0 +1,157 @@
+#!/usr/bin/perl
+
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+use Mojo::Base -signatures;
+use Test::Warnings qw(:all :report_warnings);
+use Test::MockModule;
+use Test::MockObject;
+use Test::Mock::Time;
+use Mojo::File qw(tempdir);
+use Mojo::Util qw(scope_guard);
+use FindBin '$Bin';
+use lib "$Bin/../external/os-autoinst-common/lib";
+use OpenQA::Test::TimeLimit '5';
+use backend::ova;
+use consoles::sshVirtshOVA;
+use distribution;
+
+my $dir = tempdir("/tmp/$FindBin::Script-XXXX");
+chdir $dir;
+my $cleanup = scope_guard sub { chdir $Bin; undef $dir };
+
+my $ssh_object = Test::MockObject->new();
+$ssh_object->set_true(qw/disconnect scp_get blocking/);
+$ssh_object->set_always('error', 'Mock SSH Error');
+
+my $chan_object = Test::MockObject->new();
+$chan_object->set_true(qw/exec/);
+
+my $run_ssh_cmd_mock = Test::MockModule->new('backend::baseclass');
+$run_ssh_cmd_mock->redefine(new_ssh_connection => sub ($self, %args) { return $ssh_object });
+$run_ssh_cmd_mock->redefine(start_ssh_serial => sub { return ($ssh_object, $chan_object) });
+
+my @run_cmds;
+$run_ssh_cmd_mock->redefine(run_ssh_cmd => sub ($self, $cmd, %args) {
+        push @run_cmds, $cmd;
+        return 0;
+});
+
+$bmwqemu::vars{WORKER_HOSTNAME} = 'localhost';
+$bmwqemu::vars{VIRSH_HOSTNAME} = 'foobar';
+$bmwqemu::vars{VIRSH_USERNAME} = 'root';
+$bmwqemu::vars{VIRSH_PASSWORD} = 'password';
+$bmwqemu::vars{JOBTOKEN} = 'JobToken';
+
+my $bmwqemu_mock = Test::MockModule->new('bmwqemu');
+$bmwqemu_mock->noop('diag');
+$bmwqemu_mock->noop('log_call');
+
+my $distri = $testapi::distri = distribution->new();
+
+subtest 'OVA backend initialization' => sub {
+    $bmwqemu::vars{VIRSH_VMM_FAMILY} = 'vmware';
+    my $backend = backend::ova->new;
+    ok $backend, 'can instantiate backend::ova';
+
+    $backend->{need_delete_log} = 1;
+    ok $backend->do_start_vm, 'can start vm in backend::ova';
+
+    my $console = $distri->{consoles}->{svirt};
+    ok $console, 'svirt console exists';
+    is $console->{class}, 'consoles::sshVirtshOVA', 'svirt console has correct class consoles::sshVirtshOVA';
+};
+
+subtest 'OVA console define_and_start' => sub {
+    $bmwqemu::vars{VIRSH_VMM_FAMILY} = 'vmware';
+    my $backend = backend::ova->new;
+    $backend->{need_delete_log} = 1;
+    $backend->do_start_vm;
+    my $console = $distri->{consoles}->{svirt};
+
+    $bmwqemu::vars{VIRSH_VMM_FAMILY} = 'vmware';
+    $bmwqemu::vars{OVA} = '/path/to/test.ova';
+    $bmwqemu::vars{VMWARE_HOST} = 'esxi.host';
+    $bmwqemu::vars{VMWARE_USERNAME} = 'user';
+    $bmwqemu::vars{VMWARE_PASSWORD} = 'pass';
+    $bmwqemu::vars{VMWARE_DATASTORE} = 'ds1';
+    $bmwqemu::vars{VMWARE_NETWORK} = 'target_net';
+    $bmwqemu::vars{VMWARE_SERIAL_PORT} = '1234';
+    $bmwqemu::vars{OVFTOOL_ARGS} = '--diskMode=thin';
+
+    my $ssh_virtsh_mock = Test::MockModule->new('consoles::sshVirtsh');
+    $ssh_virtsh_mock->redefine(get_cmd_output => sub ($self, $cmd) {
+            return '<domain id="123"></domain>';
+    });
+
+    @run_cmds = ();
+
+    $console->_init_ssh($console->{args});
+    $console->define_and_start;
+
+    my ($ovftool_cmd) = grep { /ovftool/ } @run_cmds;
+    ok $ovftool_cmd, 'ovftool command is generated and executed';
+    like $ovftool_cmd, qr/ovftool/, 'command binary is ovftool';
+    like $ovftool_cmd, qr/--acceptAllEulas/, 'EULA is accepted via --acceptAllEulas';
+    like $ovftool_cmd, qr/--noSSLVerify/, 'SSL verification is bypassed via --noSSLVerify';
+    like $ovftool_cmd, qr/--overwrite/, 'existing VM is overwritten via --overwrite';
+    like $ovftool_cmd, qr/--powerOffTarget/, 'target VM is powered off if running via --powerOffTarget';
+    like $ovftool_cmd, qr/--name=openQA-SUT-1/, 'VM name is set via --name=openQA-SUT-1';
+    like $ovftool_cmd, qr/--datastore=ds1/, 'target datastore is set via --datastore=ds1';
+    like $ovftool_cmd, qr/'--net:VM Network=target_net'/, 'network is mapped via --net:VM Network=target_net';
+    like $ovftool_cmd, qr/--diskMode=thin/, 'additional arguments from OVFTOOL_ARGS are appended';
+    like $ovftool_cmd, qr/'\/path\/to\/test\.ova'/, 'correct escaped OVA path is passed';
+    like $ovftool_cmd, qr/'vi:\/\/user:pass\@esxi\.host'/, 'target URL is constructed with credentials and host';
+};
+
+subtest 'OVA console define_and_start with extra options' => sub {
+    my $backend = backend::ova->new;
+    $backend->{need_delete_log} = 1;
+    $backend->do_start_vm;
+    my $console = $distri->{consoles}->{svirt};
+    $bmwqemu::vars{VIRSH_VMM_FAMILY} = 'vmware';
+    $bmwqemu::vars{OVA} = '/path/to/test.ova';
+    $bmwqemu::vars{VMWARE_HOST} = 'esxi.host';
+    $bmwqemu::vars{VMWARE_USERNAME} = 'user';
+    $bmwqemu::vars{VMWARE_PASSWORD} = 'pass';
+    $bmwqemu::vars{VMWARE_DATASTORE} = 'ds1';
+    $bmwqemu::vars{VMWARE_VM_HWVERSION} = '19';
+    $bmwqemu::vars{GUESTINFO_CONFIG} = 'combustion';
+    $bmwqemu::vars{GUESTINFO_COMBUSTION} = 'combustion.script';
+    my $ssh_virtsh_mock = Test::MockModule->new('consoles::sshVirtsh');
+    $ssh_virtsh_mock->redefine(get_cmd_output => sub ($self, $cmd) {
+            return '<domain id="123"></domain>';
+    });
+    $ssh_virtsh_mock->redefine(_encode_config => sub ($self, $conf, $var) {
+            return 'encoded_config';
+    });
+    @run_cmds = ();
+    $console->_init_ssh($console->{args});
+    $console->define_and_start;
+    my ($sed_cmd) = grep { /virtualHW.version = "19"/ } @run_cmds;
+    ok $sed_cmd, 'virtualHW.version is set when VMWARE_VM_HWVERSION is specified';
+    my ($combustion_cmd) = grep { /guestinfo.combustion.script = "encoded_config"/ } @run_cmds;
+    ok $combustion_cmd, 'guestinfo.combustion.script set correctly for combustion provisioning';
+    $bmwqemu::vars{GUESTINFO_CONFIG} = 'ignition';
+    $bmwqemu::vars{GUESTINFO_IGNITION} = 'ignition.config';
+    @run_cmds = ();
+    $console->define_and_start;
+    my ($ignition_cmd) = grep { /guestinfo.ignition.config.data = "encoded_config"/ } @run_cmds;
+    ok $ignition_cmd, 'guestinfo.ignition.config.data set correctly for ignition provisioning';
+    $bmwqemu::vars{GUESTINFO_CONFIG} = 'cloud-init';
+    $bmwqemu::vars{GUESTINFO_CLOUD_INIT} = 'user-data,meta-data';
+    @run_cmds = ();
+    $console->define_and_start;
+    my ($cloud_init_cmd) = grep { /guestinfo.userdata = "encoded_config"/ } @run_cmds;
+    ok $cloud_init_cmd, 'guestinfo.userdata set correctly for cloud-init provisioning';
+    $bmwqemu::vars{GUESTINFO_CONFIG} = 'invalid';
+    @run_cmds = ();
+    throws_ok { $console->define_and_start } qr/Unknown provisioning option/, 'throws error when invalid GUESTINFO_CONFIG is provided';
+    $bmwqemu::vars{GUESTINFO_CONFIG} = 'cloud-init';
+    delete $bmwqemu::vars{GUESTINFO_CLOUD_INIT};
+    @run_cmds = ();
+    throws_ok { $console->define_and_start } qr/GUESTINFO_CLOUD_INIT is unset/, 'throws error when GUESTINFO_CLOUD_INIT is unset for cloud-init provisioning';
+};
+done_testing;

--- a/t/30-backend-ova.t
+++ b/t/30-backend-ova.t
@@ -153,5 +153,24 @@ subtest 'OVA console define_and_start with extra options' => sub {
     delete $bmwqemu::vars{GUESTINFO_CLOUD_INIT};
     @run_cmds = ();
     throws_ok { $console->define_and_start } qr/GUESTINFO_CLOUD_INIT is unset/, 'throws error when GUESTINFO_CLOUD_INIT is unset for cloud-init provisioning';
+
+    delete $bmwqemu::vars{VMWARE_VNC_OVER_WS};
+    $bmwqemu::vars{VNC} = 4;
+    $testapi::password = 'vncpassword';
+    $bmwqemu::vars{GUESTINFO_CONFIG} = 'wizard';
+    @run_cmds = ();
+    $console->define_and_start;
+    my ($vnc_enabled_cmd) = grep { /RemoteDisplay.vnc.enabled = "TRUE"/ } @run_cmds;
+    ok $vnc_enabled_cmd, 'VNC is enabled in .vmx when VMWARE_VNC_OVER_WS is unset';
+    my ($vnc_port_cmd) = grep { /RemoteDisplay.vnc.port = "5904"/ } @run_cmds;
+    ok $vnc_port_cmd, 'VNC port is correctly configured in .vmx based on VNC offset';
+    my ($vnc_passwd_cmd) = grep { /RemoteDisplay.vnc.password = "vncpassword"/ } @run_cmds;
+    ok $vnc_passwd_cmd, 'VNC password is set in .vmx if testapi::password is defined';
+
+    $bmwqemu::vars{VMWARE_VNC_OVER_WS} = 1;
+    @run_cmds = ();
+    $console->define_and_start;
+    my ($vnc_enabled_cmd_ws) = grep { /RemoteDisplay.vnc.enabled/ } @run_cmds;
+    ok !$vnc_enabled_cmd_ws, 'VNC is not configured in .vmx when VMWARE_VNC_OVER_WS is set';
 };
 done_testing;


### PR DESCRIPTION
Motivation:
Provide automated deployment of OVA images on VMware ESXi hosts using ovftool
to eliminate manual verification efforts for major milestones.

Design Choices:
Created a new ova backend that registers a ssh-virtsh-ova console. Developed
sshVirtshOVA to deploy OVA images via ovftool on the local worker and
subsequently configure and start them via standard virsh.

Benefits:
Enables robust, flexible, and automated testing of OVA images in openQA without
modifying existing virsh-based svirt backends.

Related issue: https://progress.opensuse.org/issues/203754



Key Technical Details:
Because virsh (via the libvirt esx:// driver) does not natively support direct OVA deployments, this implementation leverages VMware's ovftool to deploy the image directly, and then seamlessly hands control back to the standard svirt infrastructure for VMX configuration, VM startup, and serial/VNC console grabbing.

- backend::ova: Inherits from svirt and registers the new ssh-virtsh-ova console type.
- consoles::sshVirtshOVA: Inherits from sshVirtsh. Overrides define_and_start to execute ovftool via SSH to the jump host. 
- Safe Credential Handling: Evaluates VMWARE_PASSWORD via Mojo::URL, automatically converting special characters (like @, #) into their hexadecimal URL-encoded equivalents (%40, %23) for the vi:// target locator.
- Direct HTTPS Streaming: Passes the OVA variable (or HDD_1 fallback) directly to ovftool, natively allowing direct streaming of HTTPS image URLs without manually caching them on the jump host.
- VMX Injection: Injects test configurations (e.g., bios.bootDelay, guestinfo.userdata for cloud-init/combustion) directly into the ESXi datastore's .vmx file before calling virsh start.
Test Suite Optimizations (os-autoinst-distri-opensuse / osado integration):
- Adapted backend helpers (is_svirt, is_svirt_except_s390x, is_remote_backend) to fully support the new 'ova' backend.
- Optimized tests/installation/bootloader_svirt.pm to bypass all legacy VMDK copying, datastore clearing, and vmkfstools setups for BACKEND=ova, as ovftool handles all virtual disk provisioning natively. This cut down setup times dramatically.
- Updated tests/installation/bootloader_uefi.pm to safely skip GRUB edit parameter typing when is_bootloader_grub2_bls is true, permitting SLES 16.1 Immutable to boot cleanly via its automatic timeout.

How It Was Tested
1. Automated Unit & Style Testing
- Created t/30-backend-ova.t to verify object instantiation, ovftool command construction, flag propagation (--acceptAllEulas, --noSSLVerify, --overwrite), and proper URL-encoding of credentials.
- Verified no regressions in existing svirt tests via make test-perl-testsuite TESTS="t/29-backend-svirt.t".
2. Local End-to-End Execution on Live Hypervisor
- Executed isotovideo locally pointing to a SLES 16.1 Immutable OVA image and utilizing live ESXi host credentials:
```
../../isotovideo -d \
  casedir=~/local/os-autoinst/osado \
  virsh_password='...' \
  VMWARE_PASSWORD='...' \
  BOOTLOADER=grub2-bls
```
- Results Confirmed via local logs and VNC screenshots:
  - Clean-up of the prior domain succeeded.
  - ovftool properly validated the manifest and streamed the OVA directly from download.suse.de to the ESXi target.
  - The custom VMX configurations (including hardware version and boot delays) were correctly written to the datastore.
  - bootloader_svirt completed cleanly in just 43 seconds (instead of 79+ seconds).
  - bootloader_uefi completed cleanly in 2 seconds, bypassing GRUB editing and allowing SLES 16.1 Immutable to boot automatically.
  - first_boot successfully detected the visible GRUB menu, clicked enter, and transitioned to waiting for the login prompt.
3. Production openQA Instance Verification
- Scheduled non-production jobs on openqa.suse.de cloning job #23644258, redirecting to our connected worker with WORKER_CLASS=ova_poo203754 and setting BACKEND=ova:
`openqa-clone-job --skip-chained-deps --within-instance https://openqa.suse.de/tests/23644258 _GROUP=0 BUILD+=-ova-poo203754 TEST+=-ova-poo203754 EXIT_AFTER_MODULE=first_boot WORKER_CLASS=ova_poo203754 BACKEND=ova OVA=https://download.suse.de/ibs/SUSE:/SLFO:/Products:/SLES:/16.1:/TEST/images/SLES-16.1-Immutable.x86_64-Base-VMware-Build12.7.ova CASEDIR=https://github.com/okurz/os-autoinst-distri-opensuse.git#feature/039_poo203754_support_ova_backend ISOTOVIDEO="mkdir -p /var/lib/openqa/cache/podman/run /var/lib/openqa/cache/podman/config /var/lib/openqa/cache/podman/data && env HOME=/var/lib/openqa/cache/podman XDG_CONFIG_HOME=/var/lib/openqa/cache/podman/config XDG_DATA_HOME=/var/lib/openqa/cache/podman/data XDG_RUNTIME_DIR=/var/lib/openqa/cache/podman/run podman --root /var/lib/openqa/cache/podman/data/containers/storage --runroot /var/lib/openqa/cache/podman/run/containers --storage-opt ignore_chown_errors=true --cgroup-manager=cgroupfs --events-backend=file run --init --rm --entrypoint \"\" --device /dev/kvm -v \$(pwd):/pool -w /pool -v /var/lib/openqa/cache:/var/lib/openqa/cache registry.opensuse.org/devel/openqa/containers/os-autoinst_dev:latest sh -c 'zypper -n al chrony ntp && zypper -n in os-autoinst-distri-opensuse-deps openQA-common && rm -rf os-autoinst && git clone --branch=feature/039_poo203754_support_ova_backend --depth=1 https://github.com/okurz/os-autoinst.git && make -C os-autoinst symlinks && os-autoinst/isotovideo -d'"`
- Production Showcase Job: https://openqa.suse.de/tests/23688225

Related Issue: https://progress.opensuse.org/issues/203754