### PR TITLE
fix: Prevent command corruption from DSR/CPR loop on serial xterm consoles

### DIFF
--- a/distribution.pm
+++ b/distribution.pm
@@ -496,7 +496,7 @@ sub install_serial_marker_hook ($self, $level) {
         3 => qq{_oap(){ r=\$?;if [ -n "\$_OANM" ];then unset _OANM;else c=\$(HISTTIMEFORMAT= history 1);c=\${c#*[0-9]  };c=\${c#\${c%%[![:space:]]*}};c=\${c%\${c##*[![:space:]]}};l=\${#c};t=\$c;[ \$l -ge 4 ]&&t=\${c: -4};printf "OA:DONE-%04x-%d-OA:%s%d%s\\nOA:START\\n" \$RANDOM \$r "\${c:0:4}" \$l "\$t">$dev;fi;}},
         2 => qq{_oap(){ r=\$?;if [ -n "\$_OANM" ];then unset _OANM;elif [ -n "\$_OAM" ];then echo "\$_OAM-\$r-">$dev;unset _OAM;fi;echo "OA:START">$dev;}},
     }->{$level};
-    my $pc = 'PROMPT_COMMAND=_oap';
+    my $pc = 'PROMPT_COMMAND=_oap; shopt -u checkwinsize 2>/dev/null; stty cols 130 rows 40 2>/dev/null';
 
     # Version tag: bump whenever the emitted marker format changes so a stale
     # hook persisted in ~/.bashrc by an older os-autoinst is replaced instead of

--- a/t/05-distribution.t
+++ b/t/05-distribution.t
@@ -379,6 +379,8 @@ subtest 'serial_marker_hook_version_migration' => sub {
     like $typed, qr/sed -i '[^']*_oap[^']*' ~\/\.bashrc ~\/\.profile/,
       'Stale hook lines are stripped before reinstall so an old-format _oap persisted by a previous os-autoinst is replaced';
     like $typed, qr/echo '_OAPV=\d+;_oap\(\)/, 'The version tag is persisted together with the hook definition';
+    like $typed, qr/shopt -u checkwinsize/, 'checkwinsize is disabled';
+    like $typed, qr/stty cols 130 rows 40/, 'terminal columns are set';
 };
 
 subtest 'serial markers are skipped for manual redirections and multiline commands' => sub {


### PR DESCRIPTION
This change might help us avoid [disabling pretty serial markers completely for xterm consoles](https://github.com/os-autoinst/os-autoinst/pull/3090). However, I haven't done any real testing; this is just based on unverified claims by an AI model.

---

Disable checkwinsize and configure valid terminal columns using stty on interactive serial terminal sessions. This avoids readline falling back to cursor position queries (\x5c033[6n), which otherwise returns a CPR response to SUT's stdin, corrupting the next typed command.

Related ticket: https://progress.opensuse.org/issues/206241

---

I'm currently doing a verification run on my local machine with an svirt host from production. It is still executing (very slowly) but it came further than the attempt using a containerized os-autoinst.

It already shows the downside of this approach: More characters need to be typed when installing the prompt.

<img width="1045" height="496" alt="Bildschirmfoto_20260902_140338" src="https://github.com/user-attachments/assets/96883714-d0f3-4365-968f-e1eaacda1cf1" />

So maybe it makes sense to do this only in cases where it is needed. (But let's see whether it works at all.)