### PR TITLE
ci: Execute developer mode fullstack test again

### DIFF
--- a/.github/workflows/openqa_fullstack.yml
+++ b/.github/workflows/openqa_fullstack.yml
@@ -37,9 +37,7 @@ jobs:
       - name: Run unit tests
         run: |
           sudo -u "$TEST_USER" mkdir -p "$OPENQA_FULLSTACK_TEMP_DIR"
-          sudo -u "$TEST_USER" make -C ../openQA test-with-database \
-            FULLSTACK=1 TIMEOUT_M=30 PROVE_ARGS="t/full-stack.t" \
-            OPENQA_FULLSTACK_TEMP_DIR="$OPENQA_FULLSTACK_TEMP_DIR"
+          sudo -u "$TEST_USER" make -C ../openQA test-fullstack OPENQA_FULLSTACK_TEMP_DIR="$OPENQA_FULLSTACK_TEMP_DIR"
         env:
           STABILITY_TEST: ${{ github.event.inputs.stability_test }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7

--- a/.github/workflows/openqa_fullstack.yml
+++ b/.github/workflows/openqa_fullstack.yml
@@ -43,6 +43,7 @@ jobs:
         env:
           STABILITY_TEST: ${{ github.event.inputs.stability_test }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        if: ${{ always() }}
         with:
           name: Test results
           path: |


### PR DESCRIPTION
This reverts commit ac1016269d297ad06b4a82454fb026d858730bb8.

The developer mode depends on the command processing done in os-autoinst so executing this test is very relevant to ensure changes in os-autoinst don't break the developer mode. It also recently exposed IPC issues in os-autoinst, see https://progress.opensuse.org/issues/205206.