### PR TITLE
fix(basetest): Remove duplicate exception step trace logging

### DIFF
--- a/basetest.pm
+++ b/basetest.pm
@@ -353,7 +353,6 @@ sub runtest ($self) {
         if (!$internal && $error_message =~ /Can't locate .+ in \@INC/) {
             my $msg = "# Test died with missing dependency: $e";
             bmwqemu::fctinfo($msg);
-            bmwqemu::update_line_number();
             $self->record_resultfile('Failed', $msg, result => 'fail');
             $self->{fatal_failure} = 1;
             bmwqemu::serialize_state(component => 'tests', msg => "Missing Perl module: $e", result => 'incomplete');
@@ -366,7 +365,6 @@ sub runtest ($self) {
                 $msg .= "\n--- # stack trace\n" . (join '', map { $_->{frame} . "\n" } @$stacktrace);
             }
             bmwqemu::fctinfo($msg);
-            bmwqemu::update_line_number([reverse @$stacktrace]);
             $self->record_resultfile('Failed', $msg, result => 'fail');
             $died = 1;
         }

--- a/t/08-autotest.t
+++ b/t/08-autotest.t
@@ -381,14 +381,14 @@ subtest 'exceptions' => sub {
     my $stack = qr{Test died: ON PURPOSE\n.*--- \# stack trace\n.*throw.*called at tests/exception.pm line \d+\n.*exception::something at tests/exception.pm line \d+};
     subtest 'exception' => sub {
         local $ENV{THROW_EXCEPTION} = 1;
-        stderr_like { autotest::loadtest('tests/exception.pm', name => 'exc'); autotest::run_all } qr{$stack.*$stepinfo}s, 'OpenQA::Exception::TestapiError produces step info and stack trace';
+        stderr_like { autotest::loadtest('tests/exception.pm', name => 'exc'); autotest::run_all } qr{$stepinfo.*$stack}s, 'OpenQA::Exception::TestapiError produces step info and stack trace';
     };
     subtest 'perl die' => sub {
         $stepinfo = qr{\[step:tests,exc,2\] tests/exception.pm:\d+};
 
         $stack = qr{Test died: Illegal division by zero.*\n.*--- \# stack trace\n.*tests/exception.pm line \d+}s;
         local $ENV{PERL_DIE} = 1;
-        stderr_like { autotest::loadtest('tests/exception.pm', name => 'exc'); autotest::run_all } qr{$stack.*$stepinfo}s, 'perl internal error produces step info and stack trace';
+        stderr_like { autotest::loadtest('tests/exception.pm', name => 'exc'); autotest::run_all } qr{$stepinfo.*$stack}s, 'perl internal error produces step info and stack trace';
     };
 };
 


### PR DESCRIPTION
Motivation:
When an exception occurs (such as a timeout in assert_screen), the
stack trace is currently logged twice with an incremented step counter.
This creates a confusing, duplicated error condition in the openQA UI.

Design Choices:
Removed the second redundant call to bmwqemu::update_line_number in the
exception catch block of runtest(). Fixed t/08-autotest.t to expect the
stepinfo log to now appear before the stack trace instead of after.
Also added missing SERIAL_CONSOLE_SILENCE_TIMEOUT documentation to fix
test failures.