### PR TITLE
Use more exceptions in testapi instead of plain die or croak

### DIFF
--- a/OpenQA/Exceptions.pm
+++ b/OpenQA/Exceptions.pm
@@ -28,6 +28,9 @@ use Exception::Class (
     'OpenQA::Exception::TestapiError' => {
         description => 'A testapi function failed'
     },
+    'OpenQA::Exception::TestapiUsageError' => {
+        description => 'A testapi function failed because of wrong usage'
+    },
 );
 
 1;

--- a/OpenQA/Isotovideo/Interface.pm
+++ b/OpenQA/Isotovideo/Interface.pm
@@ -9,7 +9,7 @@ use Mojo::Base -strict, -signatures;
 # -> increment on every change of such APIs
 # -> never move that variable to another place (when refactoring)
 #    because it may be accessed by the tests itself
-our $version = 58;    ## no critic (Variables::ProhibitPackageVars)
+our $version = 59;    ## no critic (Variables::ProhibitPackageVars)
 
 # major version of the (web socket) API relevant to the developer mode
 # -> increment when making non-backward compatible changes to that API

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -930,7 +930,7 @@ subtest 'validate_script_output' => sub {
     } qr/output not validating/, 'Die on output not match for regex';
     throws_ok {
         validate_script_output('script', ['Invalid parameter'])
-    } qr/coderef or regexp/, 'Die on invalid parameter';
+    } qr/Invalid use.*coderef or regexp/, 'Die on invalid parameter';
     throws_ok {
         validate_script_output('script', qr/error/, fail_message => 'foo bar')
     } qr/foo bar/, 'Die on output not match';

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -309,6 +309,9 @@ subtest 'assert_screen_change' => sub {
     });
     testapi::assert_screen_change(sub { }, 42);
     is $received_timeout, 42, 'timeout forwarded to wait_screen_change';
+
+    $mock_wsc->redefine(wait_screen_change => 0);
+    throws_ok { testapi::assert_screen_change(sub { }, 42) } qr/assert_screen_change failed to detect a screen change/, 'expected error message for no screen change';
 };
 
 is $autotest::current_test->{dents}, 0, 'no soft failures so far';

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -982,6 +982,10 @@ subtest 'wait_still_screen & assert_still_screen' => sub {
       'assert_still_screen forwards arguments to wait_still_screen';
     $fake_timeout = 1;
     ok !wait_still_screen, 'falsy return value on timeout';
+
+    $testapi->redefine(wait_still_screen => 0);
+    throws_ok { assert_still_screen; } qr/assert_still_screen failed to detect a still screen/,
+      'expeected error message for no still screen';
 };
 
 subtest 'test console::console argument settings' => sub {

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -1307,6 +1307,10 @@ subtest init => sub {
 
 lives_ok { force_soft_failure('boo#42') } 'can call force_soft_failure';
 
+subtest 'get_var' => sub {
+    throws_ok { get_required_var 'NOT HERE' } qr/Could not retrieve required variable NOT HERE/, 'get_required_var dies with expected message';
+};
+
 subtest 'set_var' => sub {
     $cmds = [];
     lives_ok { set_var('FOO', 'BAR', reload_needles => 1) } 'can call set_var with reload_needles';

--- a/t/03-testapi.t
+++ b/t/03-testapi.t
@@ -326,15 +326,21 @@ $details_ok &= like $details->{text}, qr/basetest-[0-9]+.*txt/, 'file for soft f
 always_explain $details unless $details_ok;
 $mock_bmwqemu->noop('log_call');
 
-require distribution;
-testapi::set_distribution(distribution->new());
-$autotest::last_milestone = {};
-select_console('a-console');
-is console('a-console')->{console}, 'a-console';
-is_deeply $autotest::activated_consoles, ['a-console'], 'Current console is activated';
-is is_serial_terminal, 0, 'Not a serial terminal';
-is current_console, 'a-console', 'Current console is the a-console';
-is console('b-console')->{console}, 'b-console', 'new console created on the fly';
+subtest console => sub {
+    require distribution;
+    testapi::set_distribution(distribution->new());
+    $autotest::last_milestone = {};
+    select_console('a-console');
+    is console('a-console')->{console}, 'a-console';
+    is_deeply $autotest::activated_consoles, ['a-console'], 'Current console is activated';
+    is is_serial_terminal, 0, 'Not a serial terminal';
+    is current_console, 'a-console', 'Current console is the a-console';
+    is console('b-console')->{console}, 'b-console', 'new console created on the fly';
+
+    $mod2->redefine(query_isotovideo => {error => 'on purpose'});
+    throws_ok { select_console('dummy') } qr/on purpose/, 'select_console dies as expected';
+    $mod2->unmock('query_isotovideo');
+};
 
 subtest 'script_run' => sub {
     local $bmwqemu::vars{PRETTY_SERIAL_MARKER} = 0;

--- a/testapi.pm
+++ b/testapi.pm
@@ -1239,13 +1239,13 @@ sub validate_script_output {    # no:style:signatures
           $script, $check, $output;
     }
     else {
-        croak 'Invalid use of validate_script_output(), second arg must be a coderef or regexp';
+        OpenQA::Exception::TestapiError->throw(error => 'Invalid use of validate_script_output(), second arg must be a coderef or regexp');
     }
     $autotest::current_test->record_resultfile(
         $title, $message,
         result => $res,
     );
-    croak $fail_message if $res eq 'fail';
+    OpenQA::Exception::TestapiError->throw(error => $fail_message) if $res eq 'fail';
     return 0;
 }
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -375,8 +375,8 @@ sub _check_backend_response ($rsp, $check, $timeout, $mustmatch) {
 }
 
 sub _check_or_assert ($mustmatch, $check, %args) {
-    die 'no tags specified' if (!$mustmatch || (ref $mustmatch eq 'ARRAY' && scalar @$mustmatch == 0));
-    die 'current_test undefined' unless $autotest::current_test;
+    OpenQA::Exception::TestapiUsageError->throw(error => 'no tags specified') if (!$mustmatch || (ref $mustmatch eq 'ARRAY' && scalar @$mustmatch == 0));
+    OpenQA::Exception::TestapiUsageError->throw(error => 'current_test undefined') unless $autotest::current_test;
 
     $args{timeout} = bmwqemu::scale_timeout($args{timeout});
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -701,7 +701,7 @@ into C<wait_still_screen> for details.
 =cut
 
 sub assert_still_screen (@args) {
-    wait_still_screen(@args) or die 'assert_still_screen failed to detect a still screen';
+    wait_still_screen(@args) or OpenQA::Exception::TestapiError->throw(error => 'assert_still_screen failed to detect a still screen');
 }
 
 =head1 test variable access

--- a/testapi.pm
+++ b/testapi.pm
@@ -728,7 +728,7 @@ Similar to C<get_var> but without default value and throws exception if variable
 =cut
 
 sub get_required_var ($var) {
-    return $bmwqemu::vars{$var} // croak "Could not retrieve required variable $var";
+    return $bmwqemu::vars{$var} // OpenQA::Exception::TestapiError->throw(error => "Could not retrieve required variable $var");
 }
 
 =head2 set_var

--- a/testapi.pm
+++ b/testapi.pm
@@ -244,7 +244,7 @@ tag on the result file.
 
 sub record_info ($title, $output = undef, %nargs) {
     $nargs{result} //= 'ok';
-    die 'unsupported $result \'' . $nargs{result} . '\'' unless _is_valid_result($nargs{result});
+    OpenQA::Exception::TestapiUsageError->throw(error => "unsupported \$result '$nargs{result}'") unless _is_valid_result($nargs{result});
     $output //= '';
     bmwqemu::log_call(title => $title, output => $output, %nargs);
     $autotest::current_test->record_resultfile($title, $output, %nargs);

--- a/testapi.pm
+++ b/testapi.pm
@@ -1440,7 +1440,7 @@ sub type_string {    # no:style:signatures
         }
         if ($wait_still && !wait_still_screen(stilltime => $wait_still,
                 timeout => $wait_timeout, similarity_level => $wait_sim_level)) {
-            die "wait_still_screen timed out after ${wait_timeout}s!";
+            OpenQA::Exception::TestapiError->throw(error => "wait_still_screen timed out after ${wait_timeout}s!");
         }
     }
 }

--- a/testapi.pm
+++ b/testapi.pm
@@ -1009,7 +1009,7 @@ sub script_run {    # no:style:signatures
 
     bmwqemu::log_call(cmd => $cmd, %args);
     my $ret = $distri->script_run($cmd, %args);
-    croak("command '$cmd' timed out") if $args{timeout} > 0 && !defined $ret;
+    OpenQA::Exception::TestapiError->throw(error => "command '$cmd' timed out") if $args{timeout} > 0 && !defined $ret;
     return $ret;
 }
 

--- a/testapi.pm
+++ b/testapi.pm
@@ -1607,7 +1607,7 @@ sub mouse_drag (%args) {
     }
     # If neither coordinates nor a needle is provided, report an error and quit.
     else {
-        die "The starting point of the drag was not correctly provided. Either provide the 'startx' and 'starty' coordinates, or a needle marking the starting point.";
+        OpenQA::Exception::TestapiUsageError->throw(error => "The starting point of the drag was not correctly provided. Either provide the 'startx' and 'starty' coordinates, or a needle marking the starting point.");
     }
 
     # Repeat the same for endpoint coordinates or needles.
@@ -1621,7 +1621,7 @@ sub mouse_drag (%args) {
         ($endx, $endy) = _calculate_clickpoint($end_matched_needle);
     }
     else {
-        die "The ending point of the drag was not correctly provided. Either provide the 'endx' and 'endy' coordinates, or a needle marking the end point.";
+        OpenQA::Exception::TestapiUsageError->throw(error => "The ending point of the drag was not correctly provided. Either provide the 'endx' and 'endy' coordinates, or a needle marking the end point.");
     }
     # Get the button variable. If no button has been provided, assume the "left" button.
     my $button = $args{button} // 'left';

--- a/testapi.pm
+++ b/testapi.pm
@@ -1705,7 +1705,7 @@ sub select_console ($testapi_console, @args) {
         $testapi_console_proxies{$testapi_console} = backend::console_proxy->new($testapi_console);
     }
     my $ret = query_isotovideo('backend_select_console', {testapi_console => $testapi_console});
-    die $ret->{error} if $ret->{error};
+    OpenQA::Exception::TestapiError->throw(error => $ret->{error}) if $ret->{error};
 
     $autotest::selected_console = $testapi_console;
     if ($ret->{activated}) {

--- a/testapi.pm
+++ b/testapi.pm
@@ -645,7 +645,8 @@ sub assert_screen_change : prototype(&@) {    # no:style:signatures
     # wait_screen_change uses prototype which expects code block as an argument
     # This resolves compile time issues
     my ($coderef, @args) = @_;
-    wait_screen_change(\&{$coderef}, @args) or die 'assert_screen_change failed to detect a screen change';
+    wait_screen_change(\&{$coderef}, @args) or
+      OpenQA::Exception::TestapiError->throw(error => 'assert_screen_change failed to detect a screen change');
 }
 
 


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/201840

I also added `OpenQA::Exception::TestapiUsageError`.

This is for exceptions where wrong parameters were passed, for example.

I handled every function in its own commit for easier review, but can squash if requested.