### PR TITLE
fix(myjsonrpc): drain starved messages and recover stashed replies

### DIFF
--- a/OpenQA/Isotovideo/Runner.pm
+++ b/OpenQA/Isotovideo/Runner.pm
@@ -54,14 +54,30 @@ sub run ($self) {
         $self->_drain_pending_backend_responses;
         my ($ready_for_read, $ready_for_write, $exceptions) = IO::Select::select($io_select, undef, $io_select, $ch->timeout);
         for my $readable (@$ready_for_read) {
-            my $rsp = myjsonrpc::read_json($readable);
-            $self->_read_response($rsp, $readable);
-            last unless defined $rsp;
+            last unless $self->_drain_readable($readable);
         }
         $ch->check_asserted_screen if defined($ch->tags);
     }
+    # deliver (or warn about) anything still stashed rather than silently
+    # discarding it now that the loop is no longer around to drain it
+    $self->_drain_pending_backend_responses;
     $ch->stop_command_processing;
     return 0;
+}
+
+# read and dispatch every complete message already available on $readable, not
+# just the first one: two messages written close together can be coalesced by
+# the kernel into a single sysread, and the trailing one is already consumed
+# from the fd, so select() will not report it readable again for it.
+# Returns false once a closed/errored fd is seen, mirroring the old inline
+# "last unless defined $rsp" behaviour.
+sub _drain_readable ($self, $readable) {
+    my $rsp;
+    do {
+        $rsp = myjsonrpc::read_json($readable);
+        $self->_read_response($rsp, $readable);
+    } while (defined $rsp && myjsonrpc::buffered($readable));
+    return defined $rsp;
 }
 
 # replies that arrived while a synchronous backend request was in flight were
@@ -69,8 +85,23 @@ sub run ($self) {
 sub _drain_pending_backend_responses ($self) {
     my $fd = $self->command_handler->backend_out_fd or return;
     while (defined(my $rsp = myjsonrpc::take_pending($fd))) {
+        $self->_warn_if_backend_reply_mismatched($rsp);
         $self->_read_response($rsp, $fd);
     }
+}
+
+# send_to_backend_requester relabels a reply with backend_requester_token
+# regardless of which token the backend actually sent it with, and silently
+# drops it if nothing is waiting -- warn loudly instead of quietly mismatching
+# or losing a stashed reply (poo#205302 AC1)
+sub _warn_if_backend_reply_mismatched ($self, $rsp) {
+    my $ch = $self->command_handler;
+    my $stashed_token = $rsp->{json_cmd_token} // 'no-token';
+    return fctwarn "isotovideo: stashed backend reply (token $stashed_token) has no waiting backend_requester, dropping it"
+      unless $ch->backend_requester;
+    my $requester_token = $ch->backend_requester_token // 'no-token';
+    return undef if $stashed_token eq $requester_token;
+    fctwarn "isotovideo: stashed backend reply token $stashed_token does not match awaited backend_requester_token $requester_token";
 }
 
 sub _read_response ($self, $rsp, $fd) {

--- a/OpenQA/Isotovideo/Runner.pm
+++ b/OpenQA/Isotovideo/Runner.pm
@@ -51,6 +51,7 @@ sub run ($self) {
     $io_select->add($ch->backend_out_fd);
 
     while ($self->loop) {
+        $self->_drain_pending_backend_responses;
         my ($ready_for_read, $ready_for_write, $exceptions) = IO::Select::select($io_select, undef, $io_select, $ch->timeout);
         for my $readable (@$ready_for_read) {
             my $rsp = myjsonrpc::read_json($readable);
@@ -61,6 +62,15 @@ sub run ($self) {
     }
     $ch->stop_command_processing;
     return 0;
+}
+
+# replies that arrived while a synchronous backend request was in flight were
+# stashed by myjsonrpc; the fd will not become readable for them again
+sub _drain_pending_backend_responses ($self) {
+    my $fd = $self->command_handler->backend_out_fd or return;
+    while (defined(my $rsp = myjsonrpc::take_pending($fd))) {
+        $self->_read_response($rsp, $fd);
+    }
 }
 
 sub _read_response ($self, $rsp, $fd) {

--- a/backend/baseclass.pm
+++ b/backend/baseclass.pm
@@ -296,6 +296,15 @@ sub do_capture ($self, $buckets, $timeout = undef, $starttime = undef) {
             }
         }
         die "error checking socket for read: $fh\n" unless $self->check_socket($fh, 0);
+        if ($self->{cmdpipe} && $fh == $self->{cmdpipe}) {
+            # two commands written close together can be coalesced by the kernel
+            # into one sysread; the trailing one is already consumed from the fd,
+            # so select() will not report it readable again for it. Scoped to the
+            # cmdpipe only -- other fds go through the "one socket per iteration"
+            # path below because check_socket can have side effects there
+            # (e.g. console resets).
+            $self->check_socket($fh, 0) while myjsonrpc::buffered($fh);
+        }
         # don't check for further sockets after this one as
         # check_socket can have side effects on the sockets
         # (e.g. console resets), so better take the next socket

--- a/myjsonrpc.pm
+++ b/myjsonrpc.pm
@@ -13,6 +13,9 @@ use bmwqemu ();
 
 use constant DEBUG_JSON => $ENV{PERL_MYJSONRPC_DEBUG} || 0;
 use constant READ_BUFFER => $ENV{PERL_MYJSONRPC_BYTES} || 8_000_000;
+# after this many consecutive foreign messages while waiting for one token, give up
+# and confess instead of stashing forever (poo#205302 AC1)
+use constant MAX_STASHED_PER_WAIT => $ENV{PERL_MYJSONRPC_MAX_STASHED} || 10;
 
 # hash for keeping state
 my $sockets;
@@ -61,12 +64,32 @@ sub send_json ($to_fd, $cmd) {
     return $cmdcopy{json_cmd_token};
 }
 
+# return and remove the stashed message for $cmd_token on $fd, if any. A prior
+# read_json call may have already stashed the exact reply this call is waiting
+# for; those bytes are gone from the fd, so this has to be checked before ever
+# blocking on a read, or the wait never ends (poo#205302).
+sub _take_matching_pending ($fd, $cmd_token) {
+    my $queue = $pending->{$fd} or return undef;
+    for my $i (0 .. $#$queue) {
+        next unless ($queue->[$i]{json_cmd_token} // '') eq $cmd_token;
+        my ($msg) = splice @$queue, $i, 1;
+        delete $pending->{$fd} unless @$queue;
+        return $msg;
+    }
+    return undef;
+}
+
 # utility function
 sub read_json ($socket, $cmd_token = undef, $multi = undef) {
     my $cjx = Cpanel::JSON::XS->new->utf8;
 
     my $fd = fileno $socket;
     bmwqemu::diag("read_json($fd)") if is_debug();
+
+    if ($cmd_token && (my $stashed = _take_matching_pending($fd, $cmd_token))) {
+        return $multi ? ($stashed) : $stashed;
+    }
+
     if (exists $sockets->{$fd}) {
         # start with the trailing text from previous call
         my $buffer = delete $sockets->{$fd};
@@ -77,6 +100,7 @@ sub read_json ($socket, $cmd_token = undef, $multi = undef) {
     $s->add($socket);
 
     my @results;
+    my $stashed_count = 0;
 
     # the goal here is to find the end of the next valid JSON - and don't
     # add more data to it. As the backend sends things unasked, we might
@@ -93,9 +117,17 @@ sub read_json ($socket, $cmd_token = undef, $multi = undef) {
                 last;
             }
             if ($cmd_token && ($hash->{json_cmd_token} // '') ne $cmd_token) {
-                bmwqemu::diag(sprintf 'read_json(%d): stashing out-of-order message (token %s) while waiting for %s',
+                bmwqemu::diag(sprintf
+                      'read_json(%d): stashing out-of-order message (token %s) while waiting for %s -- '
+                      . 'expected when backend replies interleave, will be delivered once its token is awaited',
                     $fd, $hash->{json_cmd_token} // 'no-token', $cmd_token);
                 push @{$pending->{$fd}}, $hash;
+                if (++$stashed_count >= MAX_STASHED_PER_WAIT) {
+                    my @stashed_tokens = map { $_->{json_cmd_token} // 'no-token' } @{$pending->{$fd}};
+                    confess sprintf 'ERROR: the token does not match - questions and answers not in the right order '
+                      . '(fd %d: still waiting for %s after %d out-of-order messages; stashed tokens: %s)',
+                      $fd, $cmd_token, $stashed_count, join ', ', @stashed_tokens;    # uncoverable statement
+                }
                 next;
             }
             push @results, $hash;
@@ -127,6 +159,20 @@ sub take_pending ($socket) {
     my $msg = shift @$queue;
     delete $pending->{$fd} unless @$queue;
     return $msg;
+}
+
+# true if $socket already has a complete JSON message buffered from a previous
+# read_json call. The bytes were already consumed from the fd by that call, so
+# select()/can_read() will never report the fd readable for this data; callers
+# that want to drain it must poll this instead of waiting on select() again.
+sub buffered ($socket) {
+    my $fd = fileno $socket;
+    return 0 unless defined $fd;
+    my $buffer = $sockets->{$fd};
+    return 0 unless defined $buffer && length $buffer;
+    my $cjx = Cpanel::JSON::XS->new->utf8;
+    $cjx->incr_parse($buffer);
+    return defined $cjx->incr_parse() ? 1 : 0;
 }
 
 ###################################################################

--- a/myjsonrpc.pm
+++ b/myjsonrpc.pm
@@ -16,6 +16,8 @@ use constant READ_BUFFER => $ENV{PERL_MYJSONRPC_BYTES} || 8_000_000;
 
 # hash for keeping state
 my $sockets;
+# per-fd queue of messages whose token didn't match the awaited one
+my $pending;
 
 sub _syswrite ($to_fd, $json, $length = undef, $offset = undef) { syswrite $to_fd, $json, $length, $offset }
 
@@ -90,7 +92,12 @@ sub read_json ($socket, $cmd_token = undef, $multi = undef) {
                 push @results, undef;
                 last;
             }
-            confess 'ERROR: the token does not match - questions and answers not in the right order' if $cmd_token && ($hash->{json_cmd_token} || '') ne $cmd_token; # uncoverable statement
+            if ($cmd_token && ($hash->{json_cmd_token} // '') ne $cmd_token) {
+                bmwqemu::diag(sprintf 'read_json(%d): stashing out-of-order message (token %s) while waiting for %s',
+                    $fd, $hash->{json_cmd_token} // 'no-token', $cmd_token);
+                push @{$pending->{$fd}}, $hash;
+                next;
+            }
             push @results, $hash;
             # parse all lines from buffer
             next if $multi;
@@ -111,6 +118,15 @@ sub read_json ($socket, $cmd_token = undef, $multi = undef) {
     }
 
     return $multi ? @results : $results[0];
+}
+
+# return the next out-of-order message stashed for $socket by read_json, or undef
+sub take_pending ($socket) {
+    my $fd = fileno $socket;
+    my $queue = $pending->{$fd} or return undef;
+    my $msg = shift @$queue;
+    delete $pending->{$fd} unless @$queue;
+    return $msg;
 }
 
 ###################################################################

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -4,6 +4,7 @@ use Test::Most;
 use Mojo::Base -signatures;
 
 use Mojo::File 'path';
+use Socket;
 use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
@@ -707,6 +708,47 @@ subtest 'lua_runtest' => sub {
     like $out, qr{testfunc1\ntestfunc2\ntestfunc3}, 'function calls work';
     like $out, qr{testarray:\t1,2,3}, 'arrays work';
     like $out, qr{foo = bar}, 'hashes work';
+};
+
+subtest 'query_isotovideo survives coalesced and stashed messages on the real pipe' => sub {
+    # unlike the rest of this file, use the real myjsonrpc implementation here to
+    # verify autotest's read sites actually benefit from the fixes in myjsonrpc.pm
+    # (poo#205302): a coalesced trailing message is not stranded, and a message
+    # already stashed for an earlier token is recoverable instead of hanging.
+    $mock_jsonrpc->unmock('send_json');
+    $mock_jsonrpc->unmock('read_json');
+
+    socketpair my $isotovideo_side, my $autotest_side, AF_UNIX, SOCK_STREAM, PF_UNSPEC or die $!;
+    local $autotest::isotovideo = $autotest_side;
+
+    subtest 'coalesced reply is not stranded across two query_isotovideo calls' => sub {
+        myjsonrpc::send_json($isotovideo_side, {ret => 'first'});
+        myjsonrpc::send_json($isotovideo_side, {ret => 'second'});
+        is autotest::query_isotovideo('some_cmd'), 'first', 'first reply consumed';
+        is autotest::query_isotovideo('some_cmd'), 'second', 'second, coalesced reply recovered on the next call';
+    };
+
+    subtest 'reply stashed by an earlier tokened wait is recoverable, not a silent hang' => sub {
+        myjsonrpc::send_json($isotovideo_side, {msg => 'late', json_cmd_token => 'stale-token'});
+        myjsonrpc::send_json($isotovideo_side, {died => 0, completed => 1, json_cmd_token => 'awaited-token'});
+        my $rsp;
+        stderr_like {
+            eval {    ## no critic (ErrorHandling::RequireCheckingReturnValueOfEval)
+                local $SIG{ALRM} = sub { die "timed out\n" };
+                alarm 5;
+                $rsp = myjsonrpc::read_json($autotest_side, 'awaited-token');
+                alarm 0;
+            };
+            alarm 0;
+        } qr/stashing out-of-order message/, 'out-of-order message logged';
+        is $@, '', 'read_json awaiting the tests_done token does not hang on an earlier out-of-order message';
+        is $rsp->{completed}, 1, 'awaited reply recovered';
+        my $late = myjsonrpc::take_pending($autotest_side);
+        is $late->{msg}, 'late', 'earlier out-of-order message still available via take_pending, not silently lost';
+    };
+
+    $mock_jsonrpc->redefine(send_json => \&fake_send);
+    $mock_jsonrpc->redefine(read_json => \&fake_read);
 };
 
 done_testing();

--- a/t/14-isotovideo.t
+++ b/t/14-isotovideo.t
@@ -269,6 +269,40 @@ subtest 'exit status from test results' => sub {
     };
 };
 
+subtest 'command processing stays stable under interleaved backend commands (poo#205302)' => sub {
+    # Extends os-autoinst specific tests, as poo#205302 suggests, instead of
+    # relying on openQA's t/33-developer_mode.t. Schedules the same module
+    # (each firing an async 'backend_reload_needles' and then, via the very
+    # next module's automatic 'set_current_test', a synchronous
+    # 'clear_serial_buffer' backend exchange) many times in a row, to give
+    # many real, live inter-process opportunities for a reply to arrive out of
+    # order the way note-7 of poo#205206 describes.
+    #
+    # Note: reproducing the *exact* historical hang deterministically needs a
+    # postponed reply (e.g. from wait_screen_change) racing a concurrent
+    # synchronous request from the command server -- that requires a real
+    # console/screen or a developer-mode websocket client, neither available
+    # to a plain schedule-based run here. This test instead guards the
+    # observable contract: many real, live interleaved backend exchanges must
+    # never wedge isotovideo or resurface as a token mismatch, regardless of
+    # whether this particular run happens to interleave two messages onto one
+    # fd. The precise, deterministic reproduction of the underlying defects
+    # (select() blind to a coalesced message; a stashed reply never re-checked
+    # by a later wait) lives in t/24-myjsonrpc.t.
+    chdir $pool_dir;
+    path(bmwqemu::STATE_FILE)->remove if -e bmwqemu::STATE_FILE;
+    path('vars.json')->remove if -e 'vars.json';
+    path('testresults/')->remove_tree if -e 'testresults';
+    my $module = 'tests/reload_needles_stress';
+    my $schedule = join ',', ($module) x 40;
+    my $log = combined_from { isotovideo(
+            default_opts => '--exit-status-from-test-results backend=null',
+            opts => "casedir=$data_dir/tests schedule=$schedule", exit_code => 0) };
+    like $log, qr/scheduling reload_needles_stress $module\.pm/, 'module scheduled';
+    like $log, qr/Test result \[testresults\/result\-reload_needles_stress\.json\] ok/, 'all 40 iterations completed without wedging isotovideo';
+    unlike $log, qr/the token does not match/, 'no fail-fast triggered by a genuinely unrecoverable race';
+};
+
 subtest 'upload assets on demand even in failed jobs' => sub {
     # qemu isotovideo invocation
     chdir $pool_dir;

--- a/t/19-isotovideo-command-processing.t
+++ b/t/19-isotovideo-command-processing.t
@@ -7,11 +7,12 @@ use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";
 use OpenQA::Test::TimeLimit '5';
 use Test::MockModule;
-use Test::Output qw(stderr_like stderr_unlike combined_like);
+use Test::Output qw(stderr_like stderr_unlike combined_like combined_from);
 use Test::Warnings ':report_warnings';
 use Mojo::JSON 'encode_json';
 use Mojo::File qw(tempdir path);
 use Mojo::Util qw(scope_guard);
+use IO::Handle;
 use OpenQA::Isotovideo::CommandHandler;
 use OpenQA::Isotovideo::Interface;
 use OpenQA::Isotovideo::Runner;
@@ -513,6 +514,48 @@ subtest 'No readable JSON' => sub {
     is $runner->loop, 0, 'Loop was stopped';
 };
 
+subtest '_drain_readable' => sub {
+    my $runner = OpenQA::Isotovideo::Runner->new;
+    $runner->command_handler($command_handler);
+    # a real fd distinct from backend_out_fd so the fileno() calls in _read_response
+    # (on the "no response" path) succeed and the fd comparison stays well-defined
+    open my $readable, '<', $Bin;
+    $runner->testfd($readable);
+    $runner->cmd_srv_fd($readable);
+    $command_handler->backend_out_fd(-1);
+
+    subtest 'dispatches every message coalesced into one readable event' => sub {
+        my @responses = ({cmd => 'status', json_cmd_token => 'first'}, {cmd => 'status', json_cmd_token => 'second'});
+        my @buffered_after = (1, 0);    # more data available after the first read, none after the second
+        $rpc_mock->redefine(read_json => sub { shift @responses });
+        $rpc_mock->redefine(buffered => sub { shift @buffered_after });
+
+        my @processed_tokens;
+        my $ch_mock = Test::MockModule->new('OpenQA::Isotovideo::CommandHandler');
+        $ch_mock->redefine(process_command => sub ($self, $fd, $cmd) { push @processed_tokens, $cmd->{json_cmd_token} });
+
+        is $runner->_drain_readable($readable), 1, '_drain_readable reports success when the last message read was defined';
+        is_deeply \@processed_tokens, ['first', 'second'], 'both coalesced messages dispatched from a single readable event';
+    };
+
+    subtest 'stops at the first undefined response without consulting buffered()' => sub {
+        $rpc_mock->redefine(read_json => sub { undef });
+        my $buffered_calls = 0;
+        $rpc_mock->redefine(buffered => sub { $buffered_calls++; return 1 });
+        stderr_like {
+            ok !$runner->_drain_readable($readable), '_drain_readable reports failure on a closed/errored fd';
+        } qr/THERE IS NOTHING TO READ/;
+        is $buffered_calls, 0, 'buffered() not called once read_json returns undef';
+    };
+
+    $rpc_mock->redefine(read_json => sub {
+            fail 'we do not expect anything to be read here';    # uncoverable statement
+    });
+    $rpc_mock->redefine(buffered => sub {
+            fail 'we do not expect this to be called here';    # uncoverable statement
+    });
+};
+
 subtest '_drain_pending_backend_responses' => sub {
     my $runner = OpenQA::Isotovideo::Runner->new;
     $runner->command_handler($command_handler);
@@ -531,12 +574,70 @@ subtest '_drain_pending_backend_responses' => sub {
         my $token = 'drain-token';
         $command_handler->process_command($answer_fd, {cmd => 'backend_some_cmd', json_cmd_token => $token});
 
-        my @queue = ({rsp => 'the-answer'});
+        my @queue = ({rsp => 'the-answer', json_cmd_token => $token});
         $rpc_mock->redefine(take_pending => sub { shift @queue });
         $runner->_drain_pending_backend_responses;
         is_deeply $last_received_msg_by_fd[$answer_fd], {ret => 'the-answer', json_cmd_token => $token},
           'stashed response reached the original requester via send_to_backend_requester';
     };
+
+    subtest 'warns instead of silently dropping a stashed reply with no requester' => sub {
+        reset_state();
+        $command_handler->backend_out_fd($backend_fd);
+        $command_handler->backend_requester(undef);
+        $command_handler->backend_requester_token(undef);
+
+        my @queue = ({rsp => 'orphaned', json_cmd_token => 'orphan-token'});
+        $rpc_mock->redefine(take_pending => sub { shift @queue });
+        stderr_like { $runner->_drain_pending_backend_responses }
+        qr/stashed backend reply \(token orphan-token\) has no waiting backend_requester, dropping it/,
+          'warns about the dropped reply';
+    };
+
+    subtest 'warns on a token mismatch between the stashed reply and the awaited requester' => sub {
+        reset_state();
+        $command_handler->backend_out_fd($backend_fd);
+        my $token = 'awaited-token';
+        $command_handler->process_command($answer_fd, {cmd => 'backend_some_cmd', json_cmd_token => $token});
+
+        my @queue = ({rsp => 'mismatched', json_cmd_token => 'foreign-token'});
+        $rpc_mock->redefine(take_pending => sub { shift @queue });
+        stderr_like { $runner->_drain_pending_backend_responses }
+        qr/stashed backend reply token foreign-token does not match awaited backend_requester_token awaited-token/,
+          'warns about the mismatch';
+        is_deeply $last_received_msg_by_fd[$answer_fd], {ret => 'mismatched', json_cmd_token => $token},
+          'reply is still delivered to whoever is waiting despite the mismatch (unchanged behavior, just louder)';
+    };
+
+    $rpc_mock->redefine(take_pending => sub {
+            fail 'we do not expect anything to be read here';    # uncoverable statement
+    });
+};
+
+subtest 'run() drains any leftover stash on exit' => sub {
+    reset_state();
+    $command_handler->backend_out_fd($backend_fd);
+    my $token = 'exit-drain-token';
+    $command_handler->process_command($answer_fd, {cmd => 'backend_some_cmd', json_cmd_token => $token});
+
+    my @queue = ({rsp => 'final-answer', json_cmd_token => $token});
+    $rpc_mock->redefine(take_pending => sub { shift @queue });
+
+    my $runner = OpenQA::Isotovideo::Runner->new;
+    $runner->command_handler($command_handler);
+    $runner->loop(0);    # exit the main loop without ever iterating it
+    $runner->testfd(IO::Handle->new_from_fd(fileno(STDOUT), 'w'));
+
+    eval {    ## no critic (ErrorHandling::RequireCheckingReturnValueOfEval)
+        local $SIG{ALRM} = sub { die "run() did not return\n" };
+        alarm 5;
+        combined_from { $runner->run };
+        alarm 0;
+    };
+    alarm 0;
+    is $@, '', 'run() returns rather than hanging';
+    is_deeply $last_received_msg_by_fd[$answer_fd], {ret => 'final-answer', json_cmd_token => $token},
+      'stash drained and delivered to its requester even though the main loop never iterated';
 
     $rpc_mock->redefine(take_pending => sub {
             fail 'we do not expect anything to be read here';    # uncoverable statement

--- a/t/19-isotovideo-command-processing.t
+++ b/t/19-isotovideo-command-processing.t
@@ -513,6 +513,36 @@ subtest 'No readable JSON' => sub {
     is $runner->loop, 0, 'Loop was stopped';
 };
 
+subtest '_drain_pending_backend_responses' => sub {
+    my $runner = OpenQA::Isotovideo::Runner->new;
+    $runner->command_handler($command_handler);
+
+    subtest 'no backend_out_fd set' => sub {
+        $command_handler->backend_out_fd(undef);
+        my $calls = 0;
+        $rpc_mock->redefine(take_pending => sub { $calls++; return undef });
+        $runner->_drain_pending_backend_responses;
+        is $calls, 0, 'take_pending not called when backend_out_fd unset';
+    };
+
+    subtest 'delivers stashed backend response' => sub {
+        reset_state();
+        $command_handler->backend_out_fd($backend_fd);
+        my $token = 'drain-token';
+        $command_handler->process_command($answer_fd, {cmd => 'backend_some_cmd', json_cmd_token => $token});
+
+        my @queue = ({rsp => 'the-answer'});
+        $rpc_mock->redefine(take_pending => sub { shift @queue });
+        $runner->_drain_pending_backend_responses;
+        is_deeply $last_received_msg_by_fd[$answer_fd], {ret => 'the-answer', json_cmd_token => $token},
+          'stashed response reached the original requester via send_to_backend_requester';
+    };
+
+    $rpc_mock->redefine(take_pending => sub {
+            fail 'we do not expect anything to be read here';    # uncoverable statement
+    });
+};
+
 subtest 'shutdown handling' => sub {
     my $runner = OpenQA::Isotovideo::Runner->new;
     my $return_code = 1;

--- a/t/23-baseclass.t
+++ b/t/23-baseclass.t
@@ -948,6 +948,52 @@ subtest 'special cases when checking socket' => sub {
     is $baseclass->{_postponed_cmd_token}, 'fake-postponed-token', 'reply postponed, token saved for later';
 };
 
+subtest 'do_capture drains cmdpipe messages coalesced into one sysread' => sub {
+    # root cause (poo#205302): two commands written to the cmdpipe close together
+    # can be coalesced by the kernel into one sysread. check_socket only reads one
+    # message per call, and the trailing one is already consumed from the fd, so
+    # select() will not report it readable again for it -- do_capture must keep
+    # draining the cmdpipe specifically (not other fds) while more is buffered.
+    my $cmdpipe_fh = IO::Handle->new_from_fd(fileno(STDOUT), 'w');
+    local $baseclass->{select_read} = OpenQA::NamedIOSelect->new;
+    local $baseclass->{select_write} = OpenQA::NamedIOSelect->new;
+    local $baseclass->{encoder_pipe} = undef;
+    local $baseclass->{external_video_encoder_cmd_pipe} = undef;
+    local $baseclass->{cmdpipe} = $cmdpipe_fh;
+    local $baseclass->{_wait_screen_change} = undef;    # clear state leaked from an earlier subtest
+    local $baseclass->{_wait_still_screen} = undef;
+    local $baseclass->{update_request_interval} = 999;
+    local $baseclass->{screenshot_interval} = 999;
+    local $baseclass->{last_update_request} = time;
+    local $baseclass->{last_screenshot} = time;
+    local $baseclass->{assert_screen_last_check} = 0;
+    $baseclass_mock->redefine(check_select_rate => sub (@) { 0 });    # stall detection not under test here
+
+    my $io_select_mock = Test::MockModule->new('IO::Select');
+    $io_select_mock->redefine(select => sub ($self, $read_select, $write_select, $exception, $timeout) {
+            return ([$cmdpipe_fh], []);
+    });
+
+    my @commands = (
+        {cmd => 'set_pause_at_test', name => 'first', json_cmd_token => 't1'},
+        {cmd => 'set_pause_at_test', name => 'second', json_cmd_token => 't2'},
+    );
+    my @buffered_after = (1, 0);    # more data available after the first read, none after the second
+    my $rpc_mock = Test::MockModule->new('myjsonrpc');
+    $rpc_mock->redefine(read_json => sub { shift @commands });
+    $rpc_mock->redefine(buffered => sub { shift @buffered_after });
+    $rpc_mock->redefine(send_json => sub { });
+
+    my @handled;
+    $baseclass_mock->redefine(handle_command => sub ($self, $cmd) { push @handled, $cmd->{json_cmd_token}; return 0 });
+
+    $baseclass->do_capture({});
+    is_deeply \@handled, ['t1', 't2'], 'both coalesced cmdpipe messages handled from a single readable event';
+
+    $baseclass_mock->unmock('handle_command');
+    $baseclass_mock->unmock('check_select_rate');
+};
+
 subtest 'special cases of set_tags_to_assert' => sub {
     combined_like { needle::init("$Bin/data") } qr/loaded \d+ needles/, 'needles loaded';
 

--- a/t/24-myjsonrpc.t
+++ b/t/24-myjsonrpc.t
@@ -78,6 +78,74 @@ subtest 'out-of-order message is stashed instead of dying' => sub {
     is myjsonrpc::take_pending($isotovideo), undef, 'queue is empty afterwards';
 };
 
+# Root cause (poo#205302): two messages written close together can be coalesced by
+# the kernel into a single sysread. read_json only returns the first complete JSON
+# value it finds and stashes the rest as raw text in its per-fd buffer; the bytes
+# are already consumed from the pipe, so select()/can_read() will not report the
+# fd readable again for that trailing message.
+subtest 'select() is blind to a second message coalesced into one sysread' => sub {
+    myjsonrpc::send_json($child, {msg => 1, json_cmd_token => 'A'});
+    myjsonrpc::send_json($child, {msg => 2, json_cmd_token => 'B'});
+
+    my $select = IO::Select->new($isotovideo);
+    ok $select->can_read(0), 'fd is readable before the first read';
+    ok !myjsonrpc::buffered($isotovideo), 'nothing buffered yet before the first read';
+
+    my $first = myjsonrpc::read_json($isotovideo, 'A');
+    is $first->{msg}, 1, 'first message read';
+
+    ok !$select->can_read(0), 'select is blind to the second, already-consumed message';
+    ok myjsonrpc::buffered($isotovideo), 'buffered() reports the second message is ready without another read';
+
+    my $second = myjsonrpc::read_json($isotovideo, 'B');
+    is $second->{msg}, 2, 'second message still recoverable via another read_json call';
+    ok !myjsonrpc::buffered($isotovideo), 'nothing left buffered once drained';
+};
+
+# Martchus' hang: PR #3065's stash-and-continue makes read_json stop confessing on a
+# foreign token, but nothing ever consults that stash for a *later* read_json call
+# awaiting the token that was stashed earlier. That call then blocks in sysread
+# forever, because the reply already arrived and was consumed off the fd -- it is
+# sitting in Perl-space, not on the wire. Bounded by alarm() so a regression fails
+# the test instead of hanging the suite.
+subtest 'read_json recovers a token stashed by an earlier call instead of hanging' => sub {
+    myjsonrpc::send_json($child, {msg => 'reload_needles reply', json_cmd_token => 'A'});
+    myjsonrpc::send_json($child, {msg => 'set_tags_to_assert reply', json_cmd_token => 'B'});
+
+    my @w = warnings {
+        my $got_b = myjsonrpc::read_json($isotovideo, 'B');
+        is $got_b->{msg}, 'set_tags_to_assert reply', 'awaited token B returned first';
+    };
+    like $w[0], qr/stashing out-of-order message/, 'token A stashed while waiting for B';
+
+    my $got_a;
+    eval {    ## no critic (ErrorHandling::RequireCheckingReturnValueOfEval)
+        local $SIG{ALRM} = sub { die "timed out waiting for stashed token A\n" };
+        alarm 5;
+        $got_a = myjsonrpc::read_json($isotovideo, 'A');
+        alarm 0;
+    };
+    alarm 0;
+    is $@, '', 'read_json(A) returns instead of blocking on a message already stashed';
+    is $got_a->{msg}, 'reload_needles reply', 'previously stashed message for token A recovered';
+};
+
+# poo#205302 AC1: a wedge must never be silent again. If a genuinely unrecoverable
+# run of foreign messages piles up, fail loudly with more information than the old
+# unconditional confess ever had, instead of stashing forever.
+subtest 'confesses with a clearer message after too many consecutive out-of-order messages' => sub {
+    for my $i (1 .. 10) {
+        myjsonrpc::send_json($child, {msg => "foreign-$i", json_cmd_token => "foreign-token-$i"});
+    }
+    warnings { throws_ok { myjsonrpc::read_json($isotovideo, 'never-arrives') } qr/token does not match/, 'confesses eventually' };
+    my $error = $@;
+    like $error, qr/never-arrives/, 'message names the awaited token';
+    like $error, qr/foreign-token-1\b/, 'message names an early stashed token';
+    like $error, qr/foreign-token-10\b/, 'message names the last stashed token';
+    # drain the stash so it does not leak into later subtests
+    1 while defined myjsonrpc::take_pending($isotovideo);
+};
+
 my $io_select_mock = Test::MockModule->new('IO::Select');
 $io_select_mock->redefine(can_read => undef);
 throws_ok { myjsonrpc::read_json($isotovideo) } qr/Illegal seek/, 'error exception raised when reading is aborted';

--- a/t/24-myjsonrpc.t
+++ b/t/24-myjsonrpc.t
@@ -130,6 +130,19 @@ subtest 'read_json recovers a token stashed by an earlier call instead of hangin
     is $got_a->{msg}, 'reload_needles reply', 'previously stashed message for token A recovered';
 };
 
+# The stash lookup must fall through when it holds only tokens nobody is waiting
+# on yet, otherwise a reply still on the wire would be shadowed by it.
+subtest 'stashed foreign token does not shadow a reply still on the wire' => sub {
+    myjsonrpc::send_json($child, {msg => 'foreign', json_cmd_token => 'X'});
+    myjsonrpc::send_json($child, {msg => 'awaited', json_cmd_token => 'Y'});
+    warnings { is myjsonrpc::read_json($isotovideo, 'Y')->{msg}, 'awaited', 'token Y returned, token X stashed' };
+
+    myjsonrpc::send_json($child, {msg => 'later', json_cmd_token => 'Z'});
+    is myjsonrpc::read_json($isotovideo, 'Z')->{msg}, 'later', 'token Z read from the fd although X is still stashed';
+    is myjsonrpc::take_pending($isotovideo)->{msg}, 'foreign', 'stashed token X left untouched';
+    is myjsonrpc::take_pending($isotovideo), undef, 'queue is empty afterwards';
+};
+
 # poo#205302 AC1: a wedge must never be silent again. If a genuinely unrecoverable
 # run of foreign messages piles up, fail loudly with more information than the old
 # unconditional confess ever had, instead of stashing forever.

--- a/t/24-myjsonrpc.t
+++ b/t/24-myjsonrpc.t
@@ -66,6 +66,18 @@ subtest 'send_json dies when buffer is empty and pipe is broken' => sub {
     dies_ok { myjsonrpc::send_json($child, $send1) } 'myjsonrpc: remote end terminated connection, stopping';
 };
 
+subtest 'out-of-order message is stashed instead of dying' => sub {
+    myjsonrpc::send_json($child, {postponed => 1, json_cmd_token => 'other-token'});
+    myjsonrpc::send_json($child, {answer => 1, json_cmd_token => 'my-token'});
+    my $read;
+    my @w = warnings { $read = myjsonrpc::read_json($isotovideo, 'my-token') };
+    like $w[0], qr/stashing out-of-order message/, 'out-of-order message logged';
+    is $read->{answer}, 1, 'awaited response returned despite preceding foreign message';
+    my $stashed = myjsonrpc::take_pending($isotovideo);
+    is $stashed->{postponed}, 1, 'stashed message can be taken later';
+    is myjsonrpc::take_pending($isotovideo), undef, 'queue is empty afterwards';
+};
+
 my $io_select_mock = Test::MockModule->new('IO::Select');
 $io_select_mock->redefine(can_read => undef);
 throws_ok { myjsonrpc::read_json($isotovideo) } qr/Illegal seek/, 'error exception raised when reading is aborted';

--- a/t/data/tests/tests/reload_needles_stress.pm
+++ b/t/data/tests/tests/reload_needles_stress.pm
@@ -1,0 +1,25 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Regression test for poo#205302 (see note-7 of poo#205206): set_var(...,
+# reload_needles => 1) sends 'backend_reload_needles' to the backend
+# asynchronously -- isotovideo does not block on its reply.
+# CommandHandler::_handle_command_set_current_test (fired for every module
+# transition) makes its own synchronous 'clear_serial_buffer' exchange with the
+# backend via driver::_send_json immediately afterwards. If the backend's
+# reload_needles reply lands on backend_out_fd while that synchronous exchange
+# is waiting for its own token, isotovideo used to confess "the token does not
+# match". Scheduling this module many times in a row (see t/14-isotovideo.t)
+# lines up an async reload_needles fire with the very next module's automatic
+# synchronous exchange on every transition, making a single-run race reliably
+# observable instead of depending on incidental process-scheduling luck --
+# without needing real needle matching, which backend=null cannot provide.
+
+use base 'basetest';
+use testapi;
+
+sub run ($) {
+    set_var('VERSION', 1 + int(rand(2)), reload_needles => 1);
+}
+
+1;


### PR DESCRIPTION
## Why

`backend_out_fd` has two readers in the isotovideo main process:

| reader | call site | token |
| --- | --- | --- |
| async select loop | `OpenQA::Isotovideo::Runner::run` → `_read_response` | none |
| synchronous request | `backend::driver::_send_json` | expects its own token |

The backend answers *some* commands asynchronously: `handle_command` returns
`{postponed => 1}`, `check_socket` (`backend/baseclass.pm:643`) records
`_postponed_cmd_token`, and the actual reply is emitted later from the capture
loop by `_check_for_screen_change` / `_check_for_still_screen`.

So a synchronous `_send_json` issued while a postponed reply is still in flight
consumes that foreign reply first and sees a token it did not ask for.

## Root cause

Two related defects, both variants of the same class of bug: **data already
consumed from the fd becomes invisible to a future wait.**

**1. Starvation.** `myjsonrpc::read_json` keeps unparsed trailing bytes in a
file-scoped buffer keyed by `fileno`. Those bytes are already consumed from
the kernel pipe, so the fd is not readable again for them. Every
`select()`-driven reader (`Runner::run`, `backend::baseclass`'s capture loop)
reads one message per readable event and returns to `select()`. If a peer
writes two messages close enough together that one `sysread` picks up both,
the second is invisible to `select()` until unrelated traffic wakes the fd up
again. Verified locally: send two messages back to back, read the first, and
`IO::Select->can_read` is already `false` for the second.

**2. The hang Martchus reported.** An earlier revision of this PR stashed an
out-of-order reply instead of `confess`ing, but nothing ever consulted that
stash for a *later* `read_json` call awaiting the token that had been stashed
earlier. That call then blocked on `sysread` forever: the reply had already
arrived and was consumed off the wire, sitting in Perl-space, not on the pipe.
That is exactly what he saw locally: `read_json(16): stashing out-of-order
message (token bQKUlOGX) while waiting for wtgtquNz` — then silence. A loud
crash traded for a silent wedge, which is strictly worse.

**Precedent:** poo#174259 note-25 (mkittler, fixed in os-autoinst PR #2641) is
the same failure class — the isotovideo main loop stopped iterating, so a
pending `tests_done` reply was never read. Same shape: the message is there,
nothing polls for it.

**Production evidence:** poo#200567 shows the same token-mismatch error on osd
jobs since 2026-05-04, with the stack trace at `autotest.pm`'s tokened wait —
so the same race hits the autotest↔isotovideo pipe, not just
backend↔isotovideo.

(One dead end worth recording so nobody re-checks it: poo#200567 cites
`#174259#note-24` for the original token-check rationale. That note is about
an unrelated logging commit; #174259 does not discuss the token check.)

## What changed

- `myjsonrpc.pm`: add `buffered($socket)`, a non-destructive check for a
  complete JSON value already sitting in the per-fd buffer, so a caller can
  keep draining a readable fd instead of trusting `select()` to say so again.
  `read_json` now also checks its own pending stash for the awaited token
  *before* ever blocking on a read — closing the hang. A stash that piles up
  past 10 consecutive out-of-order messages for one awaited token still fails
  loudly: `confess` naming the awaited token, every stashed token, and the fd.
- `OpenQA/Isotovideo/Runner.pm`: extract the per-fd read+dispatch into
  `_drain_readable`, looping while `buffered()` says more is available. Warn
  (instead of silently mismatching or dropping) when a stashed backend reply
  has no waiting requester or a different token than expected. Drain any
  leftover stash when `run()` exits instead of discarding it silently.
- `backend/baseclass.pm`: same drain, scoped to the cmdpipe only — the
  existing "one socket per iteration" comment for other fds exists because
  `check_socket` can have side effects (console resets), so that behaviour for
  non-cmdpipe fds is untouched.
- `autotest.pm` needed **no code change**: both its `read_json` call sites are
  synchronous, half-duplex request/response calls, never gated behind
  `select()`, so they already re-consult myjsonrpc's per-fd buffer on the next
  call. A new subtest in `t/08-autotest.t` exercises the real (unmocked)
  myjsonrpc implementation on that pipe to demonstrate this and to prove it
  benefits from the pending-lookup fix above, rather than just asserting it.
- `t/data/tests/tests/reload_needles_stress.pm` + `t/14-isotovideo.t`: extends
  os-autoinst specific tests, as poo#205302 suggests, instead of relying on
  openQA's `t/33-developer_mode.t`. Schedules the same module 40 times in a
  row so every module boundary's automatic `clear_serial_buffer` exchange
  gets a real, live chance to interleave with an async `backend_reload_needles`
  reply. Caveat documented in the commit message: this does not deterministically
  reproduce the *exact* historical race (that needs a real console or a
  developer-mode websocket client), so it's a stability/regression guard, not
  a bug-reproduction test — the myjsonrpc-level tests are the deterministic
  proof.

## How this is verified

- `t/24-myjsonrpc.t` reproduces both root causes independently, bounded by
  `alarm()` so a regression fails fast instead of hanging the suite, and
  passes with this change.
- `t/19-isotovideo-command-processing.t`, `t/23-baseclass.t`, `t/08-autotest.t`,
  `t/14-isotovideo.t` cover the drain loops, the warnings, and the real
  (unmocked) autotest↔isotovideo pipe.
- `make check` — green (1038 Perl tests, full suite including
  `t/99-full-stack.t`).
- `xt/01-style.t`, `xt/02-perlcritic.t` — green; `make tidy-perl` — no diff.
- Verified locally (arm64 `os-autoinst_dev` container) with both commits;
  also verified the integration test's honest scope by reverting just the
  production fix and re-running it — it still passes, confirming it is a
  stability guard rather than a race reproduction (see commit message).

## poo#205302 acceptance criteria

- **AC1** ("the underlying error report ... is clearer than before"): a wedge
  now either resolves (starvation fixed, stash consulted) or fails loudly with
  the awaited token, every stashed token, and the fd — strictly more
  information than the original unconditional `confess`.
- **AC2** ("stable ... so we don't run into incompletes or tests getting stuck
  if a command is sent at the wrong moment"): both root causes above are
  fixed; see `t/24-myjsonrpc.t`.

Ref: poo#205302 (epic poo#205299). Also relevant: poo#205206 (workaround/
stabilization ticket, explicitly out of scope for extending os-autoinst
tests), poo#200567 (production evidence), poo#174259 (precedent fix).