### PR TITLE
feat: Disable pretty serial markers for xterm-based consoles

### DIFF
--- a/consoles/console.pm
+++ b/consoles/console.pm
@@ -66,6 +66,8 @@ sub activate ($self) { }
 
 sub is_serial_terminal ($self) { 0 }
 
+sub disable_pretty_serial_marker ($self) { 0 }
+
 sub set_args ($self, %args) {
     my $my_args = $self->{args};
     $self->{args}->{$_} = $args{$_} for (keys %args);

--- a/consoles/sshXtermIPMI.pm
+++ b/consoles/sshXtermIPMI.pm
@@ -71,4 +71,7 @@ sub current_screen ($self) {
     }
 }
 
+# Refer to consoles::sshXtermVt for why pretty serial markers must be disabled on xterm-based consoles.
+sub disable_pretty_serial_marker ($self) { 1 }
+
 1;

--- a/consoles/sshXtermVt.pm
+++ b/consoles/sshXtermVt.pm
@@ -69,4 +69,11 @@ sub kill_ssh ($self) {
     $self->backend->stop_ssh_serial;
 }
 
+# xterm-based consoles show SUT's interactive terminal/serial shell on the screen.
+# If pretty serial markers are enabled, the shell prints markers out-of-band directly
+# to the screen. This desynchronizes readline's cursor tracking, triggering a DSR
+# cursor query (\033[6n) that responds with a CPR (e.g. \033[64;1257R) to SUT's stdin,
+# corrupting the next typed command. Disable pretty markers here to avoid this.
+sub disable_pretty_serial_marker ($self) { 1 }
+
 1;

--- a/distribution.pm
+++ b/distribution.pm
@@ -571,6 +571,13 @@ Return the current C<PRETTY_SERIAL_MARKER> state. Falls back to the test variabl
 =cut
 
 sub get_pretty_serial_marker ($self) {
+    my $console_name = testapi::current_console();
+    if ($console_name) {
+        my $console = $self->{consoles}->{$console_name};
+        if ($console && $console->disable_pretty_serial_marker) {
+            return 0;
+        }
+    }
     return $self->{_pretty_serial_marker} // testapi::get_var('PRETTY_SERIAL_MARKER', 1);
 }
 

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -8,6 +8,7 @@ use Mojo::Base -signatures;
 use Test::Warnings qw(:all :report_warnings);
 use Test::Output qw(combined_like);
 use Test::MockModule;
+use Test::MockObject;
 use FindBin '$Bin';
 use lib "$Bin/../external/os-autoinst-common/lib";
 use distribution;
@@ -347,6 +348,13 @@ subtest 'pretty_serial_marker_helpers' => sub {
         is $vars{PRETTY_SERIAL_MARKER}, 1, 'Global var remains unchanged';
     }
     is $d->get_pretty_serial_marker(), 1, 'Value restored after guard scope';
+
+    # console-specific disablement
+    my $mock_console = Test::MockObject->new;
+    $mock_console->set_always(disable_pretty_serial_marker => 1);
+    $d->{consoles}->{'test-console'} = $mock_console;
+    is $d->get_pretty_serial_marker(), 0, 'pretty serial markers disabled if console disables them';
+    delete $d->{consoles}->{'test-console'};
 };
 
 subtest 'serial_marker_hook_persistence' => sub {

--- a/t/27-consoles-sshXtermIPMI.t
+++ b/t/27-consoles-sshXtermIPMI.t
@@ -47,6 +47,7 @@ $testapi_console_mock->redefine(backend => $backend);
 $localXvnc_mock->redefine(activate => sub ($self) { $self->{DISPLAY} = 'display'; });
 
 ok my $sol_connection = consoles::sshXtermIPMI->new($testapi_console, undef), 'sol connection can be established';
+is $sol_connection->disable_pretty_serial_marker, 1, 'pretty serial markers disabled';
 
 subtest 'sshXtermIPMI activate' => sub {
     my $ipc_run_mock = Test::MockModule->new('IPC::Run');

--- a/t/27-consoles-sshXtermVt.t
+++ b/t/27-consoles-sshXtermVt.t
@@ -42,6 +42,7 @@ $backend_mock->mock(
 );
 $backend_mock->set_true('stop_ssh_serial');
 my $c = consoles::sshXtermVt->new('sut', $args);
+is $c->disable_pretty_serial_marker, 1, 'pretty serial markers disabled';
 $c->{backend} = $backend_mock;
 my $captured_output = stderr_from { $c->activate() };
 like $captured_output, qr/Wait for SSH on host testhost/, 'Captured expected debug log';

--- a/t/27-consoles-vnc_base.t
+++ b/t/27-consoles-vnc_base.t
@@ -16,6 +16,7 @@ use consoles::vnc_base;
 
 my $c = consoles::vnc_base->new('sut', {});
 is $c->screen, $c, 'screen returns self';
+is $c->disable_pretty_serial_marker, 0, 'pretty serial markers not disabled by default';
 my $vnc = Test::MockObject->new->set_true('map_and_send_key');
 $c->{vnc} = $vnc;
 $vnc->set_always('socket', 0);


### PR DESCRIPTION
Check out the added code comment for an hypothesis why this helps avoid test failures due to command corruption.

Related ticket: https://progress.opensuse.org/issues/206241

Verification run: https://openqa.suse.de/tests/24155920
Looks like the verification run already fails in `bootloader`. I started the job using [a custom worker engine](https://open.qa/docs/#running-a-custom-worker-engine) but perhaps that doesn't work for the `pvm_hmc` backend.