### PR TITLE
fix: support leading-space commands under level-3

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -185,6 +185,15 @@ sub script_run ($self, $cmd, @args) {
             $level = 1;
             $skip_pretty = 1;
         }
+        # A leading space keeps the command out of bash history (HISTCONTROL
+        # ignorespace/ignoreboth), so the level-3 _oap hook reconstructs the
+        # wrong fingerprint and its OA:DONE marker never matches, timing out.
+        # Fall back to the history-independent explicit echo marker instead.
+        if ($level > 1 && $cmd =~ /^\s/) {
+            bmwqemu::diag('Leading-space command bypasses bash history; using explicit exit marker instead of level-3 pretty serial marker to avoid a spurious serial timeout');
+            $level = 1;
+            $skip_pretty = 1;
+        }
         my ($str, $wait_pattern);
         if ($level == 3) {
             testapi::query_isotovideo('backend_clear_serial_buffer', {});

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -277,6 +277,16 @@ subtest 'level3_marker_correlation' => sub {
     is $exit_code, undef, 'Anchored match miss fails closed with undef instead of an unreliable generic fallback';
     is scalar(@regexes_seen), 1, 'No second generic wait_serial is issued, preventing stale-marker mismatch and doubled timeout';
     like $regexes_seen[0], qr/OA:DONE-\[0-9a-f\]\{4\}-\(\\d\+\)-OA(?:\\:|:)curl11logs/, 'The single wait_serial call uses the anchored fingerprint';
+
+    # Verify leading-space commands bypass history-based level-3 to avoid timeouts
+    $typed = '';
+    @regexes_seen = ();
+    my $fallback_str = testapi::hashed_string('SR' . ' ! ssh host' . 9);
+    $mock_testapi->redefine(wait_serial => sub ($regexp, @) { push @regexes_seen, $regexp; return "$fallback_str-0-" });
+    is $d->script_run(' ! ssh host', timeout => 9), 0, 'leading-space command falls back to explicit marker and returns exit code';
+    unlike $typed, qr/HISTTIMEFORMAT|OA:DONE/, 'leading-space command does not use history-based level-3 marker';
+    like $typed, qr/_OANM=1;.*echo .* > \/dev\/ttyS0/, 'leading-space command uses level-1 explicit marker';
+    like $regexes_seen[0], qr/-\(\\d\+\)-/, 'wait_serial matches explicit marker';
 };
 
 subtest 'set expected serial and autoinst failures' => sub {


### PR DESCRIPTION
Motivation:
Under level-3 pretty markers, the hook matches fingerprints via bash history.
Since leading-space commands bypass history by default, they cause timeouts.

Design Choices:
Detect leading-space commands and fall back to history-independent level-1
markers for those commands, while preserving level-3 for subsequent commands.

Benefits:
Allows reliable execution of leading-space commands under pretty markers and
prevents reviewer confusion from spurious serial timeouts.

Related issue: https://progress.opensuse.org/issues/205773