### PR TITLE
feat: improve svirt VM lifecyle & logs

### DIFF
--- a/backend/svirt.pm
+++ b/backend/svirt.pm
@@ -78,8 +78,17 @@ sub do_stop_vm_hyperv ($self) {
 
 sub do_stop_vm_svirt ($self) {
     my $vmname = $self->vmname;
-    $self->run_ssh_cmd(virsh() . " destroy $vmname");
-    $self->run_ssh_cmd(virsh() . " undefine --snapshots-metadata $vmname");
+
+    # Only attempt cleanup if the domain actually exists on the host
+    if ($self->run_ssh_cmd(virsh() . " dominfo $vmname 2>/dev/null") == 0) {
+        $self->run_ssh_cmd(virsh() . " destroy $vmname");
+        $self->run_ssh_cmd(virsh() . " undefine --snapshots-metadata $vmname");
+
+        # Verify the domain is actually gone to prevent cryptic UUID clashes later
+        if ($self->run_ssh_cmd(virsh() . " dominfo $vmname 2>/dev/null") == 0) {
+            bmwqemu::fctwarn("Domain '$vmname' still exists after undefine attempt. The QEMU process is likely stuck (D-state) on the host.");
+        }
+    }
 }
 
 sub do_stop_vm ($self, @) {
@@ -121,7 +130,7 @@ sub can_handle ($self, $args) {
 sub is_shutdown_cmd_hyperv ($vmname) { qq{powershell -Command "if (\$(Get-VM -VMName $vmname \| Where-Object {\$_.state -eq 'Off'})) { exit 1 } else { exit 0 }"} }
 
 sub is_shutdown_cmd_svirt ($vmname) {
-    return '! ' . virsh() . " dominfo $vmname | grep -w 'shut off'";
+    return '! ' . virsh() . " dominfo $vmname 2>/dev/null | grep -w 'shut off'";
 }
 
 sub is_shutdown ($self, @) {

--- a/consoles/sshVirtsh.pm
+++ b/consoles/sshVirtsh.pm
@@ -631,7 +631,12 @@ __END'
     $self->backend->do_stop_vm_svirt() if $args{pre_cleanup};
 
     # define the new domain
-    $self->run_cmd(backend::svirt::virsh() . " define $xmlfilename") && die 'virsh define failed';
+    my ($stdout, $stderr);
+    ($ret, $stdout, $stderr) = $self->run_cmd(backend::svirt::virsh() . " define $xmlfilename", wantarray => 1);
+    if ($ret) {
+        $stderr =~ s/\s+$// if $stderr;
+        die 'virsh define failed: ' . ($stderr || "exit code $ret");
+    }
     if ($self->vmm_family eq 'vmware') {
         my $vmx = sprintf '/vmfs/volumes/%s/openQA/%s.vmx', $bmwqemu::vars{VMWARE_DATASTORE} // 'datastore1', $self->name;
 

--- a/t/22-svirt.t
+++ b/t/22-svirt.t
@@ -117,8 +117,10 @@ sub _check_vmware_cmds ($cmds, $extra_cmds = []) {
     like shift @$cmds, qr/cat > \/t <<.*username=u.*password=p.*auth-esx-h/s, 'config written';
     my $s = 'virsh -c esx://u@h/?no_verify=1\\&authfile=/t ';
     my @expected = (
+        $s . ' dominfo openQA-SUT-1 2>/dev/null',
         $s . ' destroy openQA-SUT-1',
         $s . ' undefine --snapshots-metadata openQA-SUT-1',
+        $s . ' dominfo openQA-SUT-1 2>/dev/null',
         $s . ' define /var/lib/libvirt/images/openQA-SUT-1.xml',
         'echo \'bios.bootDelay = "10000"\' >> /vmfs/volumes/datastore1/openQA/openQA-SUT-1.vmx',
         'test -e /vmfs/volumes/datastore1/openQA/openQA-SUT-1.nvram',
@@ -319,6 +321,22 @@ subtest 'starting VMware console with cloud-init' => sub {
             'echo \'guestinfo.userdata = "CI_test_CONF"\' >> /vmfs/volumes/datastore1/openQA/openQA-SUT-1.vmx',
             'echo \'guestinfo.metadata = "CI_test_CONF"\' >> /vmfs/volumes/datastore1/openQA/openQA-SUT-1.vmx'
     ]);
+};
+
+subtest 'starting VMware console with define failure' => sub {
+    for my $tc (
+        {ret => 1, stderr => "some define error\n", expected => qr/virsh define failed: some define error/},
+        {ret => 2, stderr => undef, expected => qr/virsh define failed: exit code 2/}
+    ) {
+        my $mocks = _mock_svirt_vmware([], []);
+        $mocks->{console}->redefine(
+            run_cmd => sub ($self, $cmd, %args) {
+                return ($tc->{ret}, undef, $tc->{stderr}) if $cmd =~ /define/ && $args{wantarray};
+                return 0;
+            }
+        );
+        throws_ok { $svirt_console->define_and_start } $tc->{expected};
+    }
 };
 
 subtest 'SSH credentials' => sub {

--- a/t/29-backend-svirt.t
+++ b/t/29-backend-svirt.t
@@ -54,6 +54,7 @@ subtest 'Generic svirt backend' => sub {
     # silence some log output for cleaner tests
     $bmwqemu_mock->noop('diag');
     $bmwqemu_mock->noop('log_call');
+    $bmwqemu_mock->noop('fctwarn');
     redefine_ssh;
     $backend->{need_delete_log} = 1;
     ok $backend->do_start_vm, 'can start vm';
@@ -80,6 +81,7 @@ subtest 'VMWARE backend' => sub {
     # silence some log output for cleaner tests
     $bmwqemu_mock->noop('diag');
     $bmwqemu_mock->noop('log_call');
+    $bmwqemu_mock->noop('fctwarn');
     redefine_ssh;
     $backend->{need_delete_log} = 1;
     ok $backend->do_start_vm, 'can start vm';
@@ -104,6 +106,7 @@ subtest 'HyperV backend' => sub {
     # silence some log output for cleaner tests
     $bmwqemu_mock->noop('diag');
     $bmwqemu_mock->noop('log_call');
+    $bmwqemu_mock->noop('fctwarn');
     redefine_ssh;
     ok $backend->do_start_vm, 'can start vm';
     is $backend->can_handle({function => 'snapshots'})->{ret}, 1, 'can handle snapshots';
@@ -124,6 +127,31 @@ subtest 'check virsh() method' => sub {
     $bmwqemu::vars{VMWARE_REMOTE_VMM} = 'my_vmm';
     my $virsh = backend::svirt::virsh();
     is $virsh, 'virsh my_vmm', 'correct output from virsh()';
+};
+
+subtest 'do_stop_vm_svirt validation' => sub {
+    my $backend = backend::svirt->new;
+    my $bmwqemu_mock = Test::MockModule->new('bmwqemu');
+    $bmwqemu_mock->noop('diag');
+    $bmwqemu_mock->noop('log_call');
+
+    subtest 'triggers fctwarn when the domain still exists after undefining' => sub {
+        my @warn_log;
+        $bmwqemu_mock->redefine(fctwarn => sub { push @warn_log, @_ });
+        $run_ssh_cmd_mock->redefine(run_ssh_cmd => 0);
+        $backend->do_stop_vm_svirt;
+        like "@warn_log", qr/still exists/, 'logged fctwarn contains still exists warning';
+    };
+
+    subtest 'does not trigger fctwarn when the domain is successfully gone' => sub {
+        my @warn_log;
+        $bmwqemu_mock->redefine(fctwarn => sub { push @warn_log, @_ });
+        $run_ssh_cmd_mock->redefine(run_ssh_cmd => sub ($self, $cmd, %args) {
+                return $cmd =~ /dominfo/ ? 1 : 0;
+        });
+        $backend->do_stop_vm_svirt;
+        is scalar(@warn_log), 0, 'no warning was logged';
+    };
 };
 
 done_testing;


### PR DESCRIPTION
## Motivation
Previously, if a hypervisor had a stuck QEMU process in D-state, the cleanup phase would silently fail and subsequent test runs would crash during `virsh define` with a generic, unhelpful error message. Additionally, redundant cleanup commands cluttered the `autoinst-log.txt` with noisy `failed to get domain` messages.

## Changes
- **Detailed Error Reporting**: Captured `stderr` from `virsh define` inside `sshVirtsh.pm` to surface precise failure details directly in openQA instead of hiding it.
- **Cleanup Validation**: Added verification in `do_stop_vm_svirt` via `virsh dominfo` to actively detect stuck QEMU processes and log a clear warning if a domain cannot be cleanly undefine'd.
- **Log Cleaning**: Avoided redundant cleanup calls by checking domain existence first and silenced standard error redirection for power/existence status checks.

## Log Examples

### Before (Spurious Errors)

```
run_ssh_cmd(! virsh dominfo openQA-SUT-5 | grep -w 'shut off') stderr:
  error: failed to get domain 'openQA-SUT-5'
run_ssh_cmd(virsh destroy openQA-SUT-5) stderr:
  error: failed to get domain 'openQA-SUT-5'
run_ssh_cmd(virsh undefine --snapshots-metadata openQA-SUT-5) stderr:
  error: failed to get domain 'openQA-SUT-5'
```

### After (Clean Log)

```
run_ssh_cmd(! virsh dominfo openQA-SUT-5 2>/dev/null | grep -w 'shut off') exit-code: 0
run_ssh_cmd(virsh dominfo openQA-SUT-5 2>/dev/null) exit-code: 1
```

## Verification
- Verified on openqa.suse.de: https://openqa.suse.de/tt23719350 (Logs are clean of spurious `failed to get domain` errors).

Related issue: https://progress.opensuse.org/issues/201144