### PR TITLE
feat: Clean up empty serial terminal boxes

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -156,7 +156,7 @@ sub script_run ($self, $cmd, @args) {
         }, ['timeout'], @args);
 
     if (testapi::is_serial_terminal) {
-        testapi::wait_serial($self->{serial_term_prompt}, no_regex => 1, quiet => $args{quiet});
+        testapi::wait_serial($self->{serial_term_prompt}, no_regex => 1, quiet => 1);
     }
 
     if ($args{timeout} > 0) {
@@ -193,7 +193,7 @@ sub script_run ($self, $cmd, @args) {
             my $final_cmd = $skip_pretty ? "_OANM=1; $cmd" : $cmd;
             if (testapi::is_serial_terminal) {
                 testapi::type_string "$final_cmd$marker", max_interval => $args{max_interval};
-                testapi::wait_serial($final_cmd . $marker, no_regex => 1, quiet => $args{quiet}, buffer_size => (length $final_cmd) + 128, internal_marker => 1)
+                testapi::wait_serial($final_cmd . $marker, no_regex => 1, quiet => 1, buffer_size => (length $final_cmd) + 128, internal_marker => 1)
                   or _handle_cmd_typing_error($final_cmd, \%args);
                 testapi::type_string "\n", max_interval => $args{max_interval};
             }
@@ -232,7 +232,7 @@ Use C<quiet> to avoid recording serial_results.
 
 sub background_script_run ($self, $cmd, %args) {
     if (testapi::is_serial_terminal) {
-        testapi::wait_serial($self->{serial_term_prompt}, no_regex => 1, quiet => $args{quiet});
+        testapi::wait_serial($self->{serial_term_prompt}, no_regex => 1, quiet => 1);
     }
 
     $cmd = "( $cmd )";
@@ -241,7 +241,7 @@ sub background_script_run ($self, $cmd, %args) {
     my $marker = "& echo $str-\$!-" . ($args{output} ? "Comment: $args{output}" : '');
     if (testapi::is_serial_terminal) {
         testapi::type_string $marker;
-        testapi::wait_serial($cmd . $marker, no_regex => 1, quiet => $args{quiet}, internal_marker => 1) or _handle_cmd_typing_error($cmd, \%args);
+        testapi::wait_serial($cmd . $marker, no_regex => 1, quiet => 1, internal_marker => 1) or _handle_cmd_typing_error($cmd, \%args);
         testapi::type_string "\n";
     }
     else {
@@ -317,17 +317,17 @@ sub script_output ($self, $script, @args) {
     if (testapi::is_serial_terminal) {
         my $heretag = 'EOT_' . $marker;
         my $cat = "cat > $script_path << '$heretag'; echo $marker-\$?-";
-        testapi::wait_serial($self->{serial_term_prompt}, no_regex => 1, quiet => $args{quiet});
+        testapi::wait_serial($self->{serial_term_prompt}, no_regex => 1, quiet => 1);
         bmwqemu::log_call("Content of $script_path :\n \"$cat\" \n");
         testapi::type_string $cat . "\n";
-        testapi::wait_serial("$cat", no_regex => 1, quiet => $args{quiet});
+        testapi::wait_serial("$cat", no_regex => 1, quiet => 1);
         # Wait for input prompt of here tag before typing $script. This avoids
         # messy output, like duplicate output of $script. We do this in a second
         # wait_serial() call, to avoid issues during new line detection.
-        testapi::wait_serial('> ', no_regex => 1, quiet => $args{quiet});
+        testapi::wait_serial('> ', no_regex => 1, quiet => 1);
         testapi::type_string "$script\n$heretag\n";
-        testapi::wait_serial("> $heretag", no_regex => 1, quiet => $args{quiet});
-        testapi::wait_serial(qr/$marker-(0)-/, capture_name => 'Exit code', quiet => $args{quiet}, internal_marker => 1);
+        testapi::wait_serial("> $heretag", no_regex => 1, quiet => 1);
+        testapi::wait_serial(qr/$marker-(0)-/, capture_name => 'Exit code', quiet => 1, internal_marker => 1);
     }
     elsif ($args{type_command}) {
         my $cat = "cat - > $script_path;";
@@ -352,9 +352,9 @@ sub script_output ($self, $script, @args) {
     my $shell_cmd = testapi::is_serial_terminal() ? 'bash -oe pipefail' : 'bash -eox pipefail';
     my $run_script = "echo $marker; $shell_cmd $script_path ; echo SCRIPT_FINISHED$marker-\$?-";
     if (testapi::is_serial_terminal) {
-        testapi::wait_serial($self->{serial_term_prompt}, no_regex => 1, quiet => $args{quiet});
+        testapi::wait_serial($self->{serial_term_prompt}, no_regex => 1, quiet => 1);
         testapi::type_string "$run_script\n";
-        testapi::wait_serial($run_script, no_regex => 1, quiet => $args{quiet});
+        testapi::wait_serial($run_script, no_regex => 1, quiet => 1);
     }
     else {
         testapi::type_string "($run_script) | tee /dev/$testapi::serialdev\n";

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -892,8 +892,11 @@ sub script_output_test ($is_serial_terminal) {
         @wait_serial_args = ();
         is script_output('echo foo', $t->{args}->@*), 'foo', "$t->{msg}: returns expected output";
         is $wait_serial_args[-1]->{timeout}, $t->{timeout}, "$t->{msg}: correct timeout passed to final wait_serial call";
-        my @inconsistent_quiet = grep { ($_->{quiet} // 0) != ($t->{quiet} // 0) } @wait_serial_args;
-        is_deeply \@inconsistent_quiet, [], "$t->{msg}: quiet argument is consistent across all calls";
+        # The final wait_serial (the actual command execution) should match the user-specified quiet value.
+        is $wait_serial_args[-1]->{quiet}, $t->{quiet}, "$t->{msg}: correct quiet passed to final wait_serial call";
+        # Earlier wait_serials are internal and must always be quiet.
+        my @inconsistent_internal_quiet = grep { !$_->{quiet} } @wait_serial_args[0 .. $#wait_serial_args - 1];
+        is_deeply \@inconsistent_internal_quiet, [], "$t->{msg}: internal wait_serial calls are always quiet";
     }
     $mock_testapi->redefine(wait_serial => "This is a simulated output on the serial dev\nXXX\nfoo\nSCRIPT_FINISHEDXXX-0-\nand more here");
     is script_output('echo foo', type_command => 0), 'foo', 'script_output with type_command => 0 output in a file';
@@ -1063,7 +1066,9 @@ subtest 'check quiet option on script runs' => sub {
     ok !validate_script_output('script', sub { m/output/ }), 'validate_script_output with _QUIET_SCRIPT_CALLS=1';
 
     $mock_testapi->redefine(wait_serial => sub ($regex, %args) {
-            is $args{quiet}, 0, 'Check default quiet argument';
+            my $reg_str = ref $regex eq 'Regexp' ? "$regex" : $regex;
+            my $is_final = $args{capture_name} && $args{capture_name} eq 'Exit code' && $reg_str =~ /\\d\+/;
+            is $args{quiet}, ($is_final ? 0 : 1), 'Check default quiet argument';
             return "XXX\nfoo\nSCRIPT_FINISHEDXXX-0-";
     });
     is script_output('echo foo', quiet => 0), 'foo', 'script_output with _QUIET_SCRIPT_CALLS=1 and quiet=>0';


### PR DESCRIPTION
Motivation
Test executions currently create redundant empty boxes in the openQA Web UI
for internal synchronization and echo waits, cluttering the details view.

Design Choices
Unconditionally set quiet => 1 for all internal wait_serial calls in
distribution.pm while preserving quiet => $args{quiet} for final execution
results. Update tests in t/03-testapi.t to verify this decoupled behavior.

Benefits
Removes noise and provides a clean, distraction-free test result view in
the openQA user interface.

Screenshot
<img width="1455" height="1030" alt="Screenshot_20260803_140601_oqa_hide_status_marker_boxes" src="https://github.com/user-attachments/assets/47eb5bbe-7f20-4366-9bcf-646790f6031c" />

Related issue: https://progress.opensuse.org/issues/198872