### PR TITLE
ci: Optimize fullstack test target to skip developer mode tests

### DIFF
--- a/.github/workflows/openqa_fullstack.yml
+++ b/.github/workflows/openqa_fullstack.yml
@@ -34,6 +34,6 @@ jobs:
       - name: Build os-autoinst
         run: sudo -u "$TEST_USER" make symlinks
       - name: Run unit tests
-        run: sudo -u "$TEST_USER" make -C ../openQA test-fullstack
+        run: sudo -u "$TEST_USER" make -C ../openQA test-with-database FULLSTACK=1 TIMEOUT_M=30 PROVE_ARGS="t/full-stack.t"
         env:
           STABILITY_TEST: ${{ github.event.inputs.stability_test }}


### PR DESCRIPTION
Motivation:
The openQA test-fullstack Makefile target also runs developer mode
tests which are unnecessary for this specific workflow.

Design Choices:
Updated the GitHub Actions workflow to run the full-stack.t test
using the test-with-database target directly to bypass the extra
test executions.

Benefits:
Saves CI execution time and avoids running tests that aren't
relevant to the core full-stack validation.