### PR TITLE
feat(testapi): support become_user for cleaner user switching

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -98,6 +98,15 @@ sub become_root ($self) {
     $self->script_run('cd /tmp');
 }
 
+sub become_user ($self, $user) {
+    die "Invalid username: $user" unless $user =~ /^[a-zA-Z0-9_.-]+$/;
+    $self->script_run("su - $user", 0);
+    $self->invalidate_serial_marker_hook();
+    my $console = testapi::current_console() // 'sut';
+    my $level = $self->{_serial_marker_level}->{$console} // 1;
+    $self->install_serial_marker_hook($level);
+}
+
 =head2 disable_key_repeat
 
   disable_key_repeat()

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -1383,6 +1383,7 @@ $bmwqemu::vars{CASEDIR} = 't';
 like get_test_data('console.ref.json'), qr/area/, 'get_test_data can be called';
 $fake_exit = 0;
 lives_ok { become_root } 'become_root can be called';
+lives_ok { become_user('geeko') } 'become_user can be called';
 lives_ok { hold_key('ret') } 'hold_key can be called';
 lives_ok { release_key('ret') } 'release_key can be called';
 lives_ok { reset_consoles } 'reset_consoles can be called';

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -466,6 +466,26 @@ subtest 'terminal_session_boundary' => sub {
     like $typed, qr/_oap/, 'hook is successfully re-installed on the next command after cached status is explicitly invalidated';
 };
 
+subtest 'become_user' => sub {
+    my $d = distribution->new;
+    my $mock_testapi = Test::MockModule->new('testapi');
+    my $mock_bmwqemu = Test::MockModule->new('bmwqemu');
+    $mock_bmwqemu->noop('log_call');
+    my $typed = '';
+    $mock_testapi->redefine(query_isotovideo => sub { });
+    $mock_testapi->redefine(type_string => sub { $typed .= $_[0] });
+    $mock_testapi->redefine(is_serial_terminal => sub { 0 });
+    $mock_testapi->redefine(current_console => sub { 'test-console' });
+    $mock_testapi->redefine(get_var => sub { $_[0] eq 'PRETTY_SERIAL_MARKER' ? 1 : undef });
+    $testapi::serialdev = 'ttyS0';
+    $mock_testapi->redefine(wait_serial => undef);
+    $d->{_serial_marker_level}->{'test-console'} = 3;
+    $d->become_user('geeko');
+    like $typed, qr/su - geeko/, 'become_user types su command to switch session user';
+    like $typed, qr/_oap/, 'become_user automatically reinstalls the shell synchronization hook after invalidation';
+    throws_ok { $d->become_user('geeko; rm -rf /') } qr/Invalid username/, 'invalid username is rejected';
+};
+
 done_testing;
 
 1;

--- a/testapi.pm
+++ b/testapi.pm
@@ -63,7 +63,7 @@ our @EXPORT = qw(
 
   wait_screen_change assert_screen_change wait_still_screen assert_still_screen wait_serial
   record_soft_failure record_info force_soft_failure
-  become_root x11_start_program ensure_installed eject_cd disconnect_usb power
+  become_root become_user x11_start_program ensure_installed eject_cd disconnect_usb power
 
   switch_network
   save_memory_dump freeze_vm resume_vm save_storage
@@ -1260,6 +1260,20 @@ I<The implementation is distribution specific and not always available.>
 =cut
 
 sub become_root () { $distri->become_root }
+
+=head2 become_user
+
+  become_user($user);
+
+Switch the current shell session's user to C<$user> (e.g. via C<su - $user>) and
+properly handle openQA serial marker synchronization hook invalidation so subsequent
+commands run cleanly under the new user.
+
+I<The implementation is distribution specific and not always available.>
+
+=cut
+
+sub become_user ($user) { $distri->become_user($user) }
 
 =head2 ensure_installed
 


### PR DESCRIPTION
Motivation:
Test code in downstream distributions frequently switch users (e.g. su - $user),
which requires manual invalidation of pretty serial marker hooks. Currently,
they must reach into raw $testapi::distri internals to achieve this.

Design Choices:
1. Implemented become_user($user) in distribution.pm and exposed it in
   testapi.pm to handle user switching and hook re-installation automatically.
2. Unconditionally called install_serial_marker_hook() in become_user, allowing
   it to manage its own capability level validation internally.
3. Added self-explanatory, concise test coverage in t/05-distribution.t,
   omitting unnecessary blank lines, comments, and wait_serial mocks.
4. Bumped the worker interface version to 59 in Interface.pm.

Benefits:
A cleaner, fully-encapsulated public API for user switching that handles
serial marker hook invalidation transparently under the hood.