### PR TITLE
fix(myjsonrpc): omit newline delimiter between JSON objects

### DIFF
--- a/myjsonrpc.pm
+++ b/myjsonrpc.pm
@@ -47,7 +47,6 @@ sub send_json ($to_fd, $cmd) {
 
     my $json = $cjx->encode(\%cmdcopy);
     bmwqemu::diag(sprintf 'send_json(%d) JSON=%s', fileno($to_fd), $json =~ s/"([^"]{30})[^"]+"/"$1"/gr) if is_debug();
-    $json .= "\n";
 
     confess 'myjsonrpc: called on undefined file descriptor' unless defined $to_fd;
     my $written_bytes = 0;


### PR DESCRIPTION
Each JSON object sent by myjsonrpc was newline terminated, but the handling in read_json did not explicitly handle this. This can lead to a deadlock:

The sender sends an object that encodes to exactly as many bytes as the pipe fits (resp. can be send/read at once) + the terminating newline. The receiver notices pending data and calls read_json. This reads the full object ("{...}") and returns it. The pipe still has pending data and so the receiver calls read_json again. This only consumes the "\n" and waits for more data, potentially indefinitely.

incr_parse already knows where JSON objects end, so the newline termination is unnecessary and can just be removed.

Related issue: https://progress.opensuse.org/issues/206049

Verification run: http://10.168.5.231/tests/2143