### PR TITLE
docs(guidelines): prefer self-explanatory test descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,8 @@ test scripts.
   for Perl changes before claiming completion.
 - Testing: Always add tests for new features or bug fixes in `t/`. Prefer
   reusing existing failing test modules (e.g. from `t/data/tests`) for
-  integration tests.
+  integration tests. Prefer self-explanatory test description strings rather
+  than in-file comments.
 - Dependencies: Update `dependencies.yaml` and run `make update-deps`.
 
 ## Constraints


### PR DESCRIPTION
Motivation:
Align opencode with the preference for self-explanatory test description strings.

Design Choices:
Add clear guidelines to AGENTS.md to prefer self-documenting test descriptions.

Benefits:
Ensures all future test implementations remain concise and free of in-file comments.