### PR TITLE
fix(script_run): anchor level-3 exit marker on command fingerprint

### DIFF
--- a/.github/workflows/openqa_fullstack.yml
+++ b/.github/workflows/openqa_fullstack.yml
@@ -34,6 +34,6 @@ jobs:
       - name: Build os-autoinst
         run: sudo -u "$TEST_USER" make symlinks
       - name: Run unit tests
-        run: sudo -u "$TEST_USER" make -C ../openQA test-fullstack
+        run: sudo -u "$TEST_USER" make -C ../openQA test-with-database FULLSTACK=1 TIMEOUT_M=30 PROVE_ARGS="t/full-stack.t"
         env:
           STABILITY_TEST: ${{ github.event.inputs.stability_test }}

--- a/distribution.pm
+++ b/distribution.pm
@@ -177,9 +177,11 @@ sub script_run ($self, $cmd, @args) {
             testapi::query_isotovideo('backend_clear_serial_buffer', {});
             testapi::type_string "$cmd\n", max_interval => $args{max_interval};
             $self->_check_sudo_password(\%args);
-            my $res = testapi::wait_serial(qr/OA:DONE-[0-9a-f]{4}-(\d+)-/, timeout => $args{timeout}, quiet => $args{quiet}, record_command => $cmd, internal_marker => 1, capture_name => 'Exit code');
+            my $fp = $self->sut_marker($cmd);
+            my $regex = qr/OA:DONE-[0-9a-f]{4}-(\d+)-\Q$fp\E/;
+            my $res = testapi::wait_serial($regex, timeout => $args{timeout}, quiet => $args{quiet}, record_command => $cmd, internal_marker => 1, capture_name => 'Exit code');
             return undef unless $res;
-            return ($res =~ /OA:DONE-[0-9a-f]{4}-(\d+)-/)[0];
+            return ($res =~ $regex)[0];
         }
         $str = testapi::hashed_string('SR' . $cmd . $args{timeout});
         $wait_pattern = qr/$str-(\d+)-/;
@@ -432,7 +434,8 @@ sub console_selected ($self, $console) { }
     sut_marker($cmd)
 
 Generate a unique marker string for a command to be used for synchronization
-with the SUT. Used primarily for internal testing.
+with the SUT. Canonical command fingerprint used for level-3 marker
+correlation.
 
 =cut
 
@@ -462,7 +465,7 @@ sub install_serial_marker_hook ($self, $level) {
     # _OANM: openQA No Marker (skip hook done marker)
     # _OAM: openQA Marker (custom marker string)
     if ($level == 3) {
-        $func = qq{_oap(){ r=\$?;if [ -n "\$_OANM" ];then unset _OANM;else c=\$(fc -ln -1 2>/dev/null);printf "OA:DONE-%04x-%d-%s\\nOA:START\\n" \$RANDOM \$r "\${c#\${c%%[![:space:]]*}}">$dev;fi;}};
+        $func = qq{_oap(){ r=\$?;if [ -n "\$_OANM" ];then unset _OANM;else c=\$(fc -ln -1 2>/dev/null);c=\${c#\${c%%[![:space:]]*}};c=\${c%\${c##*[![:space:]]}};l=\${#c};t=\$c;[ \$l -ge 4 ]&&t=\${c: -4};printf "OA:DONE-%04x-%d-OA:%s%d%s\\nOA:START\\n" \$RANDOM \$r "\${c:0:4}" \$l "\$t">$dev;fi;}};
     }
     else {
         $func = qq{_oap(){ r=\$?;if [ -n "\$_OANM" ];then unset _OANM;elif [ -n "\$_OAM" ];then echo "\$_OAM-\$r-">$dev;unset _OAM;fi;echo "OA:START">$dev;}};

--- a/distribution.pm
+++ b/distribution.pm
@@ -465,7 +465,11 @@ sub install_serial_marker_hook ($self, $level) {
     # _OANM: openQA No Marker (skip hook done marker)
     # _OAM: openQA Marker (custom marker string)
     if ($level == 3) {
-        $func = qq{_oap(){ r=\$?;if [ -n "\$_OANM" ];then unset _OANM;else c=\$(fc -ln -1 2>/dev/null);c=\${c#\${c%%[![:space:]]*}};c=\${c%\${c##*[![:space:]]}};l=\${#c};t=\$c;[ \$l -ge 4 ]&&t=\${c: -4};printf "OA:DONE-%04x-%d-OA:%s%d%s\\nOA:START\\n" \$RANDOM \$r "\${c:0:4}" \$l "\$t">$dev;fi;}};
+        # `history 1` reads the in-memory history list, which bash updates before
+        # running PROMPT_COMMAND, so it yields the command that just ran (no
+        # off-by-one, unlike `fc -ln -1`) and the whole line (compound/pipeline
+        # commands intact). Strip the leading "<index>  " field, then trim.
+        $func = qq{_oap(){ r=\$?;if [ -n "\$_OANM" ];then unset _OANM;else c=\$(HISTTIMEFORMAT= history 1);c=\${c#*[0-9]  };c=\${c#\${c%%[![:space:]]*}};c=\${c%\${c##*[![:space:]]}};l=\${#c};t=\$c;[ \$l -ge 4 ]&&t=\${c: -4};printf "OA:DONE-%04x-%d-OA:%s%d%s\\nOA:START\\n" \$RANDOM \$r "\${c:0:4}" \$l "\$t">$dev;fi;}};
     }
     else {
         $func = qq{_oap(){ r=\$?;if [ -n "\$_OANM" ];then unset _OANM;elif [ -n "\$_OAM" ];then echo "\$_OAM-\$r-">$dev;unset _OAM;fi;echo "OA:START">$dev;}};

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -231,8 +231,12 @@ subtest 'level3_marker_correlation' => sub {
     my $typed = '';
     $mock_testapi->redefine(type_string => sub { $typed .= $_[0] });
     $d->install_serial_marker_hook(3);
+    like $typed, qr'c=\$\(HISTTIMEFORMAT= history 1\);c=\$\{c#\*\[0-9\]  \}',
+      'level-3 shell hook captures the just-run command via in-memory history (no fc off-by-one)';
     like $typed, qr'l=\$\{#c\};t=\$c;\[ \$l -ge 4 \]&&t=\$\{c: -4\};printf.*OA:DONE',
       'level-3 shell hook emits the compact head4+len+tail4 command fingerprinting script';
+    unlike $typed, qr'fc -ln -1',
+      'level-3 shell hook no longer uses fc -ln -1 (off-by-one lag emitting the previous command marker one prompt late)';
 
     $d->{_serial_marker_level}->{'test-console'} = 3;
     $d->{_serial_marker_hook_installed}->{'test-console'} = 1;

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -78,6 +78,7 @@ subtest 'pretty_serial_marker' => sub {
     my $mock_testapi = Test::MockModule->new('testapi');
     my $mock_bmwqemu = Test::MockModule->new('bmwqemu');
     $mock_bmwqemu->noop('log_call');
+    $mock_bmwqemu->noop('diag');
     my $typed_string = '';
     $mock_testapi->redefine(query_isotovideo => sub { });
     $mock_testapi->redefine(type_string => sub { $typed_string .= $_[0] });
@@ -101,7 +102,7 @@ subtest 'pretty_serial_marker' => sub {
     $mock_testapi->redefine(wait_serial => sub ($regexp, @) {
             return 'BASH:4.4:' if ref($regexp) eq 'Regexp' && 'BASH:4.4:' =~ $regexp;
             return 'FC:OK:' if ref($regexp) eq 'Regexp' && 'FC:OK:' =~ $regexp;
-            return 'OA:DONE-abcd-0-foo';
+            return 'OA:DONE-abcd-0-OA:foo3foo';
     });
 
     $d->{_serial_marker_level} = {};
@@ -171,7 +172,10 @@ subtest 'reboot_safety' => sub {
     $mock_testapi->redefine(wait_serial => sub ($regexp, @) {
             return 'BASH:4.4:' if ref($regexp) eq 'Regexp' && 'BASH:4.4:' =~ $regexp;
             return 'FC:OK:' if ref($regexp) eq 'Regexp' && 'FC:OK:' =~ $regexp;
-            return 'OA:DONE-abcd-0-';
+            my $regexp_str = "$regexp";
+            my ($fp) = grep { (my $c = $regexp_str) =~ s/\\//g; $c =~ /\Q$_\E/ }
+              map { $d->sut_marker($_) } qw(foo bar baz qux);
+            return "OA:DONE-abcd-0-$fp";
     });
 
     $d->script_run('foo');
@@ -215,6 +219,57 @@ subtest 'sut_marker' => sub {
     for my $case (@test_cases) {
         is $d->sut_marker($case->{cmd}), $case->{expected}, "sut_marker: $case->{msg}";
     }
+};
+
+subtest 'level3_marker_correlation' => sub {
+    my $d = distribution->new;
+    my $mock_testapi = Test::MockModule->new('testapi');
+    my $mock_bmwqemu = Test::MockModule->new('bmwqemu');
+    $mock_bmwqemu->noop('log_call');
+    $testapi::serialdev = 'ttyS0';
+
+    my $typed = '';
+    $mock_testapi->redefine(type_string => sub { $typed .= $_[0] });
+    $d->install_serial_marker_hook(3);
+    like $typed, qr'l=\$\{#c\};t=\$c;\[ \$l -ge 4 \]&&t=\$\{c: -4\};printf.*OA:DONE',
+      'level-3 shell hook emits the compact head4+len+tail4 command fingerprinting script';
+
+    $d->{_serial_marker_level}->{'test-console'} = 3;
+    $d->{_serial_marker_hook_installed}->{'test-console'} = 1;
+    $mock_testapi->redefine(current_console => sub { 'test-console' });
+    $mock_testapi->redefine(query_isotovideo => sub { });
+
+    my @regexes_seen;
+    $mock_testapi->redefine(wait_serial => sub ($regexp, @) {
+            push @regexes_seen, $regexp;
+            return 'OA:DONE-1234-0-OA:curl11logs';
+    });
+
+    my $exit_code = $d->script_run('curl --logs');
+    is $exit_code, 0, 'Level 3 script_run returns correct exit code on successful command match';
+    is scalar(@regexes_seen), 1, 'Only wait_serial for the anchored fingerprint is called when match succeeds';
+    like $regexes_seen[0], qr/OA:DONE-\[0-9a-f\]\{4\}-\(\\d\+\)-OA(?:\\:|:)curl11logs/,
+      'wait_serial matches the exact head4+len+tail4 command fingerprint of curl --logs';
+
+    my $fp = $d->sut_marker('curl --logs');
+    my $regex = qr/OA:DONE-[0-9a-f]{4}-(\d+)-\Q$fp\E/;
+    my $stale_systemctl = "OA:DONE-aaaa-1-OA:syst15_ctl\n";
+    my $stale_tar = "OA:DONE-bbbb-2-OA:tar_7_tar\n";
+    my $correct_curl = "OA:DONE-cccc-0-OA:curl11logs\n";
+
+    unlike $stale_systemctl, $regex, 'Stale unconsumed systemctl markers from other commands are ignored by the curl regex';
+    unlike $stale_tar, $regex, 'Stale unconsumed tar markers from other commands are ignored by the curl regex';
+    like $correct_curl, $regex, 'The target curl marker matches the anchored regex perfectly';
+
+    my ($extracted_exit) = ($correct_curl =~ $regex);
+    is $extracted_exit, 0, 'Exit code is correctly extracted from the fingerprinted marker';
+
+    @regexes_seen = ();
+    $mock_testapi->redefine(wait_serial => sub ($regexp, @) { push @regexes_seen, $regexp; return undef });
+    $exit_code = $d->script_run('curl --logs');
+    is $exit_code, undef, 'Anchored match miss fails closed with undef instead of an unreliable generic fallback';
+    is scalar(@regexes_seen), 1, 'No second generic wait_serial is issued, preventing stale-marker mismatch and doubled timeout';
+    like $regexes_seen[0], qr/OA:DONE-\[0-9a-f\]\{4\}-\(\\d\+\)-OA(?:\\:|:)curl11logs/, 'The single wait_serial call uses the anchored fingerprint';
 };
 
 subtest 'set expected serial and autoinst failures' => sub {


### PR DESCRIPTION
Motivation:
The level-3 script_run path matched exit markers with an unanchored regex
OA:DONE-<rand>-<exit>-, which matched the first OA:DONE in the serial buffer.
Stale markers left by asynchronous commands were matched instead of the
current command's, yielding wrong exit codes.

Design Choices:
Derive a per-command fingerprint via sut_marker and anchor the regex with
\Q$fp\E so wait_serial correlates the exit code to the exact command. The
level-3 shell hook is extended to emit the matching OA:<head4><len><tail4>
fingerprint. An unmatched marker returns undef, consistent with the other
marker levels. Tests assert the anchored regex ignores stale markers and
extracts the correct exit code.

Verification:

parent with `PRETTY_SERIAL_MARKER` on by default, child `PRETTY_SERIAL_MARKER=0`

```
openqa-clone-job --badge --parental-inheritance --within-instance https://openqa.suse.de/tests/23829659 ISOTOVIDEO="c=/var/lib/openqa/cache/podman_storage && p=\$(pwd)/podman_tmp && mkdir -p \$c \$p/run && env HOME=\$p XDG_RUNTIME_DIR=\$p/run podman --root \$c --runroot \$p/run/containers --storage-opt ignore_chown_errors=true --cgroup-manager=cgroupfs --events-backend=file run --init --rm --entrypoint \"\" --device /dev/kvm -v \$(pwd):/pool -w /pool -v /var/lib/openqa/cache:/var/lib/openqa/cache registry.opensuse.org/devel/openqa/containers/os-autoinst_dev:latest sh -c 'zypper -n in os-autoinst-distri-opensuse-deps && rm -rf os-autoinst && git clone --branch=feature/013_pretty_typing_fixes_7 --depth=1 https://github.com/okurz/os-autoinst.git && make -C os-autoinst symlinks && os-autoinst/isotovideo -d'" _GROUP=0 {TEST,BUILD}+=-okurz-poo199934-013_pretty_typing_fixes_7
```

Cloning parents of sle-12-SP5-Server-DVD-Updates-x86_64-Build20260807-1-mau-extratests2@64bit
Cloning children of sle-12-SP5-Server-DVD-Updates-x86_64-Build20260807-1-mru-install-minimal-with-addons@64bit
* [![sle-12-SP5-Server-DVD-Updates-x86_64-Build20260807-1-mru-install-minimal-with-addons@64bit](https://openqa.suse.de/tests/23834865/badge?label=sle-12-SP5-Server-DVD-Updates-x86_64-Build20260807-1-mru-install-minimal-with-addons@64bit)](https://openqa.suse.de/tests/23834865)
* [![sle-12-SP5-Server-DVD-Updates-x86_64-Build20260807-1-mau-extratests2@64bit](https://openqa.suse.de/tests/23834866/badge?label=sle-12-SP5-Server-DVD-Updates-x86_64-Build20260807-1-mau-extratests2@64bit)](https://openqa.suse.de/tests/23834866)

parent+child `PRETTY_SERIAL_MARKER=0`

```
openqa-clone-job --badge --parental-inheritance --within-instance https://openqa.suse.de/tests/23829659 ISOTOVIDEO="c=/var/lib/openqa/cache/podman_storage && p=\$(pwd)/podman_tmp && mkdir -p \$c \$p/run && env HOME=\$p XDG_RUNTIME_DIR=\$p/run podman --root \$c --runroot \$p/run/containers --storage-opt ignore_chown_errors=true --cgroup-manager=cgroupfs --events-backend=file run --init --rm --entrypoint \"\" --device /dev/kvm -v \$(pwd):/pool -w /pool -v /var/lib/openqa/cache:/var/lib/openqa/cache registry.opensuse.org/devel/openqa/containers/os-autoinst_dev:latest sh -c 'zypper -n in os-autoinst-distri-opensuse-deps && rm -rf os-autoinst && git clone --branch=feature/013_pretty_typing_fixes_7 --depth=1 https://github.com/okurz/os-autoinst.git && make -C os-autoinst symlinks && os-autoinst/isotovideo -d'" _GROUP=0 {TEST,BUILD}+=-okurz-poo199934-013_pretty_typing_fixes_7_pretty_serial_marker_0 PRETTY_SERIAL_MARKER=0
```

Cloning parents of sle-12-SP5-Server-DVD-Updates-x86_64-Build20260807-1-mau-extratests2@64bit
Cloning children of sle-12-SP5-Server-DVD-Updates-x86_64-Build20260807-1-mru-install-minimal-with-addons@64bit
* [![sle-12-SP5-Server-DVD-Updates-x86_64-Build20260807-1-mru-install-minimal-with-addons@64bit](https://openqa.suse.de/tests/23834867/badge?label=sle-12-SP5-Server-DVD-Updates-x86_64-Build20260807-1-mru-install-minimal-with-addons@64bit)](https://openqa.suse.de/tests/23834867)
* [![sle-12-SP5-Server-DVD-Updates-x86_64-Build20260807-1-mau-extratests2@64bit](https://openqa.suse.de/tests/23834868/badge?label=sle-12-SP5-Server-DVD-Updates-x86_64-Build20260807-1-mau-extratests2@64bit)](https://openqa.suse.de/tests/23834868)

parent+child `PRETTY_SERIAL_MARKER=1`

```
openqa-clone-job --badge --parental-inheritance --within-instance https://openqa.suse.de/tests/23829659 ISOTOVIDEO="c=/var/lib/openqa/cache/podman_storage && p=\$(pwd)/podman_tmp && mkdir -p \$c \$p/run && env HOME=\$p XDG_RUNTIME_DIR=\$p/run podman --root \$c --runroot \$p/run/containers --storage-opt ignore_chown_errors=true --cgroup-manager=cgroupfs --events-backend=file run --init --rm --entrypoint \"\" --device /dev/kvm -v \$(pwd):/pool -w /pool -v /var/lib/openqa/cache:/var/lib/openqa/cache registry.opensuse.org/devel/openqa/containers/os-autoinst_dev:latest sh -c 'zypper -n in os-autoinst-distri-opensuse-deps && rm -rf os-autoinst && git clone --branch=feature/013_pretty_typing_fixes_7 --depth=1 https://github.com/okurz/os-autoinst.git && make -C os-autoinst symlinks && os-autoinst/isotovideo -d'" _GROUP=0 {TEST,BUILD}+=-okurz-poo199934-013_pretty_typing_fixes_7_pretty_serial_marker_1 PRETTY_SERIAL_MARKER=1
```

Cloning parents of sle-12-SP5-Server-DVD-Updates-x86_64-Build20260807-1-mau-extratests2@64bit
Cloning children of sle-12-SP5-Server-DVD-Updates-x86_64-Build20260807-1-mru-install-minimal-with-addons@64bit
* [![sle-12-SP5-Server-DVD-Updates-x86_64-Build20260807-1-mru-install-minimal-with-addons@64bit](https://openqa.suse.de/tests/23834870/badge?label=sle-12-SP5-Server-DVD-Updates-x86_64-Build20260807-1-mru-install-minimal-with-addons@64bit)](https://openqa.suse.de/tests/23834870)
* [![sle-12-SP5-Server-DVD-Updates-x86_64-Build20260807-1-mau-extratests2@64bit](https://openqa.suse.de/tests/23834869/badge?label=sle-12-SP5-Server-DVD-Updates-x86_64-Build20260807-1-mau-extratests2@64bit)](https://openqa.suse.de/tests/23834869)

Benefits:
Exit codes are correctly correlated to their command even when stale markers
remain in the buffer, removing the class of false pass/fail results caused by
cross-command marker confusion.

Related issue: https://progress.opensuse.org/issues/199934