### PR TITLE
feat: Add custom dev container Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,24 @@ within the container specified via `OS_AUTOINST_CONTAINER_IMAGE`. Additional dep
 (e.g. `os-autoinst-distri-opensuse-deps`) must be provided by that container image rather
 than the worker host.
 
+For example, you can run an openQA test using your custom `os-autoinst` branch and the
+pre-built `osado-dev-container` image (which already bundles `os-autoinst-distri-opensuse-deps`).
+
+Note: You must point `CASEDIR` and `NEEDLES_DIR` to remote Git repositories because the
+rootless container starts with a clean environment and does not mount local worker directories:
+
+```sh
+openqa-clone-job --skip-chained-deps --within-instance <target_job_url> \
+  _GROUP=0 \
+  BUILD+=-custom_suffix \
+  TEST+=-custom_suffix \
+  CASEDIR=https://github.com/os-autoinst/os-autoinst-distri-opensuse.git \
+  NEEDLES_DIR=https://github.com/os-autoinst/os-autoinst-needles-opensuse.git \
+  OS_AUTOINST_GIT_REPO=https://github.com/<your_username>/os-autoinst.git \
+  OS_AUTOINST_GIT_BRANCH=<your_test_branch> \
+  OS_AUTOINST_CONTAINER_IMAGE=registry.opensuse.org/devel/openqa/containers/osado-dev-container:latest
+```
+
 ### Advanced testing with custom test-distribution dependencies
 
 If you are testing changes against tests that require custom dependencies not

--- a/container/osado-dev-container/Containerfile
+++ b/container/osado-dev-container/Containerfile
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MIT
+#!BuildTag: osado-dev-container:latest opensuse/osado-dev-container:latest opensuse/osado-dev-container:%PKG_VERSION% opensuse/osado-dev-container:%PKG_VERSION%.%RELEASE%
+# hadolint ignore=DL3007
+FROM opensuse/os-autoinst-dev:latest
+RUN zypper in -y -C os-autoinst-distri-opensuse-deps && zypper clean -a

--- a/container/osado-dev-container/Dockerfile
+++ b/container/osado-dev-container/Dockerfile
@@ -1,0 +1,1 @@
+Containerfile

--- a/container/osado-dev-container/_service
+++ b/container/osado-dev-container/_service
@@ -1,0 +1,22 @@
+<services>
+  <service name="obs_scm">
+    <param name="url">https://github.com/os-autoinst/os-autoinst</param>
+    <param name="scm">git</param>
+    <param name="revision">master</param>
+    <param name="versionprefix">5</param>
+    <param name="versionformat">%ct.%h</param>
+    <param name="subdir">container/osado-dev-container</param>
+    <param name="extract">Dockerfile</param>
+    <param name="changesgenerate">enable</param>
+    <param name="changesauthor">okurz@suse.de</param>
+  </service>
+  <service mode="buildtime" name="kiwi_metainfo_helper"/>
+  <service mode="buildtime" name="docker_label_helper"/>
+  <service mode="buildtime" name="replace_using_package_version">
+    <param name="file">Dockerfile</param>
+    <param name="regex">%PKG_VERSION%</param>
+    <param name="parse-version">patch</param>
+    <param name="package">os-autoinst-distri-opensuse-deps</param>
+  </service>
+</services>
+

--- a/tools/test_containers
+++ b/tools/test_containers
@@ -7,5 +7,12 @@ for i in container/*/Dockerfile*; do
     echo "$0 => Testing container $i"
     tag=${i,,}
     $cre build -t "$tag" -f "$i" "$(dirname "$i")"/
+    if grep -q "BuildTag:" "$i"; then
+        # shellcheck disable=SC2013
+        for t in $(sed -n 's/.*BuildTag: //p' "$i"); do
+            [[ "$t" == *%* ]] && continue
+            $cre tag "$tag" "$t"
+        done
+    fi
     $cre run --rm "$tag" --help
 done


### PR DESCRIPTION
Motivation
Enable developers and workers to run tests in a rootless container that
pre-installs both the engine development environment and openSUSE test
dependencies.

Design Choices
Create a new Dockerfile in container/os-autoinst_dev_with_opensuse_deps/ based
on the official os-autoinst_dev image and add the
os-autoinst-distri-opensuse-deps package.

Benefits
Simplifies testing setup, speeds up execution times by pre-caching
dependencies, and eliminates the need to run zypper manually in every run.